### PR TITLE
Fix: resolve merge conflict in gaboom.cpp and MPI build ordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,14 @@ else()
     endif()
 endif()
 
+# ─── MPI (optional, for distributed parallel docking) ──────────────────
+# Must precede add_subdirectory(LIB) so MPI::MPI_CXX exists when
+# LIB/CMakeLists.txt links flexaid_core against it.
+if(FLEXAIDS_USE_MPI)
+    find_package(MPI REQUIRED)
+    message(STATUS "MPI enabled — distributed parallel docking active")
+endif()
+
 # ─── Core library (LIB/) ────────────────────────────────────────────────
 add_subdirectory(LIB)
 
@@ -405,12 +413,6 @@ endif()
 # ─── OpenMP link ────────────────────────────────────────────────────────
 if(FLEXAIDS_USE_OPENMP AND OpenMP_CXX_FOUND)
     target_link_libraries(FlexAID PRIVATE OpenMP::OpenMP_CXX)
-endif()
-
-# ─── MPI (optional, for distributed parallel docking) ──────────────────
-if(FLEXAIDS_USE_MPI)
-    find_package(MPI REQUIRED)
-    message(STATUS "MPI enabled — distributed parallel docking active")
 endif()
 
 # ─── CUDA sources ───────────────────────────────────────────────────────

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -878,6 +878,9 @@ void adapt_prob(GB_Global* GB,double fit1, double fit2, double* mutp, double* cr
 
 	return;
 }
+
+static size_t hash_genes(const gene* g, int n);
+
 /***********************************************************************/
 /* 1         2         3         4         5         6          */
 /*234567890123456789012345678901234567890123456789012345678901234567890*/
@@ -1037,19 +1040,10 @@ int reproduce(FA_Global* FA,GB_Global* GB,VC_Global* VC, chromosome* chrom, cons
 	return nrejected;
 }
 
-<<<<<<< HEAD
-static size_t hash_genes(const gene genes[], int num_genes){
-	size_t h = 0;
-	for(int i = 0; i < num_genes; ++i){
-		auto v = static_cast<int32_t>(genes[i].to_ic + 0.5);
-		h ^= std::hash<int32_t>{}(v) + 0x9e3779b9 + (h << 6) + (h >> 2);
-	}
-=======
-size_t hash_genes(const gene* g, int n){
+static size_t hash_genes(const gene* g, int n){
 	size_t h = 0;
 	for(int i = 0; i < n; ++i)
 		h ^= std::hash<int32_t>{}(static_cast<int32_t>(g[i].to_ic + 0.5)) + 0x9e3779b9 + (h << 6) + (h >> 2);
->>>>>>> ce3b671 (perf: replace string chromosome signatures with integer hashing)
 	return h;
 }
 


### PR DESCRIPTION
## Summary
- Resolve unresolved `<<<<<<< HEAD` conflict markers in `hash_genes()` that broke all C++ CI jobs (FlexAID CI, Sanitizers, tsan, CodeQL)
- Move `find_package(MPI)` before `add_subdirectory(LIB)` so `MPI::MPI_CXX` target exists when `LIB/CMakeLists.txt` links `flexaid_core` — fixes Benchmark Tier 2

## Test plan
- [ ] All 5 previously-failing CI jobs pass (FlexAID CI, Sanitizers, tsan, CodeQL, Benchmark Tier 2)
- [ ] MPI build: `cmake -DFLEXAIDS_USE_MPI=ON` configures without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)