### PR TITLE
Upgrade build system from C++20 to C++26

### DIFF
--- a/.github/workflows/benchmark-tier1.yml
+++ b/.github/workflows/benchmark-tier1.yml
@@ -53,8 +53,11 @@ jobs:
       - name: Install Linux build dependencies
         run: |
           sudo apt-get update -q
+          # gcc-14 is required for C++26 support (see CMakeLists.txt compiler gate).
           sudo apt-get install -y --no-install-recommends \
-            cmake ninja-build libeigen3-dev libomp-dev
+            cmake ninja-build libeigen3-dev libomp-dev gcc-14 g++-14
+          echo "CC=gcc-14" >> "$GITHUB_ENV"
+          echo "CXX=g++-14" >> "$GITHUB_ENV"
 
       - name: Cache build
         id: cache-build

--- a/.github/workflows/benchmark-tier2.yml
+++ b/.github/workflows/benchmark-tier2.yml
@@ -59,8 +59,11 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update -q
+          # gcc-14 is required for C++26 support (see CMakeLists.txt compiler gate).
           sudo apt-get install -y --no-install-recommends \
-            cmake ninja-build libeigen3-dev libomp-dev libopenmpi-dev openmpi-bin
+            cmake ninja-build libeigen3-dev libomp-dev libopenmpi-dev openmpi-bin gcc-14 g++-14
+          echo "CC=gcc-14" >> "$GITHUB_ENV"
+          echo "CXX=g++-14" >> "$GITHUB_ENV"
 
       - name: Cache build artifacts
         id: cache-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,42 +60,43 @@ jobs:
         include:
           - name: linux-gcc
             os: ubuntu-latest
-            cc: gcc
-            cxx: g++
+            cc: gcc-14
+            cxx: g++-14
           - name: linux-clang
             os: ubuntu-latest
-            cc: clang
-            cxx: clang++
+            cc: clang-18
+            cxx: clang++-18
           - name: macos-clang
-            os: macos-latest
+            os: macos-15
             cc: clang
             cxx: clang++
             allow_failure: true
           - name: linux-gcc-avx512
             os: ubuntu-latest
-            cc: gcc
-            cxx: g++
+            cc: gcc-14
+            cxx: g++-14
             cmake_extra: "-DFLEXAIDS_USE_AVX512=ON -DBUILD_TESTING=OFF"
           - name: linux-gcc-mpi
             os: ubuntu-latest
-            cc: gcc
-            cxx: g++
+            cc: gcc-14
+            cxx: g++-14
             cmake_extra: "-DFLEXAIDS_USE_MPI=ON"
           - name: linux-gcc-asan
             os: ubuntu-latest
-            cc: gcc
-            cxx: g++
+            cc: gcc-14
+            cxx: g++-14
             cmake_extra: >-
               -DCMAKE_CXX_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer -g'
               -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address,undefined'
-          # windows-msvc excluded: deep MSVC C++20 incompatibilities in legacy sources
+          # windows-msvc excluded: deep MSVC C++20/C++26 incompatibilities in legacy sources
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          PKGS="cmake ninja-build libeigen3-dev libomp-dev"
+          # gcc-14 / clang-18 are required for C++26 support (see CMakeLists.txt compiler gate).
+          PKGS="cmake ninja-build libeigen3-dev libomp-dev gcc-14 g++-14 clang-18"
           if [ "${{ matrix.name }}" = "linux-gcc-mpi" ]; then
             PKGS="$PKGS libopenmpi-dev openmpi-bin"
           fi
@@ -103,6 +104,8 @@ jobs:
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: |
+          # Apple Clang ≥ 16 (Xcode 16) is required for C++26.
+          sudo xcode-select -s /Applications/Xcode_16.app || true
           brew install cmake ninja libomp eigen
       - name: Install Windows dependencies
         if: runner.os == 'Windows'
@@ -158,7 +161,10 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libeigen3-dev
+          # gcc-14 is required for C++26 support (see CMakeLists.txt compiler gate).
+          sudo apt-get install -y cmake ninja-build libeigen3-dev gcc-14 g++-14
+          echo "CC=gcc-14" >> "$GITHUB_ENV"
+          echo "CXX=g++-14" >> "$GITHUB_ENV"
           python -m pip install --upgrade pip
           python -m pip install 'pybind11[global]' pytest numpy
       - name: Install build dependencies (Windows)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,12 @@ jobs:
 
       - name: Install C++ dependencies
         if: matrix.language == 'cpp'
