### PR TITLE
[codex] quarantine benchmark claims

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,119 +1,72 @@
 # Benchmarks
 
-Performance and accuracy benchmarks for FlexAID∆S. Results below are from ongoing validation work — full analysis will be published in the forthcoming manuscript (Morency & Najmanovich, in preparation).
+This page tracks benchmark intent, benchmark entry points, and claim maturity for
+FlexAIDdS. It does not present accuracy, enrichment, or hardware-speedup numbers
+as repository-reproducible unless the corresponding benchmark bundle contains
+dataset provenance, immutable inputs, exact commands, seeds, metric scripts, and
+expected outputs.
+
+The claim gate follows [REPRODUCIBILITY.md](REPRODUCIBILITY.md). Manuscript or
+exploratory values may exist outside the repository, but they must not be mixed
+with replayable repository evidence.
 
 ---
 
-## Accuracy Benchmarks
+## Current validation status
 
-### ITC-187 Calorimetry Benchmark
+The current repository artifacts do not yet support final public benchmark
+tables for ITC-187, CASF-2016, DUD-E, neurological target pose rescue, hardware
+dispatch speedups, or VoronoiCFBatch throughput.
 
-Direct comparison of predicted vs. experimentally measured binding thermodynamics from isothermal titration calorimetry across 187 protein–ligand complexes.
+Known local audit status:
 
-| Metric | FlexAID∆S | AutoDock Vina | Glide (SP) |
-|:-------|:---------:|:-------------:|:----------:|
-| ΔG Pearson *r* | **0.93** | 0.64 | 0.69 |
-| RMSE (kcal/mol) | **1.4** | 3.1 | 2.9 |
-| Ranking power | **78%** | 58% | 64% |
+| Check | Status | Notes |
+|:------|:-------|:------|
+| Existing C++ tests from the build tree | Passing | 52 tests passed locally during audit. |
+| Fresh benchmark-enabled local build | Failing | `benchmark_vcfbatch` currently needs its scoring dependency linked before this target can be treated as replayable. |
+| Python tests | Failing | 3 tests failed during audit: one parallel benchmark mock test and two result-loading error-path tests. |
+| Astex committed report | Failing placeholder | `benchmark_results/astex_diverse_report.md` records 0/85 successful systems. |
+| Expected benchmark outputs | Missing | Several `benchmarks/*/expected/` directories contain placeholders rather than validated reference outputs. |
 
-FlexAID∆S achieves a 0.93 Pearson correlation with experimental ΔG values — a direct consequence of computing the Helmholtz free energy *F* = *H* − *TS* from the full canonical ensemble rather than ranking by enthalpy alone.
-
-### CASF-2016 (Comparative Assessment of Scoring Functions)
-
-The standard benchmark for docking scoring functions, evaluating scoring power, docking power, and virtual screening enrichment.
-
-| Power | FlexAID∆S | AutoDock Vina | Glide (SP) | rDock |
-|:------|:---------:|:-------------:|:----------:|:-----:|
-| Scoring (Pearson *r*) | **0.88** | 0.73 | 0.78 | 0.71 |
-| Docking (% ≤ 2Å RMSD) | **81%** | 76% | 79% | 73% |
-| Screening (EF 1%) | **15.3** | 11.2 | 13.1 | 10.8 |
-
-### DUD-E (Directory of Useful Decoys — Enhanced)
-
-Virtual screening enrichment across diverse protein targets.
-
-| Metric | FlexAID∆S | AutoDock Vina | Glide (SP) |
-|:-------|:---------:|:-------------:|:----------:|
-| Mean AUC | **0.89** | 0.72 | 0.78 |
-| Mean EF 1% | **28.4** | 16.1 | 21.3 |
-
-### Neurological Targets (23 GPCR, Ion Channels, Transporters)
-
-Validation on therapeutically relevant neurological targets where conformational entropy is critical for correct binding mode identification.
-
-| Metric | Value |
-|:-------|:------|
-| Pose rescue rate | **92%** — entropy recovers the correct binding mode when enthalpy-only scoring fails |
-| Average Shannon's Entropy correction | **+3.02 kcal/mol** |
-
-**Example** — mu-opioid receptor + fentanyl:
-
-| Scoring | ΔG (kcal/mol) | RMSD (Å) | Correct? |
-|:--------|:-------------:|:---------:|:--------:|
-| Enthalpy-only | −14.2 | 8.3 | No (wrong pocket) |
-| With Shannon's Entropy | −10.8 | 1.2 | Yes |
-| Experimental | −11.1 | — | — |
+Until these items are corrected, any numeric performance or accuracy result
+should be labeled **preliminary** or **external/manuscript-only**, not
+repository-reproducible.
 
 ---
 
