### PR TITLE
fix: 5 critical thermodynamic formula errors (C-1 through C-5)

### DIFF
--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -622,7 +622,7 @@ Pose::Pose(chromosome* chrom, int index, int iorder, float dist, uint temperatur
 	  model_coords(nullptr),
 	  receptor_strain(0.0)
 {
-	this->boltzmann_weight = exp((-1.0) * (1 / static_cast<double>(temperature)) * chrom->app_evalue);
+	this->boltzmann_weight = std::exp(-chrom->app_evalue / (statmech::kB_kcal * static_cast<double>(temperature)));
 }
 
 

--- a/LIB/ShannonThermoStack/ShannonThermoStack.cpp
+++ b/LIB/ShannonThermoStack/ShannonThermoStack.cpp
@@ -283,7 +283,9 @@ double compute_torsional_vibrational_entropy(
     if (ev_buf.empty()) return 0.0;
 
     Eigen::Map<Eigen::ArrayXd> evals(ev_buf.data(), (int)ev_buf.size());
-    Eigen::ArrayXd ln_arg = kT / evals; // element-wise
+    // eigenvalue λ = ω²; need frequency ω = sqrt(λ) for the HO entropy formula
+    Eigen::ArrayXd freqs  = evals.sqrt();
+    Eigen::ArrayXd ln_arg = kT / freqs;  // element-wise: kT/ω
     // S_mode = kB*(1 + ln(kBT/ω)) for modes where ln_arg > 1e-6
     Eigen::ArrayXd mask = (ln_arg > 1e-6).cast<double>();
     return kB_kcal * (mask * (1.0 + ln_arg.log())).sum();

--- a/LIB/encom.cpp
+++ b/LIB/encom.cpp
@@ -120,10 +120,13 @@ VibrationalEntropy ENCoMEngine::compute_vibrational_entropy(
         return result;
     }
 
-    // Quasi-harmonic entropy (Schlitter formula variant):
-    // S_vib = (3N - 6) × k_B × [1 + ln(2π k_B T / (ħ ω_eff))]
+    // Classical harmonic oscillator entropy per mode:
+    // S_HO = k_B × [1 + ln(k_B T / (ħ ω_eff))]
+    // The 2π factor does NOT appear in the classical HO formula.
+    // Including it would add k_B·ln(2π) ≈ 1.84·k_B per mode, yielding
+    // a systematic bias of ~109 kcal/mol per 100 modes in −TΔS_vib.
     const double kBT = kB_SI * temperature_K;         // J
-    const double arg = (2.0 * M_PI * kBT) / (hbar_SI * result.omega_eff);
+    const double arg = kBT / (hbar_SI * result.omega_eff);
 
     if (arg <= 0.0) {
         // Invalid frequency → zero entropy

--- a/LIB/statmech.cpp
+++ b/LIB/statmech.cpp
@@ -167,7 +167,7 @@ Thermodynamics StatMechEngine::compute() const {
     th.free_energy    = -kT * lnZ;
     th.mean_energy    = E_avg;
     th.mean_energy_sq = E2_avg;
-    th.heat_capacity  = var / (kT * kT);
+    th.heat_capacity  = var / (kB_kcal * T_ * T_);
     th.entropy        = (E_avg - th.free_energy) / T_;
     th.std_energy     = std::sqrt(std::max(0.0, var));
     return th;

--- a/LIB/statmech.cpp
+++ b/LIB/statmech.cpp
@@ -56,7 +56,7 @@ StatMechEngine::StatMechEngine(double temperature_K)
 
 // ─── add_sample ──────────────────────────────────────────────────────────────
 
-void StatMechEngine::add_sample(double energy, int multiplicity) {
+void StatMechEngine::add_sample(double energy, double multiplicity) {
     ensemble_.push_back({energy, multiplicity});
 }
 
@@ -84,7 +84,7 @@ Thermodynamics StatMechEngine::compute() const {
         Eigen::ArrayXd counts(static_cast<Eigen::Index>(N));
         Eigen::ArrayXd energies(static_cast<Eigen::Index>(N));
         for (std::size_t i = 0; i < N; ++i) {
-            counts(static_cast<Eigen::Index>(i))   = static_cast<double>(ensemble_[i].count);
+            counts(static_cast<Eigen::Index>(i))   = ensemble_[i].count;
             energies(static_cast<Eigen::Index>(i)) = ensemble_[i].energy;
         }
         Eigen::ArrayXd lw = counts.log() - beta_ * energies;
@@ -436,8 +436,8 @@ std::vector<double> StatMechEngine::serialize_energies() const {
     return out;
 }
 
-std::vector<int> StatMechEngine::serialize_multiplicities() const {
-    std::vector<int> out(ensemble_.size());
+std::vector<double> StatMechEngine::serialize_multiplicities() const {
+    std::vector<double> out(ensemble_.size());
     for (size_t i = 0; i < ensemble_.size(); ++i)
         out[i] = ensemble_[i].count;
     return out;

--- a/LIB/statmech.h
+++ b/LIB/statmech.h
@@ -30,7 +30,7 @@ inline constexpr double kB_SI   = 1.380649e-23;  // J K⁻¹
 
 struct State {
     double energy;     // CF value (kcal/mol; negative = favourable)
-    int    count;      // degeneracy / sampling multiplicity
+    double count;      // degeneracy / sampling multiplicity (double so Boltzmann weights pass without truncation)
 };
 
 struct Thermodynamics {
@@ -68,8 +68,10 @@ class StatMechEngine {
 public:
     explicit StatMechEngine(double temperature_K = 300.0);
 
-    // Add a sampled configuration
-    void add_sample(double energy, int multiplicity = 1);
+    // Add a sampled configuration.
+    // multiplicity is double so Boltzmann weights (0.0–1.0) can be passed directly
+    // without silent int-truncation to zero (which caused log(0) = -inf).
+    void add_sample(double energy, double multiplicity = 1.0);
 
     // Compute full thermodynamics over the current ensemble
     Thermodynamics compute() const;
@@ -111,7 +113,7 @@ public:
 
     // Serialize ensemble for transport (MPI, socket, etc.)
     std::vector<double> serialize_energies() const;
-    std::vector<int>    serialize_multiplicities() const;
+    std::vector<double> serialize_multiplicities() const;
 
     // Accessors
     double temperature() const noexcept { return T_; }

--- a/tests/test_statmech.cpp
+++ b/tests/test_statmech.cpp
@@ -626,6 +626,28 @@ TEST_F(StatMechEngineTest, HeatCapacityZeroForSingleState) {
     EXPECT_NEAR(th.heat_capacity, 0.0, EPSILON);
 }
 
+// Regression for C-1: Boltzmann weights (double in 0..1) were silently truncated
+// to int=0 when passed as multiplicity, producing log(0)=-inf → NaN everywhere.
+TEST_F(StatMechEngineTest, FractionalMultiplicityNoNaN) {
+    StatMechEngine eng(300.0);
+    eng.add_sample(-10.0, 0.5);
+    eng.add_sample(-8.0,  0.3);
+    eng.add_sample(-6.0,  0.2);
+
+    auto th = eng.compute();
+    EXPECT_FALSE(std::isnan(th.free_energy));
+    EXPECT_FALSE(std::isnan(th.entropy));
+    EXPECT_FALSE(std::isnan(th.heat_capacity));
+    EXPECT_TRUE(std::isfinite(th.free_energy));
+    EXPECT_TRUE(std::isfinite(th.entropy));
+
+    auto weights = eng.boltzmann_weights();
+    for (double w : weights) {
+        EXPECT_FALSE(std::isnan(w));
+        EXPECT_GE(w, 0.0);
+    }
+}
+
 // ===========================================================================
 // NUMERICAL STABILITY — EXTREME TEMPERATURES
 // ===========================================================================

--- a/tests/test_statmech.cpp
+++ b/tests/test_statmech.cpp
@@ -122,7 +122,10 @@ TEST_F(StatMechEngineTest, TwoStatePartitionFunction) {
     double expected_E = p1 * E1 + p2 * E2;
     double expected_E2 = p1 * E1 * E1 + p2 * E2 * E2;
     double expected_var = expected_E2 - expected_E * expected_E;
-    double expected_Cv = expected_var / (kB_kcal * TEMPERATURE * kB_kcal * TEMPERATURE);
+    // Correct formula: C_V = Var(E) / (k_B · T²)
+    // The previous expected_Cv used (k_B·T)² in the denominator which matches
+    // the wrong implementation and masked the bug.
+    double expected_Cv = expected_var / (kB_kcal * TEMPERATURE * TEMPERATURE);
 
     EXPECT_NEAR(th.free_energy, expected_F, EPSILON);
     EXPECT_NEAR(th.mean_energy, expected_E, EPSILON);


### PR DESCRIPTION
## Summary

Five physics bugs producing wrong thermodynamic numbers throughout the docking pipeline. None are code style issues — each corrupts numerical output.

---

### C-1 — `add_sample` Boltzmann weight truncated to int=0 → NaN thermodynamics
**File:** `LIB/statmech.h`, `LIB/statmech.cpp`  
**Root cause:** `State::count` was `int`; `add_sample(double energy, int multiplicity)` silently truncated any `double` multiplicity to `int`. When `get_global_ensemble()` passed Boltzmann weights (doubles in 0.0–1.0) as the multiplicity argument, they all became 0. `log(0) = -inf` then poisoned every thermodynamic quantity (free energy, entropy, heat capacity all NaN).  
**Fix:** `State::count int → double`; `add_sample` second parameter `int → double`; `serialize_multiplicities` return type `vector<int> → vector<double>`.  
**Test added:** `FractionalMultiplicityNoNaN` — verifies `add_sample(-10.0, 0.5)` produces finite, non-NaN output.

---

### C-2 — β = 1/T instead of 1/(k_B·T)
**File:** `LIB/BindingMode.cpp:625` (`Pose` constructor)  
**Root cause:** `boltzmann_weight = exp(-E/T)` instead of `exp(-E/(k_B·T))`. With k_B = 0.001987 kcal/(mol·K), the exponent was inflated by ≈ 503×, driving every Boltzmann factor to exp(−∞)=0 or exp(+∞)=inf depending on energy sign.  
**Fix:** `std::exp(-E / (statmech::kB_kcal * T))`  
**Verification:** The correct β = 1/(k_B·T) is already used everywhere else in the codebase (e.g., `conformer_populations()` at line 678 of the same file).

---

### C-3 — Vibrational entropy has spurious 2π factor
**File:** `LIB/encom.cpp:126`  
**Root cause:** Classical harmonic oscillator entropy: `S_HO = k_B·[1 + ln(k_BT/ħω)]`. Code computed `arg = 2π·k_BT/(ħ·ω_eff)`. The 2π factor does not appear in the classical HO formula. It adds `k_B·ln(2π) ≈ 1.84·k_B` per vibrational mode — approximately **+109 kcal/mol** systematic bias in −TΔS_vib for a 100-mode protein at 300 K. Every binding free energy computed via tENCoM/NMA was wrong by this amount.  
**Fix:** `arg = kBT / (hbar_SI * omega_eff)`

---

### C-4 — Heat capacity denominator (k_BT)² instead of k_B·T²
**File:** `LIB/statmech.cpp:170`; `tests/test_statmech.cpp:125`  
**Root cause:** Correct formula: `C_V = Var(E) / (k_B · T²)`. Code computed `var / (kT * kT) = var / (k_B² · T²)`, off by 1/k_B ≈ **503 mol/kcal**. The test `TwoStatePartitionFunction` used the same wrong formula for `expected_Cv`, so it passed green while measuring the wrong quantity.  
**Fix:** `th.heat_capacity = var / (kB_kcal * T_ * T_)`. Test expected value corrected to `expected_var / (kB_kcal * TEMPERATURE * TEMPERATURE)`.  
**Note:** The header comment `C_v = Var(E)/(kT²)` uses ambiguous notation; with the fix, `kT²` now correctly reads as `k_B·T²`.

---

### C-5 — Torsional entropy uses ω² instead of ω
**File:** `LIB/ShannonThermoStack/ShannonThermoStack.cpp:286`  
**Root cause:** `compute_torsional_vibrational_entropy` stored eigenvalues λ = ω² in `ev_buf`, then computed `kT / evals` — placing ω² in the logarithm denominator instead of ω. This is equivalent to `ln(kT/ω²) = ln(kT/ω) − ln(ω)`, adding a frequency-dependent error `−k_B·ln(ω)` per mode. The comment one line below correctly stated the formula should use ω, making this a clear discrepancy between comment and code.  
**Fix:** `freqs = evals.sqrt(); ln_arg = kT / freqs`

---

## Commits

Each fix is a separate atomic commit:
- `fix(C-1)`: statmech.h, statmech.cpp, tests/test_statmech.cpp
- `fix(C-2)`: LIB/BindingMode.cpp
- `fix(C-3)`: LIB/encom.cpp
- `fix(C-4)`: LIB/statmech.cpp, tests/test_statmech.cpp
- `fix(C-5)`: LIB/ShannonThermoStack/ShannonThermoStack.cpp

## Test plan

- [ ] `cmake -DBUILD_TESTING=ON .. && cmake --build . -j$(nproc)`
- [ ] `ctest --output-on-failure` — all tests pass, including new `FractionalMultiplicityNoNaN`
- [ ] `TwoStatePartitionFunction` now uses correct `C_V = Var(E)/(k_B·T²)` expected value
- [ ] Confirm `HeatCapacityNonNegative`, `HeatCapacityZeroForSingleState` still pass (they do not depend on the absolute scale of C_V)
- [ ] Manual spot-check: run a single docking job and verify thermodynamic outputs are finite and physically reasonable

🤖 Generated with [Claude Code](https://claude.ai/claude-code)