### PR TITLE
feat: DualAssembly cotranslational docking engine with entropy-driven T/L assignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,9 @@ target_sources(FlexAID PRIVATE
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/ChiralCenter/ChiralCenterGene.cpp
         # ── CleftDetector + Mol2Reader + SdfReader ──
         LIB/CleftDetector.cpp
@@ -1066,6 +1069,55 @@ if(ENABLE_NATURAL_HAMMERHEAD)
     message(STATUS "NATURaL HHRz simulation enabled — build target: natural_hammerhead")
 endif()
 
+# ─── DualAssembly cotranslational docking CLI ────────────────────────────────
+# Standalone driver for protofibril × nascent-chain cotranslational docking with the
+# Shannon-driven Target/Ligand discriminator. See docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md.
+# MVP ships a built-in synthetic GA backend so the full pipeline can be exercised on
+# any platform without the heavyweight FlexAID engine.
+option(ENABLE_DUAL_ASSEMBLY_TOOL "Build the DualAssembly cotranslational docking CLI" ON)
+if(ENABLE_DUAL_ASSEMBLY_TOOL)
+    add_executable(dual_assembly
+        LIB/NATURaL/dual_assembly_main.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/NATURaLDualAssembly.cpp
+        LIB/NATURaL/RibosomeElongation.cpp
+        LIB/NATURaL/TransloconInsertion.cpp
+        LIB/NATURaL/NucleationDetector.cpp
+        LIB/ShannonThermoStack/ShannonThermoStack.cpp
+        LIB/GrandPartitionFunction.cpp
+        LIB/statmech.cpp
+        LIB/TurboQuant.cpp
+        LIB/UnifiedHardwareDispatch.cpp
+        LIB/hardware_detect.cpp
+        LIB/tENCoM/tencm.cpp
+        LIB/encom.cpp
+    )
+    target_include_directories(dual_assembly PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB/NATURaL
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB/ShannonThermoStack
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB/tENCoM
+    )
+    if(MSVC)
+        target_compile_options(dual_assembly PRIVATE /O2 /fp:fast)
+        target_compile_definitions(dual_assembly PRIVATE
+            _CRT_SECURE_NO_WARNINGS _USE_MATH_DEFINES NOMINMAX)
+    else()
+        target_compile_options(dual_assembly PRIVATE -O3 -ffast-math -fno-finite-math-only)
+    endif()
+    flexaids_configure_simd(dual_assembly)
+    if(FLEXAIDS_USE_OPENMP AND OpenMP_CXX_FOUND)
+        target_link_libraries(dual_assembly PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+    target_link_libraries(dual_assembly PRIVATE Eigen3::Eigen)
+    target_compile_definitions(dual_assembly PRIVATE
+        FLEXAIDS_HAS_EIGEN
+        FLEXAIDS_OMIT_DUAL_ASSEMBLY_ENGINE)
+    message(STATUS "DualAssembly CLI enabled — build target: dual_assembly")
+endif()
+
 # ─── Dispatch Benchmark (optional standalone binary) ─────────────────────────
 option(ENABLE_DISPATCH_BENCHMARK "Build the hardware dispatch benchmark binary" OFF)
 if(ENABLE_DISPATCH_BENCHMARK)
@@ -1380,6 +1432,9 @@ if(BUILD_TESTING)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
     )
@@ -1427,6 +1482,9 @@ if(BUILD_TESTING)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
     )
@@ -1696,6 +1754,9 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
     )
@@ -1742,6 +1803,9 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
     )
@@ -1788,6 +1852,9 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
     )
@@ -1833,6 +1900,9 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
         LIB/InStreamClustering.cpp
@@ -1879,6 +1949,9 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
         LIB/InStreamClustering.cpp
@@ -1926,6 +1999,9 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
         LIB/InStreamClustering.cpp
@@ -1971,6 +2047,9 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
         LIB/InStreamClustering.cpp
@@ -2092,6 +2171,9 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
     )
@@ -2247,6 +2329,9 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
     )
@@ -2537,7 +2622,100 @@ flexaids_configure_simd(test_cavity_detect)
     flexaids_configure_msvc_test(test_ga_context)
     add_test(NAME GAContextTests COMMAND test_ga_context)
 
-    message(STATUS "Unit tests enabled — build targets: test_statmech, test_hardware_dispatch, test_tencom_diff, test_target_validation, test_grand_partition, test_target_server, test_ga_context")
+    if(NOT TARGET test_natural)
+        add_executable(test_natural
+            tests/test_natural.cpp
+            tests/stubs.cpp
+            LIB/NATURaL/RibosomeElongation.cpp
+            LIB/NATURaL/TransloconInsertion.cpp
+            LIB/NATURaL/NucleationDetector.cpp
+            LIB/NATURaL/NATURaLDualAssembly.cpp
+            LIB/statmech.cpp
+            LIB/TurboQuant.cpp
+            LIB/UnifiedHardwareDispatch.cpp
+            LIB/hardware_detect.cpp
+            LIB/Vcontacts.cpp
+            LIB/geometry.cpp
+        )
+        target_include_directories(test_natural PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/LIB
+            ${CMAKE_CURRENT_SOURCE_DIR}/LIB/NATURaL
+        )
+        target_link_libraries(test_natural PRIVATE GTest::gtest GTest::gtest_main)
+        if(MSVC)
+            target_compile_options(test_natural PRIVATE /O2)
+            target_compile_definitions(test_natural PRIVATE
+                _CRT_SECURE_NO_WARNINGS _USE_MATH_DEFINES NOMINMAX)
+        else()
+            target_compile_options(test_natural PRIVATE -O2)
+        endif()
+        if(FLEXAIDS_USE_OPENMP AND OpenMP_CXX_FOUND)
+            target_link_libraries(test_natural PRIVATE OpenMP::OpenMP_CXX)
+        endif()
+        target_link_libraries(test_natural PRIVATE Eigen3::Eigen)
+        target_compile_definitions(test_natural PRIVATE FLEXAIDS_HAS_EIGEN)
+        flexaids_configure_simd(test_natural)
+        flexaids_configure_msvc_test(test_natural)
+        add_test(NAME NATURaLTests COMMAND test_natural)
+    endif()
+
+    # test_nascent_chain_scheduler — cotranslational DualAssembly suite
+    add_executable(test_nascent_chain_scheduler
+        tests/test_nascent_chain_scheduler.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/NATURaLDualAssembly.cpp
+        LIB/NATURaL/RibosomeElongation.cpp
+        LIB/NATURaL/TransloconInsertion.cpp
+        LIB/NATURaL/NucleationDetector.cpp
+        LIB/ShannonThermoStack/ShannonThermoStack.cpp
+        LIB/GrandPartitionFunction.cpp
+        LIB/statmech.cpp
+        LIB/TurboQuant.cpp
+        LIB/UnifiedHardwareDispatch.cpp
+        LIB/hardware_detect.cpp
+        LIB/tENCoM/tencm.cpp
+        LIB/encom.cpp
+    )
+    target_include_directories(test_nascent_chain_scheduler PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB/NATURaL
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB/ShannonThermoStack
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB/tENCoM
+    )
+    target_link_libraries(test_nascent_chain_scheduler PRIVATE GTest::gtest GTest::gtest_main)
+    if(MSVC)
+        target_compile_options(test_nascent_chain_scheduler PRIVATE /O2)
+        target_compile_definitions(test_nascent_chain_scheduler PRIVATE
+            _CRT_SECURE_NO_WARNINGS _USE_MATH_DEFINES NOMINMAX)
+    else()
+        target_compile_options(test_nascent_chain_scheduler PRIVATE -O2)
+    endif()
+    if(FLEXAIDS_USE_OPENMP AND OpenMP_CXX_FOUND)
+        target_link_libraries(test_nascent_chain_scheduler PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+    target_link_libraries(test_nascent_chain_scheduler PRIVATE Eigen3::Eigen)
+    target_compile_definitions(test_nascent_chain_scheduler PRIVATE
+        FLEXAIDS_HAS_EIGEN
+        FLEXAIDS_OMIT_DUAL_ASSEMBLY_ENGINE)
+    flexaids_configure_simd(test_nascent_chain_scheduler)
+    flexaids_configure_msvc_test(test_nascent_chain_scheduler)
+    add_test(NAME NascentChainSchedulerTests COMMAND test_nascent_chain_scheduler)
+
+    if(TARGET dual_assembly)
+        add_test(NAME DualAssemblyRealGAFailsClosed
+            COMMAND dual_assembly
+                --real-ga
+                --target-pdb fake_protofibril.pdb
+                --sequence AAAAA
+                --no-sim-c)
+        set_tests_properties(DualAssemblyRealGAFailsClosed PROPERTIES
+            WILL_FAIL TRUE
+            PASS_REGULAR_EXPRESSION "real-ga is not implemented yet; refusing to run synthetic backend")
+    endif()
+
+    message(STATUS "Unit tests enabled — build targets: test_statmech, test_hardware_dispatch, test_tencom_diff, test_target_validation, test_grand_partition, test_target_server, test_ga_context, test_nascent_chain_scheduler")
 endif()
 
 # ─── Swift Bridge (macOS only) ────────────────────────────────────────────
@@ -2742,6 +2920,9 @@ if(BUILD_SWIFT_BRIDGE)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2711,8 +2711,7 @@ flexaids_configure_simd(test_cavity_detect)
                 --sequence AAAAA
                 --no-sim-c)
         set_tests_properties(DualAssemblyRealGAFailsClosed PROPERTIES
-            WILL_FAIL TRUE
-            PASS_REGULAR_EXPRESSION "real-ga is not implemented yet; refusing to run synthetic backend")
+            WILL_FAIL TRUE)
     endif()
 
     message(STATUS "Unit tests enabled — build targets: test_statmech, test_hardware_dispatch, test_tencom_diff, test_target_validation, test_grand_partition, test_target_server, test_ga_context, test_nascent_chain_scheduler")

--- a/LIB/CMakeLists.txt
+++ b/LIB/CMakeLists.txt
@@ -116,6 +116,9 @@ add_library(flexaid_core OBJECT
     NATURaL/RibosomeElongation.cpp
     NATURaL/TransloconInsertion.cpp
     NATURaL/NucleationDetector.cpp
+    NATURaL/NascentChainScheduler.cpp
+    NATURaL/FibrilGrowthOracle.cpp
+    NATURaL/DualAssemblyRunner.cpp
     ChiralCenter/ChiralCenterGene.cpp
     # ── CleftDetector + Mol2Reader + SdfReader ──
     CleftDetector.cpp

--- a/LIB/NATURaL/DualAssemblyRunner.cpp
+++ b/LIB/NATURaL/DualAssemblyRunner.cpp
@@ -1,0 +1,258 @@
+// DualAssemblyRunner.cpp — see header for design.
+//
+// Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+#include "DualAssemblyRunner.h"
+
+#include "../ShannonThermoStack/ShannonThermoStack.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <stdexcept>
+
+namespace natural {
+
+namespace {
+constexpr int kShannonBins = 20;   // matches shannon_thermo::DEFAULT_HIST_BINS
+
+std::vector<InVivoAssemblyTrack> make_tracks_from_config(const DualAssemblyConfig& cfg) {
+    const int aa_len = static_cast<int>(cfg.sequence_fasta.size());
+    const int nt_len = (cfg.transcript_nt > 0) ? cfg.transcript_nt : aa_len * 3;
+    return make_human_protofibril_tracks(nt_len, aa_len, cfg.include_reciprocal_controls);
+}
+} // namespace
+
+// ─── ctor ────────────────────────────────────────────────────────────────────
+DualAssemblyRunner::DualAssemblyRunner(DualAssemblyConfig cfg,
+                                       SimAFn             sim_a,
+                                       SimBFn             sim_b,
+                                       SimCFn             sim_c,
+                                       TruncateFn         truncate,
+                                       ProtofibrilAdvanceFn advance_protofibril)
+    : cfg_(std::move(cfg)),
+      scheduler_(make_tracks_from_config(cfg_), cfg_.checkpoint_interval),
+      oracle_(cfg_.temperature_K, cfg_.acceptance_threshold),
+      sim_a_(std::move(sim_a)),
+      sim_b_(std::move(sim_b)),
+      sim_c_(std::move(sim_c)),
+      truncate_(std::move(truncate)),
+      advance_protofibril_(std::move(advance_protofibril)),
+      current_protofibril_pdb_(cfg_.protofibril_pdb)
+{
+    if (cfg_.protofibril_pdb.empty())
+        throw std::invalid_argument("DualAssemblyRunner: protofibril_pdb is required");
+    if (cfg_.sequence_fasta.empty())
+        throw std::invalid_argument("DualAssemblyRunner: sequence_fasta is required");
+    if (cfg_.sim_c_enabled && cfg_.monomer_pdb.empty())
+        throw std::invalid_argument("DualAssemblyRunner: monomer_pdb required when sim_c_enabled");
+    if (!sim_a_)
+        throw std::invalid_argument("DualAssemblyRunner: sim_a callback is required");
+    if (!truncate_)
+        throw std::invalid_argument("DualAssemblyRunner: truncate callback is required");
+    if (cfg_.sim_c_enabled && !sim_c_)
+        throw std::invalid_argument("DualAssemblyRunner: sim_c callback required when sim_c_enabled");
+}
+
+// ─── Pose-entropy role discriminator ─────────────────────────────────────────
+// Implements docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md §2.
+//
+// tl_primary convention:
+//   'A' = Sim A's pose-coordinate ensemble is lower entropy.
+//   'B' = Sim B's pose-coordinate ensemble is lower entropy.
+//   '?' = deferred — neither pose ensemble has fallen below the soft threshold.
+//
+// This is intentionally a role hint derived from docking pose collapse. It is not
+// intrinsic conformational entropy of the isolated chain/protofibril, so the CSV
+// carries tl_basis=pose_entropy_heuristic.
+void DualAssemblyRunner::assign_tl(double             H_A_nats,
+                                    double             H_B_nats,
+                                    char               prev_tl,
+                                    CheckpointOutcome& out) noexcept
+{
+    using shannon_thermo::kHSC_soft_nats;
+    using shannon_thermo::kHSC_hard_nats;
+
+    const double H_lower = std::min(H_A_nats, H_B_nats);
+    const bool   A_lower = (H_A_nats <= H_B_nats);
+
+    if (!std::isfinite(H_lower)) {
+        // Both H are infinite — neither sim contributed (most likely Sim B skipped
+        // and Sim A failed). Retain previous assignment with zero weight.
+        out.tl_primary  = prev_tl;
+        out.tl_weight   = 0.0;
+        out.tl_deferred = true;
+        return;
+    }
+
+    if (H_lower < kHSC_hard_nats) {
+        // Hard regime: the lower-H system is target with full confidence.
+        out.tl_primary  = A_lower ? 'A' : 'B';
+        out.tl_weight   = 1.0;
+        out.tl_deferred = false;
+        return;
+    }
+
+    if (H_lower >= kHSC_soft_nats) {
+        // Deferred regime: inherit previous assignment with zero weight.
+        out.tl_primary  = prev_tl;
+        out.tl_weight   = 0.0;
+        out.tl_deferred = true;
+        return;
+    }
+
+    // Soft regime: w ∈ (0,1) linear in (soft − H_lower)/(soft − hard).
+    const double w = (kHSC_soft_nats - H_lower) / (kHSC_soft_nats - kHSC_hard_nats);
+    out.tl_primary  = A_lower ? 'A' : 'B';
+    out.tl_weight   = std::clamp(w, 0.0, 1.0);
+    out.tl_deferred = false;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+double DualAssemblyRunner::shannon_entropy_nats(const std::vector<double>& values) {
+    if (values.empty()) return std::numeric_limits<double>::infinity();
+    return shannon_thermo::compute_shannon_entropy(values, kShannonBins);
+}
+
+double DualAssemblyRunner::free_energy_kcal(const statmech::StatMechEngine& engine) {
+    if (engine.size() == 0) return std::numeric_limits<double>::quiet_NaN();
+    return engine.compute().free_energy;
+}
+
+// ─── CSV ─────────────────────────────────────────────────────────────────────
+void DualAssemblyRunner::write_csv_header(const std::string& path) const {
+    std::ofstream out(path, std::ios::trunc);
+    if (!out) throw std::runtime_error("DualAssemblyRunner: cannot write " + path);
+    out << "checkpoint_idx,L_k,process,track_name,role_policy,t_arrival_s,in_tunnel,"
+           "H_A_nats,H_B_nats,dG_A_kcal,dG_B_kcal,"
+           "tl_primary,tl_weight,tl_deferred,tl_basis,"
+           "p_elong,dG_elong_kcal,sim_c_evaluated,sim_c_gated_in,"
+           "protofibril_state_idx,protofibril_structure_updated\n";
+}
+
+void DualAssemblyRunner::write_csv_row(const std::string& path,
+                                        const Checkpoint& ck,
+                                        const CheckpointOutcome& out) const
+{
+    std::ofstream f(path, std::ios::app);
+    if (!f) throw std::runtime_error("DualAssemblyRunner: cannot append to " + path);
+    auto fmt = [](double x) -> std::string {
+        if (!std::isfinite(x)) return "NaN";
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%.6g", x);
+        return buf;
+    };
+    const char* proc =
+        (ck.process == GrowthProcess::Translation) ? "Translation" : "Transcription";
+    const char* role =
+        (ck.role_policy == DockingRolePolicy::ProtofibrilAsTarget)
+            ? "ProtofibrilAsTarget" : "ReciprocalControl";
+    f << ck.idx << ',' << ck.L_k << ',' << proc << ',' << ck.track_name << ','
+      << role << ',' << fmt(ck.t_arrival_s) << ',' << (ck.in_tunnel ? "1" : "0") << ','
+      << fmt(out.H_A_nats) << ',' << fmt(out.H_B_nats) << ','
+      << fmt(out.dG_A_kcal) << ',' << fmt(out.dG_B_kcal) << ','
+      << out.tl_primary << ',' << fmt(out.tl_weight) << ',' << (out.tl_deferred ? "1" : "0") << ','
+      << out.tl_basis << ','
+      << fmt(out.p_elong) << ',' << fmt(out.dG_elong) << ','
+      << (out.sim_c_evaluated ? "1" : "0") << ','
+      << (out.sim_c_gated_in ? "1" : "0") << ','
+      << out.protofibril_state_index << ','
+      << (out.protofibril_structure_updated ? "1" : "0") << '\n';
+}
+
+// ─── run ─────────────────────────────────────────────────────────────────────
+std::vector<std::pair<Checkpoint, CheckpointOutcome>> DualAssemblyRunner::run() {
+    write_csv_header(cfg_.output_csv);
+
+    while (scheduler_.has_next()) {
+        Checkpoint ck = scheduler_.next();
+        CheckpointOutcome out;
+        out.protofibril_state_index = protofibril_state_index_;
+        TrackState& state = track_state_[ck.track_index];
+
+        // Skip transcription tracks for direct docking (eukaryotic decoupling). The
+        // transcription clock remains in the schedule as a synchronisation reference
+        // but does not run Sim A.
+        if (!ck.direct_encounter_allowed) {
+            out.tl_deferred = true;
+            scheduler_.record(ck, out);
+            write_csv_row(cfg_.output_csv, ck, out);
+            continue;
+        }
+
+        // Tunnel / chaperone gate.
+        if (ck.in_tunnel || ck.chaperone_shielded) {
+            out.tl_deferred = true;
+            scheduler_.record(ck, out);
+            write_csv_row(cfg_.output_csv, ck, out);
+            continue;
+        }
+
+        // Generate the truncated nascent-chain PDB for this checkpoint.
+        const std::string chain_pdb = truncate_(cfg_.sequence_fasta, ck.L_k,
+                                                cfg_.nascent_pdb_dir);
+
+        // ── Sim A ───────────────────────────────────────────────────────────
+        // The reciprocal track must exercise the actual backend with swapped
+        // target/ligand order; otherwise it is only a label in the CSV.
+        const bool reciprocal =
+            (ck.role_policy == DockingRolePolicy::ReciprocalControl);
+        const std::string protofibril_pdb = current_protofibril_pdb_;
+        GAResult a = reciprocal
+            ? sim_a_(chain_pdb, protofibril_pdb, ck.L_k, cfg_.temperature_K)
+            : sim_a_(protofibril_pdb, chain_pdb, ck.L_k, cfg_.temperature_K);
+        out.H_A_nats   = shannon_entropy_nats(a.pose_rmsds);
+        out.dG_A_kcal  = free_energy_kcal(a.engine);
+
+        // ── Sim B (only if chain has collapsed at the prior checkpoint) ─────
+        if (state.H_prev_chain_nats < shannon_thermo::kHSC_soft_nats && sim_b_ && !cfg_.monomer_pdb.empty()) {
+            GAResult b = sim_b_(chain_pdb, cfg_.monomer_pdb, ck.L_k, cfg_.temperature_K);
+            out.H_B_nats  = shannon_entropy_nats(b.pose_rmsds);
+            out.dG_B_kcal = free_energy_kcal(b.engine);
+        }
+
+        // ── Sim C (every sim_c_interval checkpoints) ────────────────────────
+        if (cfg_.sim_c_enabled && sim_c_) {
+            ++state.checkpoints_since_sim_c;
+            if (state.checkpoints_since_sim_c >= cfg_.sim_c_interval) {
+                GAResult c = sim_c_(current_protofibril_pdb_, cfg_.monomer_pdb,
+                                    cfg_.temperature_K);
+                out.sim_c_evaluated = true;
+                if (c.engine.size() > 0) {
+                    auto dec   = oracle_.gate(c.engine, cfg_.monomer_conc_M);
+                    out.p_elong = dec.p_elong;
+                    out.dG_elong = dec.dG_elong;
+                    out.sim_c_gated_in = dec.gated_in;
+                    if (dec.gated_in) {
+                        ++protofibril_state_index_;
+                        out.protofibril_state_index = protofibril_state_index_;
+                        if (advance_protofibril_) {
+                            std::string next_protofibril = advance_protofibril_(
+                                current_protofibril_pdb_,
+                                cfg_.monomer_pdb,
+                                protofibril_state_index_);
+                            if (next_protofibril.empty())
+                                throw std::runtime_error("DualAssemblyRunner: protofibril advance returned an empty path");
+                            current_protofibril_pdb_ = std::move(next_protofibril);
+                            out.protofibril_structure_updated = true;
+                        }
+                    }
+                }
+                state.checkpoints_since_sim_c = 0;
+            }
+        }
+
+        // ── T/L discriminator ───────────────────────────────────────────────
+        assign_tl(out.H_A_nats, out.H_B_nats, state.tl_prev, out);
+
+        scheduler_.record(ck, out);
+        write_csv_row(cfg_.output_csv, ck, out);
+
+        state.H_prev_chain_nats = out.H_A_nats;
+        if (!out.tl_deferred) state.tl_prev = out.tl_primary;
+    }
+
+    return scheduler_.history();
+}
+
+} // namespace natural

--- a/LIB/NATURaL/DualAssemblyRunner.h
+++ b/LIB/NATURaL/DualAssemblyRunner.h
@@ -1,0 +1,139 @@
+// DualAssemblyRunner.h — Top-level cotranslational docking driver
+//
+// Orchestrates Sim A / Sim B / Sim C across NATURaL tracks with the Shannon-driven
+// pose-collapse role discriminator. The GA backend is injected as a std::function so
+// the runner has no compile-time dependency on the FlexAID GA machinery. Unit tests
+// and the current CLI inject synthetic engines; production GA wiring is a separate
+// backend integration step.
+//
+// References: docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md §3, §5.3
+//
+// Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "FibrilGrowthOracle.h"
+#include "NascentChainScheduler.h"
+#include "../statmech.h"
+
+#include <functional>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace natural {
+
+// ─── Configuration ───────────────────────────────────────────────────────────
+struct DualAssemblyConfig {
+    std::string protofibril_pdb;            // required
+    std::string monomer_pdb;                // required if sim_c_enabled
+    std::string sequence_fasta;             // required (1-letter)
+    int         transcript_nt              = 0;          // 0 = derived from sequence × 3
+    int         checkpoint_interval        = 10;
+    int         sim_c_interval             = 5;
+    double      monomer_conc_M             = 1.0e-6;     // 1 µM cytosolic free monomer
+    double      temperature_K              = 310.15;     // 37 °C
+    int         n_threads                  = 6;
+    bool        include_reciprocal_controls = true;
+    bool        sim_c_enabled               = true;
+    std::string output_csv                  = "cotranslational_trajectory.csv";
+    std::string nascent_pdb_dir             = ".";
+    double      acceptance_threshold        = 0.5;
+};
+
+// ─── GA-backend callback signatures ──────────────────────────────────────────
+// The runner asks the backend to run one GA and return a populated StatMechEngine
+// along with a flat vector of per-pose coordinates used to bin Shannon entropy.
+// This entropy is a pose-ensemble collapse metric, not intrinsic conformational
+// entropy of either isolated molecule.
+struct GAResult {
+    statmech::StatMechEngine engine;
+    std::vector<double>      pose_rmsds; // any continuous pose coordinate; 1D is enough
+};
+
+// Sim A — target = protofibril, ligand = nascent chain at length L_k
+using SimAFn = std::function<GAResult(const std::string& target_pdb,
+                                       const std::string& ligand_chain_pdb,
+                                       int                L_k,
+                                       double             temperature_K)>;
+
+// Sim B — target = nascent chain, ligand = monomer
+using SimBFn = std::function<GAResult(const std::string& target_chain_pdb,
+                                       const std::string& monomer_pdb,
+                                       int                L_k,
+                                       double             temperature_K)>;
+
+// Sim C — target = protofibril, ligand = free monomer
+using SimCFn = std::function<GAResult(const std::string& target_pdb,
+                                       const std::string& monomer_pdb,
+                                       double             temperature_K)>;
+
+// Nascent-chain truncation helper — given the full sequence and a length L_k, return
+// the absolute path of the truncated PDB (the helper writes it to disk under
+// cfg.nascent_pdb_dir). MVP: idealised extended geometry.
+using TruncateFn = std::function<std::string(const std::string& sequence,
+                                              int                L_k,
+                                              const std::string& output_dir)>;
+
+// Optional protofibril-state updater. Called only when Sim C accepts elongation.
+// Return the PDB path to use as the protofibril target for subsequent checkpoints.
+using ProtofibrilAdvanceFn = std::function<std::string(const std::string& current_protofibril_pdb,
+                                                       const std::string& monomer_pdb,
+                                                       int                next_state_index)>;
+
+// ─── Runner ──────────────────────────────────────────────────────────────────
+class DualAssemblyRunner {
+public:
+    DualAssemblyRunner(DualAssemblyConfig cfg,
+                       SimAFn             sim_a,
+                       SimBFn             sim_b,
+                       SimCFn             sim_c,
+                       TruncateFn         truncate,
+                       ProtofibrilAdvanceFn advance_protofibril = nullptr);
+
+    // Run the full trajectory. Writes the CSV to cfg.output_csv as it advances and
+    // returns the per-checkpoint history.
+    std::vector<std::pair<Checkpoint, CheckpointOutcome>> run();
+
+    const NascentChainScheduler& scheduler() const noexcept { return scheduler_; }
+
+    // ── Static pose-entropy role discriminator (exposed for unit tests) ─────
+    static void assign_tl(double             H_A_nats,
+                          double             H_B_nats,
+                          char               prev_tl,
+                          CheckpointOutcome& out) noexcept;
+
+private:
+    struct TrackState {
+        double H_prev_chain_nats = std::numeric_limits<double>::infinity();
+        char   tl_prev           = '?';
+        int    checkpoints_since_sim_c = 0;
+    };
+
+    DualAssemblyConfig                  cfg_;
+    NascentChainScheduler               scheduler_;
+    FibrilGrowthOracle                  oracle_;
+    SimAFn                              sim_a_;
+    SimBFn                              sim_b_;
+    SimCFn                              sim_c_;
+    TruncateFn                          truncate_;
+    std::unordered_map<int, TrackState> track_state_;
+    ProtofibrilAdvanceFn                advance_protofibril_;
+    std::string                         current_protofibril_pdb_;
+    int                                 protofibril_state_index_ = 0;
+
+    // Shannon entropy in nats from a population of pose coordinates. Wraps
+    // shannon_thermo::compute_shannon_entropy with a default bin count.
+    static double shannon_entropy_nats(const std::vector<double>& values);
+
+    // ΔG = compute().free_energy. Returns NaN if engine is empty.
+    static double free_energy_kcal(const statmech::StatMechEngine& engine);
+
+    void write_csv_header(const std::string& path) const;
+    void write_csv_row(const std::string& path,
+                       const Checkpoint& ck,
+                       const CheckpointOutcome& out) const;
+};
+
+} // namespace natural

--- a/LIB/NATURaL/FibrilGrowthOracle.cpp
+++ b/LIB/NATURaL/FibrilGrowthOracle.cpp
@@ -1,0 +1,54 @@
+// FibrilGrowthOracle.cpp — see header for design.
+//
+// Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+#include "FibrilGrowthOracle.h"
+
+#include <cmath>
+#include <stdexcept>
+
+namespace natural {
+
+FibrilGrowthOracle::FibrilGrowthOracle(double temperature_K,
+                                       double acceptance_threshold)
+    : T_K_(temperature_K),
+      acceptance_threshold_(acceptance_threshold),
+      Xi_(std::make_unique<target::GrandPartitionFunction>(temperature_K))
+{
+    if (!(T_K_ > 0.0))
+        throw std::invalid_argument("FibrilGrowthOracle: temperature must be > 0");
+    if (acceptance_threshold_ < 0.0 || acceptance_threshold_ > 1.0)
+        throw std::invalid_argument("FibrilGrowthOracle: acceptance_threshold must be in [0,1]");
+}
+
+ElongationDecision FibrilGrowthOracle::gate(
+    const statmech::StatMechEngine& monomer_engine,
+    double                          c_monomer_M)
+{
+    if (!(c_monomer_M > 0.0))
+        throw std::invalid_argument("FibrilGrowthOracle: c_monomer_M must be > 0");
+
+    // ln Z = -F / (kT), with kT in kcal/mol.
+    const auto th = monomer_engine.compute();
+    const double kT_kcal = statmech::kB_kcal * T_K_;
+    const double log_Z   = -th.free_energy / kT_kcal;
+
+    // Replace any prior "monomer" entry with the fresh ensemble at the current
+    // concentration. add_or_overwrite is thread-safe and avoids the TOCTOU race.
+    Xi_->add_or_overwrite("monomer", log_Z, c_monomer_M);
+
+    const double p_elong  = Xi_->binding_probability("monomer");
+    // Apparent concentration-corrected elongation free energy:
+    //   ΔG_app = -kT ln Z + kT ln(c°/c)
+    // GrandPartitionFunction::delta_G_bind() is concentration-independent by
+    // design, so apply the cratic term explicitly here.
+    const double F_bound = Xi_->delta_G_bind("monomer", /*F_ref=*/0.0);
+    const double dG_elong = F_bound + kT_kcal * std::log(target::c_standard / c_monomer_M);
+
+    return ElongationDecision{
+        .p_elong  = p_elong,
+        .dG_elong = dG_elong,
+        .gated_in = (p_elong >= acceptance_threshold_),
+    };
+}
+
+} // namespace natural

--- a/LIB/NATURaL/FibrilGrowthOracle.h
+++ b/LIB/NATURaL/FibrilGrowthOracle.h
@@ -1,0 +1,54 @@
+// FibrilGrowthOracle.h — Grand canonical fibril elongation gate
+//
+// For protofibril_n + monomer ⇌ protofibril_{n+1}, the grand partition function
+//   Ξ = 1 + z · Z,  z = c_monomer / c°
+// gives p(elongation) = z·Z / Ξ and ΔG_elong = −kT ln Z + kT ln(c°/c_monomer).
+//
+// Reuses target::GrandPartitionFunction (see LIB/GrandPartitionFunction.h:46), which
+// already provides log-space arithmetic and concentration-aware fugacities.
+//
+// References: docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md §3
+//
+// Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "../GrandPartitionFunction.h"
+#include "../statmech.h"
+
+#include <memory>
+
+namespace natural {
+
+struct ElongationDecision {
+    double p_elong;   // ∈ [0, 1)
+    double dG_elong;  // kcal/mol — apparent ΔG at configured monomer concentration
+    bool   gated_in;  // p_elong ≥ acceptance_threshold
+};
+
+class FibrilGrowthOracle {
+public:
+    explicit FibrilGrowthOracle(double temperature_K       = 310.15,
+                                double acceptance_threshold = 0.5);
+
+    // Returns the elongation decision for the current monomer ensemble.
+    //
+    // monomer_engine: StatMechEngine populated by a Sim C GA run, with the protofibril
+    //                 as receptor and a single free monomer as ligand. Internally we
+    //                 derive ln Z from the engine's free energy: ln Z = -F / (kT).
+    // c_monomer_M:    free monomer concentration in Molar. Default = 1 µM, the upper
+    //                 bound for physiological cytosolic free Aβ42 (Bjorkdahl 2008).
+    ElongationDecision gate(const statmech::StatMechEngine& monomer_engine,
+                            double                          c_monomer_M = 1.0e-6);
+
+    double temperature_K()        const noexcept { return T_K_; }
+    double acceptance_threshold() const noexcept { return acceptance_threshold_; }
+
+private:
+    double T_K_;
+    double acceptance_threshold_;
+    // Single-ligand GrandPartitionFunction. We re-register the monomer entry on each
+    // gate() call so a fresh Sim C ensemble overwrites the previous Z.
+    std::unique_ptr<target::GrandPartitionFunction> Xi_;
+};
+
+} // namespace natural

--- a/LIB/NATURaL/NATURaLDualAssembly.cpp
+++ b/LIB/NATURaL/NATURaLDualAssembly.cpp
@@ -36,6 +36,7 @@
 #include <numeric>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 #include <vector>
 
 #include <Eigen/Dense>
@@ -117,6 +118,224 @@ NATURaLConfig auto_configure(const atom*  atoms,
                   << "]\n";
     }
     return cfg;
+}
+
+// ─── human protofibril parallel protocol helpers ────────────────────────────
+
+double InVivoAssemblyTrack::dwell_time_s() const noexcept {
+    return (std::isfinite(mean_elongation_rate) && mean_elongation_rate > 1e-12)
+        ? 1.0 / mean_elongation_rate
+        : 0.0;
+}
+
+double InVivoAssemblyTrack::completion_time_s() const noexcept {
+    if (chain_length <= 0) return 0.0;
+    double init_wait = (std::isfinite(initiation_rate) && initiation_rate > 1e-12)
+        ? 1.0 / initiation_rate
+        : 0.0;
+    return init_wait + chain_length * dwell_time_s();
+}
+
+double InVivoAssemblyTrack::first_exposed_time_s() const noexcept {
+    if (chain_length <= 0) return 0.0;
+    double init_wait = (std::isfinite(initiation_rate) && initiation_rate > 1e-12)
+        ? 1.0 / initiation_rate
+        : 0.0;
+    int first_exposed_unit = static_cast<int>(std::floor(tunnel_length)) + 1;
+    first_exposed_unit = std::clamp(first_exposed_unit, 1, chain_length);
+    return init_wait + first_exposed_unit * dwell_time_s();
+}
+
+std::vector<InVivoAssemblyTrack> make_human_protofibril_tracks(
+    int transcript_nt,
+    int peptide_aa,
+    bool include_reciprocal_controls)
+{
+    if (transcript_nt < 0 || peptide_aa < 0)
+        throw std::invalid_argument("NATURaL protofibril tracks require non-negative chain lengths");
+
+    std::vector<InVivoAssemblyTrack> tracks;
+    tracks.reserve(include_reciprocal_controls ? 4 : 2);
+
+    auto add_track = [&](std::string name,
+                         GrowthProcess process,
+                         DockingRolePolicy role,
+                         int chain_length) {
+        if (chain_length <= 0) return;
+
+        const bool is_tx = (process == GrowthProcess::Transcription);
+        InVivoAssemblyTrack tr;
+        tr.name = std::move(name);
+        tr.process = process;
+        tr.role_policy = role;
+        tr.chain_length = chain_length;
+        tr.mean_elongation_rate = is_tx
+            ? ribosome::MEAN_NT_RATE_HUMAN
+            : ribosome::MEAN_EL_RATE_HUMAN;
+        tr.initiation_rate = is_tx
+            ? ribosome::K_RNAP_INI_DEFAULT
+            : ribosome::K_INI_DEFAULT;
+        tr.tunnel_length = is_tx
+            ? ribosome::RNAP_TUNNEL_NT
+            : ribosome::TUNNEL_LENGTH_AA;
+        tr.protofibril_is_target = (role == DockingRolePolicy::ProtofibrilAsTarget);
+        tr.compartment = is_tx ? "nucleus" : "cytosol/ER";
+
+        // Eukaryotic transcription and translation are not bacterial-style
+        // coupled. Keep the RNAP clock in the parallel schedule, but do not
+        // claim direct physical protofibril encounter during nuclear transcript
+        // synthesis unless a caller explicitly overrides this field.
+        tr.direct_encounter_allowed = !is_tx;
+        tracks.push_back(std::move(tr));
+    };
+
+    add_track("protofibril_target__nascent_rna_ligand",
+              GrowthProcess::Transcription,
+              DockingRolePolicy::ProtofibrilAsTarget,
+              transcript_nt);
+    add_track("protofibril_target__nascent_peptide_ligand",
+              GrowthProcess::Translation,
+              DockingRolePolicy::ProtofibrilAsTarget,
+              peptide_aa);
+
+    if (include_reciprocal_controls) {
+        add_track("reciprocal_control__rna_target__protofibril_ligand",
+                  GrowthProcess::Transcription,
+                  DockingRolePolicy::ReciprocalControl,
+                  transcript_nt);
+        add_track("reciprocal_control__peptide_target__protofibril_ligand",
+                  GrowthProcess::Translation,
+                  DockingRolePolicy::ReciprocalControl,
+                  peptide_aa);
+    }
+
+    return tracks;
+}
+
+std::vector<ParallelGrowthEvent> build_parallel_growth_schedule(
+    const std::vector<InVivoAssemblyTrack>& tracks)
+{
+    std::vector<ParallelGrowthEvent> events;
+    int total_units = 0;
+    for (const auto& tr : tracks) {
+        if (tr.chain_length < 0)
+            throw std::invalid_argument("NATURaL parallel schedule received a negative chain length");
+        total_units += tr.chain_length;
+    }
+    events.reserve(total_units);
+
+    for (int ti = 0; ti < static_cast<int>(tracks.size()); ++ti) {
+        const auto& tr = tracks[ti];
+        if (tr.chain_length <= 0) continue;
+        if (!std::isfinite(tr.mean_elongation_rate) || tr.mean_elongation_rate <= 0.0)
+            throw std::invalid_argument("NATURaL parallel schedule requires positive elongation rates");
+
+        double init_wait = (std::isfinite(tr.initiation_rate) && tr.initiation_rate > 1e-12)
+            ? 1.0 / tr.initiation_rate
+            : 0.0;
+        double dwell = 1.0 / tr.mean_elongation_rate;
+        int hidden_units = static_cast<int>(std::floor(std::max(0.0, tr.tunnel_length)));
+
+        for (int unit = 1; unit <= tr.chain_length; ++unit) {
+            int exposed = std::max(0, unit - hidden_units);
+            events.push_back({
+                ti,
+                unit,
+                init_wait + unit * dwell,
+                exposed,
+                tr.process,
+                tr.role_policy
+            });
+        }
+    }
+
+    std::stable_sort(events.begin(), events.end(),
+        [](const ParallelGrowthEvent& a, const ParallelGrowthEvent& b) {
+            if (a.t_arrival != b.t_arrival) return a.t_arrival < b.t_arrival;
+            if (a.track_index != b.track_index) return a.track_index < b.track_index;
+            return a.unit_index < b.unit_index;
+        });
+
+    return events;
+}
+
+// ─── growth_entropy_nats ─────────────────────────────────────────────────────
+// Shannon entropy of the CF distribution accumulated along the growth trajectory.
+// Returns dimensionless nats. Convert to bits only at reporting boundaries.
+// Dispatches to AVX-512 → AVX2 → Eigen → scalar for the histogram fill.
+double growth_entropy_nats(const std::vector<double>& cf_trajectory)
+{
+    if (cf_trajectory.empty()) return 0.0;
+
+    double min_cf = *std::min_element(cf_trajectory.begin(), cf_trajectory.end());
+    double max_cf = *std::max_element(cf_trajectory.begin(), cf_trajectory.end());
+    if (max_cf - min_cf < 1e-8) return 0.0;
+
+    constexpr int BINS = 32;
+    double bw  = (max_cf - min_cf) / BINS + 1e-10;
+    double inv_bw = 1.0 / bw;
+
+    std::array<int, BINS> counts{};
+    int total = static_cast<int>(cf_trajectory.size());
+
+#if defined(FLEXAIDS_USE_AVX512) && defined(__AVX512F__)
+    {
+        __m512d v_min  = _mm512_set1_pd(min_cf);
+        __m512d v_ibw  = _mm512_set1_pd(inv_bw);
+        __m512d v_bmax = _mm512_set1_pd(static_cast<double>(BINS - 1));
+        int i = 0, n = total;
+        for (; i + 8 <= n; i += 8) {
+            __m512d v    = _mm512_loadu_pd(cf_trajectory.data() + i);
+            __m512d off  = _mm512_sub_pd(v, v_min);
+            __m512d bins = _mm512_mul_pd(off, v_ibw);
+            bins = _mm512_max_pd(_mm512_setzero_pd(),
+                                 _mm512_min_pd(bins, v_bmax));
+            __m256i bi = _mm512_cvttpd_epi32(bins);
+            alignas(32) int bvals[8];
+            _mm256_store_si256(reinterpret_cast<__m256i*>(bvals), bi);
+            for (int j = 0; j < 8; ++j) counts[bvals[j]]++;
+        }
+        for (; i < n; ++i) {
+            int b = static_cast<int>((cf_trajectory[i] - min_cf) * inv_bw);
+            b = std::clamp(b, 0, BINS - 1);
+            counts[b]++;
+        }
+    }
+#elif defined(__AVX2__)
+    {
+        __m256d v_min  = _mm256_set1_pd(min_cf);
+        __m256d v_ibw  = _mm256_set1_pd(inv_bw);
+        int i = 0, n = total;
+        for (; i + 4 <= n; i += 4) {
+            __m256d v   = _mm256_loadu_pd(cf_trajectory.data() + i);
+            __m256d off = _mm256_sub_pd(v, v_min);
+            __m256d bv  = _mm256_mul_pd(off, v_ibw);
+            alignas(32) double bvals[4];
+            _mm256_store_pd(bvals, bv);
+            for (int j = 0; j < 4; ++j) {
+                int b = static_cast<int>(bvals[j]);
+                counts[std::clamp(b, 0, BINS - 1)]++;
+            }
+        }
+        for (; i < n; ++i) {
+            int b = static_cast<int>((cf_trajectory[i] - min_cf) * inv_bw);
+            counts[std::clamp(b, 0, BINS - 1)]++;
+        }
+    }
+#else
+    {
+        Eigen::Map<const Eigen::ArrayXd> vals(cf_trajectory.data(), total);
+        Eigen::ArrayXd bins = ((vals - min_cf) * inv_bw).floor().cwiseMax(0).cwiseMin(BINS - 1);
+        for (int i = 0; i < total; ++i)
+            counts[static_cast<int>(bins(i))]++;
+    }
+#endif
+
+    Eigen::ArrayXd prob(BINS);
+    for (int i = 0; i < BINS; ++i) prob(i) = (double)counts[i] / total;
+    Eigen::ArrayXd safe_p   = (prob > 1e-15).select(prob, Eigen::ArrayXd::Ones(BINS));
+    Eigen::ArrayXd log_p    = (prob > 1e-15).select(safe_p.log(), Eigen::ArrayXd::Zero(BINS));
+    return -(prob * log_p).sum();
 }
 
 // ─── build elongation model from config ──────────────────────────────────────
