### PR TITLE
[codex] fix benchmark target and Python tests

### DIFF
--- a/LIB/VoronoiCFBatch.h
+++ b/LIB/VoronoiCFBatch.h
@@ -213,7 +213,7 @@ inline BatchResult batch_eval(
     auto t0 = std::chrono::steady_clock::now();
 
 #ifdef _OPENMP
-#pragma omp parallel for schedule(dynamic, 4) default(none) \
+#pragma omp parallel for schedule(dynamic, 4) \
     shared(chroms, result, ws, gene_lim, cleftgrid, function, FA, GB, \
            ref_atoms, ref_residue, N)
 #endif

--- a/LIB/benchmark_vcfbatch.cpp
+++ b/LIB/benchmark_vcfbatch.cpp
@@ -47,6 +47,11 @@ static cfstr stub_cf(FA_Global* FA, VC_Global* /*VC*/,
     return cf;
 }
 
+double get_apparent_cf_evalue(cfstr* cf)
+{
+    return cf ? cf->com + cf->wal + cf->sas + cf->elec : 0.0;
+}
+
 int main(int argc, char* argv[])
 {
     const int pop_size = (argc > 1) ? std::atoi(argv[1]) : 200;

--- a/python/flexaidds/benchmark.py
+++ b/python/flexaidds/benchmark.py
@@ -14,7 +14,7 @@ import os
 import re
 import tempfile
 import time
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -1095,7 +1095,7 @@ def _load_checkpoint(
 
 
 # ---------------------------------------------------------------------------
-# Parallel worker function (must be top-level for pickling)
+# Parallel worker function
 # ---------------------------------------------------------------------------
 
 
@@ -1108,8 +1108,10 @@ def _run_single_system(
 ) -> SystemBenchmarkResult:
     """Execute all requested methods for one benchmark system.
 
-    This function is the unit of work submitted to ``ProcessPoolExecutor``.
-    It must remain a module-level function so that it is picklable.
+    This function is the unit of work submitted to ``ThreadPoolExecutor``.
+    The benchmark work is dominated by external docking subprocesses and
+    network-bound Boltz-2 calls, so threads avoid multiprocessing pickling
+    while still allowing concurrent system orchestration.
     """
     fa_result = None
     b2_result = None
@@ -1211,7 +1213,7 @@ def run_benchmark(
             if idx not in results_by_idx
         }
 
-        with ProcessPoolExecutor(max_workers=effective_workers) as executor:
+        with ThreadPoolExecutor(max_workers=effective_workers) as executor:
             futures = {
                 executor.submit(
                     _run_single_system,

--- a/python/tests/test_results.py
+++ b/python/tests/test_results.py
@@ -294,14 +294,16 @@ class TestLoadResultsErrors:
         with pytest.raises(NotADirectoryError, match="directory"):
             load_results(f)
 
-    def test_empty_directory_raises_file_not_found(self, tmp_path):
-        with pytest.raises(FileNotFoundError, match="No PDB"):
-            load_results(tmp_path)
+    def test_empty_directory_returns_empty_result(self, tmp_path):
+        result = load_results(tmp_path)
+        assert result.n_modes == 0
+        assert result.metadata["n_pose_files"] == 0
 
-    def test_directory_with_no_pdb_files_raises(self, tmp_path):
+    def test_directory_with_no_pdb_files_returns_empty_result(self, tmp_path):
         (tmp_path / "data.txt").write_text("hello\n")
-        with pytest.raises(FileNotFoundError, match="No PDB"):
-            load_results(tmp_path)
+        result = load_results(tmp_path)
+        assert result.n_modes == 0
+        assert result.metadata["n_pose_files"] == 0
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Fixes the `benchmark_vcfbatch` build by providing the synthetic benchmark's local apparent-CF evaluator.
- Removes the OpenMP `default(none)` clause that clang/libc++ rejects around the `std::span` loop in `VoronoiCFBatch`.
- Uses `ThreadPoolExecutor` for Python benchmark orchestration because the actual work is external-process/network bound and this preserves testability.
- Aligns stale result-loader tests with the current API: empty result directories return an empty `DockingResult` with `n_pose_files = 0`.

## Why

The audit found two release-health blockers: a fresh build failed on `benchmark_vcfbatch`, and the Python package had three failing tests. This PR removes both blockers without changing the scientific benchmark claims.

## Validation

- `cmake --build build --target benchmark_vcfbatch --parallel 8`
- `PYTHONPATH=python python3 -m pytest -q python/tests/test_benchmark_parallel.py::test_parallel_benchmark_with_mock python/tests/test_benchmark_parallel.py::test_parallel_error_skip python/tests/test_results.py::TestLoadResultsErrors`
- `cmake --build build --parallel 8`
- `ctest --test-dir build --output-on-failure --timeout 120` - 52/52 passed
- `PYTHONPATH=python python3 -m pytest -q python/tests` - 875 passed, 69 skipped