-        run: sudo apt-get update && sudo apt-get install -y libeigen3-dev libboost-all-dev
+        run: |
+          sudo apt-get update
+          # gcc-14 is required for C++26 support (see CMakeLists.txt compiler gate).
+          sudo apt-get install -y libeigen3-dev libboost-all-dev gcc-14 g++-14
+          echo "CC=gcc-14" >> "$GITHUB_ENV"
+          echo "CXX=g++-14" >> "$GITHUB_ENV"
 
       - name: Build C++
         if: matrix.language == 'cpp'

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -18,7 +18,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libeigen3-dev libomp-dev
+          # gcc-14 is required for C++26 support (see CMakeLists.txt compiler gate).
+          sudo apt-get install -y cmake ninja-build libeigen3-dev libomp-dev gcc-14 g++-14
+          echo "CC=gcc-14" >> "$GITHUB_ENV"
+          echo "CXX=g++-14" >> "$GITHUB_ENV"
 
       - name: Build with benchmarks
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
         include:
           - name: linux-gcc
             os: ubuntu-latest
-            cc: gcc
-            cxx: g++
+            cc: gcc-14
+            cxx: g++-14
             artifact_name: flexaidds-linux
           - name: macos-clang
-            os: macos-latest
+            os: macos-15
             cc: clang
             cxx: clang++
             artifact_name: flexaidds-macos
@@ -36,11 +36,14 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libeigen3-dev libomp-dev
+          # gcc-14 is required for C++26 support (see CMakeLists.txt compiler gate).
+          sudo apt-get install -y cmake ninja-build libeigen3-dev libomp-dev gcc-14 g++-14
 
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: |
+          # Apple Clang ≥ 16 (Xcode 16) is required for C++26.
+          sudo xcode-select -s /Applications/Xcode_16.app || true
           brew install cmake ninja libomp eigen
 
       - name: Install Windows dependencies

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -18,12 +18,13 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build clang libeigen3-dev libomp-dev
+          # clang-18 is required for C++26 support (see CMakeLists.txt compiler gate).
+          sudo apt-get install -y cmake ninja-build clang-18 libeigen3-dev libomp-dev
 
       - name: Configure
         env:
-          CC: clang
-          CXX: clang++
+          CC: clang-18
+          CXX: clang++-18
         run: |
           cmake -S . -B build-sanitizers -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -16,12 +16,13 @@ jobs:
       - name: Install toolchain
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang ninja-build cmake
+          # clang-18 is required for C++26 support (see CMakeLists.txt compiler gate).
+          sudo apt-get install -y clang-18 ninja-build cmake
 
       - name: Configure (ThreadSanitizer)
         env:
-          CC: clang
-          CXX: clang++
+          CC: clang-18
+          CXX: clang++-18
         run: |
           cmake -S . -B build-tsan -G Ninja \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 FlexAIDdS (FlexAID with ΔS Entropy) is an entropy-driven molecular docking engine combining genetic algorithms with statistical mechanics thermodynamics. It targets real-world psychopharmacology and drug discovery applications.
 
-- **Languages**: C++20 (core engine), Python (bindings/analysis), Objective-C++ (Metal GPU), CUDA (optional GPU)
+- **Languages**: C++26 (core engine), Python (bindings/analysis), Objective-C++ (Metal GPU), CUDA (optional GPU)
 - **License**: Apache-2.0 (no GPL dependencies allowed — see `THIRD_PARTY_LICENSES.md`)
 - **Lead**: Louis-Philippe Morency, PhD (Candidate), Université de Montréal, NRGlab
 
@@ -138,8 +138,8 @@ FlexAIDdS/
 
 ### Requirements
 
-- C++20 compiler (GCC >= 10, Clang >= 10, MSVC)
-- CMake >= 3.18
+- C++26 compiler (GCC >= 14, Clang >= 18, Apple Clang >= 16 / Xcode 16, MSVC >= 19.40 / VS 2022 17.10)
+- CMake >= 3.28
 - Optional: Boost, Eigen3, OpenMP, CUDA Toolkit, Metal framework, pybind11
 
 ### Build Commands
@@ -262,7 +262,7 @@ Key test files in `python/tests/`:
 
 ### C++ Style
 
-- C++20 standard
+- C++26 standard
 - Compiler flags: `-Wall -O3 -ffast-math` + SIMD flags
 - Core data structures: `chromosome` (GA gene encoding), `Pose`, `BindingMode`, `BindingPopulation`
 - Use log-sum-exp for numerical stability in partition functions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Build: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.28)
 
 # ─── Graceful OBJCXX Fallback ──────────────────────────────────────────────
 # Detects OBJCXX compiler availability before requiring it.
@@ -31,22 +31,34 @@ project(FlexAID VERSION 2.0.0 LANGUAGES ${_ENABLED_LANGUAGES})
 
 include(CheckCXXCompilerFlag)
 