-## Performance Benchmarks
+## Claim maturity by benchmark family
 
-### Hardware Acceleration — Shannon Entropy Computation
-
-Speedup measured on Shannon entropy histogram computation (ShannonThermoStack) over the single-threaded CPU baseline.
-
-| Backend | Hardware | Speedup | Throughput |
-|:--------|:---------|--------:|:-----------|
-| **CUDA** | NVIDIA A100 (80 GB) | **3,575×** | — |
-| **CUDA** | NVIDIA RTX 4090 | **2,890×** | — |
-| **Metal** | Apple M2 Ultra (76-core GPU) | **412×** | — |
-| **Metal** | Apple M3 Max (40-core GPU) | **298×** | — |
-| **AVX-512 + OpenMP** | Dual Xeon 8380 (80 cores) | **187×** | — |
-| **AVX2 + OpenMP** | AMD EPYC 7763 (64 cores) | **142×** | — |
-| **OpenMP** | Intel i9-13900K (24 cores) | **18×** | — |
-| **Scalar** | Single core baseline | 1× | — |
-
-### Unified Hardware Dispatch
-
-The runtime automatically selects the fastest available backend: CUDA → Metal → AVX-512 → AVX2 → OpenMP → scalar. No configuration needed — build with the desired backends enabled and `HardwareDispatch` handles selection.
-
-### tENCoM Vibrational Entropy
-
-| Operation | Time | Notes |
-|:----------|:-----|:------|
-| ENCoM Hessian build | ~0.5s | Typical 300-residue protein |
-| Jacobi diagonalisation | ~1.2s | Torsional normal modes |
-| ΔS vibrational | ~0.1s | Per structure comparison |
-
-### VoronoiCFBatch (Scoring)
-
-| Poses | Time (8 cores) | Time (1 core) | Speedup |
-|:------|:---------------|:--------------|--------:|
-| 1,000 | 0.8s | 4.2s | 5.3× |
-| 10,000 | 7.1s | 41.8s | 5.9× |
-| 100,000 | 68s | 412s | 6.1× |
+| Benchmark family | Intended metric family | Repository maturity |
+|:-----------------|:-----------------------|:--------------------|
+| ITC-187 calorimetry | Delta-G correlation, RMSE, ranking power | Preliminary only until replayable inputs, expected outputs, and metric scripts are committed. |
+| CASF-2016 | Scoring, docking, and screening power | Preliminary only until CASF acquisition/preprocessing and expected results are committed. |
+| DUD-E | AUC and enrichment factors | Preliminary only until target/decoy provenance and metric scripts are committed. |
+| Neurological targets | Pose rescue and entropy contribution analysis | Preliminary only until target list, structures, ligands, configs, and reference results are committed. |
+| Hardware dispatch | Shannon entropy throughput by backend | Preliminary only until benchmark binaries build cleanly and machine metadata is recorded. |
+| tENCoM vibrational entropy | Runtime and differential entropy behavior | Preliminary only until calibration status and reference systems are documented. |
+| VoronoiCFBatch | Batch scoring throughput | Blocked until the benchmark target links and runs cleanly. |
 
 ---
 
-## Entropy Impact Analysis
+## Reproducible benchmark bundle requirements
 
-The key innovation of FlexAID∆S is computing free energy from the full canonical ensemble. This table shows how Shannon's Entropy changes rankings:
+Every benchmark promoted to repository-reproducible must include:
 
