### PR TITLE
[codex] normalize Shannon entropy units

### DIFF
--- a/BENCHMARKING_PLAN.md
+++ b/BENCHMARKING_PLAN.md
@@ -4,6 +4,9 @@
 > **Status:** Ready to execute on iCloud+ 2TB renewal
 > **Branch:** `master` (post PR #190 — all C-1–C-5 thermodynamic fixes merged)
 > **Primary convergence metric:** Shannon Energy Collapse H(X) < 2 bits
+>
+> Core thermodynamic APIs report Shannon entropy in **nats**. Convert only at
+> reporting or convergence-boundary code with `H_bits = H_nats / ln(2)`.
 > **Thermodynamic engine:** Grand Canonical Ensemble (log Ξ, F_bound, binding selectivity)
 
 ---
@@ -84,11 +87,15 @@ ulimit -s unlimited   # stack (tENCoM deep recursion)
 
 ### 3.1 Convergence Definition (Rigorous)
 
-```
-H(X_t) = −Σᵢ p(xᵢ,t) · log₂ p(xᵢ,t)    [bits]
+```text
+H(X_t)      = -sum_i p(x_i,t) * log2(p(x_i,t))    [bits]
+H_nats(X_t) = -sum_i p(x_i,t) * ln(p(x_i,t))      [nats]
+H_bits      = H_nats / ln(2)
 ```
 
 where `p(xᵢ,t)` is the Boltzmann-weighted probability of pose cluster *i* at step *t*.
+Core scoring and thermodynamic code should keep the natural-log form and convert
+to bits only at convergence/reporting boundaries.
 
 - **Convergence threshold:** H(X) < **2.0 bits** — >75% Boltzmann weight in ≤ 2 clusters
 - **Hard convergence (thesis-quality):** H(X) < **1.0 bit** — >50% weight in single dominant pose

--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -219,11 +219,11 @@ double BindingPopulation::get_shannon_entropy() const
 		return 0.0;
 	}
 
-	// Compute Shannon entropy via ShannonThermoStack (energy histogram binning)
-	double shannon_bits = shannon_thermo::compute_shannon_entropy(all_energies);
+	// Histogram entropy over CF energies, returned in nats.
+	double shannon_nats = shannon_thermo::compute_shannon_entropy(all_energies);
 
-	// Convert from dimensionless bits to thermodynamic units: S = kB * H
-	shannonS_population_ = statmech::kB_kcal * shannon_bits;
+	// Convert from dimensionless nats to thermodynamic units: S = kB * H
+	shannonS_population_ = statmech::kB_kcal * shannon_nats;
 	shannon_cache_valid_ = true;
 	return shannonS_population_;
 }

--- a/LIB/UnifiedHardwareDispatch.cpp
+++ b/LIB/UnifiedHardwareDispatch.cpp
@@ -316,7 +316,6 @@ static DispatchTelemetry make_telemetry(
 
 static double entropy_from_hist(const int* counts, int num_bins, int total) {
     if (total == 0) return 0.0;
-    const double l2inv = 1.0 / std::log(2.0);
 
     Eigen::ArrayXd prob(num_bins);
     for (int b = 0; b < num_bins; ++b)
@@ -324,7 +323,7 @@ static double entropy_from_hist(const int* counts, int num_bins, int total) {
     prob /= static_cast<double>(total);
     Eigen::ArrayXd safe_p = (prob > 1e-15).select(prob, Eigen::ArrayXd::Constant(num_bins, 1.0));
     Eigen::ArrayXd lp     = (prob > 1e-15).select(safe_p.log(), Eigen::ArrayXd::Zero(num_bins));
-    return -(prob * lp).sum() * l2inv;
+    return -(prob * lp).sum();
 }
 
 double UnifiedHardwareDispatch::shannon_scalar(const std::vector<double>& values, int num_bins) {

--- a/LIB/UnifiedHardwareDispatch.h
+++ b/LIB/UnifiedHardwareDispatch.h
@@ -172,6 +172,8 @@ public:
 
     // ─── Dispatched compute functions (from former HardwareDispatch.h) ───
 
+    // Returns histogram Shannon entropy in nats. Convert to bits at reporting
+    // boundaries with H_bits = H_nats / ln(2).
     double compute_shannon_entropy(const std::vector<double>& values,
                                    int num_bins = 20,
                                    Backend backend = Backend::AUTO);

--- a/python/flexaidds/_core.cpp
+++ b/python/flexaidds/_core.cpp
@@ -410,7 +410,7 @@ PYBIND11_MODULE(_core, m) {
     m.def("compute_shannon_entropy",
         &shannon_thermo::compute_shannon_entropy,
         py::arg("values"), py::arg("num_bins") = 20,
-        "Compute Shannon entropy of continuous values (bits)",
+        "Compute Shannon entropy of continuous values (nats)",
         py::call_guard<py::gil_scoped_release>());
 
     m.def("compute_torsional_vibrational_entropy",

--- a/python/flexaidds/tencm.py
+++ b/python/flexaidds/tencm.py
@@ -399,7 +399,7 @@ def run_shannon_thermo_stack(
     report = (
         f"ShannonThermoStack (T={temperature_K:.1f} K)\n"
         f"{sc_info}"
-        f"  Shannon conf entropy    = {H_shannon:.4f} bits\n"
+        f"  Shannon conf entropy    = {H_shannon:.4f} nats\n"
         f"  Torsional vib entropy   = {S_vib:.6f} kcal/(mol·K)\n"
         f"  Entropy contribution    = {entropy_contribution:.4f} kcal/mol (-TΔS)\n"
         f"  Total ΔG (F + vib corr) = {deltaG:.4f} kcal/mol\n"

--- a/tests/test_unified_dispatch.cpp
+++ b/tests/test_unified_dispatch.cpp
@@ -156,7 +156,7 @@ TEST_F(ShannonDispatchTest, IdenticalValuesReturnZero) {
 TEST_F(ShannonDispatchTest, UpperBound) {
     int bins = 20;
     double H = d.compute_shannon_entropy(data, bins);
-    EXPECT_LE(H, std::log2(static_cast<double>(bins)) + EPSILON);
+    EXPECT_LE(H, std::log(static_cast<double>(bins)) + EPSILON);
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

- Makes unified hardware-dispatch Shannon entropy return nats instead of bits, matching the core thermodynamic stack.
- Updates binding-population naming/comments and Python-facing documentation from bits to nats.
- Documents the explicit `H_bits = H_nats / ln(2)` conversion for Shannon Energy Collapse reporting thresholds.

## Why

The audit found multiple entropy paths mixing nats and bits. That changes scientific thresholds materially, especially for Shannon Energy Collapse criteria such as `H < 2 bits`.

## Validation

- `cmake --build build --target test_hardware_detect_dispatch --parallel 8`
- `ctest --test-dir build -R '^HardwareDetectDispatchTests$' --output-on-failure`
- `cmake --build build --target test_hardware_dispatch --parallel 8`
- `ctest --test-dir build -R '^HardwareDispatchTests$' --output-on-failure`
- `PYTHONPATH=python python3 -m pytest -q python/tests/test_tencm.py`

Note: full `cmake --build build` is still expected to be blocked on `benchmark_vcfbatch` until the separate benchmark-linkage PR lands.