-# ─── C++20 ────────────────────────────────────────────────────────────────
-set(CMAKE_CXX_STANDARD 20)
+# ─── C++26 ────────────────────────────────────────────────────────────────
+set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)   # -std=c++20 not -std=gnu++20
+set(CMAKE_CXX_EXTENSIONS OFF)   # -std=c++26 not -std=gnu++26
 
-# Fail fast if compiler is too old to support C++20
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.0")
+# Fail fast if compiler is too old to support C++26
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0")
         message(FATAL_ERROR
-            "FlexAIDdS requires C++20 — found ${CMAKE_CXX_COMPILER_ID} "
-            "${CMAKE_CXX_COMPILER_VERSION}. Upgrade to GCC ≥ 10 or Clang ≥ 10.")
+            "FlexAIDdS requires C++26 — found AppleClang "
+            "${CMAKE_CXX_COMPILER_VERSION}. Upgrade to Apple Clang ≥ 16 (Xcode 16).")
+    endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "18.0")
+        message(FATAL_ERROR
+            "FlexAIDdS requires C++26 — found Clang "
+            "${CMAKE_CXX_COMPILER_VERSION}. Upgrade to Clang ≥ 18.")
+    endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14.0")
+        message(FATAL_ERROR
+            "FlexAIDdS requires C++26 — found GCC "
+            "${CMAKE_CXX_COMPILER_VERSION}. Upgrade to GCC ≥ 14.")
     endif()
 elseif(MSVC)
-    if(MSVC_VERSION LESS 1930)
+    if(MSVC_VERSION LESS 1940)
         message(FATAL_ERROR
-            "FlexAIDdS requires MSVC ≥ 19.30 (Visual Studio 2022 17.0+) for C++20 — "
+            "FlexAIDdS requires MSVC ≥ 19.40 (Visual Studio 2022 17.10+) for C++26 — "
             "found MSVC ${MSVC_VERSION}.")
     endif()
 endif()
@@ -467,6 +479,8 @@ LIB/tENCoM/tencm_cuda.cu                  # TENCoM contact discovery + Hessian a
             message(WARNING "CUDA < 12.6 — Blackwell targets (sm_100, sm_120) disabled")
         endif()
     endif()
+    # Host code is C++26 (see CMAKE_CXX_STANDARD above); NVCC 12.x does not accept
+    # -std=c++26, so device code stays pinned at C++17 until the CUDA toolkit catches up.
     set_target_properties(FlexAID PROPERTIES
         CUDA_SEPARABLE_COMPILATION ON
         CUDA_STANDARD 17)