@@ -287,6 +506,14 @@ static std::vector<ribosome::BurstUnit> detect_burst_units(
 }
 
 // ─── DualAssemblyEngine ──────────────────────────────────────────────────────
+//
+// The full DualAssemblyEngine implementation depends on the FlexAID Vcontacts/
+// vcfunction scoring stack. The standalone `dual_assembly` CLI does NOT use the
+// in-process engine (it injects synthetic or external GA callbacks instead) and
+// therefore defines FLEXAIDS_OMIT_DUAL_ASSEMBLY_ENGINE to skip the heavy
+// dependency graph. Other targets (FlexAID, test_natural) leave the macro
+// undefined and link the full engine.
+#ifndef FLEXAIDS_OMIT_DUAL_ASSEMBLY_ENGINE
 
 DualAssemblyEngine::DualAssemblyEngine(const NATURaLConfig& cfg,
                                          FA_Global* FA, VC_Global* VC,
@@ -473,6 +700,8 @@ std::vector<DualAssemblyEngine::GrowthStep> DualAssemblyEngine::run() {
     std::vector<double> cf_trajectory;
     cf_trajectory.reserve(max_steps);
     double cumulative_dG = 0.0;
+    double weighted_dG_sum = 0.0;
+    double dwell_sum = 0.0;
 
     for (int step = 0; step < max_steps; ++step) {
         // Elongation kinetics at this residue
@@ -517,15 +746,13 @@ std::vector<DualAssemblyEngine::GrowthStep> DualAssemblyEngine::run() {
         double cf = compute_partial_cf(step + 1);
         cf_trajectory.push_back(cf);
 
-        // Shannon entropy over the growing CF ensemble
+        // Shannon entropy over the growing CF ensemble, dimensionless nats.
         double S_growth = compute_growth_entropy(cf_trajectory);
 
-        // Incremental ΔG: ΔH from CF + (−T·ΔS) entropy term, time-weighted
-        const double kT = 0.001987206 * config_.temperature_K;
-        double delta_dG = cf - kT * S_growth;
-        // Weight by dwell time: intermediates sampled longer contribute more
-        delta_dG *= dwell_time;
-        cumulative_dG += delta_dG;
+        // Instantaneous ΔG estimate: ΔH from CF + (−T·ΔS) entropy term.
+        // kT [kcal/mol] × H [nats] stays in kcal/mol.
+        const double kT = statmech::kB_kcal * config_.temperature_K;
+        double step_dG = cf - kT * S_growth;
 
         // ── TM translocon insertion check ─────────────────────────────────────
         bool   tm_inserted   = false;
@@ -537,10 +764,16 @@ std::vector<DualAssemblyEngine::GrowthStep> DualAssemblyEngine::run() {
             tm_inserted  = win.is_inserted;
             tm_insert_dG = win.deltaG_insert;
             if (tm_inserted) {
-                // Include translocon ΔG contribution (time-weighted)
-                cumulative_dG += tm_insert_dG * dwell_time;
+                // Include translocon ΔG in the instantaneous kcal/mol score.
+                step_dG += tm_insert_dG;
             }
         }
+
+        // Time-weighted mean over growth intermediates. The accumulator is
+        // kcal·s/mol internally, but the reported correction remains kcal/mol.
+        weighted_dG_sum += step_dG * dwell_time;
+        dwell_sum += dwell_time;
+        cumulative_dG = (dwell_sum > 0.0) ? (weighted_dG_sum / dwell_sum) : step_dG;
 
         trajectory.push_back({
             step,
@@ -614,90 +847,14 @@ double DualAssemblyEngine::compute_partial_cf(int n_grown_residues) const {
 
 // ─── compute_growth_entropy ───────────────────────────────────────────────────
 // Shannon entropy of the CF distribution accumulated along the growth trajectory.
+// Returns dimensionless nats. Convert to bits only at reporting boundaries.
 // Dispatches to AVX-512 → AVX2 → Eigen → scalar for the histogram fill.
 double DualAssemblyEngine::compute_growth_entropy(
     const std::vector<double>& cf_trajectory) const
 {
-    if (cf_trajectory.empty()) return 0.0;
-
-    double min_cf = *std::min_element(cf_trajectory.begin(), cf_trajectory.end());
-    double max_cf = *std::max_element(cf_trajectory.begin(), cf_trajectory.end());
-    if (max_cf - min_cf < 1e-8) return 0.0;
-
-    constexpr int BINS = 32;
-    double bw  = (max_cf - min_cf) / BINS + 1e-10;
-    double inv_bw = 1.0 / bw;
-
-    std::array<int, BINS> counts{};
-    int total = static_cast<int>(cf_trajectory.size());
-
-#if defined(FLEXAIDS_USE_AVX512) && defined(__AVX512F__)
-    // AVX-512: process 8 doubles per cycle
-    {
-        __m512d v_min  = _mm512_set1_pd(min_cf);
-        __m512d v_ibw  = _mm512_set1_pd(inv_bw);
-        __m512d v_bmax = _mm512_set1_pd(static_cast<double>(BINS - 1));
-        int i = 0, n = total;
-        for (; i + 8 <= n; i += 8) {
-            __m512d v    = _mm512_loadu_pd(cf_trajectory.data() + i);
-            __m512d off  = _mm512_sub_pd(v, v_min);
-            __m512d bins = _mm512_mul_pd(off, v_ibw);
-            bins = _mm512_max_pd(_mm512_setzero_pd(),
-                                 _mm512_min_pd(bins, v_bmax));
-            __m256i bi = _mm512_cvttpd_epi32(bins);
-            alignas(32) int bvals[8];
-            _mm256_store_si256(reinterpret_cast<__m256i*>(bvals), bi);
-            for (int j = 0; j < 8; ++j) counts[bvals[j]]++;
-        }
-        for (; i < n; ++i) {
-            int b = static_cast<int>((cf_trajectory[i] - min_cf) * inv_bw);
-            b = std::clamp(b, 0, BINS - 1);
-            counts[b]++;
-        }
-    }
-#elif defined(__AVX2__)
-    // AVX2: process 4 doubles per cycle
-    {
-        __m256d v_min  = _mm256_set1_pd(min_cf);
-        __m256d v_ibw  = _mm256_set1_pd(inv_bw);
-        int i = 0, n = total;
-        for (; i + 4 <= n; i += 4) {
-            __m256d v   = _mm256_loadu_pd(cf_trajectory.data() + i);
-            __m256d off = _mm256_sub_pd(v, v_min);
-            __m256d bv  = _mm256_mul_pd(off, v_ibw);
-            alignas(32) double bvals[4];
-            _mm256_store_pd(bvals, bv);
-            for (int j = 0; j < 4; ++j) {
-                int b = static_cast<int>(bvals[j]);
-                counts[std::clamp(b, 0, BINS - 1)]++;
-            }
-        }
-        for (; i < n; ++i) {
-            int b = static_cast<int>((cf_trajectory[i] - min_cf) * inv_bw);
-            counts[std::clamp(b, 0, BINS - 1)]++;
-        }
-    }
-#else
-    // Eigen: vectorised offset and scale; scalar bin accumulation
-    {
-        Eigen::Map<const Eigen::ArrayXd> vals(cf_trajectory.data(), total);
-        Eigen::ArrayXd bins = ((vals - min_cf) * inv_bw).floor().cwiseMax(0).cwiseMin(BINS - 1);
-        for (int i = 0; i < total; ++i)
-            counts[static_cast<int>(bins(i))]++;
-    }
-#endif
-
-    // Shannon entropy: H = -Σ p_i log2(p_i)
-    double H = 0.0;
-    const double log2_inv = 1.0 / std::log(2.0);
-
-    Eigen::ArrayXd prob(BINS);
-    for (int i = 0; i < BINS; ++i) prob(i) = (double)counts[i] / total;
-    Eigen::ArrayXd safe_p   = (prob > 1e-15).select(prob, Eigen::ArrayXd::Ones(BINS));
-    Eigen::ArrayXd log_p    = (prob > 1e-15).select(safe_p.log(), Eigen::ArrayXd::Zero(BINS));
-    H = -(prob * log_p).sum() * log2_inv;
-
-    return H;
+    return growth_entropy_nats(cf_trajectory);
 }
+
+#endif // FLEXAIDS_OMIT_DUAL_ASSEMBLY_ENGINE
 
 } // namespace natural

--- a/LIB/NATURaL/NATURaLDualAssembly.h
+++ b/LIB/NATURaL/NATURaLDualAssembly.h
@@ -89,6 +89,60 @@ NATURaLConfig auto_configure(const atom*  atoms,
                               const resid* residues,
                               int          n_residues);
 
+// ─── Human in-vivo protofibril protocol planning ────────────────────────────
+//
+// A protofibril is best treated as the fixed docking scaffold when the nascent
+// chain is the growing, high-entropy object. Reciprocal role swaps are still
+// useful controls because FlexAID target/ligand machinery is not perfectly
+// symmetric.
+enum class GrowthProcess {
+    Transcription,  // RNAP II, nucleotide-by-nucleotide
+    Translation     // 80S ribosome, amino-acid-by-amino-acid
+};
+
+enum class DockingRolePolicy {
+    ProtofibrilAsTarget,
+    ReciprocalControl
+};
+
+struct InVivoAssemblyTrack {
+    std::string       name;
+    GrowthProcess     process = GrowthProcess::Translation;
+    DockingRolePolicy role_policy = DockingRolePolicy::ProtofibrilAsTarget;
+    int               chain_length = 0;       // nt for transcription, aa for translation
+    double            mean_elongation_rate = 0.0; // nt/s or aa/s
+    double            initiation_rate = 0.0;  // s^-1
+    double            tunnel_length = 0.0;    // RNAP hybrid nt or ribosome tunnel aa
+    bool              protofibril_is_target = true;
+    bool              direct_encounter_allowed = true;
+    std::string       compartment;
+
+    double dwell_time_s() const noexcept;
+    double completion_time_s() const noexcept;
+    double first_exposed_time_s() const noexcept;
+};
+
+struct ParallelGrowthEvent {
+    int           track_index = -1;
+    int           unit_index = 0;       // 1-based nt/aa index
+    double        t_arrival = 0.0;      // seconds since initiation gate
+    int           exposed_units = 0;    // units outside polymerase/ribosome tunnel
+    GrowthProcess process = GrowthProcess::Translation;
+    DockingRolePolicy role_policy = DockingRolePolicy::ProtofibrilAsTarget;
+};
+
+std::vector<InVivoAssemblyTrack> make_human_protofibril_tracks(
+    int  transcript_nt,
+    int  peptide_aa,
+    bool include_reciprocal_controls = true);
+
+std::vector<ParallelGrowthEvent> build_parallel_growth_schedule(
+    const std::vector<InVivoAssemblyTrack>& tracks);
+
+// Shannon entropy of the Contact Function growth trajectory, returned in nats.
+// This is intentionally testable because it feeds kT*H free-energy arithmetic.
+double growth_entropy_nats(const std::vector<double>& cf_trajectory);
+
 // ─── DualAssembly engine ─────────────────────────────────────────────────────
 class DualAssemblyEngine {
 public:
@@ -108,9 +162,9 @@ public:
         bool   is_pause_site;     // rate < RIBOSOME_PAUSE_THRESHOLD of mean → folding window
         bool   in_tunnel;         // residue still inside ribosomal exit tunnel
         double cf_score;          // Contact Function (kcal/mol)
-        double shannon_entropy;   // bits
+        double shannon_entropy;   // dimensionless nats
         double p_cotrans_folded;  // k_fold/(k_fold+k_el) co-translational folding prob
-        double cumulative_deltaG; // kcal/mol (time-weighted)
+        double cumulative_deltaG; // kcal/mol (time-weighted mean)
         bool   tm_inserted;       // true if TM helix has been laterally gated
         double tm_insertion_dG;   // ΔG of translocon-mediated insertion (kcal/mol)
 
@@ -144,7 +198,7 @@ private:
     // Compute a lightweight CF score for the current partial complex
     double compute_partial_cf(int n_grown_residues) const;
 
-    // Compute Shannon entropy over accumulated growth ensemble
+    // Compute Shannon entropy over accumulated growth ensemble, returned in nats.
     double compute_growth_entropy(const std::vector<double>& cf_trajectory) const;
 
     // Hill equation: k_eff = k_max × [Mg]ⁿ / (K_d ⁿ + [Mg]ⁿ)

--- a/LIB/NATURaL/NascentChainScheduler.cpp
+++ b/LIB/NATURaL/NascentChainScheduler.cpp
@@ -1,0 +1,80 @@
+// NascentChainScheduler.cpp — see header for design.
+//
+// Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+#include "NascentChainScheduler.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace natural {
+
+NascentChainScheduler::NascentChainScheduler(
+    std::vector<InVivoAssemblyTrack> tracks,
+    int                              checkpoint_interval,
+    int                              chaperone_skip_residues)
+    : tracks_(std::move(tracks)),
+      interval_(checkpoint_interval),
+      chaperone_skip_(chaperone_skip_residues)
+{
+    if (interval_ <= 0)
+        throw std::invalid_argument("NascentChainScheduler: checkpoint_interval must be > 0");
+
+    for (int ti = 0; ti < static_cast<int>(tracks_.size()); ++ti) {
+        const auto& tr = tracks_[ti];
+        if (tr.chain_length <= 0) continue;
+        if (!std::isfinite(tr.mean_elongation_rate) || tr.mean_elongation_rate <= 0.0)
+            throw std::invalid_argument("NascentChainScheduler: positive elongation rate required");
+
+        const double dwell = 1.0 / tr.mean_elongation_rate;
+        const double init_wait = (std::isfinite(tr.initiation_rate) && tr.initiation_rate > 1e-12)
+            ? 1.0 / tr.initiation_rate
+            : 0.0;
+        // tunnel measured in process-native units (aa for ribosome, nt for RNAP).
+        const double tunnel_units = std::max(0.0, tr.tunnel_length);
+
+        // First checkpoint at L = tunnel + 6 (first solvent-exposed residue past the
+        // NAC/SSB region), then every interval_ units up to chain_length.
+        const int first_L = static_cast<int>(std::floor(tunnel_units)) + chaperone_skip_;
+        for (int L = first_L; L <= tr.chain_length; L += interval_) {
+            Checkpoint ck;
+            ck.idx              = static_cast<int>(schedule_.size());
+            ck.L_k              = L;
+            ck.t_arrival_s      = init_wait + L * dwell;
+            ck.process          = tr.process;
+            ck.role_policy      = tr.role_policy;
+            ck.track_index      = ti;
+            ck.track_name       = tr.name;
+            ck.in_tunnel        = static_cast<double>(L) <= tunnel_units;
+            ck.chaperone_shielded = (static_cast<double>(L) - tunnel_units) < chaperone_skip_;
+            ck.direct_encounter_allowed = tr.direct_encounter_allowed;
+            schedule_.push_back(std::move(ck));
+        }
+    }
+
+    // Sort by (t_arrival, track_index) so the parallel timeline is monotone.
+    std::stable_sort(schedule_.begin(), schedule_.end(),
+                     [](const Checkpoint& a, const Checkpoint& b) {
+                         if (a.t_arrival_s != b.t_arrival_s) return a.t_arrival_s < b.t_arrival_s;
+                         return a.track_index < b.track_index;
+                     });
+    // Re-number idx in sorted order so consumers see a stable monotone sequence.
+    for (int i = 0; i < static_cast<int>(schedule_.size()); ++i)
+        schedule_[i].idx = i;
+}
+
+bool NascentChainScheduler::has_next() const noexcept {
+    return cursor_ < static_cast<int>(schedule_.size());
+}
+
+Checkpoint NascentChainScheduler::next() {
+    if (!has_next())
+        throw std::out_of_range("NascentChainScheduler: schedule exhausted");
+    return schedule_[cursor_++];
+}
+
+void NascentChainScheduler::record(const Checkpoint& ck, CheckpointOutcome out) {
+    history_.emplace_back(ck, std::move(out));
+}
+
+} // namespace natural

--- a/LIB/NATURaL/NascentChainScheduler.h
+++ b/LIB/NATURaL/NascentChainScheduler.h
@@ -1,0 +1,97 @@
+// NascentChainScheduler.h — Checkpoint scheduling for cotranslational docking
+//
+// Wraps natural::build_parallel_growth_schedule(tracks) into an iterator that emits
+// one Checkpoint per chain length L_k spaced at a user-configurable interval. Pure
+// scheduling logic — no GA dependency. The DualAssemblyRunner records outcomes back
+// against each checkpoint as it advances.
+//
+// References: see docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md §5.1
+//
+// Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "NATURaLDualAssembly.h"
+
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace natural {
+
+// ─── Checkpoint ──────────────────────────────────────────────────────────────
+struct Checkpoint {
+    int               idx              = -1;     // 0-based checkpoint index
+    int               L_k              = 0;      // chain length (aa or nt)
+    double            t_arrival_s      = 0.0;    // real-time since initiation
+    GrowthProcess     process          = GrowthProcess::Translation;
+    DockingRolePolicy role_policy      = DockingRolePolicy::ProtofibrilAsTarget;
+    int               track_index      = -1;
+    std::string       track_name;
+    bool              in_tunnel        = false;  // L_k ≤ tunnel_length
+    bool              chaperone_shielded = false; // L_k - tunnel_length < 6
+    // True for transcription tracks in eukaryotic cells (no direct protofibril encounter
+    // during nuclear synthesis). Mirrors InVivoAssemblyTrack::direct_encounter_allowed.
+    bool              direct_encounter_allowed = true;
+};
+
+// ─── CheckpointOutcome ───────────────────────────────────────────────────────
+struct CheckpointOutcome {
+    // Shannon entropy over backend-projected pose coordinates, not intrinsic
+    // conformational entropy of the isolated molecule.
+    double H_A_nats   = std::numeric_limits<double>::infinity();
+    double H_B_nats   = std::numeric_limits<double>::infinity();
+    double dG_A_kcal  = std::numeric_limits<double>::quiet_NaN();
+    double dG_B_kcal  = std::numeric_limits<double>::quiet_NaN();
+    // Pose-entropy role hint. This is a reproducible heuristic label, not a
+    // proof that one molecule is intrinsically "the" receptor.
+    // 'A' = Sim A pose ensemble lower entropy, 'B' = Sim B pose ensemble lower
+    // entropy, '?' = deferred.
+    char   tl_primary  = '?';
+    double tl_weight   = 0.0;     // confidence ∈ [0,1]
+    bool   tl_deferred = true;
+    std::string tl_basis = "pose_entropy_heuristic";
+    double p_elong     = std::numeric_limits<double>::quiet_NaN();
+    double dG_elong    = std::numeric_limits<double>::quiet_NaN();
+    bool   sim_c_evaluated = false;
+    bool   sim_c_gated_in = false;
+    int    protofibril_state_index = 0;
+    bool   protofibril_structure_updated = false;
+};
+
+// ─── NascentChainScheduler ───────────────────────────────────────────────────
+class NascentChainScheduler {
+public:
+    // tunnel_length is taken from each InVivoAssemblyTrack (process-native units —
+    // aa for ribosome, nt for RNAP) rather than from a global default. The
+    // chaperone_skip_residues parameter delays the first checkpoint past the NAC/SSB
+    // binding region.
+    NascentChainScheduler(std::vector<InVivoAssemblyTrack> tracks,
+                          int                              checkpoint_interval,
+                          int                              chaperone_skip_residues = 6);
+
+    bool       has_next() const noexcept;
+    Checkpoint next();                                        // advance the cursor
+    void       record(const Checkpoint& ck, CheckpointOutcome out);
+
+    const std::vector<std::pair<Checkpoint, CheckpointOutcome>>& history() const noexcept
+    { return history_; }
+
+    // Pre-computed schedule (read-only). Pre-computation is deterministic and
+    // depends only on the input tracks + interval.
+    const std::vector<Checkpoint>& schedule() const noexcept { return schedule_; }
+
+    int  checkpoint_interval() const noexcept { return interval_; }
+    int  cursor()              const noexcept { return cursor_; }
+    void reset()                              { cursor_ = 0; history_.clear(); }
+
+private:
+    std::vector<InVivoAssemblyTrack> tracks_;
+    int                              interval_;
+    int                              chaperone_skip_;
+    std::vector<Checkpoint>          schedule_;
+    int                              cursor_ = 0;
+    std::vector<std::pair<Checkpoint, CheckpointOutcome>> history_;
+};
+
+} // namespace natural

--- a/LIB/NATURaL/RibosomeElongation.cpp
+++ b/LIB/NATURaL/RibosomeElongation.cpp
@@ -407,9 +407,8 @@ double RibosomeElongation::mean_total_time() const {
 //   dP_n/dt = k_el[n-1] · P_{n-1} − k_el[n] · P_n   (1 ≤ n < N)
 //   dP_N/dt = k_el[N-1] · P_{N-1} − k_ter · P_N
 //
-// For mean first-passage time we use the absorbing boundary formulation:
-// integrate until the cumulative probability at the last state reaches 0.5
-// (median arrival time ≈ mean arrival time for near-Poisson kinetics).
+// Uses an absorbing post-termination state so probability is conserved across
+// initiation, elongation, termination, and completion.
 MasterEqState RibosomeElongation::integrate(double t_max, double dt, bool adaptive) const {
     int N = static_cast<int>(k_el_.size());
     MasterEqState state;
@@ -418,13 +417,15 @@ MasterEqState RibosomeElongation::integrate(double t_max, double dt, bool adapti
     state.k_el       = k_el_;
     state.k_ini      = k_ini_;
     state.k_ter      = k_ter_;
-    state.P.assign(N + 1, 0.0); // P[0..N-1] = growing chain; P[N] = completed
+    // P[0] = pre-initiation, P[1..N] = elongation stages,
+    // P[N+1] = termination stage, P[N+2] = absorbing completed chain.
+    state.P.assign(N + 3, 0.0);
     state.t_arrival.resize(N + 1, -1.0);
 
     // Inject probability at position 0 at t=0 (initiation)
     // Model: ribosome starts outside; rate k_ini brings it to position 1
     // Here we use the discrete-chain formulation with P[0] = pre-initiation
-    std::vector<double> P_init(N + 1, 0.0);
+    std::vector<double> P_init(N + 3, 0.0);
     P_init[0] = 1.0; // all ribosomes at initiation complex
     state.P = P_init;
 
@@ -434,25 +435,24 @@ MasterEqState RibosomeElongation::integrate(double t_max, double dt, bool adapti
     if (adaptive) dt = std::min(dt, 0.5 / k_max);
 
     double t = 0.0;
-    std::vector<double> dP(N + 1, 0.0);
+    std::vector<double> dP(N + 3, 0.0);
 
     // Use Eigen for the tridiagonal ODE vector update
-    Eigen::VectorXd P_vec(N + 1), dP_vec(N + 1);
-    for (int i = 0; i <= N; ++i) P_vec(i) = P_init[i];
-
-    Eigen::VectorXd k_vec(N + 1);
-    k_vec(0) = k_ini_;
-    for (int i = 1; i < N; ++i) k_vec(i) = k_el_[i];
-    k_vec(N) = k_ter_;
+    Eigen::VectorXd P_vec(N + 3), dP_vec(N + 3);
+    for (int i = 0; i <= N + 2; ++i) P_vec(i) = P_init[i];
 
     while (t < t_max) {
         // dP[0] = -k_ini * P[0]
         dP_vec(0) = -k_ini_ * P_vec(0);
-        // dP[n] = k[n-1]*P[n-1] - k[n]*P[n]  (n = 1..N-1)
-        for (int n = 1; n < N; ++n)
-            dP_vec(n) = k_el_[n - 1] * P_vec(n - 1) - k_el_[n] * P_vec(n);
-        // dP[N] = k[N-1]*P[N-1] - k_ter*P[N]
-        dP_vec(N) = k_el_[N - 1] * P_vec(N - 1) - k_ter_ * P_vec(N);
+        // dP[1] = k_ini*P[0] - k_el[0]*P[1]
+        dP_vec(1) = k_ini_ * P_vec(0) - k_el_[0] * P_vec(1);
+        // dP[n] = k_el[n-2]*P[n-1] - k_el[n-1]*P[n]  (n = 2..N)
+        for (int n = 2; n <= N; ++n)
+            dP_vec(n) = k_el_[n - 2] * P_vec(n - 1) - k_el_[n - 1] * P_vec(n);
+        // dP[N+1] = k_el[N-1]*P[N] - k_ter*P[N+1]
+        dP_vec(N + 1) = k_el_[N - 1] * P_vec(N) - k_ter_ * P_vec(N + 1);
+        // dP[N+2] = k_ter*P[N+1]  (absorbing completed chain)
+        dP_vec(N + 2) = k_ter_ * P_vec(N + 1);
 
         P_vec += dt * dP_vec;
         // Clamp non-negative
@@ -463,11 +463,11 @@ MasterEqState RibosomeElongation::integrate(double t_max, double dt, bool adapti
         for (int n = 0; n < N; ++n)
             if (state.t_arrival[n] < 0 && P_vec(n) > 1e-3)
                 state.t_arrival[n] = t;
-        // Terminal state: record median — P[N] is absorbing/monotone; 0.5 ≈ mean
-        if (state.t_median_terminal < 0 && P_vec(N) >= 0.5)
+        // Terminal absorbing state: record the median completion time.
+        if (state.t_median_terminal < 0 && P_vec(N + 2) >= 0.5)
             state.t_median_terminal = t;
     }
-    for (int i = 0; i <= N; ++i) state.P[i] = P_vec(i);
+    for (int i = 0; i <= N + 2; ++i) state.P[i] = P_vec(i);
 
     state.t_current = t;
 
@@ -483,7 +483,7 @@ double MasterEqState::fraction_reached(int n) const {
     if (n < 0 || n > n_residues) return 0.0;
     // Sum of P[n..N] = probability that ribosome has passed position n
     double sum = 0.0;
-    for (int i = n; i <= n_residues; ++i) sum += P[i];
+    for (int i = n; i < static_cast<int>(P.size()); ++i) sum += P[i];
     return std::min(sum, 1.0);
 }
 
@@ -526,22 +526,23 @@ RibosomeElongation::folding_windows(double k_fold_base) const
 }
 
 // ─── Time-weighted thermodynamic score ───────────────────────────────────────
-// Integrates S(n) * (1/k_n) / T_total — each intermediate weighted by its
-// dwell time relative to total translation time (Zhao 2011 Eq. 12).
+// Integrates S(n) over elongating intermediates, weighted by dwell time 1/k_n.
+// Initiation/termination are excluded because score_fn is defined only on chain
+// intermediates; a constant score must remain constant after normalization.
 double RibosomeElongation::time_weighted_score(
     const std::function<double(int)>& score_fn) const
 {
-    double T_total = mean_total_time();
-    if (T_total < 1e-12) return 0.0;
-
     double weighted_sum = 0.0;
+    double dwell_sum = 0.0;
     int N = static_cast<int>(k_el_.size());
     for (int n = 0; n < N; ++n) {
         double ki = k_el_[n];
         double dwell = (std::isfinite(ki) && ki > 1e-9) ? 1.0 / ki : 1.0 / mean_rate_;
         weighted_sum += score_fn(n) * dwell;
+        dwell_sum += dwell;
     }
-    return weighted_sum / T_total; // dimensionless time-weighted average
+    if (dwell_sum < 1e-12) return 0.0;
+    return weighted_sum / dwell_sum; // time-weighted average over scored intermediates
 }
 
 // ─── Validation (Zhao 2011 internal consistency check) ───────────────────────
@@ -560,19 +561,37 @@ ValidationResult validate_master_equation(int n_residues, Organism org)
 
     double T_analytic = model.mean_total_time();
 
-    // ODE integration: run until P[N] (completed chain) reaches 0.5
-    // For uniform rates: T_ode ≈ T_analytic (should match within 5%)
-    double t_max = T_analytic * 4.0;
-    double dt    = 1.0 / (k_mean * 50.0); // 50 steps per mean dwell
-    auto state = model.integrate(t_max, dt, true);
+    // Numerical mean first-passage time from the same master equation:
+    // E[T_abs] = integral_0^inf P(not completed at t) dt.
+    // This validates the kinetic ODE against the analytic sum without confusing
+    // the median terminal occupancy with the mean of an initiation-dominated
+    // sequential process.
+    const double t_max = T_analytic * 12.0;
+    double dt = 1.0 / (k_mean * 100.0);
+    double k_max = std::max({k_mean, K_INI_DEFAULT, K_TERM_DEFAULT});
+    dt = std::min(dt, 0.25 / k_max);
 
-    // Median first-passage time: when P[N] (absorbing/terminal state) ≥ 0.5
-    // This matches T_analytic which is also the mean (≈ median for Erlang-N).
-    // Previously used t_arrival.back() which recorded the leading edge (P > 1e-3),
-    // causing a systematic 5–6× underestimate → 83% relative error.
-    double T_ode = (state.t_median_terminal > 0)
-                   ? state.t_median_terminal
-                   : model.mean_arrival_time(n_residues); // analytic fallback
+    const int N = n_residues;
+    Eigen::VectorXd P = Eigen::VectorXd::Zero(N + 3);
+    Eigen::VectorXd dP = Eigen::VectorXd::Zero(N + 3);
+    P(0) = 1.0;
+
+    double T_ode = 0.0;
+    for (double t = 0.0; t < t_max; t += dt) {
+        double survival = std::max(0.0, 1.0 - P(N + 2));
+        T_ode += survival * dt;
+
+        dP.setZero();
+        dP(0) = -K_INI_DEFAULT * P(0);
+        dP(1) = K_INI_DEFAULT * P(0) - k_mean * P(1);
+        for (int n = 2; n <= N; ++n)
+            dP(n) = k_mean * P(n - 1) - k_mean * P(n);
+        dP(N + 1) = k_mean * P(N) - K_TERM_DEFAULT * P(N + 1);
+        dP(N + 2) = K_TERM_DEFAULT * P(N + 1);
+
+        P += dt * dP;
+        P = P.cwiseMax(0.0);
+    }
 
     double rel_err = std::abs(T_ode - T_analytic) / T_analytic;
     bool passed   = rel_err < 0.05; // 5% tolerance

--- a/LIB/NATURaL/disco_natural.hpp
+++ b/LIB/NATURaL/disco_natural.hpp
@@ -95,7 +95,7 @@ public:
     // \param R_flat_   Flattened 3×3 row-major rotation matrix for chain
     //                  orientation at this step.  Passed FIRST so callers
     //                  cannot accidentally omit the orientation argument.
-    // \param entropy   Shannon entropy of the current growth ensemble (bits).
+    // \param entropy   Shannon entropy of the current growth ensemble (nats).
     // \param cf_score  Contact Function score (kcal/mol).
     // \returns         Composite funnel score (kcal/mol).
     //                  More negative = deeper funnel (orthosteric character).
@@ -137,7 +137,7 @@ public:
         : funnel_(params) {}
 
     // ── Per-step scoring ─────────────────────────────────────────────────────
-    // \param entropy       Shannon entropy at this growth step (bits).
+    // \param entropy       Shannon entropy at this growth step (nats).
     // \param cf_score      Contact Function score (kcal/mol).
     // \param chain_R_flat  Orientation of the emerging chain segment.
     // \returns             Funnel score (kcal/mol).

--- a/LIB/NATURaL/dual_assembly_main.cpp
+++ b/LIB/NATURaL/dual_assembly_main.cpp
@@ -1,0 +1,232 @@
+// dual_assembly_main.cpp — Cotranslational docking CLI entry point.
+//
+// Usage:
+//   dual_assembly --target-pdb <protofibril.pdb>
+//                 --sequence   <FASTA-1-letter or @file.fasta>
+//                 [--monomer-pdb <monomer.pdb>]
+//                 [--checkpoint-interval 10]
+//                 [--sim-c-interval 5]
+//                 [--monomer-conc-M 1e-6]
+//                 [--temperature 310.15]
+//                 [--threads 6]
+//                 [--no-reciprocal-controls]
+//                 [--no-sim-c]
+//                 [--output-csv cotranslational_trajectory.csv]
+//                 [--nascent-pdb-dir .]
+//                 [--synthetic]    # use built-in synthetic GA backend (MVP default)
+//                 [--real-ga]      # reserved; exits until FlexAID GA callback lands
+//
+// The MVP ships a built-in synthetic GA backend (Gaussian pose distributions whose
+// width narrows as L_k grows) so the full pipeline can be exercised end-to-end on
+// any platform. The `--real-ga` flag intentionally fails closed until the FlexAID
+// GA callback wiring lands, so production users cannot mistake synthetic evidence
+// for real docking.
+//
+// Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+#include "DualAssemblyRunner.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// ─── argv helpers ────────────────────────────────────────────────────────────
+struct Args {
+    std::string target_pdb;
+    std::string monomer_pdb;
+    std::string sequence_or_at_file;
+    int    checkpoint_interval = 10;
+    int    sim_c_interval      = 5;
+    double monomer_conc_M      = 1.0e-6;
+    double temperature         = 310.15;
+    int    threads             = 6;
+    bool   reciprocal_controls = true;
+    bool   sim_c_enabled       = true;
+    bool   synthetic           = true;   // MVP default
+    std::string output_csv     = "cotranslational_trajectory.csv";
+    std::string nascent_pdb_dir = ".";
+};
+
+std::string load_sequence(const std::string& spec) {
+    if (spec.empty() || spec[0] != '@') return spec;
+    std::ifstream in(spec.substr(1));
+    if (!in) throw std::runtime_error("cannot open FASTA: " + spec.substr(1));
+    std::string line, seq;
+    while (std::getline(in, line)) {
+        if (!line.empty() && line[0] == '>') continue;
+        for (char c : line)
+            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) seq.push_back(c);
+    }
+    return seq;
+}
+
+void usage() {
+    std::cerr <<
+        "usage: dual_assembly --target-pdb <pdb> --sequence <FASTA|@file> [opts]\n"
+        "see file header for full option list\n";
+}
+
+Args parse_args(int argc, char** argv) {
+    Args a;
+    for (int i = 1; i < argc; ++i) {
+        std::string k = argv[i];
+        auto next = [&](const char* name) -> std::string {
+            if (i + 1 >= argc) { usage(); std::exit(2); }
+            (void)name;
+            return argv[++i];
+        };
+        if      (k == "--target-pdb")          a.target_pdb = next(k.c_str());
+        else if (k == "--monomer-pdb")         a.monomer_pdb = next(k.c_str());
+        else if (k == "--sequence")            a.sequence_or_at_file = next(k.c_str());
+        else if (k == "--checkpoint-interval") a.checkpoint_interval = std::atoi(next(k.c_str()).c_str());
+        else if (k == "--sim-c-interval")      a.sim_c_interval      = std::atoi(next(k.c_str()).c_str());
+        else if (k == "--monomer-conc-M")      a.monomer_conc_M      = std::atof(next(k.c_str()).c_str());
+        else if (k == "--temperature")         a.temperature         = std::atof(next(k.c_str()).c_str());
+        else if (k == "--threads")             a.threads             = std::atoi(next(k.c_str()).c_str());
+        else if (k == "--no-reciprocal-controls") a.reciprocal_controls = false;
+        else if (k == "--no-sim-c")            a.sim_c_enabled       = false;
+        else if (k == "--synthetic")           a.synthetic           = true;
+        else if (k == "--real-ga")             a.synthetic           = false;
+        else if (k == "--output-csv")          a.output_csv          = next(k.c_str());
+        else if (k == "--nascent-pdb-dir")     a.nascent_pdb_dir     = next(k.c_str());
+        else if (k == "--help" || k == "-h") { usage(); std::exit(0); }
+        else {
+            std::cerr << "unknown flag: " << k << "\n";
+            usage();
+            std::exit(2);
+        }
+    }
+    return a;
+}
+
+// ─── Synthetic GA backend ────────────────────────────────────────────────────
+// Generates a Gaussian-spread pose ensemble whose width narrows as L_k grows. The
+// resulting Shannon entropy crosses through the soft and hard thresholds at
+// physiologically plausible chain lengths, exercising every regime of the T/L
+// discriminator. This is for end-to-end smoke testing, NOT for production docking.
+natural::GAResult synthetic_sim(double temperature_K,
+                                 int    n_poses,
+                                 double width_A,
+                                 double dG_kcal,
+                                 unsigned seed)
+{
+    statmech::StatMechEngine engine(temperature_K);
+    std::mt19937 rng(seed);
+    std::normal_distribution<double> rmsd_dist(0.0, std::max(1e-3, width_A));
+    // We seed the engine with energies drawn from a Gaussian centred at dG_kcal.
+    // The Helmholtz F = -kT ln Z then approximates dG_kcal for large N.
+    std::normal_distribution<double> e_dist(dG_kcal, 1.0);
+    std::vector<double> rmsds;
+    rmsds.reserve(n_poses);
+    for (int i = 0; i < n_poses; ++i) {
+        engine.add_sample(e_dist(rng), 1.0);
+        rmsds.push_back(std::abs(rmsd_dist(rng)));
+    }
+    return {std::move(engine), std::move(rmsds)};
+}
+
+natural::SimAFn make_synthetic_sim_a() {
+    return [](const std::string&, const std::string&, int L_k, double T_K) {
+        // Wider Gaussian when chain is short (still floppy); narrows past L_k ≈ 60.
+        const double width = std::max(0.5, 8.0 - 0.07 * L_k);
+        const double dG    = -2.0 - 0.04 * L_k;
+        return synthetic_sim(T_K, 256, width, dG, /*seed=*/0xA5A5u + L_k);
+    };
+}
+
+natural::SimBFn make_synthetic_sim_b() {
+    return [](const std::string&, const std::string&, int L_k, double T_K) {
+        const double width = std::max(0.3, 4.0 - 0.02 * L_k);
+        const double dG    = -1.0 - 0.02 * L_k;
+        return synthetic_sim(T_K, 128, width, dG, /*seed=*/0xB5B5u + L_k);
+    };
+}
+
+natural::SimCFn make_synthetic_sim_c() {
+    return [](const std::string&, const std::string&, double T_K) {
+        // Slightly favourable monomer addition.
+        return synthetic_sim(T_K, 128, 1.5, -3.0, /*seed=*/0xC5C5u);
+    };
+}
+
+// ─── Truncation helper (extended geometry MVP) ───────────────────────────────
+// MVP: write a marker PDB with one CA atom per residue along the +X axis at 3.8 Å
+// spacing. Real geometry comes later via a Python/ESMFold helper.
+natural::TruncateFn make_synthetic_truncate() {
+    return [](const std::string& seq, int L_k, const std::string& out_dir) -> std::string {
+        const int  L  = std::min(L_k, static_cast<int>(seq.size()));
+        fs::create_directories(out_dir);
+        const std::string path = (fs::path(out_dir) / ("nascent_L" + std::to_string(L_k) + ".pdb")).string();
+        std::ofstream f(path, std::ios::trunc);
+        if (!f) throw std::runtime_error("cannot write " + path);
+        f << "REMARK 100  Synthetic nascent chain at L_k = " << L_k << "\n";
+        for (int i = 0; i < L; ++i) {
+            const char aa = seq[i];
+            char buf[96];
+            std::snprintf(buf, sizeof(buf),
+                "ATOM  %5d  CA  %-3s A%4d    %8.3f%8.3f%8.3f  1.00  0.00           C\n",
+                i + 1, "ALA", i + 1, 3.8 * i, 0.0, 0.0);
+            (void)aa;
+            f << buf;
+        }
+        f << "TER\nEND\n";
+        return path;
+    };
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        Args a = parse_args(argc, argv);
+        if (!a.synthetic) {
+            std::cerr << "[dual_assembly] --real-ga is not implemented yet; refusing to run synthetic backend\n";
+            return 2;
+        }
+        if (a.target_pdb.empty() || a.sequence_or_at_file.empty()) {
+            usage();
+            return 2;
+        }
+
+        natural::DualAssemblyConfig cfg;
+        cfg.protofibril_pdb              = a.target_pdb;
+        cfg.monomer_pdb                  = a.monomer_pdb;
+        cfg.sequence_fasta               = load_sequence(a.sequence_or_at_file);
+        cfg.checkpoint_interval          = a.checkpoint_interval;
+        cfg.sim_c_interval               = a.sim_c_interval;
+        cfg.monomer_conc_M               = a.monomer_conc_M;
+        cfg.temperature_K                = a.temperature;
+        cfg.n_threads                    = a.threads;
+        cfg.include_reciprocal_controls  = a.reciprocal_controls;
+        cfg.sim_c_enabled                = a.sim_c_enabled && !a.monomer_pdb.empty();
+        cfg.output_csv                   = a.output_csv;
+        cfg.nascent_pdb_dir              = a.nascent_pdb_dir;
+
+        natural::SimAFn sim_a = make_synthetic_sim_a();
+        natural::SimBFn sim_b = make_synthetic_sim_b();
+        natural::SimCFn sim_c = cfg.sim_c_enabled ? make_synthetic_sim_c() : nullptr;
+        natural::TruncateFn truncate = make_synthetic_truncate();
+
+        natural::DualAssemblyRunner runner(std::move(cfg),
+                                            std::move(sim_a),
+                                            std::move(sim_b),
+                                            std::move(sim_c),
+                                            std::move(truncate));
+        auto history = runner.run();
+        std::cerr << "[dual_assembly] wrote " << history.size()
+                  << " checkpoints to " << a.output_csv << "\n";
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "dual_assembly: " << e.what() << "\n";
+        return 1;
+    }
+}

--- a/docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md
+++ b/docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md
@@ -1,0 +1,419 @@
+# DualAssembly Cotranscriptional/Cotranslational Docking
+
+**Scope.** This document describes how FlexAIDdS solves the moving-target / moving-ligand
+problem that arises when a nascent polypeptide chain (or nascent RNA transcript) and a
+protofibril simultaneously evolve in vivo. It introduces an entropy-driven target/ligand
+discriminator, three parallel simulation modes, and the temporal schedule that maps a
+docking trajectory onto human-cell elongation rates. The Aβ42 protofibril (PDB 5OQV or
+2NAO) is used as the canonical target for the validation track. The C++ implementation
+lives under `LIB/NATURaL/` and is exposed through the `dual_assembly` CLI and
+`scripts/run_dual_assembly_cotranslational.sh`.
+
+---
+
+## 1. Motivation: the Target/Ligand assignment problem
+
+Classical FlexAID assumes a static receptor and a flexible ligand. When both the receptor
+(a growing protofibril surface) and the ligand (a nascent chain emerging from the
+ribosome) are non-stationary in conformation and in chain length, the classical assignment
+is undefined. Picking one by convention (e.g. always treat the protofibril as the target)
+hides the question rather than answering it: at early checkpoints the nascent chain has no
+defined pocket, and at late checkpoints both partners can carry well-defined surfaces.
+
+We need a rule that:
+
+  1. is grounded in physics, not convention;
+  2. is testable against a reciprocal control;
+  3. is computable from quantities the existing engine already emits.
+
+Shannon configurational entropy over the binned pose distribution satisfies all three. The
+codebase already reports entropy in nats (`LIB/ShannonThermoStack/ShannonThermoStack.h:34`)
+and ships two named thresholds (`kHSC_soft_nats = 2·ln 2 ≈ 1.386` and
+`kHSC_hard_nats = ln 2 ≈ 0.693`).
+
+---
+
+## 2. Shannon-driven pose-collapse role hint
+
+Let an ensemble of `N` GA-sampled poses be binned into `K` mega-clusters with normalised
+occupancies `p_i` (Σ p_i = 1, i = 1…K). The Shannon entropy in nats is
+
+  H(X) = −Σᵢ pᵢ ln pᵢ,  0 ≤ H(X) ≤ ln K.
+
+Let `H_A` denote the entropy of Sim A's backend-projected pose-coordinate ensemble at the
+current checkpoint and `H_B` that of Sim B. These are **not** intrinsic isolated-chain or
+protofibril conformational entropies. The discriminator is therefore a reproducible
+pose-collapse role hint, not a proof that one physical object is always "the receptor":
+
+  • **Hard regime** — `min(H_A, H_B) < ln 2`. The lower-entropy system carries a single
+    cluster with > 50% probability mass. The lower-entropy simulation direction is the
+    primary role hint for that checkpoint.
+    Confidence weight `w = 1`.
+
+  • **Deferred regime** — `min(H_A, H_B) ≥ 2·ln 2`. Both ensembles have effective support
+    of ≥ 4 clusters. Neither pose ensemble has collapsed; **no assignment**. The schedule either
+    extends the GA pass (more generations until one falls below `kHSC_soft_nats`) or
+    inherits the prior checkpoint's assignment with the flag `tl_deferred = true`.
+
+  • **Soft regime** — `ln 2 ≤ min(H_A, H_B) < 2·ln 2`. The lower-entropy system is the
+    *probable* target, with assignment weight
+
+      w = (kHSC_soft_nats − H_lower) / (kHSC_soft_nats − kHSC_hard_nats) ∈ [0, 1].
+
+    `w` is logged into the trajectory CSV and propagated downstream as a confidence on the
+    A-or-B identity at that timepoint.
+
+### 2.1 Justification
+
+  • `H = 0`  ⇔ a single pose-coordinate bin carries all the mass. This is a collapsed
+    docking ensemble, not automatically a rigid isolated molecule.
+
+  • `H < ln 2`  ⇒ p_max > 0.5 (since for the worst case with H = ln 2 and a 2-cluster
+    distribution we have p_max = 1/2 exactly; lowering H below ln 2 requires p_max > 1/2).
+    A single cluster dominates: the simulation direction has a defined pose basin.
+
+  • `H ≥ 2·ln 2 = ln 4` ⇒ the entropy is at least that of a 4-cluster equi-probable
+    distribution. The simulated pose ensemble remains diffuse.
+
+  • Units: the engine returns nats. Comparisons use `kHSC_*_nats` constants. Bits are
+    *only* emitted at user-facing reporting boundaries, per the header policy.
+
+### 2.2 Falsification — the reciprocal control track
+
+Without a control, the discriminator above is a definition rather than a test. NATURaL
+already emits a `DockingRolePolicy::ReciprocalControl` (see
+`LIB/NATURaL/NATURaLDualAssembly.h:103`). The runner generates **both** the forward
+(`ProtofibrilAsTarget`) and reciprocal control tracks. The reciprocal track now swaps the
+actual Sim A target/ligand arguments instead of only changing the label. If the
+pose-collapse role hint remains stable under that swap, the target/ligand conclusion is
+stronger; if it flips, downstream analysis must treat the checkpoint as direction-sensitive.
+The current runner records both tracks but does not yet compute a cross-track
+`tl_assignment_inconsistent` aggregate flag.
+
+---
+
+## 3. Three parallel simulation modes per checkpoint
+
+At checkpoint `k` of chain length `L_k`, run the following GA-based docking simulations,
+each on a separate OMP thread group:
+
+  • **Sim A — canonical in-vivo.** Target = full protofibril (5OQV/2NAO), fixed. Ligand =
+    nascent chain truncated at `L_k` (extended geometry MVP; ESMFold-aware in the
+    post-MVP). Produces ΔG_A(L_k), H_A(L_k), best pose seed for `L_{k+1}`.
+
+  • **Sim B — reciprocal control.** Target = nascent chain at `L_k`. Ligand = single Aβ42
+    monomer. Run **only if** `H_chain(L_{k-1}) < kHSC_soft_nats` — i.e. only when the
+    chain has actually collapsed to a pocket-bearing state at the prior checkpoint.
+    Otherwise B is skipped, ΔG_B = NaN, H_B = +∞.
+
+  • **Sim C — fibril elongation oracle.** Target = protofibril (fixed), Ligand = free
+    monomer from solution. Runs every `K` checkpoints (default `K = 5`). Output is fed to
+    a `FibrilGrowthOracle` which wraps `target::GrandPartitionFunction` and returns
+
+      Ξ = 1 + z·Z,  z = c_monomer / c°,  c° = 1 M (IUPAC convention),
+      p(elongation) = z·Z / Ξ = 1 − 1/Ξ,
+      ΔG_elong      = −kT ln Z + kT ln(c°/c_monomer).
+
+    Default `c_monomer = 1 µM` (upper bound for physiological cytosolic free Aβ42; see
+    Roher 1996, Bjorkdahl 2008). Gates whether the runner advances the protofibril
+    state. When a structural advance callback is installed, an accepted gate returns the
+    next protofibril PDB path and subsequent checkpoints use that structure. Without that
+    callback, the CSV still records the logical state transition but
+    `protofibril_structure_updated = 0`, so no coordinate mutation is claimed.
+
+All three simulations write a `StatMechEngine` per Sim; the trajectory CSV aggregates
+their `compute().free_energy` and the Shannon entropy over backend-supplied
+pose-coordinate samples (`GAResult::pose_rmsds`).
+
+---
+
+## 4. Temporal schedule — human cell
+
+Using `LIB/NATURaL/RibosomeElongation.h` constants:
+
+  • Translation: 5.6 aa/s → 1 aa per 178 ms (`MEAN_EL_RATE_HUMAN`).
+  • Transcription: 25 nt/s → 1 nt per 40 ms (`MEAN_NT_RATE_HUMAN`).
+  • Ribosomal exit tunnel: 34 aa (`TUNNEL_LENGTH_AA`). No simulation before `L_k ≥ 40`.
+  • Chaperone/NAC occlusion: skip docking while `L_k − TUNNEL_LENGTH_AA < 6`.
+  • Eukaryotic transcription is nuclear: `direct_encounter_allowed = false` for
+    transcription tracks (`LIB/NATURaL/NATURaLDualAssembly.cpp:184..188`). The
+    transcription clock is retained as an internal synchronisation reference (a polysome
+    may load before splicing completes), but transcription poses do not dock against the
+    protofibril directly. The transcription tracks still contribute their `H` to the
+    discriminator when the user enables polysome-mode in a future extension; for now their
+    Sim A is skipped and only Sim B/C remain, recording an "ineligible-for-encounter"
+    flag.
+
+For a 300-aa target sequence with `--checkpoint-interval 10`:
+  – first translation checkpoint at `L = 40`, scheduled time
+    `t_40 = 1/k_ini + 40/5.6 ≈ 17.14 s` with the default human initiation rate
+    (`k_ini = 0.1 s⁻¹`),
+  – successive checkpoints every 1.78 s real-time,
+  – wall-time is backend-dependent; the shipped CLI is synthetic and must not be used as
+    production docking evidence.
+
+---
+
+## 5. C++ class design
+
+All three new types live in `namespace natural` and reuse existing primitives without
+modification.
+
+### 5.1 `NascentChainScheduler`
+
+Owns the ordered list of checkpoints derived from
+`natural::build_parallel_growth_schedule(tracks)`. Tracks are produced via
+`natural::make_human_protofibril_tracks(transcript_nt, peptide_aa,
+include_reciprocal_controls=true)`.
+
+```cpp
+struct Checkpoint {
+    int                 idx;            // 0-based checkpoint index
+    int                 L_k;            // chain length (aa or nt)
+    double              t_arrival_s;    // real-time since initiation
+    GrowthProcess       process;        // Transcription | Translation
+    DockingRolePolicy   role_policy;    // ProtofibrilAsTarget | ReciprocalControl
+    int                 track_index;    // index into the tracks vector
+    std::string         track_name;     // pretty name
+    bool                in_tunnel;      // true if L_k ≤ tunnel_length
+    bool                chaperone_shielded; // L_k - tunnel < 6
+};
+
+struct CheckpointOutcome {
+    double H_A_nats     = std::numeric_limits<double>::infinity();
+    double H_B_nats     = std::numeric_limits<double>::infinity();
+    double dG_A_kcal    = std::numeric_limits<double>::quiet_NaN();
+    double dG_B_kcal    = std::numeric_limits<double>::quiet_NaN();
+    char   tl_primary   = '?';   // 'A' = chain-as-target, 'B' = protofibril-as-target, '?' = deferred
+    double tl_weight    = 0.0;   // confidence ∈ [0,1]
+    bool   tl_deferred  = true;
+    std::string tl_basis = "pose_entropy_heuristic";
+    double p_elong      = std::numeric_limits<double>::quiet_NaN();
+    double dG_elong     = std::numeric_limits<double>::quiet_NaN();
+    bool   sim_c_evaluated = false;
+    bool   sim_c_gated_in = false;
+    int    protofibril_state_index = 0;
+    bool   protofibril_structure_updated = false;
+};
+
+class NascentChainScheduler {
+public:
+    NascentChainScheduler(std::vector<InVivoAssemblyTrack> tracks, int checkpoint_interval);
+
+    bool has_next() const;
+    Checkpoint next();                                  // advance the cursor
+    void record(const Checkpoint& ck, CheckpointOutcome out);
+    const std::vector<std::pair<Checkpoint, CheckpointOutcome>>& history() const;
+};
+```
+
+### 5.2 `FibrilGrowthOracle`
+
+Thin wrapper around `target::GrandPartitionFunction`. One instance per runner, reused
+across all Sim C invocations.
+
+```cpp
+struct ElongationDecision {
+    double p_elong;    // ∈ [0, 1)
+    double dG_elong;   // kcal/mol (negative = favourable)
+    bool   gated_in;   // p_elong ≥ acceptance_threshold
+};
+
+class FibrilGrowthOracle {
+public:
+    explicit FibrilGrowthOracle(double temperature_K = 310.15,
+                                double acceptance_threshold = 0.5);
+
+    // Returns the elongation decision for the current monomer ensemble.
+    // monomer_engine: StatMechEngine populated by Sim C.
+    // c_monomer_M:    free monomer concentration in molar (default 1e-6 M = 1 µM)
+    ElongationDecision gate(const statmech::StatMechEngine& monomer_engine,
+                            double c_monomer_M = 1.0e-6);
+
+private:
+    double T_K_;
+    double acceptance_threshold_;
+};
+```
+
+### 5.3 `DualAssemblyRunner`
+
+Top-level driver. Coordinates Sim A/B/C across NATURaL tracks. Returns a vector of
+`(Checkpoint, CheckpointOutcome)` and writes a CSV.
+
+```cpp
+struct DualAssemblyConfig {
+    std::string   protofibril_pdb;         // required
+    std::string   monomer_pdb;             // required if sim_c_enabled
+    std::string   sequence_fasta;          // required, residues encoded 1-letter
+    int           transcript_nt = 0;       // 0 = derive from sequence × 3 + UTR (post-MVP)
+    int           checkpoint_interval = 10;
+    int           sim_c_interval = 5;
+    double        monomer_conc_M = 1.0e-6;
+    double        temperature_K = 310.15;
+    int           n_threads = 6;
+    bool          include_reciprocal_controls = true;
+    bool          sim_c_enabled = true;
+    std::string   output_csv = "cotranslational_trajectory.csv";
+    std::string   nascent_pdb_dir = ".";   // where per-L_k nascent PDBs are dumped
+};
+
+class DualAssemblyRunner {
+public:
+    DualAssemblyRunner(DualAssemblyConfig cfg,
+                       SimAFn sim_a,
+                       SimBFn sim_b,
+                       SimCFn sim_c,
+                       TruncateFn truncate,
+                       ProtofibrilAdvanceFn advance_protofibril = nullptr);
+
+    // Run the full trajectory. Returns the per-checkpoint history.
+    std::vector<std::pair<Checkpoint, CheckpointOutcome>> run();
+
+private:
+    struct TrackState {
+        double H_prev_chain_nats;
+        char   tl_prev;
+        int    checkpoints_since_sim_c;
+    };
+
+    std::unordered_map<int, TrackState> track_state_;
+    std::string current_protofibril_pdb_;
+    int         protofibril_state_index_;
+
+    // Pose-entropy role hint; updates outcome.tl_primary, tl_weight, tl_deferred.
+    static void assign_tl(double H_A_nats, double H_B_nats,
+                          char prev_tl, CheckpointOutcome& out);
+};
+```
+
+### 5.4 Pseudocode
+
+```
+for ck in scheduler:
+    state = track_state[ck.track_index]
+    if ck.chaperone_shielded:
+        scheduler.record(ck, outcome={ all-NaN, tl_deferred=true })
+        continue
+
+    if ck.role_policy == ReciprocalControl:
+        (dG_A, H_A) = sim_A(target=nascent_chain, ligand=current_protofibril)
+    else:
+        (dG_A, H_A) = sim_A(target=current_protofibril, ligand=nascent_chain)
+
+    H_B = +inf; dG_B = NaN
+    if state.H_prev_chain < kHSC_soft_nats:
+        (dG_B, H_B) = sim_B(target=nascent_chain, ligand=monomer)
+
+    decision = {NaN, NaN, false}
+    if (++state.checkpoints_since_sim_c) >= sim_c_interval:
+        engine_C  = sim_C(target=current_protofibril, ligand=monomer)
+        decision  = oracle.gate(engine_C, cfg.monomer_conc_M)
+        if decision.gated_in:
+            protofibril_state_index += 1
+            if advance_protofibril:
+                current_protofibril = advance_protofibril(current_protofibril, monomer)
+        state.checkpoints_since_sim_c = 0
+
+    assign_tl(H_A, H_B, state.tl_prev, outcome)
+
+    scheduler.record(ck, outcome={H_A,H_B,dG_A,dG_B,...,decision.p_elong,decision.dG_elong})
+    state.H_prev_chain = H_A
+    state.tl_prev      = outcome.tl_primary
+```
+
+---
+
+## 6. CSV schema
+
+`cotranslational_trajectory.csv` columns:
+
+```
+checkpoint_idx, L_k, process, track_name, role_policy, t_arrival_s, in_tunnel,
+H_A_nats, H_B_nats, dG_A_kcal, dG_B_kcal, tl_primary, tl_weight, tl_deferred,
+tl_basis, p_elong, dG_elong_kcal, sim_c_evaluated, sim_c_gated_in,
+protofibril_state_idx, protofibril_structure_updated
+```
+
+21 columns. `tl_basis` is currently `pose_entropy_heuristic`. NaN is written as the literal string `NaN`. The CSV is appended-as-you-go so
+a long trajectory is partially readable on disk even if the run is interrupted.
+
+---
+
+## 7. Integration with existing engine
+
+  • `LIB/gaboom.cpp:89 calculate_fitness(...)` — black-boxed; one full GA pass per Sim.
+  • `LIB/ShannonThermoStack/ShannonThermoStack.h:96 compute_shannon_entropy(values, bins)`
+    — invoked on backend-supplied pose-coordinate samples from each GA result.
+  • `LIB/statmech.h::StatMechEngine` — one engine per Sim; `compute().free_energy` feeds
+    ΔG into the CSV; `log_sum_exp` reused via `GrandPartitionFunction::log_Xi`.
+  • `LIB/GrandPartitionFunction.h::GrandPartitionFunction` — one instance per oracle. Two
+    entries: the empty site (implicit "1") and `"monomer"` updated each Sim C via
+    `add_or_overwrite("monomer", log_Z_monomer, c_monomer_M)`.
+  • `LIB/NATURaL/{NATURaLDualAssembly,RibosomeElongation}.{h,cpp}` — unchanged.
+  • `LIB/DatasetRunner.{h,cpp}` — not touched. The cotranslational runner is a separate
+    top-level driver to avoid cross-cutting changes.
+
+---
+
+## 8. Validation strategy
+
+  1. **Unit tests.** `tests/test_nascent_chain_scheduler.cpp` and
+     `tests/test_dual_assembly_runner.cpp`. Cover:
+       – schedule ordering against `build_parallel_growth_schedule` (deterministic);
+       – T/L discriminator at the three entropy regimes;
+       – `FibrilGrowthOracle` against analytic `Ξ = 1 + z·Z` for known z, Z;
+       – chaperone-shield gate;
+       – tunnel-exclusion (no Sim A while `L_k < 40`).
+
+  2. **Integration smoke test.** A two-layer β-sheet stub PDB shipped under
+     `tests/data/fake_protofibril_stub.pdb` plus a 60-aa synthetic sequence; the CSV must
+     emit exactly 3 checkpoints (L = 40, 50, 60), 21 columns, no NaN in `H_A_nats`,
+     finite `dG_A`.
+
+  3. **Scientific validation (Aβ42).** User downloads PDB 5OQV (or 2NAO), prepares it
+     with FlexAID's standard target-prep workflow, then runs the full
+     `DAEFRHDSGYEVHHQKLVFFAEDVGSNKGAIIGLMVGGVVIA` (42-aa Aβ42) sequence with
+     `--checkpoint-interval 5` (this is a short sequence — finer resolution). The
+     falsifiable claim:
+
+       ΔG_A(L_k) becomes monotonically favourable past a critical L_k that matches the
+       experimental nucleation length reported by ThT fluorescence kinetics (Knowles 2009;
+       Cohen 2013, PNAS 110:9758; Meisl 2014, Nat. Protoc. 11:252).
+
+  4. **T/L falsification.** The Shannon-driven role hint should remain stable when the
+     forward and reciprocal-control tracks are flipped. Mismatches are interpreted from the
+     paired rows; an explicit aggregate inconsistency flag is not implemented yet.
+
+---
+
+## 9. Known limitations
+
+  • The MVP truncates the nascent chain in extended geometry only. ESMFold integration for
+    per-residue secondary-structure-aware truncation is post-MVP.
+  • The transcription tracks do not dock directly against the protofibril
+    (`direct_encounter_allowed = false`). Polysome-mode (multiple nascent chains at
+    staggered lengths sharing one mRNA against a single protofibril) is a future
+    extension.
+  • The Sim C occupancy probability uses `GrandPartitionFunction` fugacity
+    (`z = c/c°`). The reported `dG_elong_kcal` is the apparent concentration-corrected
+    value `−kT ln Z + kT ln(c°/c)`, not the intrinsic `F_bound` alone.
+  • Debye screening of electrostatics at 150 mM KCl (κ⁻¹ ≈ 7.8 Å) is a flag, not a
+    default. FlexAID's `Vcontacts` is short-range and largely unaffected.
+  • The fibril-growth oracle assumes a single monomer-binding site per checkpoint and a
+    well-mixed monomer pool. Surface-bound oligomeric intermediates (e.g. dodecameric
+    Aβ*56) are not represented.
+
+---
+
+## 10. References
+
+  • Hessa et al. 2007 Nature 450:1026 — TM-helix code.
+  • Zhao et al. 2011 J. Phys. Chem. B 115:3987 — ribosome master equation.
+  • Wohlgemuth et al. 2008 — E. coli elongation rate.
+  • Ingolia et al. 2011 — human elongation rate.
+  • Pechmann & Frydman 2013 Nat. Struct. Mol. Biol. 20:237 — translational pausing.
+  • Knowles et al. 2009 Science 326:1533 — amyloid aggregation kinetics.
+  • Cohen et al. 2013 PNAS 110:9758 — Aβ42 secondary nucleation.
+  • Meisl et al. 2014 Nat. Protoc. 11:252 — ThT-based mechanistic analysis.
+  • Bjorkdahl et al. 2008 — Aβ42 cytosolic concentrations.

--- a/docs/test-coverage-analysis.md
+++ b/docs/test-coverage-analysis.md
@@ -96,7 +96,7 @@ PyMOL integration module has zero test coverage. No validation of graceful degra
 | Area | Issue |
 |------|-------|
 | **tENCoM Hessian construction** (`tencm.cpp`) | Hessian matrix building and Jacobi eigendecomposition untested (~65% coverage) |
-| **NATURaL module** (`NATURaL/`, 600+ lines) | Co-translational assembly entirely untested |
+| **NATURaL module** (`NATURaL/`, 600+ lines) | Core planning, scheduler, DualAssembly synthetic backend, Sim C gating, and fail-closed `--real-ga` paths covered by C++ tests; real GA backend wiring and calibration remain unvalidated |
 | **OpenMP concurrency** | Race conditions and thread-safety of global RNG state not tested |
 | **GPU fallback paths** | CUDA/Metal unavailable → scalar fallback not validated |
 | **CLI --csv and --top flags** | Python CLI output formats partially untested |
@@ -125,7 +125,7 @@ PyMOL integration module has zero test coverage. No validation of graceful degra
 | `CavityDetect/` | ~200 | Cavity detection (Metal GPU) |
 | `ChiralCenter/` | ~150 | Stereocenter discrimination |
 | `LigandRingFlex/` | ~400 | Ring conformation sampling |
-| `NATURaL/` | ~600 | Co-translational assembly |
+| `NATURaL/` | ~600 | Co-translational assembly; DualAssembly C++ coverage now exists, real GA backend still uncovered |
 | `Mol2Reader.cpp` | ~150 | MOL2 file parsing |
 | `SdfReader.cpp` | ~150 | SDF file parsing |
 | `fileio.cpp` | ~200 | File I/O operations |

--- a/python/flexaidds/truncate_chain.py
+++ b/python/flexaidds/truncate_chain.py
@@ -1,0 +1,86 @@
+"""truncate_chain.py — Write a nascent-chain PDB at a given length.
+
+MVP: extended geometry (Cα atoms along +X axis at 3.8 Å spacing). Post-MVP can
+plug in ESMFold or AlphaFold-derived φ/ψ angles per residue.
+
+Used by ``scripts/run_dual_assembly_cotranslational.sh`` when the runner needs a
+ligand PDB at chain length L_k for the cotranslational docking pipeline.
+
+Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Three-letter codes for the canonical 20 amino acids (used in the PDB output).
+_AA3 = {
+    "A": "ALA", "C": "CYS", "D": "ASP", "E": "GLU", "F": "PHE",
+    "G": "GLY", "H": "HIS", "I": "ILE", "K": "LYS", "L": "LEU",
+    "M": "MET", "N": "ASN", "P": "PRO", "Q": "GLN", "R": "ARG",
+    "S": "SER", "T": "THR", "V": "VAL", "W": "TRP", "Y": "TYR",
+    "X": "UNK",
+}
+
+_CA_CA_DIST_A = 3.8  # canonical Cα–Cα separation in an extended chain
+
+
+def write_extended_ca_chain(sequence: str, length: int, output_path: Path) -> Path:
+    """Write a 1-atom-per-residue PDB at ``output_path`` for the first ``length``
+    residues of ``sequence``. The Cα atoms lie along +X at 3.8 Å spacing.
+
+    Returns ``output_path`` for convenience.
+    """
+    seq = sequence[:length]
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w") as fh:
+        fh.write(f"REMARK 100  Synthetic nascent chain at L_k = {length}\n")
+        fh.write(f"REMARK 100  Generator: flexaidds.truncate_chain (extended geometry)\n")
+        for i, code in enumerate(seq, start=1):
+            res3 = _AA3.get(code.upper(), "UNK")
+            x = _CA_CA_DIST_A * (i - 1)
+            fh.write(
+                "ATOM  {atom_idx:>5d}  CA  {res3:<3s} A{res_idx:>4d}    "
+                "{x:>8.3f}{y:>8.3f}{z:>8.3f}  1.00  0.00           C\n".format(
+                    atom_idx=i, res3=res3, res_idx=i, x=x, y=0.0, z=0.0,
+                )
+            )
+        fh.write("TER\nEND\n")
+    return output_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--sequence", required=True,
+                   help="1-letter amino-acid sequence, OR @path/to.fasta")
+    p.add_argument("--length", type=int, required=True,
+                   help="Chain length L_k to emit")
+    p.add_argument("--output", required=True, type=Path,
+                   help="Destination PDB path")
+    args = p.parse_args(argv)
+
+    seq = args.sequence
+    if seq.startswith("@"):
+        seq_path = Path(seq[1:])
+        seq = "".join(
+            line.strip() for line in seq_path.read_text().splitlines()
+            if not line.startswith(">")
+        ).replace(" ", "")
+
+    if not seq:
+        print("ERROR: empty sequence", file=sys.stderr)
+        return 2
+    if args.length <= 0 or args.length > len(seq):
+        print(f"ERROR: length must be in 1..{len(seq)}", file=sys.stderr)
+        return 2
+
+    write_extended_ca_chain(seq, args.length, args.output)
+    print(f"wrote {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_benchmark_production.sh
+++ b/scripts/run_benchmark_production.sh
@@ -1,0 +1,803 @@
+#!/usr/bin/env bash
+# =============================================================================
+# run_benchmark_production.sh — FlexAIDdS Production Benchmark Runner
+#
+# MacBook Pro M3 Pro 18 GB · macOS 14+ · OMP_NUM_THREADS=6
+#
+# Execution order:
+#   0. Pre-flight: build freshness, constants, ulimits, disk space
+#   1. Thermodynamic validation gate (C-1 through C-5 + GPF)
+#   2. Pilot calibration: 5 complexes → empirical wall-clock estimate
+#   3. Full Astex Diverse (85 complexes) production run
+#   4. Summary CSV aggregation
+#
+# Usage:
+#   ./scripts/run_benchmark_production.sh [--dry-run] [--pilot-only]
+#        [--skip-pilot] [--phase2] [--seed N] [--threads N]
+#
+#   caffeinate -i ./scripts/run_benchmark_production.sh
+#
+# Apache-2.0 · Le Bonhomme Pharma / NRGlab, Université de Montréal
+# =============================================================================
+
+set -euo pipefail
+trap 'on_exit $?' EXIT
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+LOG_DIR="${REPO_ROOT}/logs/benchmark/${TIMESTAMP}"
+RESULTS_DIR="${REPO_ROOT}/benchmark_results/${TIMESTAMP}"
+FIGURES_DIR="${RESULTS_DIR}/figures"
+ASTEX_CSV="${REPO_ROOT}/benchmarks/astex_diverse/astex_diverse_set.csv"
+ASTEX_STRUCT="${REPO_ROOT}/benchmarks/astex_diverse/structures"
+ASTEX_DATA="${REPO_ROOT}/benchmarks/astex_diverse/data"
+SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
+PILOT_WALL_MIN=300   # 5 min — lower bound acceptable pilot wall clock
+PILOT_WALL_MAX=600   # 10 min — upper bound acceptable pilot wall clock
+
+# ─── Colours ─────────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+info()  { printf "${CYAN}[INFO]${NC}  %s\n" "$*"; }
+ok()    { printf "${GREEN}[ OK ]${NC}  %s\n" "$*"; }
+warn()  { printf "${YELLOW}[WARN]${NC}  %s\n" "$*"; }
+fail()  { printf "${RED}[FAIL]${NC}  %s\n" "$*" >&2; }
+phase() { printf "\n${BOLD}══════════════════════════════════════════════════${NC}\n"
+          printf "${BOLD}  %s${NC}\n" "$*"
+          printf "${BOLD}══════════════════════════════════════════════════${NC}\n\n"; }
+
+# ─── Parse arguments ─────────────────────────────────────────────────────────
+
+DRY_RUN=false
+PILOT_ONLY=false
+SKIP_PILOT=false
+RUN_PHASE2=false
+SEED=42
+N_THREADS=6
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)      DRY_RUN=true  ;;
+        --pilot-only)   PILOT_ONLY=true ;;
+        --skip-pilot)   SKIP_PILOT=true ;;
+        --phase2)       RUN_PHASE2=true ;;
+        --seed)         SEED="$2";     shift ;;
+        --threads)      N_THREADS="$2"; shift ;;
+        -h|--help)
+            grep '^#' "$0" | head -30 | sed 's/^# \?//'
+            exit 0 ;;
+        *) fail "Unknown argument: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# ─── Dry-run wrapper ──────────────────────────────────────────────────────────
+
+run() {
+    if [[ "${DRY_RUN}" == true ]]; then
+        printf "${YELLOW}[DRY]${NC}   %s\n" "$*"
+    else
+        "$@"
+    fi
+}
+
+# ─── Cleanup trap ─────────────────────────────────────────────────────────────
+
+ACTIVE_PID=""
+on_exit() {
+    local exit_code="$1"
+    if [[ -n "${ACTIVE_PID}" ]] && kill -0 "${ACTIVE_PID}" 2>/dev/null; then
+        warn "Killing active docking process PID=${ACTIVE_PID}"
+        kill -TERM "${ACTIVE_PID}" 2>/dev/null || true
+        sleep 2
+        kill -KILL "${ACTIVE_PID}" 2>/dev/null || true
+    fi
+    if [[ "${exit_code}" -ne 0 ]]; then
+        fail "Script exited with code ${exit_code}"
+        fail "Check logs in: ${LOG_DIR}"
+    fi
+}
+
+# ─── OMP / environment ────────────────────────────────────────────────────────
+
+setup_env() {
+    export OMP_NUM_THREADS="${N_THREADS}"
+    export OMP_PLACES=cores
+    export OMP_PROC_BIND=spread
+    export OMP_WAIT_POLICY=passive
+    export FLEXAID_MAX_MEM_MB=16384
+    export FLEXAID_SIMD=NEON          # M3 Pro: Neon replaces AVX2
+    export FLEXAID_SEED="${SEED}"
+    export SHANNON_TRACE_LEVEL=2      # per-step CSV for Astex runs
+    ulimit -n 65536 2>/dev/null || warn "Could not raise file descriptor limit"
+    ulimit -s unlimited 2>/dev/null || warn "Could not raise stack limit"
+
+    info "OMP_NUM_THREADS=${OMP_NUM_THREADS}  SEED=${SEED}  DRY_RUN=${DRY_RUN}"
+}
+
+# ─── Locate binary ────────────────────────────────────────────────────────────
+
+locate_binary() {
+    local candidates=(
+        "${BUILD_DIR}/FlexAIDdS"
+        "${REPO_ROOT}/WRK/FlexAID"
+        "${BUILD_DIR}/FlexAID"
+    )
+    for b in "${candidates[@]}"; do
+        if [[ -x "${b}" ]]; then
+            FLEXAIDDS_BIN="${b}"
+            ok "Binary: ${FLEXAIDDS_BIN}"
+            return 0
+        fi
+    done
+    fail "FlexAIDdS binary not found in: ${candidates[*]}"
+    fail "Run: cmake --build ${BUILD_DIR} --target FlexAIDdS -j ${N_THREADS}"
+    return 1
+}
+
+locate_dataset_runner() {
+    DATASET_BIN="${BUILD_DIR}/benchmark_datasets"
+    if [[ -x "${DATASET_BIN}" ]]; then
+        ok "benchmark_datasets: ${DATASET_BIN}"
+        return 0
+    fi
+    warn "benchmark_datasets not found — will use individual FlexAIDdS calls"
+    DATASET_BIN=""
+    return 0
+}
+
+# ─── Locate structure files ───────────────────────────────────────────────────
+
+# Returns receptor and ligand paths for a given PDB code.
+# Searches multiple candidate layouts produced by download.sh / prepare-only.
+find_structure_files() {
+    local pdb="$1"
+    local pdb_lower="${pdb,,}"
+    local pdb_upper="${pdb^^}"
+
+    local receptor="" ligand=""
+
+    # Layout 1: structures/{PDB}/{pdb}_protein.pdb  (plan Section 9 canonical)
+    if [[ -f "${ASTEX_STRUCT}/${pdb_upper}/${pdb_lower}_protein.pdb" ]]; then
+        receptor="${ASTEX_STRUCT}/${pdb_upper}/${pdb_lower}_protein.pdb"
+        ligand="${ASTEX_STRUCT}/${pdb_upper}/${pdb_lower}_ligand.mol2"
+    elif [[ -f "${ASTEX_STRUCT}/${pdb_lower}/${pdb_lower}_protein.pdb" ]]; then
+        receptor="${ASTEX_STRUCT}/${pdb_lower}/${pdb_lower}_protein.pdb"
+        ligand="${ASTEX_STRUCT}/${pdb_lower}/${pdb_lower}_ligand.mol2"
+    # Layout 2: data/{pdb}.pdb  (download.sh flat layout)
+    elif [[ -f "${ASTEX_DATA}/${pdb_lower}.pdb" ]]; then
+        receptor="${ASTEX_DATA}/${pdb_lower}.pdb"
+        ligand="${ASTEX_DATA}/${pdb_lower}_ligand.mol2"
+    fi
+
+    if [[ -z "${receptor}" ]] || [[ ! -f "${receptor}" ]]; then
+        echo "MISSING_RECEPTOR"
+        return 1
+    fi
+    if [[ -z "${ligand}" ]] || [[ ! -f "${ligand}" ]]; then
+        echo "MISSING_LIGAND"
+        return 1
+    fi
+
+    echo "${receptor}:${ligand}"
+}
+
+# ─── Pre-flight checks ────────────────────────────────────────────────────────
+
+preflight() {
+    phase "PRE-FLIGHT CHECKLIST"
+    local n_fail=0
+
+    # 1. Git state
+    info "1. Git state"
+    local git_commit git_dirty
+    git_commit="$(cd "${REPO_ROOT}" && git rev-parse --short HEAD 2>/dev/null || echo 'UNKNOWN')"
+    git_dirty="$(cd "${REPO_ROOT}" && git status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+    if [[ "${git_dirty}" -eq 0 ]]; then
+        ok "   HEAD=${git_commit} (clean)"
+    else
+        warn "   HEAD=${git_commit} — ${git_dirty} uncommitted file(s)"
+    fi
+
+    # 2. Binary exists
+    info "2. Binary"
+    if locate_binary; then
+        # Check freshness: find any source newer than binary using POSIX -newer
+        # Guard: only pass directories that exist (set -o pipefail + nonexistent
+        # dir causes find to exit 1, poisoning the pipeline even with 2>/dev/null)
+        local stale_count=0
+        local _search_dirs=()
+        for _d in "${REPO_ROOT}/LIB" "${REPO_ROOT}/src"; do
+            [[ -d "${_d}" ]] && _search_dirs+=("${_d}")
+        done
+        if [[ ${#_search_dirs[@]} -gt 0 ]]; then
+            stale_count="$(find "${_search_dirs[@]}" \
+                            \( -name '*.cpp' -o -name '*.h' \) \
+                            -newer "${FLEXAIDDS_BIN}" 2>/dev/null \
+                          | wc -l | tr -d ' ')" || stale_count=0
+        fi
+        if [[ "${stale_count}" -gt 0 ]]; then
+            warn "   Binary is STALE — ${stale_count} source file(s) newer than binary"
+            warn "   Run: cmake --build ${BUILD_DIR} --target FlexAIDdS -j ${N_THREADS}"
+            n_fail=$((n_fail + 1))
+        else
+            ok "   Binary is fresh"
+        fi
+    else
+        n_fail=$((n_fail + 1))
+    fi
+    locate_dataset_runner
+
+    # 3. Unit tests (last ctest run)
+    info "3. Unit test gate"
+    local failed_log="${BUILD_DIR}/Testing/Temporary/LastTestsFailed.log"
+    if [[ -f "${failed_log}" ]] && [[ -s "${failed_log}" ]]; then
+        local n_failed
+        n_failed="$(wc -l < "${failed_log}" | tr -d ' ')"
+        fail "   ${n_failed} test(s) failed in last ctest run:"
+        cat "${failed_log}" | sed 's/^/       /'
+        fail "   Run: cd ${BUILD_DIR} && ctest --output-on-failure -j${N_THREADS}"
+        n_fail=$((n_fail + 1))
+    else
+        ok "   No failed tests in last ctest run"
+        warn "   (Verify with: cd ${BUILD_DIR} && ctest -j${N_THREADS})"
+    fi
+
+    # 4. Disk space ≥ 50 GB
+    info "4. Disk space"
+    local free_gb
+    free_gb="$(df -BG "${REPO_ROOT}" 2>/dev/null \
+               | awk 'NR==2{gsub(/G/,"",$4); print $4}' \
+               || df -g "${REPO_ROOT}" 2>/dev/null \
+               | awk 'NR==2{print $4}' \
+               || echo 0)"
+    if [[ "${free_gb}" -ge 50 ]] 2>/dev/null; then
+        ok "   ${free_gb} GB free (≥ 50 GB required)"
+    else
+        warn "   Only ${free_gb} GB free — need ≥ 50 GB for Phase 1"
+        [[ "${free_gb}" -lt 10 ]] && n_fail=$((n_fail + 1))
+    fi
+
+    # 5. Astex CSV
+    info "5. Astex Diverse CSV"
+    if [[ -f "${ASTEX_CSV}" ]]; then
+        local n_complexes
+        n_complexes="$(tail -n +2 "${ASTEX_CSV}" | wc -l | tr -d ' ')"
+        ok "   ${ASTEX_CSV} (${n_complexes} complexes)"
+        if [[ "${n_complexes}" -lt 85 ]]; then
+            warn "   Expected 85 complexes, found ${n_complexes}"
+        fi
+    else
+        fail "   Astex CSV not found: ${ASTEX_CSV}"
+        n_fail=$((n_fail + 1))
+    fi
+
+    # 6. Structure files (sample check)
+    info "6. Astex structure files"
+    local pilot_pdb
+    pilot_pdb="$(tail -n +2 "${ASTEX_CSV}" | head -1 | cut -d',' -f1)"
+    local struct_info
+    struct_info="$(find_structure_files "${pilot_pdb}" 2>/dev/null || echo 'MISSING')"
+    if [[ "${struct_info}" == MISSING* ]]; then
+        warn "   Structures NOT downloaded yet — run before pilot:"
+        warn "   bash benchmarks/astex_diverse/download.sh"
+        warn "   OR: ${BUILD_DIR}/benchmark_datasets --benchmark astex --prepare-only"
+        n_fail=$((n_fail + 1))
+    else
+        ok "   Sample structure found: ${pilot_pdb}"
+    fi
+
+    # 7. kB_kcal constant sanity (grep source)
+    info "7. kB_kcal constant"
+    local kb_count
+    kb_count="$(grep -r 'kB_kcal.*0\.001987206\|0\.001987206.*kB_kcal' \
+                "${REPO_ROOT}/LIB" --include='*.h' --include='*.cpp' 2>/dev/null \
+                | wc -l | tr -d ' ')"
+    if [[ "${kb_count}" -ge 2 ]]; then
+        ok "   kB_kcal = 0.001987206 confirmed in ${kb_count} source location(s)"
+    else
+        warn "   kB_kcal constant not verified (grep matched ${kb_count} lines)"
+    fi
+
+    # 8. Shannon thresholds
+    info "8. Shannon HSC thresholds"
+    local hsc_soft hsc_hard
+    hsc_soft="$(grep -r 'kHSC_soft_nats\|1\.3863\|kHSC_soft_bits.*2\.0' \
+                "${REPO_ROOT}/LIB" --include='*.h' 2>/dev/null | head -1 | xargs echo)"
+    hsc_hard="$(grep -r 'kHSC_hard_nats\|0\.6931\|kHSC_hard_bits.*1\.0' \
+                "${REPO_ROOT}/LIB" --include='*.h' 2>/dev/null | head -1 | xargs echo)"
+    if [[ -n "${hsc_soft}" ]] && [[ -n "${hsc_hard}" ]]; then
+        ok "   HSC thresholds: soft=2·ln2 nats (1.3863), hard=1·ln2 nats (0.6931)"
+    else
+        warn "   HSC thresholds not verified in source"
+    fi
+
+    # 9. Git tag
+    info "9. Git tag (pre-benchmark snapshot)"
+    local tag_name="benchmark-$(date +%Y%m%d)"
+    local existing_tag
+    existing_tag="$(cd "${REPO_ROOT}" && git tag -l "${tag_name}" 2>/dev/null)"
+    if [[ -z "${existing_tag}" ]]; then
+        if [[ "${DRY_RUN}" == true ]]; then
+            info "   [DRY] git tag ${tag_name} -m 'Pre-benchmark snapshot'"
+        else
+            cd "${REPO_ROOT}" && git tag "${tag_name}" \
+                -m "Pre-benchmark snapshot (${git_commit})" 2>/dev/null \
+                && ok "   Tagged: ${tag_name}" \
+                || warn "   Could not create tag ${tag_name} (already exists?)"
+        fi
+    else
+        ok "   Tag already exists: ${tag_name}"
+    fi
+
+    # Summary
+    echo ""
+    if [[ "${n_fail}" -gt 0 ]]; then
+        fail "Pre-flight: ${n_fail} BLOCKING issue(s) — address before running full benchmark"
+        if [[ "${DRY_RUN}" == false ]] && [[ "${SKIP_PILOT}" == false ]]; then
+            exit 1
+        else
+            warn "Continuing despite ${n_fail} failure(s) (dry-run or --skip-pilot mode)"
+        fi
+    else
+        ok "Pre-flight: ALL CLEAR"
+    fi
+}
+
+# ─── Thermodynamic validation gate ────────────────────────────────────────────
+
+thermo_gate() {
+    phase "THERMODYNAMIC VALIDATION GATE (C-1 … C-5 + GPF)"
+    local thermo_script="${REPO_ROOT}/tests/thermodynamic_validation.py"
+    local thermo_out="${RESULTS_DIR}/thermo_validation.json"
+
+    if [[ ! -f "${thermo_script}" ]]; then
+        warn "Thermodynamic validation script not found: ${thermo_script}"
+        warn "Skipping C-1…C-5 gate — build with Python bindings to enable"
+        return 0
+    fi
+
+    run python3 "${thermo_script}" \
+        --build-dir "${BUILD_DIR}" \
+        --output "${thermo_out}" \
+        || { fail "THERMODYNAMIC VALIDATION FAILED — abort"; exit 1; }
+    ok "Thermodynamic gate passed"
+}
+
+# ─── Dock one complex ─────────────────────────────────────────────────────────
+
+# dock_complex <pdb_id> <receptor.pdb> <ligand.mol2> <out_dir> <log_file>
+# Writes wall_time_s to <out_dir>/wall_time_s
+dock_complex() {
+    local pdb="$1" receptor="$2" ligand="$3" out_dir="$4" log_file="$5"
+
+    run mkdir -p "${out_dir}"
+
+    if [[ "${DRY_RUN}" == true ]]; then
+        printf "[DRY]   FlexAIDdS --input %s --ligand %s --output %s --seed %d --nthreads %d\n" \
+               "${receptor}" "${ligand}" "${out_dir}" "${SEED}" "${N_THREADS}"
+        echo "0" > "${out_dir}/wall_time_s" 2>/dev/null || true
+        return 0
+    fi
+
+    local t_start t_end wall_s
+    t_start="$(date +%s%N)"
+
+    ACTIVE_PID=""
+    "${FLEXAIDDS_BIN}" \
+        --input   "${receptor}" \
+        --ligand  "${ligand}" \
+        --output  "${out_dir}" \
+        --seed    "${SEED}" \
+        --nthreads "${N_THREADS}" \
+        >> "${log_file}" 2>&1 &
+    ACTIVE_PID=$!
+    wait "${ACTIVE_PID}" || {
+        fail "Docking failed for ${pdb} (exit code $?)"
+        ACTIVE_PID=""
+        return 1
+    }
+    ACTIVE_PID=""
+
+    t_end="$(date +%s%N)"
+    wall_s=$(( (t_end - t_start) / 1000000000 ))
+    echo "${wall_s}" > "${out_dir}/wall_time_s"
+    return 0
+}
+
+# ─── Extract top-1 score and RMSD from output ─────────────────────────────────
+
+extract_result() {
+    local out_dir="$1" pdb="$2" rmsd_threshold="$3"
+    local wall_s top1_score rmsd success
+
+    wall_s="$(cat "${out_dir}/wall_time_s" 2>/dev/null || echo 0)"
+
+    # Try JSON binding modes first
+    if [[ -f "${out_dir}/binding_modes.json" ]]; then
+        top1_score="$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('${out_dir}/binding_modes.json'))
+    modes = d.get('binding_modes', [])
+    if modes:
+        print(modes[0].get('best_score', modes[0].get('score', 'N/A')))
+    else:
+        print('N/A')
+except Exception as e:
+    print('N/A')
+" 2>/dev/null || echo 'N/A')"
+
+        rmsd="$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('${out_dir}/binding_modes.json'))
+    modes = d.get('binding_modes', [])
+    if modes:
+        val = modes[0].get('best_pose_rmsd', modes[0].get('rmsd_to_crystal', 'N/A'))
+        print(val)
+    else:
+        print('N/A')
+except Exception as e:
+    print('N/A')
+" 2>/dev/null || echo 'N/A')"
+    else
+        top1_score="N/A"
+        rmsd="N/A"
+    fi
+
+    # Determine success
+    if [[ "${rmsd}" != "N/A" ]] && python3 -c \
+        "import sys; sys.exit(0 if float('${rmsd}') < ${rmsd_threshold} else 1)" \
+        2>/dev/null; then
+        success=1
+    else
+        success=0
+    fi
+
+    echo "${pdb},${wall_s},${top1_score},${rmsd},${success}"
+}
+
+# ─── Pilot calibration (5 complexes) ─────────────────────────────────────────
+
+run_pilot() {
+    phase "PILOT CALIBRATION (5 complexes)"
+
+    # Take lines 2-6 from CSV (skip header), use first column (pdb_id)
+    local pilot_ids=()
+    while IFS=',' read -r pdb_id lig_id res rmsd_thr ref; do
+        pilot_ids+=("${pdb_id}")
+    done < <(tail -n +2 "${ASTEX_CSV}" | head -5)
+
+    info "Pilot complexes: ${pilot_ids[*]}"
+    info "Expected wall-clock: 5–8 min/complex (${PILOT_WALL_MIN}–${PILOT_WALL_MAX} s)"
+    echo ""
+
+    local pilot_dir="${RESULTS_DIR}/pilot"
+    run mkdir -p "${pilot_dir}"
+
+    local total_wall=0 n_docked=0
+
+    for pdb in "${pilot_ids[@]}"; do
+        local struct_info
+        struct_info="$(find_structure_files "${pdb}" 2>/dev/null | head -1 || echo 'MISSING')"
+
+        if [[ "${struct_info}" == MISSING* ]] || [[ -z "${struct_info}" ]]; then
+            warn "  ${pdb}: structures not found — skipping (run download.sh first)"
+            continue
+        fi
+
+        local receptor="${struct_info%%:*}"
+        local ligand="${struct_info##*:}"
+        local out_dir="${pilot_dir}/${pdb}"
+        local log_file="${LOG_DIR}/pilot_${pdb}.log"
+
+        run mkdir -p "${LOG_DIR}"
+        info "  Docking ${pdb} ..."
+
+        if dock_complex "${pdb}" "${receptor}" "${ligand}" "${out_dir}" "${log_file}"; then
+            local wall_s
+            wall_s="$(cat "${out_dir}/wall_time_s" 2>/dev/null || echo 0)"
+            ok "  ${pdb}: ${wall_s}s"
+            total_wall=$((total_wall + wall_s))
+            n_docked=$((n_docked + 1))
+        else
+            warn "  ${pdb}: docking failed"
+        fi
+    done
+
+    if [[ "${n_docked}" -eq 0 ]]; then
+        if [[ "${DRY_RUN}" == true ]]; then
+            info "Dry-run: skipping pilot timing check"
+            return 0
+        fi
+        fail "No complexes docked in pilot — check binary and structure files"
+        exit 1
+    fi
+
+    local mean_wall=$(( total_wall / n_docked ))
+    local est_full_h=$(( mean_wall * 85 / 3600 ))
+
+    echo ""
+    info "Pilot results:"
+    info "  Complexes docked: ${n_docked}/5"
+    info "  Mean wall-clock:  ${mean_wall}s/complex"
+    info "  Estimated full Astex (85): ~${est_full_h}h"
+    echo ""
+
+    if [[ "${mean_wall}" -lt "${PILOT_WALL_MIN}" ]] && [[ "${DRY_RUN}" == false ]]; then
+        warn "Mean wall-clock ${mean_wall}s < ${PILOT_WALL_MIN}s — unusually fast"
+        warn "Possible GA misconfiguration (check num_chromosomes=1000, num_generations=500)"
+    elif [[ "${mean_wall}" -gt "${PILOT_WALL_MAX}" ]] && [[ "${DRY_RUN}" == false ]]; then
+        warn "Mean wall-clock ${mean_wall}s > ${PILOT_WALL_MAX}s — slower than expected"
+        warn "Verify OMP_NUM_THREADS=${N_THREADS} and FLEXAID_SIMD=NEON are active"
+    else
+        ok "Wall-clock within expected range (${PILOT_WALL_MIN}–${PILOT_WALL_MAX}s/complex)"
+    fi
+
+    # Write pilot wall-clock to results dir for downstream use
+    echo "${mean_wall}" > "${RESULTS_DIR}/pilot_mean_wall_s"
+}
+
+# ─── Full Astex Diverse run (85 complexes) ────────────────────────────────────
+
+run_full_astex() {
+    phase "FULL ASTEX DIVERSE RUN (85 complexes)"
+
+    local ast_out="${RESULTS_DIR}/astex_diverse"
+    # Always create log dir (infrastructure, not docking — no dry-run guard here)
+    mkdir -p "${LOG_DIR}" "${ast_out}" 2>/dev/null || true
+
+    # Write summary CSV header
+    if [[ "${DRY_RUN}" == false ]]; then
+        echo "complex_id,wall_time_s,top1_score,rmsd_to_crystal,success" > "${SUMMARY_CSV}"
+    else
+        printf "[DRY]   echo 'complex_id,wall_time_s,top1_score,rmsd_to_crystal,success' > %s\n" \
+               "${SUMMARY_CSV}"
+    fi
+
+    # In dry-run mode, tee to /dev/null so the pipeline doesn't fail on missing log dirs
+    local _astex_log="${LOG_DIR}/astex_full.log"
+    [[ "${DRY_RUN}" == true ]] && _astex_log="/dev/null"
+
+    # Prefer benchmark_datasets binary if available (handles download + dock atomically)
+    if [[ -n "${DATASET_BIN:-}" ]]; then
+        info "Using benchmark_datasets binary for full Astex run"
+        run "${DATASET_BIN}" \
+            --benchmark astex \
+            --output    "${ast_out}" \
+            --threads   "${N_THREADS}" \
+            --cache     "${REPO_ROOT}/benchmarks/astex_diverse" \
+            2>&1 | tee "${_astex_log}"
+
+        # Extract per-complex results into summary CSV from results directory
+        if [[ "${DRY_RUN}" == false ]] && [[ -d "${ast_out}" ]]; then
+            for pdb_dir in "${ast_out}"/*/; do
+                local pdb="${pdb_dir%/}"
+                pdb="${pdb##*/}"
+                local wt top1 rmsd succ
+                wt="$(cat "${pdb_dir}/wall_time_s"    2>/dev/null || echo 0)"
+                top1="$(python3 -c "
+import json
+try:
+    d=json.load(open('${pdb_dir}/binding_modes.json'))
+    m=d.get('binding_modes',[])
+    print(m[0].get('best_score','N/A') if m else 'N/A')
+except: print('N/A')
+" 2>/dev/null || echo 'N/A')"
+                rmsd="$(python3 -c "
+import json
+try:
+    d=json.load(open('${pdb_dir}/binding_modes.json'))
+    m=d.get('binding_modes',[])
+    print(m[0].get('best_pose_rmsd','N/A') if m else 'N/A')
+except: print('N/A')
+" 2>/dev/null || echo 'N/A')"
+                succ=0
+                python3 -c "import sys; sys.exit(0 if '${rmsd}'!='N/A' and float('${rmsd}')<2.0 else 1)" \
+                    2>/dev/null && succ=1 || true
+                echo "${pdb},${wt},${top1},${rmsd},${succ}" >> "${SUMMARY_CSV}"
+            done
+        fi
+        return 0
+    fi
+
+    # Fallback: individual FlexAIDdS calls per complex
+    info "Falling back to per-complex FlexAIDdS invocations"
+    local n_total n_success=0 n_fail=0 n_skip=0
+
+    # Read all complexes from CSV
+    local all_pdbs=() all_rmsd_thrs=()
+    while IFS=',' read -r pdb_id lig_id res rmsd_thr ref; do
+        all_pdbs+=("${pdb_id}")
+        all_rmsd_thrs+=("${rmsd_thr}")
+    done < <(tail -n +2 "${ASTEX_CSV}")
+    n_total="${#all_pdbs[@]}"
+
+    info "Total complexes: ${n_total}"
+
+    local idx=0
+    for pdb in "${all_pdbs[@]}"; do
+        local rmsd_thr="${all_rmsd_thrs[$idx]}"
+        idx=$((idx + 1))
+
+        local struct_info
+        struct_info="$(find_structure_files "${pdb}" 2>/dev/null | head -1 || echo 'MISSING')"
+
+        if [[ "${struct_info}" == MISSING* ]] || [[ -z "${struct_info}" ]]; then
+            warn "[${idx}/${n_total}] ${pdb}: structures not found (run download.sh)"
+            n_skip=$((n_skip + 1))
+            echo "${pdb},0,N/A,N/A,0" >> "${SUMMARY_CSV}"
+            continue
+        fi
+
+        local receptor="${struct_info%%:*}"
+        local ligand="${struct_info##*:}"
+        local out_dir="${ast_out}/${pdb}"
+        local log_file="${LOG_DIR}/astex_${pdb}.log"
+
+        info "[${idx}/${n_total}] Docking ${pdb} ..."
+
+        if dock_complex "${pdb}" "${receptor}" "${ligand}" "${out_dir}" "${log_file}"; then
+            local result_line
+            result_line="$(extract_result "${out_dir}" "${pdb}" "${rmsd_thr}")"
+            echo "${result_line}" >> "${SUMMARY_CSV}"
+            local success="${result_line##*,}"
+            if [[ "${success}" -eq 1 ]]; then
+                n_success=$((n_success + 1))
+            fi
+            local wall_s
+            wall_s="$(cat "${out_dir}/wall_time_s" 2>/dev/null || echo 0)"
+            ok "[${idx}/${n_total}] ${pdb}: ${wall_s}s"
+        else
+            fail "[${idx}/${n_total}] ${pdb}: docking failed"
+            echo "${pdb},0,N/A,N/A,0" >> "${SUMMARY_CSV}"
+            n_fail=$((n_fail + 1))
+        fi
+    done
+
+    local sr=0
+    [[ $((n_success + n_fail)) -gt 0 ]] && \
+        sr=$(( n_success * 100 / (n_success + n_fail) ))
+
+    echo ""
+    ok "Astex Diverse complete"
+    info "  Success: ${n_success}/${n_total} (${sr}%)"
+    info "  Failed:  ${n_fail}"
+    info "  Skipped: ${n_skip} (structures missing)"
+    info "  Summary: ${SUMMARY_CSV}"
+}
+
+# ─── Phase 2: Astex Non-Native + CASF-2016 ────────────────────────────────────
+
+run_phase2() {
+    phase "PHASE 2: ASTEX NON-NATIVE + CASF-2016"
+    export SHANNON_TRACE_LEVEL=1   # final H only for non-native cross-docking
+
+    if [[ -n "${DATASET_BIN:-}" ]]; then
+        info "Running Astex Non-Native..."
+        run "${DATASET_BIN}" \
+            --benchmark astex_nonnative \
+            --output    "${RESULTS_DIR}/astex_nonnative" \
+            --threads   "${N_THREADS}" \
+            2>&1 | tee "${LOG_DIR}/astex_nonnative.log"
+
+        if [[ -d "${REPO_ROOT}/benchmarks/casf2016" ]]; then
+            export SHANNON_TRACE_LEVEL=2
+            info "Running CASF-2016..."
+            run "${DATASET_BIN}" \
+                --benchmark casf2016 \
+                --output    "${RESULTS_DIR}/casf2016" \
+                --threads   "${N_THREADS}" \
+                2>&1 | tee "${LOG_DIR}/casf2016.log"
+        else
+            warn "CASF-2016 data not found — skipping (download to benchmarks/casf2016/)"
+        fi
+    else
+        warn "benchmark_datasets binary not available — Phase 2 requires it"
+        warn "Build with: cmake -DENABLE_BENCHMARK_DATASETS=ON ..."
+    fi
+}
+
+# ─── Final report ─────────────────────────────────────────────────────────────
+
+print_final_report() {
+    phase "BENCHMARK COMPLETE"
+    info "Timestamp:    ${TIMESTAMP}"
+    info "Results dir:  ${RESULTS_DIR}"
+    info "Logs dir:     ${LOG_DIR}"
+    info "Summary CSV:  ${SUMMARY_CSV}"
+    echo ""
+
+    if [[ -f "${SUMMARY_CSV}" ]] && [[ "${DRY_RUN}" == false ]]; then
+        python3 - "${SUMMARY_CSV}" <<'PYEOF'
+import sys, csv, math
+
+csv_file = sys.argv[1]
+rows = []
+with open(csv_file) as f:
+    reader = csv.DictReader(f)
+    for r in reader:
+        rows.append(r)
+
+n = len(rows)
+if n == 0:
+    print("No results in summary CSV")
+    sys.exit(0)
+
+wall_times = [float(r['wall_time_s']) for r in rows if r['wall_time_s'] not in ('0','N/A','')]
+successes  = [int(r['success']) for r in rows]
+n_success  = sum(successes)
+sr         = n_success / n * 100 if n > 0 else 0.0
+
+mean_wall = sum(wall_times) / len(wall_times) if wall_times else 0.0
+var_wall  = sum((x - mean_wall)**2 for x in wall_times) / max(len(wall_times)-1, 1)
+std_wall  = math.sqrt(var_wall)
+
+print(f"  Complexes:     {n}")
+print(f"  Success rate:  {n_success}/{n}  ({sr:.1f}%)")
+print(f"  Target:        ≥65% (Vina baseline 57.6%)")
+print(f"  Status:        {'PASS ✅' if sr >= 65.0 else 'NEEDS WORK ⚠️' if sr >= 58.0 else 'FAIL ❌'}")
+print(f"  Mean wall:     {mean_wall:.0f}s ± {std_wall:.0f}s/complex")
+PYEOF
+    fi
+
+    echo ""
+    info "Next steps:"
+    info "  1. Run validate_benchmark_results.py for full statistical analysis"
+    info "  2. python3 scripts/validate_benchmark_results.py ${SUMMARY_CSV}"
+    info "  3. Deposit raw results to Zenodo (DOI required for thesis)"
+    echo ""
+}
+
+# ─── Entry point ─────────────────────────────────────────────────────────────
+
+main() {
+    echo ""
+    printf "${BOLD}FlexAIDdS Production Benchmark Runner${NC}\n"
+    printf "  SEED=${SEED}  THREADS=${N_THREADS}  DRY_RUN=${DRY_RUN}\n"
+    printf "  TIMESTAMP=${TIMESTAMP}\n\n"
+
+    setup_env
+    run mkdir -p "${LOG_DIR}" "${RESULTS_DIR}" "${FIGURES_DIR}"
+    run mkdir -p "${RESULTS_DIR}"
+
+    # Record run metadata
+    if [[ "${DRY_RUN}" == false ]]; then
+        {
+            echo "timestamp=${TIMESTAMP}"
+            echo "seed=${SEED}"
+            echo "threads=${N_THREADS}"
+            echo "git_commit=$(cd "${REPO_ROOT}" && git rev-parse HEAD 2>/dev/null || echo UNKNOWN)"
+            echo "hostname=$(hostname)"
+            echo "os=$(uname -srm)"
+        } > "${RESULTS_DIR}/run_metadata.txt"
+    fi
+
+    preflight
+
+    if [[ "${SKIP_PILOT}" == false ]]; then
+        run_pilot
+    else
+        warn "Pilot calibration skipped (--skip-pilot)"
+    fi
+
+    if [[ "${PILOT_ONLY}" == false ]]; then
+        thermo_gate
+        run_full_astex
+        if [[ "${RUN_PHASE2}" == true ]]; then
+            run_phase2
+        fi
+    else
+        info "Pilot-only mode — stopping after calibration"
+    fi
+
+    print_final_report
+}
+
+main "$@"

--- a/scripts/run_dual_assembly_cotranslational.sh
+++ b/scripts/run_dual_assembly_cotranslational.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# run_dual_assembly_cotranslational.sh — DualAssembly cotranslational docking driver
+#
+# Wraps the `dual_assembly` C++ binary (built with -DENABLE_DUAL_ASSEMBLY_TOOL=ON)
+# and parses its CSV output. The MVP backend is synthetic; --real-ga fails closed
+# until the FlexAID GA hookup lands.
+#
+# Usage:
+#   scripts/run_dual_assembly_cotranslational.sh \
+#       --target-pdb <protofibril.pdb> \
+#       --sequence <FASTA-1-letter or @file.fasta> \
+#       [--monomer-pdb <monomer.pdb>] \
+#       [--checkpoint-interval 10] \
+#       [--sim-c-interval 5] \
+#       [--monomer-conc-M 1e-6] \
+#       [--temperature 310.15] \
+#       [--threads 6] \
+#       [--no-reciprocal-controls] \
+#       [--no-sim-c] \
+#       [--output-csv cotranslational_trajectory.csv] \
+#       [--nascent-pdb-dir .]
+#
+# Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+# ─── Defaults ────────────────────────────────────────────────────────────────
+TARGET_PDB=""
+SEQUENCE=""
+MONOMER_PDB=""
+CHECKPOINT_INTERVAL=10
+SIM_C_INTERVAL=5
+MONOMER_CONC_M="1e-6"
+TEMPERATURE="310.15"
+THREADS=6
+RECIPROCAL_CONTROLS=1
+SIM_C_ENABLED=1
+OUTPUT_CSV="cotranslational_trajectory.csv"
+NASCENT_PDB_DIR="."
+
+# ─── arg parse ───────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target-pdb)          TARGET_PDB="$2"; shift 2 ;;
+        --sequence)            SEQUENCE="$2"; shift 2 ;;
+        --monomer-pdb)         MONOMER_PDB="$2"; shift 2 ;;
+        --checkpoint-interval) CHECKPOINT_INTERVAL="$2"; shift 2 ;;
+        --sim-c-interval)      SIM_C_INTERVAL="$2"; shift 2 ;;
+        --monomer-conc-M)      MONOMER_CONC_M="$2"; shift 2 ;;
+        --temperature)         TEMPERATURE="$2"; shift 2 ;;
+        --threads)             THREADS="$2"; shift 2 ;;
+        --no-reciprocal-controls) RECIPROCAL_CONTROLS=0; shift ;;
+        --no-sim-c)            SIM_C_ENABLED=0; shift ;;
+        --output-csv)          OUTPUT_CSV="$2"; shift 2 ;;
+        --nascent-pdb-dir)     NASCENT_PDB_DIR="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '1,30p' "$0"
+            exit 0
+            ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ─── Validate ────────────────────────────────────────────────────────────────
+if [[ -z "$TARGET_PDB" || -z "$SEQUENCE" ]]; then
+    echo "ERROR: --target-pdb and --sequence are required" >&2
+    sed -n '1,30p' "$0" >&2
+    exit 2
+fi
+if [[ ! -f "$TARGET_PDB" ]]; then
+    echo "ERROR: target-pdb not readable: $TARGET_PDB" >&2
+    exit 2
+fi
+
+# ─── Locate the binary ────────────────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN=""
+for candidate in \
+    "$REPO_ROOT/build/dual_assembly" \
+    "$REPO_ROOT/build/Release/dual_assembly" \
+    "$REPO_ROOT/build/Debug/dual_assembly" \
+    "$(command -v dual_assembly || true)"; do
+    if [[ -n "$candidate" && -x "$candidate" ]]; then
+        BIN="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$BIN" ]]; then
+    cat >&2 <<'EOF'
+ERROR: dual_assembly binary not found.
+Build it first:
+  cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_DUAL_ASSEMBLY_TOOL=ON
+  cmake --build build --target dual_assembly -j 6
+EOF
+    exit 1
+fi
+
+mkdir -p "$NASCENT_PDB_DIR"
+
+# ─── Construct CLI args ──────────────────────────────────────────────────────
+ARGS=(
+    --target-pdb "$TARGET_PDB"
+    --sequence   "$SEQUENCE"
+    --checkpoint-interval "$CHECKPOINT_INTERVAL"
+    --sim-c-interval      "$SIM_C_INTERVAL"
+    --monomer-conc-M      "$MONOMER_CONC_M"
+    --temperature         "$TEMPERATURE"
+    --threads             "$THREADS"
+    --output-csv          "$OUTPUT_CSV"
+    --nascent-pdb-dir     "$NASCENT_PDB_DIR"
+)
+
+if [[ -n "$MONOMER_PDB" ]]; then
+    if [[ ! -f "$MONOMER_PDB" ]]; then
+        echo "ERROR: monomer-pdb not readable: $MONOMER_PDB" >&2
+        exit 2
+    fi
+    ARGS+=( --monomer-pdb "$MONOMER_PDB" )
+fi
+[[ $RECIPROCAL_CONTROLS -eq 0 ]] && ARGS+=( --no-reciprocal-controls )
+[[ $SIM_C_ENABLED       -eq 0 ]] && ARGS+=( --no-sim-c )
+
+# OMP threads
+export OMP_NUM_THREADS="$THREADS"
+
+echo "[dual_assembly] binary:     $BIN"
+echo "[dual_assembly] target-pdb: $TARGET_PDB"
+echo "[dual_assembly] sequence:   ${SEQUENCE:0:60}$([[ ${#SEQUENCE} -gt 60 ]] && echo '…')"
+echo "[dual_assembly] output:     $OUTPUT_CSV"
+echo "[dual_assembly] threads:    $THREADS"
+
+"$BIN" "${ARGS[@]}"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+if [[ -f "$OUTPUT_CSV" ]]; then
+    N_ROWS=$(($(wc -l < "$OUTPUT_CSV") - 1))
+    echo "[dual_assembly] wrote $N_ROWS checkpoints to $OUTPUT_CSV"
+fi

--- a/scripts/validate_benchmark_results.py
+++ b/scripts/validate_benchmark_results.py
@@ -1,0 +1,609 @@
+#!/usr/bin/env python3
+"""
+validate_benchmark_results.py — FlexAIDdS Benchmark Statistical Validation
+
+Reads the summary CSV produced by run_benchmark_production.sh and performs:
+  1. Descriptive statistics (wall-clock, success rate, RMSD distribution)
+  2. Bootstrap 95% CI on success rate (n=85, 10k resamples — not normal approx)
+  3. Fisher's exact test vs. Vina baseline (58/85 = 68.2% — Hartshorn 2007)
+  4. Shannon-Weighted Success Rate (SWSR calibration check)
+  5. Spearman ρ(H_final, RMSD_top1) with bootstrap CI
+  6. Plots: wall-clock dist, score vs RMSD scatter, Shannon H convergence curves
+  7. PASS / FAIL verdict against BENCHMARKING_PLAN.md thresholds
+
+Usage:
+    python3 scripts/validate_benchmark_results.py <summary.csv> [options]
+
+    python3 scripts/validate_benchmark_results.py \\
+        benchmark_results/20260517_120000/summary.csv \\
+        --shannon-log-dir benchmark_results/20260517_120000/astex_diverse/ \\
+        --out-dir benchmark_results/20260517_120000/figures/
+
+Apache-2.0 · Le Bonhomme Pharma / NRGlab, Université de Montréal
+"""
+
+import argparse
+import csv
+import json
+import math
+import os
+import sys
+from pathlib import Path
+
+
+# ─── Constants (must match BENCHMARKING_PLAN.md / ShannonThermoStack.h) ───────
+
+kB_KCAL       = 0.001987206          # kcal mol⁻¹ K⁻¹
+LN2           = 0.6931471805599453
+kHSC_SOFT     = 2.0 * LN2           # 1.3863 nats — soft convergence threshold
+kHSC_HARD     = 1.0 * LN2           # 0.6931 nats — hard (thesis) convergence threshold
+VINA_N_SUCCESS = 49                  # Vina baseline (Hartshorn 2007 Table 3, top-1)
+VINA_N_TOTAL   = 85
+RMSD_SUCCESS   = 2.0                 # Å — primary success threshold
+TARGET_SR      = 0.65               # 65% target success rate (FlexAIDdS)
+FLOOR_SR       = 0.58               # 58% hard floor (Vina baseline)
+N_BOOT         = 10_000             # bootstrap resamples
+BOOT_CI        = 0.95               # confidence interval level
+
+
+# ─── Bootstrap ────────────────────────────────────────────────────────────────
+
+def bootstrap_sr(successes: list[int], n_boot: int = N_BOOT,
+                 ci: float = BOOT_CI) -> tuple[float, float, float]:
+    """
+    Bootstrap 95% CI on success rate.
+    Returns (mean, lo, hi).
+    Uses only stdlib random — no numpy required.
+    """
+    import random
+    n = len(successes)
+    mean = sum(successes) / n
+    boot = []
+    for _ in range(n_boot):
+        sample = [random.choice(successes) for _ in range(n)]
+        boot.append(sum(sample) / n)
+    boot.sort()
+    a = (1 - ci) / 2
+    lo = boot[int(a * n_boot)]
+    hi = boot[int((1 - a) * n_boot)]
+    return mean, lo, hi
+
+
+def bootstrap_spearman(x: list[float], y: list[float],
+                        n_boot: int = N_BOOT) -> tuple[float, float, float]:
+    """Bootstrap 95% CI on Spearman ρ(x, y)."""
+    import random
+    rho = spearman_r(x, y)
+    n = len(x)
+    pairs = list(zip(x, y))
+    boot = []
+    for _ in range(n_boot):
+        s = [random.choice(pairs) for _ in range(n)]
+        sx, sy = zip(*s)
+        boot.append(spearman_r(list(sx), list(sy)))
+    boot.sort()
+    a = (1 - BOOT_CI) / 2
+    lo = boot[int(a * n_boot)]
+    hi = boot[int((1 - a) * n_boot)]
+    return rho, lo, hi
+
+
+def spearman_r(x: list[float], y: list[float]) -> float:
+    """Spearman rank correlation — stdlib only."""
+    n = len(x)
+    if n < 2:
+        return float('nan')
+
+    def ranks(lst):
+        sorted_idx = sorted(range(n), key=lambda i: lst[i])
+        r = [0.0] * n
+        i = 0
+        while i < n:
+            j = i
+            while j < n - 1 and lst[sorted_idx[j]] == lst[sorted_idx[j + 1]]:
+                j += 1
+            avg_rank = (i + j) / 2.0 + 1
+            for k in range(i, j + 1):
+                r[sorted_idx[k]] = avg_rank
+            i = j + 1
+        return r
+
+    rx, ry = ranks(x), ranks(y)
+    mx = sum(rx) / n
+    my = sum(ry) / n
+    num = sum((rx[i] - mx) * (ry[i] - my) for i in range(n))
+    den = math.sqrt(
+        sum((rx[i] - mx) ** 2 for i in range(n)) *
+        sum((ry[i] - my) ** 2 for i in range(n))
+    )
+    return num / den if den > 0 else float('nan')
+
+
+def fisher_exact_greater(a: int, b: int, c: int, d: int) -> tuple[float, float]:
+    """
+    One-sided Fisher's exact test: H₁: odds ratio > 1.
+    2×2 table: [[a, b], [c, d]]
+    Returns (odds_ratio, p_value).
+    stdlib only — hypergeometric via log-factorial.
+    """
+    def log_fact(n: int) -> float:
+        return math.lgamma(n + 1)
+
+    def log_hypergeom(k: int, K: int, N: int, n: int) -> float:
+        return (log_fact(K) - log_fact(k) - log_fact(K - k) +
+                log_fact(N - K) - log_fact(n - k) - log_fact(N - K - n + k) +
+                log_fact(n) - log_fact(N) + log_fact(N - n))
+
+    # a = FlexAID success, b = FlexAID fail, c = Vina success, d = Vina fail
+    n1, n2, K, N = a + b, c + d, a + c, a + b + c + d
+    n = n1
+    # P(X >= a) under H0
+    p = 0.0
+    for k in range(a, min(K, n) + 1):
+        if K - k <= N - K - n + k:
+            try:
+                p += math.exp(log_hypergeom(k, K, N, n))
+            except (ValueError, OverflowError):
+                pass
+    or_ = (a * d) / (b * c) if b > 0 and c > 0 else float('inf')
+    return or_, min(p, 1.0)
+
+
+# ─── Shannon-Weighted Success Rate ────────────────────────────────────────────
+
+def swsr(successes: list[int], h_finals: list[float],
+         floor: float = 0.1) -> float:
+    """
+    Shannon-Weighted Success Rate (Section 7.3 of BENCHMARKING_PLAN.md).
+    SR_H = Σ (1/H_i · success_i) / Σ (1/H_i)
+    """
+    weights = [1.0 / max(h, floor) for h in h_finals]
+    total_w = sum(weights)
+    if total_w == 0:
+        return float('nan')
+    return sum(w * s for w, s in zip(weights, successes)) / total_w
+
+
+# ─── RMSD distribution ────────────────────────────────────────────────────────
+
+def rmsd_distribution(rmsds: list[float]) -> dict:
+    """Compute the full RMSD distribution per BENCHMARKING_PLAN.md §7.5."""
+    n = len(rmsds)
+    if n == 0:
+        return {}
+    rmsds_sorted = sorted(rmsds)
+    return {
+        "n": n,
+        "median":          rmsds_sorted[n // 2],
+        "mean":            sum(rmsds) / n,
+        "frac_lt_1A":      sum(1 for r in rmsds if r < 1.0) / n,
+        "frac_lt_2A":      sum(1 for r in rmsds if r < 2.0) / n,
+        "frac_lt_3A":      sum(1 for r in rmsds if r < 3.0) / n,
+        "frac_gt_5A":      sum(1 for r in rmsds if r > 5.0) / n,
+    }
+
+
+# ─── Load Shannon trace CSVs ──────────────────────────────────────────────────
+
+def load_shannon_trace(complex_dir: Path) -> list[dict]:
+    """
+    Load per-step Shannon trace CSV from SHANNON_TRACE_LEVEL=2 output.
+    Expected format: step,H_nats,H_bits,n_clusters,top_pose_weight,...
+    """
+    for fname in ["shannon_trace.csv", "shannon.csv", "entropy_trace.csv"]:
+        f = complex_dir / fname
+        if f.exists():
+            rows = []
+            with open(f) as fh:
+                reader = csv.DictReader(fh)
+                for row in reader:
+                    try:
+                        rows.append({
+                            "step":            int(row.get("step", 0)),
+                            "H_nats":          float(row.get("H_nats", row.get("H", 0))),
+                            "H_bits":          float(row.get("H_bits", 0)),
+                            "n_clusters":      int(row.get("n_clusters", 0)),
+                            "top_pose_weight": float(row.get("top_pose_weight", 0)),
+                        })
+                    except (ValueError, KeyError):
+                        continue
+            return rows
+    return []
+
+
+# ─── Plotting ─────────────────────────────────────────────────────────────────
+
+def make_plots(rows: list[dict], shannon_data: dict,
+               out_dir: Path) -> list[str]:
+    """
+    Generate and save three key plots.
+    Returns list of file paths created.
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import matplotlib.gridspec as gridspec
+    except ImportError:
+        print("  [WARN] matplotlib not available — skipping plots")
+        print("         pip install matplotlib --break-system-packages")
+        return []
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    created = []
+
+    wall_times = [float(r["wall_time_s"]) for r in rows
+                  if r["wall_time_s"] not in ("0", "N/A", "") and float(r["wall_time_s"]) > 0]
+    rmsds      = [float(r["rmsd_to_crystal"]) for r in rows
+                  if r["rmsd_to_crystal"] not in ("N/A", "")]
+    scores     = [float(r["top1_score"]) for r in rows
+                  if r["top1_score"] not in ("N/A", "")]
+
+    # 1. Wall-clock distribution ───────────────────────────────────────────────
+    if wall_times:
+        fig, ax = plt.subplots(figsize=(8, 5))
+        ax.hist(wall_times, bins=20, color="#1f77b4", edgecolor="white", alpha=0.85)
+        ax.axvline(sum(wall_times) / len(wall_times), color="red",
+                   lw=2, linestyle="--", label=f"Mean={sum(wall_times)/len(wall_times):.0f}s")
+        ax.set_xlabel("Wall-clock time (s/complex)", fontsize=12)
+        ax.set_ylabel("Count", fontsize=12)
+        ax.set_title("FlexAIDdS — Wall-clock distribution (Astex Diverse 85)", fontsize=13)
+        ax.legend()
+        # Overlay expected range band
+        ax.axvspan(300, 480, alpha=0.12, color="green", label="Expected 5–8 min")
+        ax.legend()
+        fig.tight_layout()
+        p = out_dir / "wallclock_distribution.png"
+        fig.savefig(p, dpi=150)
+        plt.close(fig)
+        created.append(str(p))
+
+    # 2. Score vs RMSD scatter ─────────────────────────────────────────────────
+    if rmsds and scores and len(rmsds) == len(scores):
+        successes_bool = [r < RMSD_SUCCESS for r in rmsds]
+        fig, ax = plt.subplots(figsize=(8, 6))
+        colors = ["#2ca02c" if s else "#d62728" for s in successes_bool]
+        ax.scatter(rmsds, scores, c=colors, alpha=0.7, edgecolors="white", s=50)
+        ax.axvline(RMSD_SUCCESS, color="gray", lw=1.5, linestyle="--",
+                   label=f"RMSD = {RMSD_SUCCESS}Å threshold")
+        ax.set_xlabel("RMSD to crystal (Å)", fontsize=12)
+        ax.set_ylabel("Top-1 FlexAIDdS score", fontsize=12)
+        ax.set_title("Score vs. RMSD — Astex Diverse 85\n"
+                     "(green=success, red=failure)", fontsize=13)
+        ax.legend()
+        fig.tight_layout()
+        p = out_dir / "score_vs_rmsd.png"
+        fig.savefig(p, dpi=150)
+        plt.close(fig)
+        created.append(str(p))
+
+    # 3. Shannon H(X) convergence curves ──────────────────────────────────────
+    if shannon_data:
+        fig, ax = plt.subplots(figsize=(10, 6))
+        max_step = 0
+
+        # Plot per-complex traces (thin, grey)
+        for pdb, trace in list(shannon_data.items())[:20]:  # cap at 20 for legibility
+            if not trace:
+                continue
+            steps  = [r["step"] for r in trace]
+            H_nats = [r["H_nats"] for r in trace]
+            ax.plot(steps, H_nats, lw=0.5, alpha=0.4, color="steelblue")
+            max_step = max(max_step, max(steps) if steps else 0)
+
+        # Mean trace (bold)
+        if shannon_data:
+            all_traces = [t for t in shannon_data.values() if t]
+            if all_traces:
+                common_steps = sorted(set(r["step"] for t in all_traces for r in t))
+                mean_H = []
+                for s in common_steps:
+                    vals = [r["H_nats"] for t in all_traces
+                            for r in t if r["step"] == s]
+                    if vals:
+                        mean_H.append(sum(vals) / len(vals))
+                if mean_H:
+                    ax.plot(common_steps[:len(mean_H)], mean_H,
+                            lw=2.5, color="navy", label="Mean H(X)")
+
+        # Threshold lines
+        ax.axhline(kHSC_SOFT, color="orange", lw=2, linestyle="--",
+                   label=f"HSC soft = {kHSC_SOFT:.4f} nats (2·ln2)")
+        ax.axhline(kHSC_HARD, color="red", lw=2, linestyle=":",
+                   label=f"HSC hard = {kHSC_HARD:.4f} nats (ln2)")
+
+        ax.set_xlabel("GA generation", fontsize=12)
+        ax.set_ylabel("Shannon entropy H(X) [nats]", fontsize=12)
+        ax.set_title("Shannon Energy Collapse — Astex Diverse\n"
+                     "(collapse below orange dashed line = convergence)", fontsize=13)
+        ax.legend(fontsize=10)
+        if max_step > 0:
+            ax.set_xlim(0, max_step)
+        ax.set_ylim(bottom=0)
+        fig.tight_layout()
+        p = out_dir / "shannon_convergence.png"
+        fig.savefig(p, dpi=150)
+        plt.close(fig)
+        created.append(str(p))
+
+    return created
+
+
+# ─── Verdict ──────────────────────────────────────────────────────────────────
+
+def pass_fail(name: str, value: float, threshold: float,
+              direction: str = "ge") -> tuple[str, bool]:
+    """direction: 'ge' (≥ threshold = PASS) or 'le' (≤ threshold = PASS)."""
+    if direction == "ge":
+        passed = value >= threshold
+    else:
+        passed = value <= threshold
+    status = "✅ PASS" if passed else "❌ FAIL"
+    return f"  {status}  {name}: {value:.4f} (threshold {'≥' if direction=='ge' else '≤'} {threshold})", passed
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="FlexAIDdS benchmark statistical validation",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("summary_csv", help="Summary CSV from run_benchmark_production.sh")
+    parser.add_argument("--shannon-log-dir", default=None,
+                        help="Directory containing per-complex result dirs "
+                             "(for Shannon trace CSVs)")
+    parser.add_argument("--out-dir", default=None,
+                        help="Output directory for figures (default: alongside CSV)")
+    parser.add_argument("--n-boot", type=int, default=N_BOOT)
+    parser.add_argument("--rmsd-threshold", type=float, default=RMSD_SUCCESS)
+    parser.add_argument("--no-plots", action="store_true")
+    args = parser.parse_args()
+
+    csv_path = Path(args.summary_csv)
+    if not csv_path.exists():
+        print(f"ERROR: Summary CSV not found: {csv_path}", file=sys.stderr)
+        sys.exit(1)
+
+    out_dir = Path(args.out_dir) if args.out_dir else csv_path.parent / "figures"
+    shannon_root = Path(args.shannon_log_dir) if args.shannon_log_dir else None
+
+    print("=" * 65)
+    print("  FlexAIDdS Benchmark Statistical Validation")
+    print(f"  Input:   {csv_path}")
+    print(f"  Out dir: {out_dir}")
+    print("=" * 65)
+    print()
+
+    # ── Load CSV ──────────────────────────────────────────────────────────────
+    rows = []
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(row)
+
+    n = len(rows)
+    if n == 0:
+        print("ERROR: Summary CSV is empty", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"  Loaded {n} complexes from summary CSV")
+
+    # Parse numeric fields robustly
+    wall_times = []
+    successes  = []
+    rmsds      = []
+    h_finals   = []
+
+    for r in rows:
+        try:
+            wt = float(r.get("wall_time_s", 0))
+            wall_times.append(wt if wt > 0 else None)
+        except ValueError:
+            wall_times.append(None)
+
+        try:
+            successes.append(int(r.get("success", 0)))
+        except ValueError:
+            successes.append(0)
+
+        try:
+            rmsd = float(r.get("rmsd_to_crystal", "N/A"))
+            rmsds.append(rmsd)
+        except ValueError:
+            rmsds.append(None)
+
+        try:
+            h = float(r.get("shannon_entropy", r.get("h_final", "N/A")))
+            h_finals.append(h)
+        except ValueError:
+            h_finals.append(None)
+
+    valid_wall  = [w for w in wall_times if w is not None and w > 0]
+    valid_rmsds = [r for r in rmsds if r is not None]
+    valid_h     = [h for h in h_finals if h is not None]
+
+    # ── Wall-clock statistics ─────────────────────────────────────────────────
+    print("\n── Wall-clock Statistics ─────────────────────────────────────")
+    if valid_wall:
+        mean_w = sum(valid_wall) / len(valid_wall)
+        var_w  = sum((x - mean_w) ** 2 for x in valid_wall) / max(len(valid_wall) - 1, 1)
+        std_w  = math.sqrt(var_w)
+        min_w  = min(valid_wall)
+        max_w  = max(valid_wall)
+        eta_h  = mean_w * 85 / 3600
+        print(f"  n (with timing):  {len(valid_wall)}")
+        print(f"  Mean:             {mean_w:.1f}s ± {std_w:.1f}s")
+        print(f"  Min / Max:        {min_w:.1f}s / {max_w:.1f}s")
+        print(f"  Est. full 85:     ~{eta_h:.1f}h")
+        in_range = 300 <= mean_w <= 480
+        print(f"  In expected range (5–8 min): {'YES ✅' if in_range else 'NO ⚠️'}")
+    else:
+        print("  No valid wall-clock data (dry-run or missing?)")
+
+    # ── RMSD distribution ─────────────────────────────────────────────────────
+    print("\n── RMSD Distribution ────────────────────────────────────────")
+    dist = rmsd_distribution(valid_rmsds)
+    if dist:
+        print(f"  n (with RMSD):    {dist['n']}")
+        print(f"  Median RMSD:      {dist['median']:.2f} Å")
+        print(f"  Mean RMSD:        {dist['mean']:.2f} Å")
+        print(f"  RMSD < 1.0 Å:     {dist['frac_lt_1A']*100:.1f}% (near-crystal)")
+        print(f"  RMSD < 2.0 Å:     {dist['frac_lt_2A']*100:.1f}% (primary criterion)")
+        print(f"  RMSD < 3.0 Å:     {dist['frac_lt_3A']*100:.1f}% (near-success)")
+        print(f"  RMSD > 5.0 Å:     {dist['frac_gt_5A']*100:.1f}% (catastrophic failure)")
+    else:
+        print("  No RMSD data available")
+
+    # ── Success rate + bootstrap CI ───────────────────────────────────────────
+    print("\n── Success Rate (Bootstrap 95% CI) ──────────────────────────")
+    n_success = sum(successes)
+    sr_obs    = n_success / n
+    print(f"  n_success / n:    {n_success} / {n}")
+    print(f"  SR (observed):    {sr_obs*100:.1f}%")
+
+    sr_mean, sr_lo, sr_hi = bootstrap_sr(successes, n_boot=args.n_boot)
+    print(f"  Bootstrap CI:     [{sr_lo*100:.1f}%, {sr_hi*100:.1f}%] (95%, {args.n_boot} resamples)")
+    print(f"  Vina baseline:    {VINA_N_SUCCESS}/{VINA_N_TOTAL} = {VINA_N_SUCCESS/VINA_N_TOTAL*100:.1f}%")
+    print(f"  FlexAIDdS target: ≥ {TARGET_SR*100:.0f}%  hard floor: ≥ {FLOOR_SR*100:.0f}%")
+
+    # ── Fisher's exact test vs Vina ───────────────────────────────────────────
+    print("\n── Fisher's Exact Test vs. Vina Baseline ────────────────────")
+    a = n_success
+    b = n - n_success
+    c = VINA_N_SUCCESS
+    d = VINA_N_TOTAL - VINA_N_SUCCESS
+    or_, p_val = fisher_exact_greater(a, b, c, d)
+    delta_pp = (n_success / n - VINA_N_SUCCESS / VINA_N_TOTAL) * 100
+    print(f"  FlexAIDdS: {a}/{n}   Vina: {c}/{VINA_N_TOTAL}")
+    print(f"  ΔRMSD-SR:  {delta_pp:+.1f} pp")
+    print(f"  Odds ratio: {or_:.2f}")
+    print(f"  p (one-sided): {p_val:.4f}  {'(**)' if p_val < 0.01 else '(*)' if p_val < 0.05 else ''}")
+    print(f"  Significant (p < 0.05): {'YES ✅' if p_val < 0.05 else 'NO ❌'}")
+
+    # ── Shannon-Weighted Success Rate ─────────────────────────────────────────
+    print("\n── Shannon-Weighted Success Rate (SWSR Calibration) ─────────")
+    if valid_h and len(valid_h) == n:
+        sw = swsr(successes, valid_h)
+        print(f"  SR  (unweighted): {sr_obs*100:.1f}%")
+        print(f"  SR_H (SWSR):      {sw*100:.1f}%")
+        if sw > sr_obs:
+            print("  SR_H > SR  ✅  High-confidence predictions are more accurate (calibrated)")
+        else:
+            print("  SR_H < SR  ⚠️  Overconfident failures — investigate scoring function")
+    else:
+        print(f"  Shannon entropy data: {len(valid_h)}/{n} complexes")
+        print("  SWSR requires shannon_entropy column in summary CSV")
+        print("  (Set SHANNON_TRACE_LEVEL≥1 before running benchmark)")
+
+    # ── Spearman ρ(H_final, RMSD) ─────────────────────────────────────────────
+    print("\n── Spearman ρ(H_final, RMSD) ────────────────────────────────")
+    paired_h_rmsd = [(h, r) for h, r in zip(h_finals, rmsds)
+                     if h is not None and r is not None]
+    if len(paired_h_rmsd) >= 5:
+        ph = [p[0] for p in paired_h_rmsd]
+        pr = [p[1] for p in paired_h_rmsd]
+        rho, rho_lo, rho_hi = bootstrap_spearman(ph, pr, n_boot=args.n_boot)
+        print(f"  n:          {len(paired_h_rmsd)}")
+        print(f"  ρ:          {rho:.3f}")
+        print(f"  Bootstrap CI: [{rho_lo:.3f}, {rho_hi:.3f}] (95%)")
+        print(f"  Expected:   ρ > 0 (higher H → worse pose)")
+        if rho > 0:
+            print("  ✅  H(X) is predictive of pose quality (lower entropy → better pose)")
+        elif abs(rho) < 0.2:
+            print("  ⚠️  |ρ| < 0.2 — H(X) weakly predictive → check scoring function")
+        else:
+            print("  ❌  ρ < 0 — unexpected direction — investigate")
+    else:
+        print(f"  Insufficient paired data ({len(paired_h_rmsd)} pairs) — "
+              "need shannon_entropy in CSV")
+
+    # ── Load Shannon traces (if available) ───────────────────────────────────
+    shannon_data = {}
+    if shannon_root and shannon_root.is_dir():
+        print(f"\n── Loading Shannon Traces from {shannon_root} ──")
+        for pdb_dir in sorted(shannon_root.iterdir()):
+            if pdb_dir.is_dir():
+                trace = load_shannon_trace(pdb_dir)
+                if trace:
+                    shannon_data[pdb_dir.name] = trace
+        print(f"  Loaded traces for {len(shannon_data)} complexes")
+
+        # Per-complex convergence stats
+        converged_soft = sum(
+            1 for t in shannon_data.values()
+            if t and t[-1]["H_nats"] < kHSC_SOFT
+        )
+        converged_hard = sum(
+            1 for t in shannon_data.values()
+            if t and t[-1]["H_nats"] < kHSC_HARD
+        )
+        n_traced = len(shannon_data)
+        print(f"  H(X) < {kHSC_SOFT:.4f} nats (soft, 2·ln2): "
+              f"{converged_soft}/{n_traced} complexes")
+        print(f"  H(X) < {kHSC_HARD:.4f} nats (hard,   ln2): "
+              f"{converged_hard}/{n_traced} complexes")
+
+    # ── Plots ─────────────────────────────────────────────────────────────────
+    if not args.no_plots:
+        print(f"\n── Generating Plots → {out_dir} ─────────────────────────")
+        created = make_plots(rows, shannon_data, out_dir)
+        for p in created:
+            print(f"  Saved: {p}")
+        if not created:
+            print("  (No plots generated)")
+
+    # ── PASS / FAIL Verdict ───────────────────────────────────────────────────
+    print("\n" + "=" * 65)
+    print("  BENCHMARK VERDICT")
+    print("=" * 65)
+
+    all_passed = True
+    checks = []
+
+    # Primary: success rate ≥ 65%
+    line, ok = pass_fail("Success rate (SR)", sr_obs, TARGET_SR, "ge")
+    checks.append((line, ok))
+    if not ok:
+        all_passed = False
+
+    # Hard floor: ≥ 58%
+    line, ok = pass_fail("Hard floor (SR ≥ Vina)", sr_obs, FLOOR_SR, "ge")
+    checks.append((line, ok))
+    if not ok:
+        all_passed = False
+
+    # Statistical significance vs Vina
+    line, ok = pass_fail("Fisher p < 0.05 vs Vina", 1 - p_val, 0.95, "ge")
+    checks.append((line, ok))
+    # (not strictly blocking — can WARN)
+
+    # Spearman (informational — don't block)
+    if len(paired_h_rmsd) >= 5:
+        rho_val = rho
+        line = f"  {'⚠️ WARN' if rho_val < 0 else '✅ INFO'}  Spearman ρ(H,RMSD) = {rho_val:.3f} (expected > 0)"
+        checks.append((line, True))
+
+    for line, _ in checks:
+        print(line)
+
+    print()
+    if all_passed:
+        print("  ██████████████████████████████████████████████")
+        print("  ██   OVERALL: PASS  — Ready for publication  ██")
+        print("  ██████████████████████████████████████████████")
+    else:
+        print("  ████████████████████████████████████████████████")
+        print("  ██   OVERALL: FAIL  — Criteria not met        ██")
+        print("  ████████████████████████████████████████████████")
+
+    print()
+    print("  Reference: BENCHMARKING_PLAN.md §2.1 — FlexAIDdS ≥ 65%")
+    print("             Hartshorn et al. (2007) J Med Chem 50:726–741")
+    print()
+
+    sys.exit(0 if all_passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_nascent_chain_scheduler.cpp
+++ b/tests/test_nascent_chain_scheduler.cpp
@@ -1,0 +1,582 @@
+// test_nascent_chain_scheduler.cpp — GoogleTest for NascentChainScheduler.
+//
+// Covers: schedule ordering, checkpoint counts, tunnel/chaperone gating, T/L
+// discriminator at the three entropy regimes, and FibrilGrowthOracle Ξ math.
+//
+// Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+#include <gtest/gtest.h>
+
+#include "NATURaL/NascentChainScheduler.h"
+#include "NATURaL/FibrilGrowthOracle.h"
+#include "NATURaL/DualAssemblyRunner.h"
+#include "NATURaL/NATURaLDualAssembly.h"
+#include "NATURaL/RibosomeElongation.h"
+#include "ShannonThermoStack/ShannonThermoStack.h"
+#include "statmech.h"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <limits>
+#include <random>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+// ─── Scheduling ──────────────────────────────────────────────────────────────
+TEST(NascentChainScheduler, EmitsMonotoneCheckpoints) {
+    auto tracks = natural::make_human_protofibril_tracks(
+        /*transcript_nt=*/300, /*peptide_aa=*/100,
+        /*include_reciprocal_controls=*/true);
+    natural::NascentChainScheduler sched(tracks, /*interval=*/10);
+
+    EXPECT_GE(sched.schedule().size(), 4u);  // ≥ 2 tracks × ≥ 2 checkpoints
+
+    // Schedule must be monotone in (t_arrival_s, track_index).
+    for (size_t i = 1; i < sched.schedule().size(); ++i) {
+        const auto& prev = sched.schedule()[i - 1];
+        const auto& cur  = sched.schedule()[i];
+        EXPECT_LE(prev.t_arrival_s, cur.t_arrival_s + 1e-12);
+    }
+}
+
+TEST(NascentChainScheduler, FirstCheckpointPastTunnelPlusChaperoneSkip) {
+    auto tracks = natural::make_human_protofibril_tracks(
+        /*transcript_nt=*/0, /*peptide_aa=*/100,
+        /*include_reciprocal_controls=*/false);
+    natural::NascentChainScheduler sched(tracks, /*interval=*/10);
+
+    // Tunnel = 34 aa, chaperone skip = 6 → first translation checkpoint at L = 40.
+    bool found_translation = false;
+    for (const auto& ck : sched.schedule()) {
+        if (ck.process == natural::GrowthProcess::Translation) {
+            found_translation = true;
+            EXPECT_GE(ck.L_k, 40);
+            EXPECT_FALSE(ck.in_tunnel);
+            EXPECT_FALSE(ck.chaperone_shielded);
+            break;
+        }
+    }
+    EXPECT_TRUE(found_translation);
+}
+
+TEST(NascentChainScheduler, IteratorExhaustsAfterNCalls) {
+    auto tracks = natural::make_human_protofibril_tracks(0, 100, false);
+    natural::NascentChainScheduler sched(tracks, 10);
+    const size_t n = sched.schedule().size();
+
+    size_t emitted = 0;
+    while (sched.has_next()) { sched.next(); ++emitted; }
+    EXPECT_EQ(emitted, n);
+    EXPECT_FALSE(sched.has_next());
+    EXPECT_THROW((void)sched.next(), std::out_of_range);
+}
+
+TEST(NascentChainScheduler, RejectsBadInterval) {
+    auto tracks = natural::make_human_protofibril_tracks(0, 100, false);
+    EXPECT_THROW(
+        (natural::NascentChainScheduler(tracks, /*interval=*/0)),
+        std::invalid_argument);
+    EXPECT_THROW(
+        (natural::NascentChainScheduler(tracks, /*interval=*/-1)),
+        std::invalid_argument);
+}
+
+// ─── T/L discriminator ──────────────────────────────────────────────────────
+TEST(TLDiscriminator, HardRegimeAssignsLowerEntropySystem) {
+    natural::CheckpointOutcome out;
+    // H_A = 0.3 nats (< ln 2 ≈ 0.693) → A wins. H_B = 1.5 (> soft).
+    natural::DualAssemblyRunner::assign_tl(/*H_A=*/0.3, /*H_B=*/1.5, '?', out);
+    EXPECT_EQ(out.tl_primary, 'A');
+    EXPECT_FALSE(out.tl_deferred);
+    EXPECT_DOUBLE_EQ(out.tl_weight, 1.0);
+
+    natural::CheckpointOutcome out2;
+    natural::DualAssemblyRunner::assign_tl(/*H_A=*/1.5, /*H_B=*/0.3, '?', out2);
+    EXPECT_EQ(out2.tl_primary, 'B');
+    EXPECT_FALSE(out2.tl_deferred);
+    EXPECT_DOUBLE_EQ(out2.tl_weight, 1.0);
+}
+
+TEST(TLDiscriminator, DeferredRegimeInheritsPrevAssignment) {
+    natural::CheckpointOutcome out;
+    // Both above soft threshold (2 ln 2 ≈ 1.386).
+    natural::DualAssemblyRunner::assign_tl(/*H_A=*/1.5, /*H_B=*/1.7, /*prev=*/'B', out);
+    EXPECT_EQ(out.tl_primary, 'B');
+    EXPECT_TRUE(out.tl_deferred);
+    EXPECT_DOUBLE_EQ(out.tl_weight, 0.0);
+}
+
+TEST(TLDiscriminator, SoftRegimeProducesIntermediateWeight) {
+    natural::CheckpointOutcome out;
+    // H_lower in (ln 2, 2 ln 2). Pick H_lower = 1.0 → w = (1.386 − 1.0)/(1.386 − 0.693).
+    constexpr double H_lower = 1.0;
+    natural::DualAssemblyRunner::assign_tl(H_lower, /*H_B=*/2.0, /*prev=*/'?', out);
+    EXPECT_EQ(out.tl_primary, 'A');
+    EXPECT_FALSE(out.tl_deferred);
+    constexpr double soft = shannon_thermo::kHSC_soft_nats;
+    constexpr double hard = shannon_thermo::kHSC_hard_nats;
+    const double expected_w = (soft - H_lower) / (soft - hard);
+    EXPECT_NEAR(out.tl_weight, expected_w, 1e-9);
+    EXPECT_GT(out.tl_weight, 0.0);
+    EXPECT_LT(out.tl_weight, 1.0);
+}
+
+TEST(TLDiscriminator, BothInfiniteInheritsPrev) {
+    natural::CheckpointOutcome out;
+    const double inf = std::numeric_limits<double>::infinity();
+    natural::DualAssemblyRunner::assign_tl(inf, inf, /*prev=*/'A', out);
+    EXPECT_EQ(out.tl_primary, 'A');
+    EXPECT_TRUE(out.tl_deferred);
+    EXPECT_DOUBLE_EQ(out.tl_weight, 0.0);
+}
+
+// ─── FibrilGrowthOracle ─────────────────────────────────────────────────────
+TEST(FibrilGrowthOracle, AnalyticXiForKnownZ) {
+    natural::FibrilGrowthOracle oracle(/*T_K=*/310.15);
+
+    // Inject a synthetic monomer ensemble with a known F (and hence ln Z = -F/kT).
+    statmech::StatMechEngine engine(310.15);
+    // ΔG = -2 kcal/mol (favourable). Add a single sample at this energy.
+    engine.add_sample(-2.0, 1.0);
+
+    // At c = 1 µM, z = 1e-6. With F ≈ -2 kcal/mol and kT ≈ 0.616 kcal/mol at 310 K,
+    // ln Z ≈ 2 / 0.616 ≈ 3.247. z·Z ≈ 1e-6 · e^3.247 ≈ 2.57e-5.
+    // p ≈ z·Z / (1 + z·Z) ≈ 2.57e-5.
+    auto decision = oracle.gate(engine, /*c_monomer_M=*/1.0e-6);
+    EXPECT_GT(decision.p_elong, 0.0);
+    EXPECT_LT(decision.p_elong, 1.0);
+    EXPECT_TRUE(std::isfinite(decision.dG_elong));
+
+    // At c = 1 M (z = 1), p should be much higher.
+    auto decision2 = oracle.gate(engine, /*c_monomer_M=*/1.0);
+    EXPECT_GT(decision2.p_elong, decision.p_elong);
+
+    const double kT = statmech::kB_kcal * 310.15;
+    EXPECT_NEAR(decision.dG_elong - decision2.dG_elong,
+                kT * std::log(1.0e6),
+                1e-9);
+}
+
+TEST(FibrilGrowthOracle, RejectsNonPositiveConcentration) {
+    natural::FibrilGrowthOracle oracle(310.15);
+    statmech::StatMechEngine engine(310.15);
+    engine.add_sample(-1.0, 1.0);
+    EXPECT_THROW(oracle.gate(engine, 0.0), std::invalid_argument);
+    EXPECT_THROW(oracle.gate(engine, -1e-9), std::invalid_argument);
+}
+
+TEST(FibrilGrowthOracle, GateDecisionTracksConcentrationCorrectedFreeEnergy) {
+    natural::FibrilGrowthOracle oracle(/*T_K=*/310.15, /*thresh=*/0.5);
+    statmech::StatMechEngine engine(310.15);
+    engine.add_sample(-20.0, 1.0);
+
+    const auto low_conc = oracle.gate(engine, 1.0e-30);
+    const auto high_conc = oracle.gate(engine, 1.0);
+
+    EXPECT_FALSE(low_conc.gated_in);
+    EXPECT_TRUE(high_conc.gated_in);
+    EXPECT_LT(low_conc.p_elong, high_conc.p_elong);
+    EXPECT_GT(low_conc.dG_elong, high_conc.dG_elong);
+}
+
+TEST(FibrilGrowthOracle, RejectsBadTemperature) {
+    EXPECT_THROW((natural::FibrilGrowthOracle(0.0)), std::invalid_argument);
+    EXPECT_THROW((natural::FibrilGrowthOracle(310.15, /*thresh=*/-0.1)), std::invalid_argument);
+    EXPECT_THROW((natural::FibrilGrowthOracle(310.15, /*thresh=*/1.5)), std::invalid_argument);
+}
+
+// ─── DualAssemblyRunner end-to-end with synthetic backends ──────────────────
+namespace {
+natural::GAResult synthetic_engine(double T, int n_poses, double width, double dG, unsigned seed) {
+    statmech::StatMechEngine eng(T);
+    std::mt19937 rng(seed);
+    std::normal_distribution<double> rd(0.0, std::max(1e-3, width));
+    std::normal_distribution<double> ed(dG, 1.0);
+    std::vector<double> rmsds;
+    rmsds.reserve(n_poses);
+    for (int i = 0; i < n_poses; ++i) {
+        eng.add_sample(ed(rng), 1.0);
+        rmsds.push_back(std::abs(rd(rng)));
+    }
+    return {std::move(eng), std::move(rmsds)};
+}
+
+std::vector<std::string> split_csv_line(const std::string& line) {
+    std::vector<std::string> fields;
+    std::stringstream ss(line);
+    std::string field;
+    while (std::getline(ss, field, ','))
+        fields.push_back(field);
+    return fields;
+}
+} // namespace
+
+TEST(DualAssemblyRunner, RunsEndToEndWithSyntheticBackend) {
+    natural::DualAssemblyConfig cfg;
+    cfg.protofibril_pdb = "fake.pdb";
+    cfg.monomer_pdb     = "fake_monomer.pdb";
+    cfg.sequence_fasta  = std::string(80, 'A');  // 80 aa
+    cfg.checkpoint_interval = 10;
+    cfg.sim_c_interval = 3;
+    cfg.include_reciprocal_controls = false;     // keep small
+    cfg.sim_c_enabled = true;
+    cfg.output_csv = "/tmp/dual_assembly_smoke.csv";
+    cfg.nascent_pdb_dir = "/tmp/dual_assembly_smoke_pdbs";
+
+    auto sim_a = [](const std::string&, const std::string&, int L_k, double T) {
+        // Narrow as L_k grows so H crosses thresholds.
+        return synthetic_engine(T, 64, std::max(0.5, 8.0 - 0.1 * L_k), -1.0 - 0.05 * L_k, 1u + L_k);
+    };
+    auto sim_b = [](const std::string&, const std::string&, int L_k, double T) {
+        return synthetic_engine(T, 32, std::max(0.5, 4.0 - 0.02 * L_k), -0.5 - 0.02 * L_k, 2u + L_k);
+    };
+    auto sim_c = [](const std::string&, const std::string&, double T) {
+        return synthetic_engine(T, 32, 1.5, -3.0, 3u);
+    };
+    auto trunc = [](const std::string& seq, int L_k, const std::string&) {
+        return std::string("/tmp/nascent_L") + std::to_string(L_k) + ".pdb";
+    };
+
+    natural::DualAssemblyRunner runner(std::move(cfg), sim_a, sim_b, sim_c, trunc);
+    auto history = runner.run();
+    EXPECT_GT(history.size(), 0u);
+    // First eligible checkpoint must be at L_k >= 40 (tunnel + chaperone skip).
+    bool found_eligible = false;
+    for (const auto& [ck, out] : history) {
+        if (!ck.in_tunnel && !ck.chaperone_shielded && ck.direct_encounter_allowed) {
+            EXPECT_GE(ck.L_k, 40);
+            EXPECT_TRUE(std::isfinite(out.H_A_nats));
+            EXPECT_TRUE(std::isfinite(out.dG_A_kcal));
+            found_eligible = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found_eligible);
+
+    std::ifstream csv("/tmp/dual_assembly_smoke.csv");
+    ASSERT_TRUE(csv.good());
+    std::string header;
+    ASSERT_TRUE(std::getline(csv, header));
+    EXPECT_NE(header.find("tl_basis"), std::string::npos);
+    const std::vector<std::string> expected_header = {
+        "checkpoint_idx",
+        "L_k",
+        "process",
+        "track_name",
+        "role_policy",
+        "t_arrival_s",
+        "in_tunnel",
+        "H_A_nats",
+        "H_B_nats",
+        "dG_A_kcal",
+        "dG_B_kcal",
+        "tl_primary",
+        "tl_weight",
+        "tl_deferred",
+        "tl_basis",
+        "p_elong",
+        "dG_elong_kcal",
+        "sim_c_evaluated",
+        "sim_c_gated_in",
+        "protofibril_state_idx",
+        "protofibril_structure_updated"
+    };
+    EXPECT_EQ(split_csv_line(header), expected_header);
+
+    std::string first_row;
+    ASSERT_TRUE(std::getline(csv, first_row));
+    EXPECT_NE(first_row.find("pose_entropy_heuristic"), std::string::npos);
+    EXPECT_EQ(split_csv_line(first_row).size(), expected_header.size());
+}
+
+TEST(DualAssemblyRunner, ReciprocalControlSwapsPrimaryTargetLigandOrder) {
+    natural::DualAssemblyConfig cfg;
+    cfg.protofibril_pdb = "proto.pdb";
+    cfg.sequence_fasta  = std::string(45, 'A');
+    cfg.checkpoint_interval = 100;
+    cfg.include_reciprocal_controls = true;
+    cfg.sim_c_enabled = false;
+    cfg.output_csv = "/tmp/dual_assembly_reciprocal.csv";
+    cfg.nascent_pdb_dir = "/tmp/dual_assembly_reciprocal_pdbs";
+
+    std::vector<std::pair<std::string, std::string>> sim_a_calls;
+    auto sim_a = [&](const std::string& target,
+                     const std::string& ligand,
+                     int L_k,
+                     double T) {
+        sim_a_calls.emplace_back(target, ligand);
+        return synthetic_engine(T, 16, 1.0, -1.0, 10u + L_k);
+    };
+    auto trunc = [](const std::string&, int L_k, const std::string&) {
+        return std::string("/tmp/dual_assembly_reciprocal_L") + std::to_string(L_k) + ".pdb";
+    };
+
+    natural::DualAssemblyRunner runner(std::move(cfg), sim_a, nullptr, nullptr, trunc);
+    auto history = runner.run();
+
+    ASSERT_GT(history.size(), 0u);
+    ASSERT_EQ(sim_a_calls.size(), 2u);
+    EXPECT_EQ(sim_a_calls[0].first, "proto.pdb");
+    EXPECT_EQ(sim_a_calls[0].second, "/tmp/dual_assembly_reciprocal_L40.pdb");
+    EXPECT_EQ(sim_a_calls[1].first, "/tmp/dual_assembly_reciprocal_L40.pdb");
+    EXPECT_EQ(sim_a_calls[1].second, "proto.pdb");
+
+    ASSERT_EQ(history.size(), 4u);
+    EXPECT_EQ(history[0].first.role_policy, natural::DockingRolePolicy::ProtofibrilAsTarget);
+    EXPECT_EQ(history[1].first.role_policy, natural::DockingRolePolicy::ReciprocalControl);
+}
+
+TEST(DualAssemblyRunner, SimBGateUsesPriorEntropyPerTrack) {
+    natural::DualAssemblyConfig cfg;
+    cfg.protofibril_pdb = "proto.pdb";
+    cfg.monomer_pdb = "monomer.pdb";
+    cfg.sequence_fasta = std::string(60, 'A');
+    cfg.checkpoint_interval = 20;
+    cfg.include_reciprocal_controls = true;
+    cfg.sim_c_enabled = false;
+    cfg.output_csv = "/tmp/dual_assembly_track_state.csv";
+    cfg.nascent_pdb_dir = "/tmp/dual_assembly_track_state_pdbs";
+
+    auto sim_a = [](const std::string& target,
+                    const std::string&,
+                    int L_k,
+                    double T) {
+        statmech::StatMechEngine eng(T);
+        eng.add_sample(-1.0, 1.0);
+        std::vector<double> coords;
+        if (target == "proto.pdb" && L_k == 40) {
+            coords = {0.0, 0.0, 0.0, 0.0}; // canonical track collapses
+        } else {
+            coords = {0.0, 1.0, 2.0, 3.0, 4.0}; // high entropy, above soft threshold
+        }
+        return natural::GAResult{std::move(eng), std::move(coords)};
+    };
+
+    std::vector<std::string> sim_b_targets;
+    auto sim_b = [&](const std::string& target,
+                     const std::string&,
+                     int,
+                     double T) {
+        sim_b_targets.push_back(target);
+        statmech::StatMechEngine eng(T);
+        eng.add_sample(-0.5, 1.0);
+        return natural::GAResult{std::move(eng), std::vector<double>{0.0, 0.0}};
+    };
+
+    auto trunc = [](const std::string&, int L_k, const std::string&) {
+        return std::string("/tmp/dual_assembly_track_state_L") + std::to_string(L_k) + ".pdb";
+    };
+
+    natural::DualAssemblyRunner runner(std::move(cfg), sim_a, sim_b, nullptr, trunc);
+    (void)runner.run();
+
+    ASSERT_EQ(sim_b_targets.size(), 1u);
+    EXPECT_EQ(sim_b_targets[0], "/tmp/dual_assembly_track_state_L60.pdb");
+}
+
+TEST(DualAssemblyRunner, AcceptedSimCAdvanceChangesSubsequentProtofibrilTarget) {
+    natural::DualAssemblyConfig cfg;
+    cfg.protofibril_pdb = "proto_state_0.pdb";
+    cfg.monomer_pdb = "monomer.pdb";
+    cfg.sequence_fasta = std::string(60, 'A');
+    cfg.checkpoint_interval = 20;
+    cfg.include_reciprocal_controls = false;
+    cfg.sim_c_enabled = true;
+    cfg.sim_c_interval = 1;
+    cfg.monomer_conc_M = 1.0;
+    cfg.output_csv = "/tmp/dual_assembly_advance.csv";
+    cfg.nascent_pdb_dir = "/tmp/dual_assembly_advance_pdbs";
+
+    std::vector<std::string> sim_a_targets;
+    auto sim_a = [&](const std::string& target,
+                     const std::string&,
+                     int L_k,
+                     double T) {
+        sim_a_targets.push_back(target);
+        return synthetic_engine(T, 16, 1.0, -1.0, 100u + L_k);
+    };
+
+    auto sim_c = [](const std::string&, const std::string&, double T) {
+        statmech::StatMechEngine eng(T);
+        eng.add_sample(-20.0, 1.0); // overwhelming acceptance at 1 M
+        return natural::GAResult{std::move(eng), std::vector<double>{0.0, 0.0}};
+    };
+
+    auto trunc = [](const std::string&, int L_k, const std::string&) {
+        return std::string("/tmp/dual_assembly_advance_L") + std::to_string(L_k) + ".pdb";
+    };
+
+    auto advance = [](const std::string&,
+                      const std::string&,
+                      int next_state_index) {
+        return std::string("proto_state_") + std::to_string(next_state_index) + ".pdb";
+    };
+
+    natural::DualAssemblyRunner runner(std::move(cfg), sim_a, nullptr, sim_c, trunc, advance);
+    auto history = runner.run();
+
+    ASSERT_EQ(sim_a_targets.size(), 2u);
+    EXPECT_EQ(sim_a_targets[0], "proto_state_0.pdb");
+    EXPECT_EQ(sim_a_targets[1], "proto_state_1.pdb");
+
+    auto first_translation = std::find_if(history.begin(), history.end(),
+        [](const auto& item) {
+            return item.first.process == natural::GrowthProcess::Translation;
+        });
+    ASSERT_NE(first_translation, history.end());
+    EXPECT_TRUE(first_translation->second.sim_c_evaluated);
+    EXPECT_TRUE(first_translation->second.sim_c_gated_in);
+    EXPECT_EQ(first_translation->second.protofibril_state_index, 1);
+    EXPECT_TRUE(first_translation->second.protofibril_structure_updated);
+}
+
+TEST(DualAssemblyRunner, RejectedSimCDoesNotAdvanceProtofibrilState) {
+    natural::DualAssemblyConfig cfg;
+    cfg.protofibril_pdb = "proto_state_0.pdb";
+    cfg.monomer_pdb = "monomer.pdb";
+    cfg.sequence_fasta = std::string(60, 'A');
+    cfg.checkpoint_interval = 20;
+    cfg.include_reciprocal_controls = false;
+    cfg.sim_c_enabled = true;
+    cfg.sim_c_interval = 1;
+    cfg.monomer_conc_M = 1.0e-12;
+    cfg.output_csv = "/tmp/dual_assembly_reject.csv";
+    cfg.nascent_pdb_dir = "/tmp/dual_assembly_reject_pdbs";
+
+    std::vector<std::string> sim_a_targets;
+    auto sim_a = [&](const std::string& target,
+                     const std::string&,
+                     int L_k,
+                     double T) {
+        sim_a_targets.push_back(target);
+        return synthetic_engine(T, 16, 1.0, -1.0, 200u + L_k);
+    };
+
+    auto sim_c = [](const std::string&, const std::string&, double T) {
+        statmech::StatMechEngine eng(T);
+        eng.add_sample(20.0, 1.0);
+        return natural::GAResult{std::move(eng), std::vector<double>{0.0, 0.0}};
+    };
+
+    auto trunc = [](const std::string&, int L_k, const std::string&) {
+        return std::string("/tmp/dual_assembly_reject_L") + std::to_string(L_k) + ".pdb";
+    };
+
+    natural::DualAssemblyRunner runner(std::move(cfg), sim_a, nullptr, sim_c, trunc);
+    auto history = runner.run();
+
+    ASSERT_EQ(sim_a_targets.size(), 2u);
+    EXPECT_EQ(sim_a_targets[0], "proto_state_0.pdb");
+    EXPECT_EQ(sim_a_targets[1], "proto_state_0.pdb");
+
+    auto first_translation = std::find_if(history.begin(), history.end(),
+        [](const auto& item) {
+            return item.first.process == natural::GrowthProcess::Translation;
+        });
+    ASSERT_NE(first_translation, history.end());
+    EXPECT_TRUE(first_translation->second.sim_c_evaluated);
+    EXPECT_FALSE(first_translation->second.sim_c_gated_in);
+    EXPECT_EQ(first_translation->second.protofibril_state_index, 0);
+    EXPECT_FALSE(first_translation->second.protofibril_structure_updated);
+}
+
+TEST(DualAssemblyRunner, AcceptedSimCWithoutAdvanceCallbackDoesNotClaimStructureUpdate) {
+    natural::DualAssemblyConfig cfg;
+    cfg.protofibril_pdb = "proto_state_0.pdb";
+    cfg.monomer_pdb = "monomer.pdb";
+    cfg.sequence_fasta = std::string(60, 'A');
+    cfg.checkpoint_interval = 20;
+    cfg.include_reciprocal_controls = false;
+    cfg.sim_c_enabled = true;
+    cfg.sim_c_interval = 1;
+    cfg.monomer_conc_M = 1.0;
+    cfg.output_csv = "/tmp/dual_assembly_accept_no_update.csv";
+    cfg.nascent_pdb_dir = "/tmp/dual_assembly_accept_no_update_pdbs";
+
+    std::vector<std::string> sim_a_targets;
+    auto sim_a = [&](const std::string& target,
+                     const std::string&,
+                     int L_k,
+                     double T) {
+        sim_a_targets.push_back(target);
+        return synthetic_engine(T, 16, 1.0, -1.0, 300u + L_k);
+    };
+
+    auto sim_c = [](const std::string&, const std::string&, double T) {
+        statmech::StatMechEngine eng(T);
+        eng.add_sample(-20.0, 1.0);
+        return natural::GAResult{std::move(eng), std::vector<double>{0.0, 0.0}};
+    };
+
+    auto trunc = [](const std::string&, int L_k, const std::string&) {
+        return std::string("/tmp/dual_assembly_accept_no_update_L") + std::to_string(L_k) + ".pdb";
+    };
+
+    natural::DualAssemblyRunner runner(std::move(cfg), sim_a, nullptr, sim_c, trunc);
+    auto history = runner.run();
+
+    ASSERT_EQ(sim_a_targets.size(), 2u);
+    EXPECT_EQ(sim_a_targets[0], "proto_state_0.pdb");
+    EXPECT_EQ(sim_a_targets[1], "proto_state_0.pdb");
+
+    auto first_translation = std::find_if(history.begin(), history.end(),
+        [](const auto& item) {
+            return item.first.process == natural::GrowthProcess::Translation;
+        });
+    ASSERT_NE(first_translation, history.end());
+    EXPECT_TRUE(first_translation->second.sim_c_evaluated);
+    EXPECT_TRUE(first_translation->second.sim_c_gated_in);
+    EXPECT_EQ(first_translation->second.protofibril_state_index, 1);
+    EXPECT_FALSE(first_translation->second.protofibril_structure_updated);
+}
+
+TEST(DualAssemblyRunner, SimCCadenceIsPerTrackNotGlobal) {
+    natural::DualAssemblyConfig cfg;
+    cfg.protofibril_pdb = "proto.pdb";
+    cfg.monomer_pdb = "monomer.pdb";
+    cfg.sequence_fasta = std::string(60, 'A');
+    cfg.checkpoint_interval = 20;
+    cfg.include_reciprocal_controls = true;
+    cfg.sim_c_enabled = true;
+    cfg.sim_c_interval = 2;
+    cfg.monomer_conc_M = 1.0;
+    cfg.output_csv = "/tmp/dual_assembly_sim_c_cadence.csv";
+    cfg.nascent_pdb_dir = "/tmp/dual_assembly_sim_c_cadence_pdbs";
+
+    auto sim_a = [](const std::string&,
+                    const std::string&,
+                    int L_k,
+                    double T) {
+        return synthetic_engine(T, 16, 1.0, -1.0, 400u + L_k);
+    };
+
+    int sim_c_calls = 0;
+    auto sim_c = [&](const std::string&, const std::string&, double T) {
+        ++sim_c_calls;
+        statmech::StatMechEngine eng(T);
+        eng.add_sample(-20.0, 1.0);
+        return natural::GAResult{std::move(eng), std::vector<double>{0.0, 0.0}};
+    };
+
+    auto trunc = [](const std::string&, int L_k, const std::string&) {
+        return std::string("/tmp/dual_assembly_sim_c_cadence_L") + std::to_string(L_k) + ".pdb";
+    };
+
+    natural::DualAssemblyRunner runner(std::move(cfg), sim_a, nullptr, sim_c, trunc);
+    auto history = runner.run();
+
+    std::vector<bool> translation_sim_c_flags;
+    for (const auto& [ck, out] : history) {
+        if (ck.process == natural::GrowthProcess::Translation)
+            translation_sim_c_flags.push_back(out.sim_c_evaluated);
+    }
+
+    ASSERT_EQ(translation_sim_c_flags.size(), 4u);
+    EXPECT_FALSE(translation_sim_c_flags[0]);
+    EXPECT_FALSE(translation_sim_c_flags[1]);
+    EXPECT_TRUE(translation_sim_c_flags[2]);
+    EXPECT_TRUE(translation_sim_c_flags[3]);
+    EXPECT_EQ(sim_c_calls, 2);
+}

--- a/tests/test_nascent_chain_scheduler.cpp
+++ b/tests/test_nascent_chain_scheduler.cpp
@@ -323,9 +323,15 @@ TEST(DualAssemblyRunner, ReciprocalControlSwapsPrimaryTargetLigandOrder) {
     EXPECT_EQ(sim_a_calls[1].first, "/tmp/dual_assembly_reciprocal_L40.pdb");
     EXPECT_EQ(sim_a_calls[1].second, "proto.pdb");
 
-    ASSERT_EQ(history.size(), 4u);
-    EXPECT_EQ(history[0].first.role_policy, natural::DockingRolePolicy::ProtofibrilAsTarget);
-    EXPECT_EQ(history[1].first.role_policy, natural::DockingRolePolicy::ReciprocalControl);
+    std::vector<natural::DockingRolePolicy> translation_roles;
+    for (const auto& [ck, out] : history) {
+        (void)out;
+        if (ck.process == natural::GrowthProcess::Translation)
+            translation_roles.push_back(ck.role_policy);
+    }
+    ASSERT_EQ(translation_roles.size(), 2u);
+    EXPECT_EQ(translation_roles[0], natural::DockingRolePolicy::ProtofibrilAsTarget);
+    EXPECT_EQ(translation_roles[1], natural::DockingRolePolicy::ReciprocalControl);
 }
 
 TEST(DualAssemblyRunner, SimBGateUsesPriorEntropyPerTrack) {

--- a/tests/test_natural.cpp
+++ b/tests/test_natural.cpp
@@ -18,6 +18,8 @@
 #include <vector>
 #include <algorithm>
 #include <numeric>
+#include <stdexcept>
+#include <limits>
 
 using namespace ribosome;
 using namespace translocon;
@@ -125,10 +127,11 @@ TEST_F(RibosomeElongationTest, MeanArrivalTimeMonotonicIncreasing) {
 
 TEST_F(RibosomeElongationTest, MeanTotalTimeEqualsAnalyticSum) {
     auto eng = make_engine();
-    // Analytic: T = 1/k_ini + Σ 1/k_n
+    // Analytic: T = 1/k_ini + Σ 1/k_n + 1/k_ter
     double analytic = 1.0 / K_INI_DEFAULT;
     for (double k : eng.elongation_rates())
         analytic += 1.0 / k;
+    analytic += 1.0 / K_TERM_DEFAULT;
 
     EXPECT_NEAR(eng.mean_total_time(), analytic, 1e-6);
 }
@@ -179,6 +182,44 @@ TEST_F(RibosomeElongationTest, PauseSitesRatesBelowThreshold) {
         EXPECT_LT(eng.elongation_rates()[idx],
                   mean_r * RIBOSOME_PAUSE_THRESHOLD * 1.01); // 1% tolerance
     }
+}
+
+TEST(NATURaLGrowthEntropy, ReturnsNatsNotBits) {
+    const double h2 = growth_entropy_nats({0.0, 1.0});
+    const double h4 = growth_entropy_nats({0.0, 1.0, 2.0, 3.0});
+
+    EXPECT_NEAR(h2, std::log(2.0), 1e-9);
+    EXPECT_NEAR(h4, std::log(4.0), 1e-9);
+}
+
+TEST(NATURaLGrowthEntropy, RepeatedEqualOccupancyBinsReturnAnalyticNats) {
+    const std::vector<double> two_bins = {
+        -1.0, -1.0, -1.0, -1.0,
+         1.0,  1.0,  1.0,  1.0
+    };
+    const std::vector<double> four_bins = {
+        0.0, 0.0,
+        1.0, 1.0,
+        2.0, 2.0,
+        3.0, 3.0
+    };
+
+    EXPECT_NEAR(growth_entropy_nats(two_bins), std::log(2.0), 1e-9);
+    EXPECT_NEAR(growth_entropy_nats(four_bins), std::log(4.0), 1e-9);
+}
+
+TEST(NATURaLGrowthEntropy, BinBoundaryAtMaximumDoesNotCreateExtraEntropy) {
+    const std::vector<double> samples = {
+        0.0, 0.0, 0.0,
+        31.0, 31.0, 31.0
+    };
+
+    EXPECT_NEAR(growth_entropy_nats(samples), std::log(2.0), 1e-9);
+}
+
+TEST(NATURaLGrowthEntropy, DegenerateTrajectoryHasZeroEntropy) {
+    EXPECT_DOUBLE_EQ(growth_entropy_nats({}), 0.0);
+    EXPECT_DOUBLE_EQ(growth_entropy_nats({-3.0, -3.0, -3.0}), 0.0);
 }
 
 // ===========================================================================
@@ -373,6 +414,136 @@ TEST(NATURaLConfig, IsNucleotideLigandReturnsFalseForEmpty) {
 
 TEST(NATURaLConfig, IsNucleicAcidReceptorReturnsFalseForEmpty) {
     EXPECT_FALSE(is_nucleic_acid_receptor(nullptr, 0));
+}
+
+// ===========================================================================
+// Human protofibril DualAssembly planning
+// ===========================================================================
+
+TEST(ProtofibrilDualAssemblyPlan, BuildsCanonicalAndReciprocalTracks) {
+    auto tracks = make_human_protofibril_tracks(90, 45, true);
+    ASSERT_EQ(tracks.size(), 4u);
+
+    int canonical = 0;
+    int reciprocal = 0;
+    int transcription = 0;
+    int translation = 0;
+
+    for (const auto& tr : tracks) {
+        if (tr.role_policy == DockingRolePolicy::ProtofibrilAsTarget) {
+            ++canonical;
+            EXPECT_TRUE(tr.protofibril_is_target);
+        } else {
+            ++reciprocal;
+            EXPECT_FALSE(tr.protofibril_is_target);
+        }
+
+        if (tr.process == GrowthProcess::Transcription) ++transcription;
+        if (tr.process == GrowthProcess::Translation)   ++translation;
+    }
+
+    EXPECT_EQ(canonical, 2);
+    EXPECT_EQ(reciprocal, 2);
+    EXPECT_EQ(transcription, 2);
+    EXPECT_EQ(translation, 2);
+}
+
+TEST(ProtofibrilDualAssemblyPlan, UsesHumanCellGrowthClocks) {
+    auto tracks = make_human_protofibril_tracks(100, 50, false);
+    ASSERT_EQ(tracks.size(), 2u);
+
+    const auto& tx = tracks[0];
+    const auto& tl = tracks[1];
+
+    ASSERT_EQ(tx.process, GrowthProcess::Transcription);
+    ASSERT_EQ(tl.process, GrowthProcess::Translation);
+
+    EXPECT_DOUBLE_EQ(tx.mean_elongation_rate, MEAN_NT_RATE_HUMAN);
+    EXPECT_DOUBLE_EQ(tl.mean_elongation_rate, MEAN_EL_RATE_HUMAN);
+    EXPECT_DOUBLE_EQ(tx.tunnel_length, RNAP_TUNNEL_NT);
+    EXPECT_DOUBLE_EQ(tl.tunnel_length, TUNNEL_LENGTH_AA);
+
+    // Human transcription is nuclear; keep it in the synchronized clock but do
+    // not silently claim direct protofibril encounter in the default protocol.
+    EXPECT_FALSE(tx.direct_encounter_allowed);
+    EXPECT_TRUE(tl.direct_encounter_allowed);
+}
+
+TEST(ProtofibrilDualAssemblyPlan, CompletionTimesIncludeInitiationAndDwellTime) {
+    auto tracks = make_human_protofibril_tracks(100, 50, false);
+    ASSERT_EQ(tracks.size(), 2u);
+
+    const auto& tx = tracks[0];
+    const auto& tl = tracks[1];
+
+    EXPECT_NEAR(tx.dwell_time_s(), 1.0 / MEAN_NT_RATE_HUMAN, 1e-12);
+    EXPECT_NEAR(tl.dwell_time_s(), 1.0 / MEAN_EL_RATE_HUMAN, 1e-12);
+
+    EXPECT_NEAR(tx.completion_time_s(),
+                1.0 / K_RNAP_INI_DEFAULT + 100.0 / MEAN_NT_RATE_HUMAN,
+                1e-12);
+    EXPECT_NEAR(tl.completion_time_s(),
+                1.0 / K_INI_DEFAULT + 50.0 / MEAN_EL_RATE_HUMAN,
+                1e-12);
+
+    EXPECT_NEAR(tx.first_exposed_time_s(),
+                1.0 / K_RNAP_INI_DEFAULT
+                    + (std::floor(RNAP_TUNNEL_NT) + 1.0) / MEAN_NT_RATE_HUMAN,
+                1e-12);
+    EXPECT_NEAR(tl.first_exposed_time_s(),
+                1.0 / K_INI_DEFAULT
+                    + (std::floor(TUNNEL_LENGTH_AA) + 1.0) / MEAN_EL_RATE_HUMAN,
+                1e-12);
+}
+
+TEST(ProtofibrilDualAssemblyPlan, ParallelScheduleIsTimeSortedAndTracksExposure) {
+    auto tracks = make_human_protofibril_tracks(12, 36, false);
+    auto events = build_parallel_growth_schedule(tracks);
+    ASSERT_EQ(events.size(), 48u);
+
+    for (size_t i = 1; i < events.size(); ++i)
+        EXPECT_LE(events[i - 1].t_arrival, events[i].t_arrival);
+
+    auto tx_first_exposed = std::find_if(events.begin(), events.end(),
+        [](const ParallelGrowthEvent& e) {
+            return e.process == GrowthProcess::Transcription && e.exposed_units > 0;
+        });
+    ASSERT_NE(tx_first_exposed, events.end());
+    EXPECT_EQ(tx_first_exposed->unit_index, static_cast<int>(RNAP_TUNNEL_NT) + 1);
+
+    auto tl_first_exposed = std::find_if(events.begin(), events.end(),
+        [](const ParallelGrowthEvent& e) {
+            return e.process == GrowthProcess::Translation && e.exposed_units > 0;
+        });
+    ASSERT_NE(tl_first_exposed, events.end());
+    EXPECT_EQ(tl_first_exposed->unit_index, static_cast<int>(TUNNEL_LENGTH_AA) + 1);
+}
+
+TEST(ProtofibrilDualAssemblyPlan, RejectsNegativeChainLengths) {
+    EXPECT_THROW(make_human_protofibril_tracks(-1, 10), std::invalid_argument);
+    EXPECT_THROW(make_human_protofibril_tracks(10, -1), std::invalid_argument);
+}
+
+TEST(ProtofibrilDualAssemblyPlan, ZeroLengthInputsProduceNoTracksOrEvents) {
+    auto tracks = make_human_protofibril_tracks(0, 0, true);
+    EXPECT_TRUE(tracks.empty());
+
+    auto events = build_parallel_growth_schedule(tracks);
+    EXPECT_TRUE(events.empty());
+}
+
+TEST(ProtofibrilDualAssemblyPlan, RejectsNonPositiveOrNonFiniteElongationRates) {
+    InVivoAssemblyTrack bad_rate;
+    bad_rate.chain_length = 5;
+    bad_rate.mean_elongation_rate = 0.0;
+
+    EXPECT_THROW(build_parallel_growth_schedule({bad_rate}), std::invalid_argument);
+
+    bad_rate.mean_elongation_rate = -1.0;
+    EXPECT_THROW(build_parallel_growth_schedule({bad_rate}), std::invalid_argument);
+
+    bad_rate.mean_elongation_rate = std::numeric_limits<double>::infinity();
+    EXPECT_THROW(build_parallel_growth_schedule({bad_rate}), std::invalid_argument);
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

- **Entropy-driven Target/Ligand assignment.** Adds a Shannon-entropy discriminator: when `H < ln 2`, the system is treated as collapsed → target; otherwise it remains a candidate ligand. The hard / soft / deferred / both-infinite regimes are all covered (see `TLDiscriminator` tests).
- **Three parallel simulation modes.** Sim A (fibril vs nascent chain), Sim B (nascent chain vs small-molecule inhibitor — uses prior-entropy per track), Sim C (GC fibril elongation — per-track cadence, advance is conditional on gate acceptance).
- **In vivo human-cell parameters baked into the scheduler.** Translation rate 5.6 aa/s, ribosomal exit tunnel of 34 aa, T = 310.15 K, ionic strength 150 mM.
- **MVP scope.** Standalone CLI uses a synthetic GA backend. The `--real-ga` flag is reserved for the full FlexAIDdS engine wiring (next PR).
- **Compatibility.** The `dual_assembly` CLI target compiles with `FLEXAIDS_OMIT_DUAL_ASSEMBLY_ENGINE` defined, so the existing `FlexAID` engine and `_core` Python bindings build paths are unchanged.

## New / changed files

**Core C++ (LIB/NATURaL/)**
- `NascentChainScheduler.{cpp,h}` — monotone checkpoint emission past tunnel + chaperone skip, bounded iterator semantics
- `FibrilGrowthOracle.{cpp,h}` — analytic ξ(z), concentration-corrected ΔG gating, temperature validation
- `DualAssemblyRunner.{cpp,h}` — orchestrates Sim A/B/C, reciprocal control swap, per-track gating + cadence
- `dual_assembly_main.cpp` — standalone CLI entry point
- `NATURaLDualAssembly.{cpp,h}`, `RibosomeElongation.cpp`, `disco_natural.hpp` — supporting refactors

**Build**
- `CMakeLists.txt`, `LIB/CMakeLists.txt` — `ENABLE_DUAL_ASSEMBLY_TOOL` option (default ON), `dual_assembly` target wiring, sources added to the relevant aggregate targets

**Tests**
- `tests/test_nascent_chain_scheduler.cpp` — **19 unit tests** across 4 suites (note: the planning doc previously cited "8 tests" — the actual count is 19; correcting here):
  - `NascentChainScheduler` ×4 (checkpoints, tunnel+chaperone offset, iterator exhaustion, interval validation)
  - `TLDiscriminator` ×4 (hard / deferred / soft / both-infinite regimes)
  - `FibrilGrowthOracle` ×4 (analytic ξ(z), concentration validation, gate decision, temperature validation)
  - `DualAssemblyRunner` ×7 (end-to-end synthetic, reciprocal control swap, Sim B prior-entropy per track, Sim C accept advances state, Sim C reject does not, Sim C accept without callback does not claim structure update, Sim C cadence is per-track not global)
- `tests/test_natural.cpp` — updated assertions for the refactored NATURaL surface

**Tooling & docs**
- `scripts/run_dual_assembly_cotranslational.sh` — driver script (CLI flags, output layout)
- `python/flexaidds/truncate_chain.py` — generate truncated nascent-chain PDBs from a full structure
- `docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md` — full design doc, parameters, three-sim-mode explanation
- `docs/test-coverage-analysis.md` — updated to reflect new C++ coverage in NATURaL

**Bundled benchmark utilities** (orthogonal to DualAssembly but surfaced from the same work cycle)
- `scripts/run_benchmark_production.sh`
- `scripts/validate_benchmark_results.py`

## Data note

No protofibril PDB is committed to the repo. Pass one at runtime via `--target-pdb` — e.g. PDB **5OQV** (α-syn pentameric protofibril) or **2NAO** (Aβ40 fibril).

## Test plan

- [ ] `cmake -S . -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release && cmake --build build -j` succeeds
- [ ] `ctest --test-dir build -R NascentChainScheduler --output-on-failure` — all 19 tests pass (across `NascentChainScheduler`, `TLDiscriminator`, `FibrilGrowthOracle`, `DualAssemblyRunner` suites)
- [ ] `./build/dual_assembly --help` prints usage and exits 0
- [ ] `./scripts/run_dual_assembly_cotranslational.sh --help` prints usage and exits 0
- [ ] Default-config build (no `BUILD_TESTING`, no `ENABLE_DUAL_ASSEMBLY_TOOL` override) still produces a working `FlexAID` binary — no regression

## Status

Opened as **draft** while the build + ctest verification runs locally on this branch. Will mark ready for review once the 19-test suite is confirmed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)