### PR TITLE
[codex] mark tENCoM entropy as heuristic

### DIFF
--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -485,7 +485,7 @@ void BindingMode::output_BindingMode(int num_result, char* end_strfile, char* tm
 	{
 		double vib_corr = this->compute_vibrational_correction();
 		if (std::abs(vib_corr) > 1e-12) {
-			snprintf(tmpremark, MAX_REMARK, "REMARK Vibrational correction (ENCoM): %10.4f kcal/mol\n", vib_corr);
+			snprintf(tmpremark, MAX_REMARK, "REMARK Vibrational correction (ENCoM heuristic): %10.4f kcal/mol\n", vib_corr);
 			safe_remark_cat(remark, tmpremark, &remark_len);
 		}
 	}

--- a/LIB/ShannonThermoStack/ShannonThermoStack.cpp
+++ b/LIB/ShannonThermoStack/ShannonThermoStack.cpp
@@ -334,9 +334,9 @@ FullThermoResult run_shannon_thermo_stack(
     //     S_conf [kcal/(mol·K)] = k_B · H [nats]
     double S_conf_phys  = S_conf_nats * kB_kcal;
 
-    // Additive decomposition: S_total = S_conf + S_vib
-    // Valid for independent conformational and vibrational DOFs
-    // (standard assumption in rigid-body docking + normal-mode analysis).
+    // Additive decomposition: S_total = S_conf + S_vib.
+    // S_vib is a relative tENCoM heuristic unless the eigenvalue scale has
+    // been calibrated for the benchmark protocol.
     double total_S      = S_conf_phys + S_vib;
     double S_contrib    = -temperature_K * total_S;
     double final_dG     = base_deltaG + S_contrib;
@@ -358,8 +358,9 @@ FullThermoResult run_shannon_thermo_stack(
         std::string("ShannonThermoStack[") + hw +
         "+Eigen"
         "]: S_conf=" + std::to_string(S_conf_nats) +
-        " nats, S_vib=" + std::to_string(S_vib) +
-        " kcal/mol/K, ΔG=" + std::to_string(final_dG) + " kcal/mol";
+        " nats, S_vib_heuristic=" + std::to_string(S_vib) +
+        " kcal/mol/K, ΔG=" + std::to_string(final_dG) +
+        " kcal/mol (vib requires calibration for absolute claims)";
 
     return { final_dG, S_conf_nats, S_vib, S_contrib, report };
 }

--- a/LIB/ShannonThermoStack/ShannonThermoStack.h
+++ b/LIB/ShannonThermoStack/ShannonThermoStack.h
@@ -2,7 +2,8 @@
 //
 // Combines:
 //   – Shannon configurational entropy over GA ensemble (binned into 256 mega-clusters)
-//   – Torsional ENCoM vibrational entropy from NormalMode fluctuations (protein + nucleotide backbones)
+//   – Torsional ENCoM vibrational entropy heuristic from NormalMode fluctuations
+//     (protein + nucleotide backbones; absolute magnitudes require calibration)
 //   – Hardware-accelerated histogram computation (Metal on Apple Silicon, OpenMP/Eigen on other platforms)
 //
 // Reuses StatMechEngine (statmech.h) and TorsionalENM (tencm.h) without modification.
@@ -30,7 +31,7 @@ inline constexpr int   GPU_DISPATCH_THRESHOLD = 500000; // only use GPU for N > 
 struct FullThermoResult {
     double deltaG;              // total free energy (kcal/mol)
     double shannonEntropy;      // dimensionless nats (conformational, natural log)
-    double torsionalVibEntropy; // kcal/mol·K (from ENCoM modes)
+    double torsionalVibEntropy; // kcal/mol·K heuristic unless ENCoM scale calibrated
     double entropyContribution; // -T*S term (kcal/mol)
     std::string report;
 };
@@ -81,6 +82,8 @@ double compute_shannon_entropy(const std::vector<double>& values,
 double compute_shannon_entropy_discrete(const std::vector<int>& states);
 
 // ─── torsional vibrational entropy from ENCoM modes ─────────────────────────
+// Current status: relative heuristic unless eigenvalue scale calibration is
+// supplied by the benchmark protocol.
 // Sums harmonic oscillator entropy contribution for each normal mode:
 //   S_vib = kB * [ hν/kBT / (exp(hν/kBT)-1) - ln(1-exp(-hν/kBT)) ]
 // For low-frequency torsional modes approximated as: S ≈ kB * ln(kBT/hν)

--- a/LIB/encom.cpp
+++ b/LIB/encom.cpp
@@ -107,10 +107,9 @@ VibrationalEntropy ENCoMEngine::compute_vibrational_entropy(
     // Compute geometric mean of eigenvalues
     double geom_mean_eigenvalue = geometric_mean(nonzero_eigenvalues);
     
-    // Convert to effective frequency (rad/s)
-    // Note: ENCoM eigenvalues are in arbitrary units. For real calculations,
-    // need proper force constant → frequency conversion with mass weighting.
-    // Here we assume eigenvalues are already in frequency² units (rad/s)².
+    // Convert to an effective model frequency. ENCoM eigenvalues are not SI
+    // frequencies without an external calibration scale, so absolute S_vib
+    // magnitudes should be treated as heuristic unless calibrated.
     result.omega_eff = std::sqrt(geom_mean_eigenvalue);
 
     if (result.omega_eff <= 0.0) {

--- a/LIB/encom.h
+++ b/LIB/encom.h
@@ -5,13 +5,19 @@
 //   – Calculate quasi-harmonic vibrational entropy S_vib
 //   – Combine with configurational entropy S_conf for total entropy
 //
+// Calibration status:
+//   ENCoM eigenvalues are model-scale quantities, not SI frequencies by
+//   default. Absolute S_vib and -T*S_vib values are therefore heuristic unless
+//   the eigenvalue-to-frequency scale is calibrated for the benchmark system.
+//   Differential comparisons under one fixed protocol are the supported use.
+//
 // Reference:
 //   Frappier et al. (2015). *Proteins* 83(11):2073-82.
 //   DOI: 10.1002/prot.24922
 //
 // Mathematical framework:
-//   S_vib = (3N - 6) × k_B × [1 + ln(2πkT/ħω_eff)]
-//   ω_eff = geometric mean of non-zero eigenvalues
+//   S_vib = (3N - 6) × k_B × [1 + ln(kT/ħω_eff)]
+//   ω_eff = calibrated geometric mean frequency from non-zero eigenvalues
 
 #pragma once
 
@@ -43,14 +49,14 @@ inline constexpr double amu_to_kg  = 1.66053906660e-27;// kg
 struct NormalMode {
     int     index;               // Mode number (1-based)
     double  eigenvalue;          // λ_i (arbitrary units from ENCoM)
-    double  frequency;           // ω_i = sqrt(λ_i) (rad/s when converted to SI)
+    double  frequency;           // ω_i = sqrt(λ_i) before any calibration scale
     std::vector<double> eigenvector; // Displacement vector (3N components)
 };
 
 struct VibrationalEntropy {
-    double S_vib_kcal_mol_K;     // Vibrational entropy (kcal mol⁻¹ K⁻¹)
-    double S_vib_J_mol_K;        // Vibrational entropy (J mol⁻¹ K⁻¹)
-    double omega_eff;            // Effective frequency (rad/s)
+    double S_vib_kcal_mol_K;     // Heuristic vibrational entropy unless calibrated
+    double S_vib_J_mol_K;        // Same value in J mol⁻¹ K⁻¹
+    double omega_eff;            // Effective model frequency
     int    n_modes;              // Number of non-zero modes (3N - 6)
     double temperature;          // K
 };
@@ -68,8 +74,9 @@ public:
         const std::string& eigenvector_file
     );
     
-    /// Compute quasi-harmonic vibrational entropy from normal modes
-    /// Uses Schlitter formula: S_vib = k_B (3N-6) [1 + ln(2πkT/ħω_eff)]
+    /// Compute quasi-harmonic vibrational entropy from normal modes.
+    /// Absolute magnitudes require a calibrated eigenvalue-to-frequency scale.
+    /// Without calibration, use only as a relative heuristic.
     static VibrationalEntropy compute_vibrational_entropy(
         const std::vector<NormalMode>& modes,
         double temperature_K = 300.0,

--- a/README.md
+++ b/README.md
@@ -286,6 +286,10 @@ All parameters have built-in defaults. Override only what you need via JSON:
 tENCoM reference.pdb target1.pdb [target2.pdb ...] [-T temp] [-r cutoff] [-k k0] [-o prefix]
 ```
 
+tENCoM vibrational entropy is currently a relative heuristic unless a
+benchmark-specific eigenvalue-to-frequency calibration is supplied. See
+[docs/TENCOM_ENTROPY_CALIBRATION.md](docs/TENCOM_ENTROPY_CALIBRATION.md).
+
 ### Python Package
 
 ```bash

--- a/docs/TENCOM_ENTROPY_CALIBRATION.md
+++ b/docs/TENCOM_ENTROPY_CALIBRATION.md
@@ -1,0 +1,28 @@
+# tENCoM Entropy Calibration Status
+
+tENCoM and ENCoM-derived vibrational entropy are currently supported as a
+relative, protocol-fixed heuristic in FlexAIDdS.
+
+The important boundary is simple: ENCoM eigenvalues are model-scale quantities.
+They are not physical SI frequencies unless an eigenvalue-to-frequency
+calibration is supplied and documented for the benchmark system. Therefore:
+
+- differential comparisons such as `Delta S_vib = S_vib(holo) - S_vib(apo)` are
+  acceptable when apo/holo are processed with the same protocol
+- absolute `S_vib` and `-T*S_vib` magnitudes must be labeled heuristic unless a
+  calibration artifact is present
+- benchmark tables must not present tENCoM vibrational entropy as absolute
+  thermodynamic truth without calibration provenance
+
+## Required calibration artifact
+
+Before promoting absolute vibrational entropy claims, commit a bundle with:
+
+- reference structures and preprocessing commands
+- ENCoM/tENCoM parameters
+- eigenvalue-to-frequency scale or normal-mode reference
+- expected `S_vib`, `Delta S_vib`, and `-T*S_vib` values
+- metric scripts and tolerances
+- git SHA, compiler, backend, thread count, and temperature
+
+Until then, use labels such as `S_vib_heuristic` or `relative Delta S_vib`.

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -68,6 +68,10 @@ Inputs are auto-detected from file content — argument order doesn't matter. Ac
 tENCoM <reference.pdb> <target1.pdb> [target2.pdb ...] [options]
 ```
 
+Use tENCoM entropy differentials as relative values under one fixed protocol.
+Absolute `S_vib` and `-T*S_vib` values are heuristic until a calibration bundle
+is supplied.
+
 | Flag | Description |
 |:-----|:------------|
 | `-T <temp>` | Temperature in Kelvin (default: 300) |

--- a/python/flexaidds/encom.py
+++ b/python/flexaidds/encom.py
@@ -4,6 +4,11 @@ Provides Pythonic wrappers around the C++ ENCoMEngine, plus a pure-Python
 quasi-harmonic fallback for environments where the compiled extension is not
 available.
 
+Current calibration status: ENCoM eigenvalues are model-scale quantities.
+Absolute S_vib and -T*S_vib magnitudes should be treated as heuristic unless a
+benchmark protocol supplies an eigenvalue-to-frequency calibration. Differential
+comparisons under one fixed protocol are the supported use.
+
 Reference:
     Frappier et al. (2015). Proteins 83(11):2073-82.
     DOI: 10.1002/prot.24922
@@ -40,7 +45,7 @@ class NormalMode:
     Attributes:
         index:      1-based mode index.
         eigenvalue: λ_i in ENCoM arbitrary units.
-        frequency:  ω_i = sqrt(λ_i), rad/s when converted to SI.
+        frequency:  ω_i = sqrt(λ_i) before any calibration scale.
         eigenvector: Displacement vector with 3N components.
     """
     index: int = 0
@@ -57,9 +62,9 @@ class VibrationalEntropy:
     """Quasi-harmonic vibrational entropy from ENCoM normal modes.
 
     Attributes:
-        S_vib_kcal_mol_K: Vibrational entropy in kcal mol⁻¹ K⁻¹.
-        S_vib_J_mol_K:    Vibrational entropy in J mol⁻¹ K⁻¹.
-        omega_eff:         Effective angular frequency ω_eff (rad/s).
+        S_vib_kcal_mol_K: Heuristic vibrational entropy in kcal mol⁻¹ K⁻¹.
+        S_vib_J_mol_K:    Same heuristic in J mol⁻¹ K⁻¹.
+        omega_eff:         Effective model frequency ω_eff.
         n_modes:           Number of non-trivial normal modes (3N − 6).
         temperature:       Temperature in Kelvin.
     """
@@ -87,12 +92,12 @@ def _python_compute_vibrational_entropy(
     temperature_K: float = 300.0,
     eigenvalue_cutoff: float = 1e-6,
 ) -> VibrationalEntropy:
-    """Pure-Python quasi-harmonic S_vib (Schlitter 1993 approximation).
+    """Pure-Python quasi-harmonic S_vib heuristic.
 
     Used when the C++ extension is not available.  Matches the C++ engine
-    formula:
+    formula after applying the local scale factor:
         ω_eff = geometric_mean(sqrt(λ_i)  for non-trivial modes)
-        S_vib = n × k_B × [1 + ln(2π k_B T / (ħ ω_eff))]
+        S_vib = n * k_B * [1 + ln(k_B T / (hbar * omega_eff))]
     """
     non_trivial = [m for m in modes if m.eigenvalue > eigenvalue_cutoff]
     if not non_trivial:
@@ -101,14 +106,15 @@ def _python_compute_vibrational_entropy(
     # Geometric mean of frequencies in ENCoM units, then convert to SI.
     # ENCoM eigenvalues are dimensionless; we apply a scale factor so that
     # ω_eff has units of rad/s consistent with the Schlitter formula.
-    # Scale chosen to match Frappier et al. (2015) reference values.
+    # Placeholder scale for continuity with existing outputs. Treat absolute
+    # values as heuristic until benchmark-specific calibration is committed.
     _ENCOM_SCALE = 1.0e12  # rad/s per sqrt(ENCoM unit)
 
     log_sum = sum(0.5 * math.log(m.eigenvalue) for m in non_trivial)
     omega_eff = _ENCOM_SCALE * math.exp(log_sum / len(non_trivial))
 
     kT = kB_SI * temperature_K
-    x = 2.0 * math.pi * kT / (hbar_SI * omega_eff)
+    x = kT / (hbar_SI * omega_eff)
     x = max(x, 1.0)  # ln argument must be ≥ 1
 
     n = len(non_trivial)

--- a/tests/test_hardware_dispatch.cpp
+++ b/tests/test_hardware_dispatch.cpp
@@ -370,7 +370,7 @@ TEST_F(ShannonThermoStackTest, ReportContainsMetrics) {
     auto result = run_shannon_thermo_stack(engine, tencm_model, -10.0);
 
     EXPECT_NE(result.report.find("S_conf="), std::string::npos);
-    EXPECT_NE(result.report.find("S_vib="), std::string::npos);
+    EXPECT_NE(result.report.find("S_vib_heuristic="), std::string::npos);
     EXPECT_NE(result.report.find("kcal/mol"), std::string::npos);
 }
 


### PR DESCRIPTION
## Summary

- Marks ENCoM/tENCoM vibrational entropy as a relative heuristic unless an eigenvalue-to-frequency calibration exists.
- Renames the combined ShannonThermoStack report field from `S_vib` to `S_vib_heuristic`.
- Updates C++/Python comments and docs so absolute `S_vib` and `-T*S_vib` claims require calibration provenance.
- Adds `docs/TENCOM_ENTROPY_CALIBRATION.md` with the required artifact checklist.
- Aligns the Python fallback formula with the C++ harmonic-oscillator expression by removing the stale `2*pi` factor.

## Why

The audit found ENCoM eigenvalues being treated as physical frequencies despite being model-scale quantities. This PR keeps differential use available but prevents absolute thermodynamic claims from being presented as calibrated physics.

## Validation

- `cmake --build build --target test_encom test_hardware_dispatch test_binding_mode_vibrational test_tencom_entropy_diff --parallel 8`
- `ctest --test-dir build -R 'ENCoMTests|HardwareDispatchTests|BindingModeVibrationalTests|TencomEntropyDiffTests' --output-on-failure`
- `PYTHONPATH=python python3 -m pytest -q python/tests/test_encom.py python/tests/test_tencm.py`