-| System | Enthalpy rank | Free energy rank | Rank change | ΔΔG_entropy (kcal/mol) |
-|:-------|:------------:|:----------------:|:-----------:|:----------------------:|
-| HIV-1 protease + darunavir | 3 | **1** | +2 | −2.8 |
-| CDK2 + dinaciclib | 5 | **1** | +4 | −4.1 |
-| BACE1 + verubecestat | 2 | **1** | +1 | −1.7 |
-| Mu-opioid + fentanyl | 7 | **1** | +6 | −3.4 |
-| Thrombin + dabigatran | 1 | **1** | 0 | −0.3 |
+- dataset provenance or an acquisition script
+- immutable identifiers, checksums, or archived input snapshots
+- preprocessing commands
+- exact command lines
+- fixed seeds where stochastic sampling is used
+- metric calculation scripts
+- expected outputs or metric snapshots
+- git SHA and machine/environment details
 
-In the majority of cases, Shannon's Entropy corrections rescue the correct binding mode from lower enthalpy-only rankings to the top-ranked free energy pose.
+A benchmark should not publish final table values in this page until its bundle
+satisfies those requirements.
 
 ---
 
-## Reproducing Benchmarks
-
-### Build with Benchmarking
+## Build with benchmarking
 
 ```bash
 cmake .. -DCMAKE_BUILD_TYPE=Release \
@@ -122,15 +75,27 @@ cmake .. -DCMAKE_BUILD_TYPE=Release \
 cmake --build . -j $(nproc)
 ```
 
-### Run Benchmark Binaries
+At the time this page was updated, the `benchmark_vcfbatch` target still needed
+a linkage fix before the benchmark-enabled build could be used as validation
+evidence.
+
+---
+
+## Run benchmark binaries
 
 ```bash
-./build/benchmark_tencom     # tENCoM performance
-./build/benchmark_vcfbatch   # VoronoiCFBatch scoring performance
-./build/benchmark_dispatch   # Hardware dispatch throughput
+./build/benchmark_tencom
+./build/benchmark_vcfbatch
+./build/benchmark_dispatch
 ```
 
-### Test Suite (Validation)
+Record the executable path, git SHA, compiler, CPU/GPU model, enabled backends,
+thread count, seed values, input bundle checksums, and output artifact hashes
+for every run intended to support a public claim.
+
+---
+
+## Test suite
 
 ```bash
 # C++ validation tests
@@ -141,6 +106,10 @@ ctest --test-dir build --output-on-failure
 cd python && pytest tests/ -q
 ```
 
+Treat green tests as necessary but not sufficient for scientific benchmark
+claims. The benchmark bundle still has to prove provenance, replayability, and
+metric calculation integrity.
+
 ---
 
 ## References
@@ -148,4 +117,3 @@ cd python && pytest tests/ -q
 - Gaudreault F & Najmanovich RJ (2015). FlexAID: Revisiting Docking on Non-Native-Complex Structures. *J. Chem. Inf. Model.* 55(7):1323-36. [DOI:10.1021/acs.jcim.5b00078](https://doi.org/10.1021/acs.jcim.5b00078)
 - Su M et al. (2019). Comparative Assessment of Scoring Functions: The CASF-2016 Update. *J. Chem. Inf. Model.* 59(2):895-913.
 - Mysinger MM et al. (2012). Directory of Useful Decoys, Enhanced (DUD-E). *J. Med. Chem.* 55(14):6582-94.
-- Morency LP & Najmanovich RJ (2026). FlexAID∆S: Information-Theoretic Entropy Improves Molecular Docking Accuracy and Binding Mode Prediction. *Manuscript in preparation.*


### PR DESCRIPTION
## Summary

- Replaces final-looking benchmark tables with a claim-maturity gate.
- Records the current local validation state from the audit: C++ tests pass from the existing build tree, benchmark-enabled fresh build is blocked, Python tests have three failures, Astex committed report is 0/85, and expected outputs are placeholders.
- Keeps build/run instructions, but marks benchmark numbers as preliminary or external until replayable bundles exist.

## Why

The previous benchmark page mixed strong numerical claims with repository artifacts that do not currently reproduce those claims. This makes the science story look stronger than the evidence committed to the repo.

## Validation

- Documentation-only change.
- Reviewed diff for `docs/BENCHMARKS.md`.
