### PR TITLE
[codex] fix GIST path parsing and refresh security docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2356,6 +2356,21 @@ flexaids_configure_simd(test_cavity_detect)
     flexaids_configure_msvc_test(test_gist_hbond)
     add_test(NAME GISTHBondTests COMMAND test_gist_hbond)
 
+    # test_buffer_safety — bounded legacy config parsing regressions
+    add_executable(test_buffer_safety
+        tests/test_buffer_safety.cpp
+    )
+    target_include_directories(test_buffer_safety PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB)
+    target_link_libraries(test_buffer_safety PRIVATE GTest::gtest GTest::gtest_main)
+    if(MSVC)
+        target_compile_options(test_buffer_safety PRIVATE /O2)
+    else()
+        target_compile_options(test_buffer_safety PRIVATE -O2)
+    endif()
+    flexaids_configure_msvc_test(test_buffer_safety)
+    add_test(NAME BufferSafetyTests COMMAND test_buffer_safety)
+
     message(STATUS "Unit tests enabled — build targets: test_statmech, test_hardware_dispatch, test_tencom_diff, test_target_validation, test_grand_partition, test_target_server, test_multi_site_gpf")
     # test_hbond_potential — Angular-dependent H-bond potential unit tests
     add_executable(test_hbond_potential

--- a/LIB/read_input.cpp
+++ b/LIB/read_input.cpp
@@ -7,6 +7,7 @@
 #include "RefLigSeed.h"
 #include "CavityDetect/SpatialGrid.h"
 #include "BindingResidues.h"
+#include "read_input_utils.h"
 #include <vector>
 #include <algorithm>
 #include <random>
@@ -209,8 +210,8 @@ void read_input(FA_Global* FA,atom** atoms, resid** residue,rot** rotamer,gridpo
 		if(strcmp(field,"USEELC") == 0){FA->use_elec=1;}
 		if(strcmp(field,"DIELEC") == 0){sscanf(buffer,"%s %f",field,&FA->dielectric);}
 		if(strcmp(field,"USEGIS") == 0){FA->use_gist=1;}
-		if(strcmp(field,"GISTDG") == 0){sscanf(buffer,"%s %s",field,FA->gist_dg_file);}
-		if(strcmp(field,"GISTDN") == 0){sscanf(buffer,"%s %s",field,FA->gist_dens_file);}
+		if(strcmp(field,"GISTDG") == 0){flexaids_copy_config_value(buffer,FA->gist_dg_file,MAX_PATH__);}
+		if(strcmp(field,"GISTDN") == 0){flexaids_copy_config_value(buffer,FA->gist_dens_file,MAX_PATH__);}
 		if(strcmp(field,"GISTWT") == 0){sscanf(buffer,"%s %lf",field,&FA->gist_weight);}
 		if(strcmp(field,"GISTGC") == 0){sscanf(buffer,"%s %f",field,&FA->gist_dg_cutoff);}
 		if(strcmp(field,"GISTRC") == 0){sscanf(buffer,"%s %f",field,&FA->gist_rho_cutoff);}

--- a/LIB/read_input_utils.h
+++ b/LIB/read_input_utils.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cctype>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+
+inline void flexaids_copy_config_value(
+    const char* line,
+    char* dest,
+    std::size_t dest_size)
+{
+    if (!dest || dest_size == 0) return;
+    dest[0] = '\0';
+    if (!line) return;
+
+    const unsigned char* p = reinterpret_cast<const unsigned char*>(line);
+    while (*p && !std::isspace(*p)) ++p;
+    while (*p && std::isspace(*p)) ++p;
+
+    std::snprintf(dest, dest_size, "%s", reinterpret_cast<const char*>(p));
+
+    std::size_t len = std::strlen(dest);
+    while (len > 0 && (dest[len - 1] == '\n' || dest[len - 1] == '\r')) {
+        dest[--len] = '\0';
+    }
+}

--- a/SECURITY_AUDIT_BUFFER_OVERFLOW.md
+++ b/SECURITY_AUDIT_BUFFER_OVERFLOW.md
@@ -4,6 +4,10 @@
 **Scope:** Full codebase — C++, CUDA, Metal, Objective-C++, Python bindings
 **Auditor:** Automated static analysis
 
+> Status note, May 2026: this document is a historical audit input, not a live
+> closure report. Some findings have since been fixed or partially bounded.
+> Current status belongs in `docs/KNOWN_LIMITATIONS.md` and source-level tests.
+
 ---
 
 ## Executive Summary

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -28,31 +28,30 @@ This file documents limitations that matter for installation trust, scientific i
 - Legacy C and C++ parsing surfaces require continued hardening and regression testing.
 - Presence of an audit or policy document does not itself imply closure; fixes and automation are the real closure criteria.
 
-### Current Security Status (April 2026)
+### Current Security Status (May 2026)
 
-**Recent Audit Results:**
-- 7 HIGH-severity buffer overflow vulnerabilities identified in config parsing (H-1 through H-7)
-- 14 MEDIUM-severity unsafe string handling patterns documented
-- 7 LOW-severity information disclosure issues noted
+The March 2026 buffer-overflow audit remains useful as a historical threat
+inventory, but it is not a current closure report. Several high-risk patterns
+have since been bounded in source, while legacy C/C++ config parsing still
+requires ongoing hardening and regression tests.
 
-**Remediation Timeline:**
-- Phase 1 (Code Coverage CI): ✅ COMPLETE
-- Phase 2 (Buffer Overflow Fixes): ⏳ IN PROGRESS
-- Phase 3 (DatasetRunner Integration): ⏳ PENDING
-- Phase 4 (Documentation): ✅ COMPLETE
+**Current live status:**
+- legacy GIST config path parsing now uses bounded copy helpers instead of
+  unbounded `%s` reads
+- buffer-safety regression coverage exists in `tests/test_buffer_safety.cpp`
+- remaining unsafe string patterns should be tracked as source findings, not
+  inferred from the stale March audit totals
 
-See [`SECURITY_HARDENING_ROADMAP.md`](SECURITY_HARDENING_ROADMAP.md) for details on vulnerabilities and fixes.
+**Recommended mitigation until the legacy parser is fully retired:**
+- do not process untrusted configuration files
+- use signed or repository-controlled configuration bundles for benchmarks
+- keep config files small and reviewable
+- run parser changes under ASAN/UBSAN where available
 
-**Recommended Mitigation** (Until Phase 2 Completes):
-- Do not process untrusted configuration files
-- Use signed configuration bundles from official sources
-- Validate config file sizes (<1MB recommended)
-- Deploy with strict filesystem permissions
-
-**Testing Infrastructure:**
-- All fixes validated with ASAN/UBSAN sanitizers
-- New test suite: `tests/test_buffer_safety.cpp` with 6+ boundary condition tests
-- Continuous coverage tracking via GitHub Actions (target ≥50%)
+See [`SECURITY_HARDENING_ROADMAP.md`](SECURITY_HARDENING_ROADMAP.md) and
+[`SECURITY_AUDIT_BUFFER_OVERFLOW.md`](../SECURITY_AUDIT_BUFFER_OVERFLOW.md) for
+historical context. Treat those documents as audit inputs, not proof of current
+security closure.
 
 ## Scientific interpretation limitations
 

--- a/tests/test_buffer_safety.cpp
+++ b/tests/test_buffer_safety.cpp
@@ -1,0 +1,37 @@
+// test_buffer_safety.cpp — regression tests for bounded legacy config parsing.
+
+#include <gtest/gtest.h>
+
+#include "read_input_utils.h"
+
+#include <cstring>
+#include <string>
+
+TEST(BufferSafety, LongConfigValueIsTruncatedAndTerminated) {
+    char dest[16];
+    std::memset(dest, 'X', sizeof(dest));
+
+    std::string line = "GISTDG " + std::string(256, 'a');
+    flexaids_copy_config_value(line.c_str(), dest, sizeof(dest));
+
+    EXPECT_EQ(std::strlen(dest), sizeof(dest) - 1);
+    EXPECT_EQ(dest[sizeof(dest) - 1], '\0');
+}
+
+TEST(BufferSafety, ConfigValueTrimsTrailingNewline) {
+    char dest[32];
+    flexaids_copy_config_value("GISTDN /tmp/rho.dx\n", dest, sizeof(dest));
+
+    EXPECT_STREQ(dest, "/tmp/rho.dx");
+}
+
+TEST(BufferSafety, NullOrEmptyInputsStayTerminated) {
+    char dest[8];
+    std::memset(dest, 'X', sizeof(dest));
+
+    flexaids_copy_config_value(nullptr, dest, sizeof(dest));
+    EXPECT_EQ(dest[0], '\0');
+
+    flexaids_copy_config_value("GISTDG", dest, sizeof(dest));
+    EXPECT_EQ(dest[0], '\0');
+}


### PR DESCRIPTION
## Summary

- Replaces the legacy unbounded GIST path `%s` parsing in `read_input.cpp` with a bounded copy helper.
- Adds `LIB/read_input_utils.h` and `BufferSafetyTests` for long config values, newline trimming, and null/empty inputs.
- Registers the new `test_buffer_safety` target in CMake.
- Refreshes the security-status docs so the March audit is treated as historical input rather than a live closure report.

## Why

The audit found a live unsafe parser path and stale security docs claiming buffer-safety tests existed. This PR fixes that concrete parser path and makes the documentation match the current source/test state.

## Validation

- `cmake -S . -B build`
- `cmake --build build --target test_buffer_safety test_gist_hbond test_gist_grid --parallel 8`
- `ctest --test-dir build -R 'BufferSafetyTests|GISTHBondTests|GISTGridTests' --output-on-failure`
- `cmake --build build --target FlexAID FlexAIDdS --parallel 8`