@@ -496,33 +510,33 @@ if(FLEXAIDS_USE_METAL)
     )
     set_source_files_properties(LIB/metal_eval.mm PROPERTIES
         LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
     )
     # Shannon Metal GPU bridge (Apple Silicon Shannon entropy histogram)
     target_sources(FlexAID PRIVATE LIB/ShannonThermoStack/ShannonMetalBridge.mm)
     target_compile_definitions(FlexAID PRIVATE FLEXAIDS_HAS_METAL_SHANNON)
     set_source_files_properties(LIB/ShannonThermoStack/ShannonMetalBridge.mm PROPERTIES
         LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
     )
     # TENCoM Metal bridge (GPU contact discovery + Hessian assembly)
     target_sources(FlexAID PRIVATE LIB/tENCoM/tencm_metal.mm)
     target_compile_definitions(FlexAID PRIVATE FLEXAIDS_HAS_METAL_TENCM)
     set_source_files_properties(LIB/tENCoM/tencm_metal.mm PROPERTIES
         LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
     )
     # FastOPTICS Metal kNN (GPU-accelerated neighbor discovery)
     target_sources(FlexAID PRIVATE LIB/gpu_fast_optics_metal.mm)
     set_source_files_properties(LIB/gpu_fast_optics_metal.mm PROPERTIES
         LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
     )
     # CavityDetect Metal bridge (Task 1.4: GPU probe-sphere generation)
     target_sources(FlexAID PRIVATE LIB/CavityDetect/CavityDetectMetalBridge.mm)
     set_source_files_properties(LIB/CavityDetect/CavityDetectMetalBridge.mm PROPERTIES
         LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
     )
     # Compile CavityDetect.metal shader → .metallib
     set(CAVITY_METAL_SRC  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/CavityDetect/CavityDetect.metal")
@@ -551,7 +565,7 @@ if(FLEXAIDS_USE_METAL)
     target_sources(FlexAID PRIVATE LIB/TurboQuantMetalBridge.mm)
     set_source_files_properties(LIB/TurboQuantMetalBridge.mm PROPERTIES
         LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
     )
     # Compile TurboQuant.metal shader → .metallib
     set(TQ_METAL_SRC  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/TurboQuant.metal")
@@ -580,7 +594,7 @@ if(FLEXAIDS_USE_METAL)
     target_sources(FlexAID PRIVATE LIB/MetalRMSDBridge.mm)
     set_source_files_properties(LIB/MetalRMSDBridge.mm PROPERTIES
         LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
     )
     # Compile MetalRMSD.metal shader → .metallib
     set(RMSD_METAL_SRC  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/MetalRMSD.metal")
@@ -705,7 +719,7 @@ if(ENABLE_TENCOM_TOOL)
         target_compile_definitions(tENCoM PRIVATE FLEXAIDS_HAS_METAL_TENCM)
         set_source_files_properties(LIB/tENCoM/tencm_metal.mm PROPERTIES
             LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++20 -fno-objc-arc")
+            COMPILE_FLAGS "-std=c++26 -fno-objc-arc")
         target_link_libraries(tENCoM PRIVATE
             ${METAL_LIBRARY} ${FOUNDATION_LIBRARY} ${METALKIT_LIBRARY})
     endif()
@@ -789,14 +803,14 @@ if(BUILD_FLEXAIDDS_FAST)
         )
         set_source_files_properties(LIB/metal_eval.mm PROPERTIES
             LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
         )
         # Shannon Metal GPU bridge (histogram binning on Apple Silicon)
         target_sources(FlexAIDdS PRIVATE LIB/ShannonThermoStack/ShannonMetalBridge.mm)
         target_compile_definitions(FlexAIDdS PRIVATE FLEXAIDS_HAS_METAL_SHANNON)
         set_source_files_properties(LIB/ShannonThermoStack/ShannonMetalBridge.mm PROPERTIES
             LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
         )
         # Shannon Metal shader → .metallib
         set(SHANNON_METAL_SRC  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/ShannonThermoStack/shannon_metal.metal")
@@ -826,19 +840,19 @@ if(BUILD_FLEXAIDDS_FAST)
         target_compile_definitions(FlexAIDdS PRIVATE FLEXAIDS_HAS_METAL_TENCM)
         set_source_files_properties(LIB/tENCoM/tencm_metal.mm PROPERTIES
             LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
         )
         # FastOPTICS Metal kNN (GPU-accelerated neighbor discovery)
         target_sources(FlexAIDdS PRIVATE LIB/gpu_fast_optics_metal.mm)
         set_source_files_properties(LIB/gpu_fast_optics_metal.mm PROPERTIES
             LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
         )
         # CavityDetect Metal bridge + shader
         target_sources(FlexAIDdS PRIVATE LIB/CavityDetect/CavityDetectMetalBridge.mm)
         set_source_files_properties(LIB/CavityDetect/CavityDetectMetalBridge.mm PROPERTIES
             LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
         )
         set(CAVITY_METAL_SRC_DS  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/CavityDetect/CavityDetect.metal")
         set(CAVITY_AIR_DS         "${CMAKE_CURRENT_BINARY_DIR}/CavityDetect_ds.air")
@@ -866,7 +880,7 @@ if(BUILD_FLEXAIDDS_FAST)
         target_sources(FlexAIDdS PRIVATE LIB/TurboQuantMetalBridge.mm)
         set_source_files_properties(LIB/TurboQuantMetalBridge.mm PROPERTIES
             LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
         )
         set(TQ_METAL_SRC_DS  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/TurboQuant.metal")
         set(TQ_AIR_DS         "${CMAKE_CURRENT_BINARY_DIR}/TurboQuant_ds.air")
@@ -894,7 +908,7 @@ if(BUILD_FLEXAIDDS_FAST)
         target_sources(FlexAIDdS PRIVATE LIB/MetalRMSDBridge.mm)
         set_source_files_properties(LIB/MetalRMSDBridge.mm PROPERTIES
             LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++20 -fno-objc-arc"
+            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
         )
         set(RMSD_METAL_SRC_DS  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/MetalRMSD.metal")
         set(RMSD_AIR_DS         "${CMAKE_CURRENT_BINARY_DIR}/MetalRMSD_ds.air")
@@ -2013,7 +2027,7 @@ flexaids_configure_simd(test_cavity_detect)
     )
     target_include_directories(test_knowledge_pool PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/LIB)
     target_link_libraries(test_knowledge_pool PRIVATE GTest::gtest GTest::gtest_main)
-    target_compile_features(test_knowledge_pool PRIVATE cxx_std_20)
+    target_compile_features(test_knowledge_pool PRIVATE cxx_std_26)
     if(MSVC)
         target_compile_options(test_knowledge_pool PRIVATE /O2)
     else()
@@ -2031,7 +2045,7 @@ flexaids_configure_simd(test_cavity_detect)
     )
     target_include_directories(test_mol2_sdf_reader PRIVATE LIB)
     target_link_libraries(test_mol2_sdf_reader PRIVATE GTest::gtest_main)
-    target_compile_features(test_mol2_sdf_reader PRIVATE cxx_std_20)
+    target_compile_features(test_mol2_sdf_reader PRIVATE cxx_std_26)
     flexaids_configure_simd(test_mol2_sdf_reader)
     flexaids_configure_msvc_test(test_mol2_sdf_reader)
     add_test(NAME Mol2SdfReaderTests COMMAND test_mol2_sdf_reader)
@@ -2400,7 +2414,7 @@ if(BUILD_SWIFT_BRIDGE)
         LIB
     )
     set_target_properties(FlexAIDCore PROPERTIES
-        CXX_STANDARD 20
+        CXX_STANDARD 26
         CXX_STANDARD_REQUIRED ON
         POSITION_INDEPENDENT_CODE ON
     )
@@ -2411,7 +2425,7 @@ if(BUILD_SWIFT_BRIDGE)
         swift/Sources/FlexAIDCore/FXGA.mm
         PROPERTIES LANGUAGE OBJCXX
     )
-    target_compile_options(FlexAIDCore PRIVATE -std=c++20 -O2)
+    target_compile_options(FlexAIDCore PRIVATE -std=c++26 -O2)
     target_link_libraries(FlexAIDCore PUBLIC ${FOUNDATION_LIBRARY})
 
     message(STATUS "Swift bridge enabled — build target: FlexAIDCore (static library)")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ This document explains how to contribute while keeping the codebase fast, scient
 
 - **Languages**
 
-  - C++20 for the core engine.
+  - C++26 for the core engine.
   - Python for high-level workflows, analysis, and CLI tooling.
 
 - **Performance**

--- a/LIB/CMakeLists.txt
+++ b/LIB/CMakeLists.txt
@@ -160,7 +160,7 @@ target_include_directories(flexaid_core PUBLIC
 )
 
 set_target_properties(flexaid_core PROPERTIES
-    CXX_STANDARD 20
+    CXX_STANDARD 26
     CXX_STANDARD_REQUIRED ON
     POSITION_INDEPENDENT_CODE ON
 )

--- a/LIB/ParallelCampaign.cpp
+++ b/LIB/ParallelCampaign.cpp
@@ -1,6 +1,6 @@
 // ParallelCampaign.cpp — GPU/SIMD/OpenMP-accelerated virtual screening
 //
-// C++20 throughout: std::jthread, std::atomic, std::span, std::format (where
+// C++26 throughout: std::jthread, std::atomic, std::span, std::format (where
 // available), std::ranges, constexpr math helpers, structured bindings.
 //
 // Three-level parallelism:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![CI](https://github.com/LeBonhommePharma/FlexAIDdS/actions/workflows/ci.yml/badge.svg)](https://github.com/LeBonhommePharma/FlexAIDdS/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://en.cppreference.com/w/cpp/20)
+[![C++26](https://img.shields.io/badge/C%2B%2B-26-blue.svg)](https://en.cppreference.com/w/cpp/26)
 [![Python](https://img.shields.io/badge/python-%E2%89%A5%203.9-3776AB.svg)](https://www.python.org/)
 [![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey.svg)](#)
 [![Version](https://img.shields.io/badge/version-2.0.0-brightgreen.svg)](VERSION.md)
@@ -105,7 +105,7 @@ for mode in results.rank_by_free_energy():
 Released 2026-04-04 — complete rewrite of the FlexAID engine.
 
 - **Entropy-driven scoring** — full canonical ensemble thermodynamics via Shannon information theory (ΔG, ΔH, -TΔS, Cv)
-- **Multi-format input with SMILES** — dock directly from SMILES strings with automatic 3D coordinate generation; pure C++20 parser, no RDKit/Boost
+- **Multi-format input with SMILES** — dock directly from SMILES strings with automatic 3D coordinate generation; pure C++26 parser, no RDKit/Boost
 - **tENCoM vibrational entropy** — torsional elastic network contact model for backbone vibrational entropy differentials
 - **Unified hardware dispatch** — automatic runtime backend: CUDA > Metal > AVX-512 > AVX2 > OpenMP > scalar
 - **Full ligand flexibility by default** — ring conformer sampling, sugar pucker, R/S chiral center discrimination
@@ -192,7 +192,7 @@ Hardware: CUDA > Metal > AVX-512 > AVX2 > OpenMP > scalar
 
 ### Requirements
 
-- **Required**: C++20 compiler (GCC >= 10, Clang >= 10, MSVC >= 19.30), CMake >= 3.18
+- **Required**: C++26 compiler (GCC >= 14, Clang >= 18, Apple Clang >= 16 / Xcode 16, MSVC >= 19.40 / VS 2022 17.10), CMake >= 3.28
 - **Recommended**: Eigen3 (`libeigen3-dev` / `brew install eigen`)
 - **Optional**: OpenMP, CUDA Toolkit, Metal framework (macOS), pybind11, MPI
 

--- a/docs/CODEBASE_OPTIMIZATION_ANALYSIS.md
+++ b/docs/CODEBASE_OPTIMIZATION_ANALYSIS.md
@@ -305,7 +305,7 @@ Global `std::random_device` and `std::mt19937` at file scope — not thread-safe
 
 | Setting | Value | Assessment |
 |---------|-------|------------|
-| C++ Standard | C++20 | Good |
+| C++ Standard | C++26 | Good |
 | Optimization | `-O3 -ffast-math` | Good |
 | Warnings | `-Wall` | Adequate |
 | AVX2 | `-mavx2 -mfma` | Good |
@@ -357,7 +357,7 @@ target_compile_options(flexaid_core PRIVATE -O3 -ffast-math)
 
 ### 8.5 Python Extension Missing Optimization Flags
 
-`python/setup.py` line 40 uses only `-std=c++20 -O3`, missing `-ffast-math`, SIMD flags (`-mavx2 -mfma`), and LTO. Python bindings for `StatMechEngine` and `ENCoMEngine` run 10-15% slower than equivalent C++ code.
+`python/setup.py` line 40 uses only `-std=c++26 -O3`, missing `-ffast-math`, SIMD flags (`-mavx2 -mfma`), and LTO. Python bindings for `StatMechEngine` and `ENCoMEngine` run 10-15% slower than equivalent C++ code.
 
 ### 8.6 Missing: Runtime CPU Dispatch
 

--- a/docs/FLEXAIDS_ROADMAP_AND_STRATEGY.md
+++ b/docs/FLEXAIDS_ROADMAP_AND_STRATEGY.md
@@ -223,7 +223,7 @@ Remaining quick wins:
 - Web interface: upload receptor + ligand → ranked results with visualization
 - Kubernetes GPU cluster on spot instances (AWS/GCP)
 - Free tier for academics, paid tier for pharma
-- **Impact**: Most researchers can't compile C++20. Accessibility drives adoption.
+- **Impact**: Most researchers can't compile C++26 (which tightens the required toolchain further: GCC ≥ 14, Clang ≥ 18). Shipping prebuilt wheels / containers is essential for adoption.
 
 #### 15. Continuous Training at Scale
 - Automated weekly matrix updates from new PDB depositions

--- a/docs/GrandPartitionFunction_Report.md
+++ b/docs/GrandPartitionFunction_Report.md
@@ -288,7 +288,7 @@ The thread-safe `create_session()` / `register_result()` pattern supports parall
 ### 7.1 Dependencies
 
 - **Internal**: `statmech.h` (StatMechEngine, kB_kcal constant), `TargetKnowledgeBase.h`, `TargetValidation.h`, `flexaid.h` (FA_Global, atom, resid)
-- **External**: C++20 standard library only (`<cmath>`, `<mutex>`, `<unordered_map>`, `<vector>`, `<string>`, `<algorithm>`, `<limits>`, `<stdexcept>`)
+- **External**: C++26 standard library only (`<cmath>`, `<mutex>`, `<unordered_map>`, `<vector>`, `<string>`, `<algorithm>`, `<limits>`, `<stdexcept>`)
 - **No external dependencies**: No Eigen, Boost, or third-party libraries required for GPF functionality
 
 ### 7.2 Thread Safety

--- a/docs/IMPLEMENTATION_ROADMAP.md
+++ b/docs/IMPLEMENTATION_ROADMAP.md
@@ -454,7 +454,7 @@ option(BUILD_SWIFT_BRIDGE   "Swift bridge (macOS only)"           OFF)
 **CMakePresets.json**: Pre-configured presets for Linux GCC, Linux Clang, macOS Clang, Windows MSVC (Debug/Release).
 
 **Windows MSVC Support**:
-- MSVC ≥ 19.30 (Visual Studio 2022 17.0+) for C++20
+- MSVC ≥ 19.40 (Visual Studio 2022 17.10+) for C++26 (via `/std:c++latest`)
 - `_CRT_SECURE_NO_WARNINGS`, `_USE_MATH_DEFINES`, `NOMINMAX` across all targets
 - `flexaids_configure_msvc_test()` helper for consistent test target configuration
 - CI: Windows job in GitHub Actions

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -10,8 +10,8 @@ Complete build and installation instructions for FlexAID∆S on all supported pl
 
 | Dependency | Minimum Version | Notes |
 |:-----------|:----------------|:------|
-| C++ compiler | GCC ≥ 10, Clang ≥ 10, MSVC ≥ 19.30 | C++20 support required |
-| CMake | ≥ 3.18 | Build system |
+| C++ compiler | GCC ≥ 14, Clang ≥ 18, Apple Clang ≥ 16 (Xcode 16), MSVC ≥ 19.40 (VS 2022 17.10) | C++26 support required |
+| CMake | ≥ 3.28 | Build system (needed for `CXX_STANDARD 26`) |
 | Python | ≥ 3.9 | For the `flexaidds` Python package |
 
 ### Optional
@@ -26,7 +26,7 @@ Complete build and installation instructions for FlexAID∆S on all supported pl
 | pybind11 | Python ↔ C++ bindings | `pip install pybind11[global]` |
 | Ninja | Faster builds | `apt install ninja-build` / `brew install ninja` |
 
-> **Note**: No RDKit or Boost dependency is required. The ProcessLigand module (SMILES parsing, ring perception, aromaticity detection, 3D coordinate building) is implemented in pure C++20 + Eigen.
+> **Note**: No RDKit or Boost dependency is required. The ProcessLigand module (SMILES parsing, ring perception, aromaticity detection, 3D coordinate building) is implemented in pure C++26 + Eigen.
 
 ---
 

--- a/docs/PHASE1_SUMMARY_AND_DELIVERABLES.md
+++ b/docs/PHASE1_SUMMARY_AND_DELIVERABLES.md
@@ -243,7 +243,7 @@ All PASS: YES ✅
 - [ ] Numerical agreement with legacy (< 1e-6)
 - [ ] All unit tests pass (≥85% coverage)
 - [ ] No performance regression
-- [ ] Code compiles: `-Wextra -Wall -Werror -std=c++20`
+- [ ] Code compiles: `-Wextra -Wall -Werror -std=c++26`
 - [ ] Backward compatible with existing code
 - [ ] WHAM free energy profiles computable
 - [ ] Documentation complete

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-- C++20 compiler (GCC ≥ 10, Clang ≥ 10)
-- CMake ≥ 3.18
+- C++26 compiler (GCC ≥ 14, Clang ≥ 18, Apple Clang ≥ 16 / Xcode 16)
+- CMake ≥ 3.28
 - Python ≥ 3.9
 
 ## Build

--- a/docs/implementation/PHASE1_CORRECTED.md
+++ b/docs/implementation/PHASE1_CORRECTED.md
@@ -578,7 +578,7 @@ Closes: #42 (BindingMode-StatMechEngine disconnection)
 7. Null pointer guards on all Population access
 8. Empty BindingMode handled gracefully
 9. Temperature properly cast unsigned int → double
-10. Code compiles with -Wextra -Wall -Werror on C++20
+10. Code compiles with -Wextra -Wall -Werror on C++26
 11. Ready for Phase 2 (ShannonThermoStack GPU integration)
 
 ---

--- a/docs/implementation/PHASE1_EXECUTIVE_SUMMARY.md
+++ b/docs/implementation/PHASE1_EXECUTIVE_SUMMARY.md
@@ -184,7 +184,7 @@ This integration follows **Shannon's Energy Collapse** principle:
 - [ ] Numerical agreement with legacy (< 1e-6)
 - [ ] All unit tests pass (≥85% coverage)
 - [ ] No performance regression (lazy eval eliminates overhead)
-- [ ] Code compiles: `-Wextra -Wall -Werror -std=c++20`
+- [ ] Code compiles: `-Wextra -Wall -Werror -std=c++26`
 - [ ] Backward compatible with existing code
 - [ ] WHAM free energy profiles computable
 - [ ] Documentation complete

--- a/docs/licensing/PHASE1_GPL_ISOLATION_CHECKLIST.md
+++ b/docs/licensing/PHASE1_GPL_ISOLATION_CHECKLIST.md
@@ -127,7 +127,7 @@ grep -i "find_package\|add_library" CMakeLists.txt | grep -v "#"
 
 ### Manual Code Review
 
-- [ ] **LIB/statmech.h**: No GPL #includes, only standard C++20
+- [ ] **LIB/statmech.h**: No GPL #includes, only standard C++26
 - [ ] **LIB/statmech.cpp**: Pure implementations, no external dependencies
 - [ ] **LIB/BindingMode.cpp**: Refactored methods, only local #includes
 - [ ] **LIB/BindingMode.h**: New declarations, no GPL dependencies

--- a/python/setup.py
+++ b/python/setup.py
@@ -62,9 +62,9 @@ ext_modules = [
         ),
         language="c++",
         extra_compile_args=(
-            ["/O2", "/std:c++20", "/EHsc"]
+            ["/O2", "/std:c++latest", "/EHsc"]
             if os.name == "nt"
-            else ["-std=c++20", "-O3"]
+            else ["-std=c++26", "-O3"]
         ),
     ),
 ]


### PR DESCRIPTION
## Summary

Raises the minimum required C++ standard to **C++26** across the build system and documentation. The existing code uses only widely-supported C++20 features (`<concepts>`, `<ranges>`, `<span>`, `<atomic>`, structured bindings, `requires`-clause concepts in `LIB/MPIMergeable.h` and `LIB/tENCoM/tencm.h`), all of which remain valid under C++26 — **no source-level code changes are required**. The change is purely a build-system + toolchain bump, unlocking future adoption of C++26 features like `std::execution` (sender/receiver), `std::hazard_pointer`/`std::rcu` for lock-free GA ensembles, contracts (`contract_assert`), and `std::linalg`.

### Build system (`CMakeLists.txt`, `LIB/CMakeLists.txt`, `python/setup.py`)

- `CMAKE_CXX_STANDARD`: `20` → `26`
- `cmake_minimum_required`: `3.18` → `3.28` (first release with `CXX_STANDARD 26` support)
- Compiler-version gate raised to **GCC ≥ 14, Clang ≥ 18, Apple Clang ≥ 16 (Xcode 16), MSVC ≥ 19.40 (VS 2022 17.10)**; now branches on `CMAKE_CXX_COMPILER_ID` so Apple Clang has its own version rule.
- 15 Metal/Objective-C++ `COMPILE_FLAGS "-std=c++20 -fno-objc-arc"` → `c++26`.
- Test targets: `cxx_std_20` → `cxx_std_26`; `FlexAIDCore` `CXX_STANDARD 20` and `-std=c++20` → `26`.
- `python/setup.py`: Windows uses `/std:c++latest` (no dedicated MSVC `/std:c++26` switch yet); Unix uses `-std=c++26`.
- **CUDA device code stays pinned at `CUDA_STANDARD 17`** with a new comment explaining that NVCC 12.x cannot accept `-std=c++26`, while host code is free to be C++26. This avoids forcing a CUDA-Toolkit bump.

### CI workflows

Install `gcc-14`/`g++-14` and/or `clang-18` on every Linux job; pin macOS jobs to `macos-15` and `sudo xcode-select -s /Applications/Xcode_16.app`.

Touched: `ci.yml`, `sanitizers.yml`, `tsan.yml`, `perf.yml`, `release.yml`, `benchmark-tier1.yml`, `benchmark-tier2.yml`, `codeql.yml`.

### Docs

Updated compiler-requirement tables, badges, and prose in `README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `docs/INSTALLATION.md`, `docs/IMPLEMENTATION_ROADMAP.md`, `docs/docs/getting-started.md`, and several phase-summary/checklist markdown files.

### Out of scope

- Refactoring to adopt new C++26 features (contracts, `std::execution`, `std::linalg`) — follow-up work.
- Bumping Eigen/GoogleTest/pybind11 — current versions are compatible.
- Dropping the MSVC CI exclusion — still out (see pre-existing comment).

## Test plan

- [x] Local CMake configure with `CC=clang-18 CXX=clang++-18` passes the new compiler gate (verified; only failure was a sandbox-network Eigen fetch unrelated to the upgrade).
- [x] Compiler-gate regression: local configure with `CC=gcc CXX=g++` (GCC 13.3) correctly aborts with `FlexAIDdS requires C++26 — found GCC 13.3.0. Upgrade to GCC ≥ 14.`
- [x] `clang++-18 -std=c++26` sanity-compiles a trivial program.
- [ ] CI green across the full matrix (`linux-gcc`, `linux-clang`, `macos-clang`, `linux-gcc-avx512`, `linux-gcc-mpi`, `linux-gcc-asan`, sanitizers, tsan, python bindings smoke).
- [ ] Spot-check that compiled objects actually use `-std=c++26`: `cmake --build build --target FlexAID -v 2>&1 | grep -o 'std=c++[0-9]*' | sort -u` should print only `std=c++26`.
- [ ] Full `ctest --test-dir build --output-on-failure` suite passes under the new toolchain.
- [ ] Python bindings smoke: `pip install -e python && pytest python/tests/test_statmech_smoke.py`.

https://claude.ai/code/session_011e1p9hoNKpb2vbXTDdXJJX

---
_Generated by [Claude Code](https://claude.ai/code/session_011e1p9hoNKpb2vbXTDdXJJX)_