### PR TITLE
[codex] add seed provenance helper

### DIFF
--- a/BENCHMARKING_PLAN.md
+++ b/BENCHMARKING_PLAN.md
@@ -32,6 +32,10 @@ export FLEXAID_SIMD=NEON         # disable AVX512 (not on M3), enable NEON
 export FLEXAID_SEED=42
 ```
 
+`FLEXAID_SEED` is the run-level stochastic provenance handle. Benchmark logs
+must record it with the git SHA, compiler, backend selection, and thread count.
+Unset seeds are exploratory only.
+
 ### ulimits
 ```bash
 ulimit -n 65536   # file descriptors (85 complexes × multiple outputs)

--- a/LIB/ChiralCenter/ChiralCenterGene.cpp
+++ b/LIB/ChiralCenter/ChiralCenterGene.cpp
@@ -4,6 +4,7 @@
 #include "ChiralCenterGene.h"
 
 #include "../flexaid.h"
+#include "../RngSeed.h"
 
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
@@ -18,7 +19,7 @@
 namespace chiral {
 
 static std::mt19937& rng() {
-    thread_local std::mt19937 gen(std::random_device{}());
+    thread_local std::mt19937 gen = flexaids_rng::make_thread_rng(0xC417A1ULL);
     return gen;
 }
 

--- a/LIB/FOPTICS.cpp
+++ b/LIB/FOPTICS.cpp
@@ -1,5 +1,6 @@
 #include "FOPTICS.h"
 #include "gaboom.h"
+#include "RngSeed.h"
 
 #include <random>
 #include <algorithm>
@@ -8,14 +9,17 @@
 #include "MetalRMSDBridge.h"
 #endif
 
-std::random_device rd;
-std::mt19937 gen(rd());
+static std::mt19937& foptics_rng()
+{
+    thread_local std::mt19937 gen = flexaids_rng::make_thread_rng(0xF0701C5ULL);
+    return gen;
+}
 
 struct RNG
 {
     int operator() (int n) {
         std::uniform_int_distribution<int> dist(0, n - 1);
-        return dist(gen);
+        return dist(foptics_rng());
     }
 };
 
@@ -763,7 +767,7 @@ void RandomProjectedNeighborsAndDensities::computeSetBounds(std::vector< int > &
 //			tempProj.push_back(this->projectedPoints[i]);
             tempProj[i] = this->projectedPoints[i];
         }
-        std::shuffle(projInd.begin(), projInd.end(), gen);
+        std::shuffle(projInd.begin(), projInd.end(), foptics_rng());
 
 		int i = 0;
         for(std::vector<int>::iterator it = projInd.begin(); it != projInd.end(); ++it, i++)
@@ -1222,7 +1226,7 @@ void RandomProjectedNeighborsAndDensities::output_projected_distance(char* end_s
 int roll_die()
 {
     std::uniform_int_distribution<> dist(0, MAX_RANDOM_VALUE);
-    return dist(gen);
+    return dist(foptics_rng());
 }
 int roll_rand_die()
 {

--- a/LIB/LigandRingFlex/RingConformerLibrary.cpp
+++ b/LIB/LigandRingFlex/RingConformerLibrary.cpp
@@ -1,5 +1,6 @@
 // RingConformerLibrary.cpp — ring conformer tables and detection
 #include "RingConformerLibrary.h"
+#include "../RngSeed.h"
 #include "../flexaid.h"   // atom_struct (bond graph), MBNDS
 #include <cstdlib>
 #include <cstring>
@@ -65,12 +66,12 @@ void RingConformerLibrary::build_five_conformers() {
 }
 
 int RingConformerLibrary::random_six_index() const {
-    thread_local std::mt19937 rng(std::random_device{}());
+    thread_local std::mt19937 rng = flexaids_rng::make_thread_rng(0x516ULL);
     return std::uniform_int_distribution<int>(0, n_six() - 1)(rng);
 }
 
 int RingConformerLibrary::random_five_index() const {
-    thread_local std::mt19937 rng(std::random_device{}());
+    thread_local std::mt19937 rng = flexaids_rng::make_thread_rng(0x515ULL);
     return std::uniform_int_distribution<int>(0, n_five() - 1)(rng);
 }
 

--- a/LIB/LigandRingFlex/SugarPucker.cpp
+++ b/LIB/LigandRingFlex/SugarPucker.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 
 #include "SugarPucker.h"
+#include "../RngSeed.h"
 
 #include <Eigen/Dense>
 #ifdef __AVX512F__
@@ -113,7 +114,7 @@ void apply_sugar_puckers(
 
 // ─── mutate_phase ────────────────────────────────────────────────────────────
 float mutate_phase(float current_phase_deg, float sigma_deg) {
-    thread_local std::mt19937 rng(std::random_device{}());
+    thread_local std::mt19937 rng = flexaids_rng::make_thread_rng(0x5A6A9ULL);
     std::normal_distribution<float> dist(0.0f, sigma_deg);
     float new_phase = current_phase_deg + dist(rng);
     // Wrap to [0, 360)

--- a/LIB/RngSeed.h
+++ b/LIB/RngSeed.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <random>
+
+namespace flexaids_rng {
+
+inline std::uint64_t splitmix64(std::uint64_t x)
+{
+    x += 0x9e3779b97f4a7c15ULL;
+    x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+    return x ^ (x >> 31);
+}
+
+inline bool env_seed(std::uint64_t& seed)
+{
+    const char* raw = std::getenv("FLEXAID_SEED");
+    if (!raw || !*raw) return false;
+
+    char* end = nullptr;
+    unsigned long long parsed = std::strtoull(raw, &end, 10);
+    if (end == raw) return false;
+
+    seed = static_cast<std::uint64_t>(parsed);
+    return true;
+}
+
+inline std::uint32_t seed_from_env_or_random(std::uint64_t stream = 0)
+{
+    std::uint64_t base = 0;
+    if (env_seed(base)) {
+        return static_cast<std::uint32_t>(splitmix64(base ^ stream));
+    }
+
+    std::random_device rd;
+    std::uint64_t random_base =
+        (static_cast<std::uint64_t>(rd()) << 32) ^ static_cast<std::uint64_t>(rd());
+    return static_cast<std::uint32_t>(splitmix64(random_base ^ stream));
+}
+
+inline std::uint64_t next_thread_stream()
+{
+    static std::atomic<std::uint64_t> counter{0};
+    return counter.fetch_add(1, std::memory_order_relaxed);
+}
+
+inline std::mt19937 make_rng(std::uint64_t stream = 0)
+{
+    return std::mt19937(seed_from_env_or_random(stream));
+}
+
+inline std::mt19937 make_thread_rng(std::uint64_t stream = 0)
+{
+    return std::mt19937(seed_from_env_or_random(stream ^ next_thread_stream()));
+}
+
+} // namespace flexaids_rng

--- a/LIB/Vcontacts.cpp
+++ b/LIB/Vcontacts.cpp
@@ -1,4 +1,5 @@
 #include "Vcontacts.h"
+#include "RngSeed.h"
 #include "fileio.h"
 #include <random>
 
@@ -384,7 +385,7 @@ RESTART:
 				origcoor[2] = VC->Calc[atomzero].atom->coor[2];
 				
 				// perturb atom coordinates (thread-safe RNG)
-				thread_local std::mt19937 vc_rng(std::random_device{}());
+				thread_local std::mt19937 vc_rng = flexaids_rng::make_thread_rng(0x0C0A11ULL);
 				thread_local std::uniform_real_distribution<float> vc_dist(-0.005f, 0.005f);
 				VC->Calc[atomzero].atom->coor[0] += vc_dist(vc_rng);
 				VC->Calc[atomzero].atom->coor[1] += vc_dist(vc_rng);

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -6,6 +6,7 @@
 #include "UnifiedHardwareDispatch.h"
 #include "MIFGrid.h"
 #include "CavityDetect/SpatialGrid.h"
+#include "RngSeed.h"
 
 #include <random>
 #include <functional>
@@ -3060,7 +3061,7 @@ double RandomDouble(int32_t gene){
 
 double RandomDouble(){
 	// Thread-safe RNG (replaces non-reentrant rand())
-	thread_local std::mt19937 tl_rng(std::random_device{}());
+	thread_local std::mt19937 tl_rng = flexaids_rng::make_thread_rng(0x9A800DULL);
 	std::uniform_real_distribution<double> dist(0.0, 1.0);
 	return dist(tl_rng);
 }

--- a/LIB/shannon_ga.cpp
+++ b/LIB/shannon_ga.cpp
@@ -4,6 +4,7 @@
  * @author Le Bonhomme Pharma / FlexAIDdS
  */
 #include "shannon_ga.h"
+#include "RngSeed.h"
 
 #include <cmath>
 #include <algorithm>
@@ -28,7 +29,7 @@ ShannonThermodynamicGA::ShannonThermodynamicGA(size_t pop_size,
     , current_log_Z_(0.0)
     , engine_(temperature_K)
     , last_thermo_{}
-    , rng_(std::random_device{}())
+    , rng_(flexaids_rng::seed_from_env_or_random(0x534841ULL))
 {
     (void)pop_size_;  // reserved for future population-level heuristics
 }

--- a/docs/REPRODUCIBILITY.md
+++ b/docs/REPRODUCIBILITY.md
@@ -16,6 +16,26 @@ A claim reaches this level only when all of the following are present:
 - expected outputs and metric calculation scripts
 - recorded git SHA and environment details
 
+## Seed provenance
+
+Repository-reproducible stochastic runs must record the run-level seed. The
+canonical environment variable is:
+
+```bash
+export FLEXAID_SEED=42
+```
+
+Core fallback RNG paths that previously seeded directly from
+`std::random_device` should route through `LIB/RngSeed.h`. When
+`FLEXAID_SEED` is set, each call site derives a deterministic stream seed from
+that run seed. When it is unset, the helper falls back to `std::random_device`
+for exploratory runs.
+
+This seed is necessary provenance, not a complete determinism guarantee for
+parallel algorithms. Any benchmark intended to be replayable must also record
+thread counts, backend selection, compiler flags, input order, and whether
+parallel scheduling can change draw order.
+
 ### 2. Preliminary
 
 A claim is preliminary if it appears in documentation but is not yet backed by a replayable bundle in the repository.

--- a/tests/test_ga_context.cpp
+++ b/tests/test_ga_context.cpp
@@ -9,6 +9,25 @@
 #include <gtest/gtest.h>
 #include "GAContext.h"
 #include "GPUContextPool.h"
+#include "RngSeed.h"
+
+#include <cstdlib>
+
+static void set_test_env(const char* key, const char* value) {
+#ifdef _WIN32
+    _putenv_s(key, value);
+#else
+    setenv(key, value, 1);
+#endif
+}
+
+static void unset_test_env(const char* key) {
+#ifdef _WIN32
+    _putenv_s(key, "");
+#else
+    unsetenv(key);
+#endif
+}
 
 TEST(GAContextTest, DefaultConstruction) {
     GAContext ctx;
@@ -56,6 +75,17 @@ TEST(GAContextTest, NotCopyable) {
 TEST(GAContextTest, IsMovable) {
     EXPECT_TRUE(std::is_move_constructible_v<GAContext>);
     EXPECT_TRUE(std::is_move_assignable_v<GAContext>);
+}
+
+TEST(RngSeedTest, FlexaidSeedMakesStreamSeedsRepeatable) {
+    set_test_env("FLEXAID_SEED", "42");
+    auto s1 = flexaids_rng::seed_from_env_or_random(123);
+    auto s2 = flexaids_rng::seed_from_env_or_random(123);
+    auto s3 = flexaids_rng::seed_from_env_or_random(124);
+    unset_test_env("FLEXAID_SEED");
+
+    EXPECT_EQ(s1, s2);
+    EXPECT_NE(s1, s3);
 }
 
 #ifdef FLEXAIDS_USE_CUDA


### PR DESCRIPTION
## Summary

- Adds `LIB/RngSeed.h` as a single helper for deriving per-stream RNG seeds from `FLEXAID_SEED`.
- Routes several previously hidden `std::random_device` paths through the helper: GA fallback `RandomDouble`, Shannon GA, FOPTICS, Vcontacts perturbation, chiral-center mutation, ring conformer sampling, and sugar pucker sampling.
- Documents `FLEXAID_SEED` as the run-level stochastic provenance handle in reproducibility and benchmarking docs.
- Adds a regression test proving a fixed `FLEXAID_SEED` gives repeatable stream seeds.

## Why

The audit found fixed-seed benchmark claims were not defensible while important stochastic paths still seeded directly from `std::random_device`. This PR makes those paths seed-aware without claiming full bitwise replay across every parallel schedule.

## Validation

- `cmake --build build --target test_ga_context test_gaboom test_shannon_ga test_chiral_center test_ring_conformer_library test_sugar_pucker test_vcontacts --parallel 8`
- `ctest --test-dir build -R 'GAContextTests|GABoomTests|ShannonGATests|ChiralCenterTests|RingConformerLibraryTests|SugarPuckerTests|VcontactsTests' --output-on-failure`

## Notes

This is seed provenance, not the final determinism layer. Benchmarks still need to record thread counts, backend selection, input order, and any nondeterministic parallel scheduling choices.
