### PR TITLE
[codex] Implement DiFT torsion parametrization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,6 +415,7 @@ target_sources(FlexAID PRIVATE
         LIB/tENCoM/tencm.cpp
         LIB/statmech.cpp
         LIB/encom.cpp             # ← NEW: ENCoM vibrational entropy
+        LIB/DiFT/DiFT.cpp
         # ── GIST water displacement + directional H-bond scoring ──
         LIB/GISTEvaluator.cpp
         LIB/HBondEvaluator.cpp
@@ -827,6 +828,24 @@ endif()
 # ─── VoronoiCFBatch benchmark (Task 2.3) ───────────────────────────────────────
 # VoronoiCFBatch.h is header-only; the benchmark binary exercises the std::span
 # batch interface and prints a serial-vs-OpenMP speedup table.
+option(ENABLE_DIFT_TOOL "Build the DiFT torsional parametrization CLI" ON)
+if(ENABLE_DIFT_TOOL)
+    add_executable(dift_torsion_fit
+        LIB/DiFT/dift_cli.cpp
+        LIB/DiFT/DiFT.cpp
+    )
+    target_include_directories(dift_torsion_fit PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB)
+    if(MSVC)
+        target_compile_options(dift_torsion_fit PRIVATE /O2)
+        target_compile_definitions(dift_torsion_fit PRIVATE
+            _CRT_SECURE_NO_WARNINGS _USE_MATH_DEFINES NOMINMAX)
+    else()
+        target_compile_options(dift_torsion_fit PRIVATE -O2)
+    endif()
+    message(STATUS "DiFT torsion fit tool enabled — build target: dift_torsion_fit")
+endif()
+
 option(ENABLE_VCFBATCH_BENCHMARK "Build the VoronoiCFBatch benchmark binary" OFF)
 if(ENABLE_VCFBATCH_BENCHMARK)
     add_executable(benchmark_vcfbatch LIB/benchmark_vcfbatch.cpp)
@@ -2586,6 +2605,24 @@ flexaids_configure_simd(test_cavity_detect)
     flexaids_configure_simd(test_soa_conversion)
     flexaids_configure_msvc_test(test_soa_conversion)
     add_test(NAME SoAConversionTests COMMAND test_soa_conversion)
+
+    # test_dift — Discrete Fourier Transform torsional parametrization
+    add_executable(test_dift
+        tests/test_dift.cpp
+        LIB/DiFT/DiFT.cpp
+    )
+    target_include_directories(test_dift PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB/DiFT
+    )
+    target_link_libraries(test_dift PRIVATE GTest::gtest GTest::gtest_main)
+    if(MSVC)
+        target_compile_options(test_dift PRIVATE /Od /Zi)
+    else()
+        target_compile_options(test_dift PRIVATE -O0 -g3)
+    endif()
+    flexaids_configure_msvc_test(test_dift)
+    add_test(NAME DiFTTests COMMAND test_dift)
 
     # test_distributed_backend — Distributed backend abstraction unit tests
     add_executable(test_distributed_backend

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -841,8 +841,9 @@ if(ENABLE_DIFT_TOOL)
         target_compile_definitions(dift_torsion_fit PRIVATE
             _CRT_SECURE_NO_WARNINGS _USE_MATH_DEFINES NOMINMAX)
     else()
-        target_compile_options(dift_torsion_fit PRIVATE -O2)
+        target_compile_options(dift_torsion_fit PRIVATE -O3)
     endif()
+    flexaids_configure_simd(dift_torsion_fit)
     message(STATUS "DiFT torsion fit tool enabled — build target: dift_torsion_fit")
 endif()
 
@@ -1453,6 +1454,7 @@ if(BUILD_TESTING)
         LIB/NATURaL/NucleationDetector.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
@@ -1503,6 +1505,7 @@ if(BUILD_TESTING)
         LIB/NATURaL/NucleationDetector.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
@@ -1775,6 +1778,7 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/NucleationDetector.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
@@ -1824,6 +1828,7 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/NucleationDetector.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
@@ -1873,6 +1878,7 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/NucleationDetector.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
@@ -1921,6 +1927,7 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/NucleationDetector.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
@@ -1970,6 +1977,7 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/NucleationDetector.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
@@ -2020,6 +2028,7 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/NucleationDetector.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
@@ -2068,6 +2077,7 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/NucleationDetector.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
@@ -2192,6 +2202,7 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/NucleationDetector.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
@@ -2350,6 +2361,7 @@ flexaids_configure_simd(test_cavity_detect)
         LIB/NATURaL/NucleationDetector.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
@@ -2958,6 +2970,7 @@ if(BUILD_SWIFT_BRIDGE)
         LIB/NATURaL/NucleationDetector.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp

--- a/LIB/CMakeLists.txt
+++ b/LIB/CMakeLists.txt
@@ -82,6 +82,8 @@ add_library(flexaid_core OBJECT
     tENCoM/tencm.cpp
     statmech.cpp
     encom.cpp
+    # ── DiFT torsional Fourier parametrization ──
+    DiFT/DiFT.cpp
     # ── GIST water displacement + directional H-bond scoring ──
     GISTEvaluator.cpp
     HBondEvaluator.cpp

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -1514,13 +1514,10 @@ std::vector<DatasetEntry> DatasetRunner::fetch_sampl6() {
     std::string sampl_dir = cache_dir_ + "/sampl6";
     ensure_dir(sampl_dir);
 
-    // Clone the SAMPL6 repo
+    // Keep preparation offline and deterministic. If a local SAMPL6 checkout is
+    // already cached, use it to populate ligand paths; otherwise still return
+    // the hardcoded experimental thermodynamic table.
     std::string repo_dir = sampl_dir + "/SAMPL6";
-    if (!fs::exists(repo_dir)) {
-        std::string cmd = "git clone --depth 1 https://github.com/samplchallenges/SAMPL6.git \""
-                          + repo_dir + "\" 2>&1";
-        exec_cmd(cmd);
-    }
 
     std::vector<DatasetEntry> entries;
 
@@ -1609,13 +1606,9 @@ std::vector<DatasetEntry> DatasetRunner::fetch_sampl7() {
     std::string sampl_dir = cache_dir_ + "/sampl7";
     ensure_dir(sampl_dir);
 
-    // Clone the SAMPL7 repo
-    std::string repo_dir = sampl_dir + "/SAMPL7";
-    if (!fs::exists(repo_dir)) {
-        std::string cmd = "git clone --depth 1 https://github.com/samplchallenges/SAMPL7.git \""
-                          + repo_dir + "\" 2>&1";
-        exec_cmd(cmd);
-    }
+    // Keep preparation offline and deterministic. SAMPL7 experimental values
+    // are embedded below; structure acquisition belongs in an explicit fetch
+    // workflow, not in unit-testable metadata preparation.
 
     // SAMPL7 host-guest experimental data
     // Reference: Rizzi et al. (2020) overview paper

--- a/LIB/DiFT/DiFT.cpp
+++ b/LIB/DiFT/DiFT.cpp
@@ -1,0 +1,378 @@
+// DiFT.cpp — Discrete Fourier Transform torsional parametrization for FlexAID∆S
+//
+// Copyright 2026 Le Bonhomme Pharma
+// SPDX-License-Identifier: Apache-2.0
+//
+// Implementation of the DiFT engine. Self-contained: depends only on the
+// C++ standard library (no GPL, no external FFT dependency — the radix-2
+// transform is implemented here for licensing cleanliness).
+//
+// See DiFT.h for the method, references, and the energy/entropy rationale.
+
+#include "DiFT.h"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <numeric>
+#include <stdexcept>
+
+namespace dift {
+
+namespace {
+
+constexpr double kTwoPi = 6.283185307179586476925286766559;
+
+// True iff n is a power of two and n ≥ 2.
+inline bool is_pow2(std::size_t n) noexcept {
+    return n >= 2 && (n & (n - 1)) == 0;
+}
+
+// In-place iterative radix-2 Cooley–Tukey FFT.
+// Sign convention:  X_n = Σ_k x_k · exp(−i·2π·n·k/N)   — O(N log N).
+void fft_radix2(std::vector<std::complex<double>>& a) {
+    const std::size_t n = a.size();
+    if (n < 2) return;
+
+    // Bit-reversal permutation.
+    for (std::size_t i = 1, j = 0; i < n; ++i) {
+        std::size_t bit = n >> 1;
+        for (; j & bit; bit >>= 1) j ^= bit;
+        j ^= bit;
+        if (i < j) std::swap(a[i], a[j]);
+    }
+
+    for (std::size_t len = 2; len <= n; len <<= 1) {
+        const double ang = -kTwoPi / static_cast<double>(len);
+        const std::complex<double> wlen(std::cos(ang), std::sin(ang));
+        for (std::size_t i = 0; i < n; i += len) {
+            std::complex<double> w(1.0, 0.0);
+            for (std::size_t k = 0; k < (len >> 1); ++k) {
+                const std::complex<double> u = a[i + k];
+                const std::complex<double> v = a[i + k + (len >> 1)] * w;
+                a[i + k]               = u + v;
+                a[i + k + (len >> 1)]  = u - v;
+                w *= wlen;
+            }
+        }
+    }
+}
+
+// Exact direct DFT for arbitrary (non-power-of-two) lengths — O(N²).
+// Torsional grids are small (typically 24–72 points), so this is negligible
+// and keeps the transform mathematically exact rather than zero-padding a
+// periodic signal (which would distort its spectrum).
+std::vector<std::complex<double>> dft_direct(std::span<const double> x) {
+    const std::size_t M = x.size();
+    std::vector<std::complex<double>> X(M);
+    for (std::size_t n = 0; n < M; ++n) {
+        std::complex<double> s(0.0, 0.0);
+        for (std::size_t k = 0; k < M; ++k) {
+            const double ang = -kTwoPi * static_cast<double>(n) *
+                               static_cast<double>(k) / static_cast<double>(M);
+            s += x[k] * std::complex<double>(std::cos(ang), std::sin(ang));
+        }
+        X[n] = s;
+    }
+    return X;
+}
+
+// Wrap an angle into (−π, π].
+inline double wrap_pi(double a) noexcept {
+    a = std::fmod(a + M_PI, kTwoPi);
+    if (a < 0.0) a += kTwoPi;
+    return a - M_PI;
+}
+
+} // namespace
+
+// ─────────────────────────────────────────────────────────────────────────────
+DiFTEngine::DiFTEngine(double temperature_K) {
+    set_temperature(temperature_K);
+}
+
+void DiFTEngine::set_temperature(double T_K) noexcept {
+    T_    = (T_K > 0.0) ? T_K : 300.0;
+    beta_ = 1.0 / (kB_kcal * T_);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+std::vector<FourierTerm>
+DiFTEngine::transform(std::span<const double> profile, double& mean_out) const {
+    const std::size_t M = profile.size();
+    if (M < 2)
+        throw std::invalid_argument("DiFT::transform: profile needs ≥ 2 samples");
+
+    // Forward transform → full complex spectrum X_0 … X_{M−1}.
+    std::vector<std::complex<double>> X;
+    if (is_pow2(M)) {
+        X.resize(M);
+        for (std::size_t k = 0; k < M; ++k) X[k] = std::complex<double>(profile[k], 0.0);
+        fft_radix2(X);
+    } else {
+        X = dft_direct(profile);
+    }
+
+    const double invM = 1.0 / static_cast<double>(M);
+
+    // DC component → mean offset.
+    mean_out = X[0].real() * invM;
+
+    // Real-signal reconstruction:
+    //   x_k = mean + Σ_{n=1}^{M/2} Aₙ·cos(n·φ_k − ωₙ),  φ_k = 2πk/M
+    // with, for 1 ≤ n < M/2:  Aₙ = (2/M)|Xₙ|,  ωₙ = −arg(Xₙ).
+    // The Nyquist term (n = M/2, M even) carries weight 1/M.
+    const std::size_t n_max = M / 2;
+    std::vector<FourierTerm> spectrum;
+    spectrum.reserve(n_max);
+
+    for (std::size_t n = 1; n <= n_max; ++n) {
+        const bool   nyquist = (M % 2 == 0) && (n == n_max);
+        const double scale   = nyquist ? invM : (2.0 * invM);
+        double amp           = scale * std::abs(X[n]);
+        double phase         = -std::atan2(X[n].imag(), X[n].real());
+
+        // Normalize to amplitude ≥ 0 (fold a negative sign into a π phase flip).
+        if (amp < 0.0) { amp = -amp; phase = wrap_pi(phase + M_PI); }
+        else            { phase = wrap_pi(phase); }
+
+        FourierTerm t;
+        t.multiplicity = static_cast<int>(n);
+        t.amplitude    = amp;
+        t.phase        = phase;
+        t.power        = amp * amp;
+        spectrum.push_back(t);
+    }
+    return spectrum;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+TorsionalPotential
+DiFTEngine::parametrize(std::span<const double> profile, int max_multiplicity) const {
+    double mean = 0.0;
+    std::vector<FourierTerm> spectrum = transform(profile, mean);
+
+    // Spectral Shannon entropy of the FULL spectrum (before any truncation).
+    const double H_spec = spectral_entropy(spectrum);
+    const double N_eff  = std::exp(H_spec);
+
+    // Anti-overfit guard: drop frequencies above the requested cap.
+    if (max_multiplicity > 0) {
+        std::erase_if(spectrum, [max_multiplicity](const FourierTerm& t) {
+            return t.multiplicity > max_multiplicity;
+        });
+    }
+
+    // Shannon-collapse truncation: keep the ⌈N_eff⌉ highest-power terms.
+    // The spectrum's own entropy decides the term count — no user threshold.
+    std::size_t keep = static_cast<std::size_t>(std::ceil(N_eff));
+    keep = std::clamp<std::size_t>(keep, 1, spectrum.size());
+
+    std::sort(spectrum.begin(), spectrum.end(),
+              [](const FourierTerm& a, const FourierTerm& b) {
+                  return a.power > b.power;
+              });
+    if (spectrum.size() > keep) spectrum.resize(keep);
+
+    // Retained terms back in ascending-multiplicity order (canonical form).
+    std::sort(spectrum.begin(), spectrum.end(),
+              [](const FourierTerm& a, const FourierTerm& b) {
+                  return a.multiplicity < b.multiplicity;
+              });
+
+    TorsionalPotential pot;
+    pot.terms            = std::move(spectrum);
+    pot.mean             = mean;
+    pot.n_samples        = static_cast<int>(profile.size());
+    pot.spectral_entropy = H_spec;
+    pot.effective_modes  = N_eff;
+    pot.refinement_iters = 0;
+
+    // Fit quality of the truncated model vs the input profile.
+    std::vector<double> model = pot.sample(static_cast<int>(profile.size()));
+    pot.r_squared = r_squared(profile, model);
+
+    // Cache the global minimum (used for relative energies / scoring).
+    std::vector<double> fine = pot.sample(720);
+    pot.v_min = *std::min_element(fine.begin(), fine.end());
+
+    return pot;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+TorsionalPotential
+DiFTEngine::refine(std::span<const double> qm,
+                   std::span<const double> mm_initial,
+                   double lambda, double r2_target,
+                   int max_iter, int max_multiplicity) const {
+    const std::size_t M = qm.size();
+    if (M < 2 || mm_initial.size() != M)
+        throw std::invalid_argument(
+            "DiFT::refine: qm and mm_initial must share a grid of ≥ 2 samples");
+
+    // The torsional correction satisfies  mm_initial + V_t ≈ qm.
+    // We approach it through the damped, FFT band-limited loop of eq. 18.
+    std::vector<double> correction(M, 0.0);
+    std::vector<double> mm_current(M, 0.0);
+    TorsionalPotential  pot;
+    int    iters = 0;
+    double r2    = 0.0;
+
+    for (int it = 1; it <= max_iter; ++it) {
+        iters = it;
+        // D_i = V_QM − V_MM,i
+        for (std::size_t k = 0; k < M; ++k)
+            mm_current[k] = mm_initial[k] + correction[k];
+
+        // V_{i+1} = V_i + λ·D_i
+        for (std::size_t k = 0; k < M; ++k)
+            correction[k] += lambda * (qm[k] - mm_current[k]);
+
+        // Band-limit the correction through the FFT (paper: FFT applied to V_i).
+        pot        = parametrize(correction, max_multiplicity);
+        correction = pot.sample(static_cast<int>(M));
+
+        // Convergence: does mm_initial + correction reproduce qm?
+        for (std::size_t k = 0; k < M; ++k)
+            mm_current[k] = mm_initial[k] + correction[k];
+        r2 = r_squared(qm, mm_current);
+        if (r2 >= r2_target) break;
+    }
+
+    pot.r_squared        = r2;
+    pot.refinement_iters = iters;
+    return pot;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+std::vector<double>
+DiFTEngine::boltzmann_invert(std::span<const double> histogram) const {
+    const std::size_t M = histogram.size();
+    if (M < 2)
+        throw std::invalid_argument("DiFT::boltzmann_invert: need ≥ 2 bins");
+
+    double total = 0.0;
+    for (double c : histogram) {
+        if (c < 0.0)
+            throw std::invalid_argument("DiFT::boltzmann_invert: negative count");
+        total += c;
+    }
+    if (total <= 0.0)
+        throw std::invalid_argument("DiFT::boltzmann_invert: empty histogram");
+
+    // E(φ) = −kT ln p(φ). No Jacobian: dihedral angles are uniformly
+    // distributed for a free rotor (unlike bond lengths or bond angles).
+    const double kT = kB_kcal * T_;
+    std::vector<double> energy(M);
+    double e_min =  1e300;
+    double e_max = -1e300;
+    for (std::size_t k = 0; k < M; ++k) {
+        if (histogram[k] > 0.0) {
+            energy[k] = -kT * std::log(histogram[k] / total);
+            e_min = std::min(e_min, energy[k]);
+            e_max = std::max(e_max, energy[k]);
+        } else {
+            energy[k] = std::nan("");   // flag empty bins; filled below
+        }
+    }
+    // Empty bins → capped well wall at the highest observed energy.
+    for (double& e : energy)
+        if (std::isnan(e)) e = e_max;
+    // Shift so the global minimum sits at 0 (relative energies).
+    for (double& e : energy) e -= e_min;
+    return energy;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+TorsionalThermo
+DiFTEngine::thermodynamics(const TorsionalPotential& pot) const {
+    // Integrate the 1-D torsional partition function on a fine grid using the
+    // analytical potential. Energies are taken relative to the global minimum
+    // so the result is the EXCESS thermodynamics vs an (unconfined) free rotor.
+    constexpr int Nf = 1440;
+    double Z = 0.0, EZ = 0.0;
+    for (int j = 0; j < Nf; ++j) {
+        const double phi = kTwoPi * static_cast<double>(j) / static_cast<double>(Nf);
+        const double V   = pot.evaluate(phi) - pot.v_min;   // ≥ 0
+        const double w   = std::exp(-beta_ * V);
+        Z  += w;
+        EZ += w * V;
+    }
+    const double invNf = 1.0 / static_cast<double>(Nf);
+    const double z     = Z * invNf;                 // ⟨exp(−βV)⟩; 1 for a free rotor
+    const double mean  = (Z > 0.0) ? (EZ / Z) : 0.0;
+    const double F     = -kB_kcal * T_ * std::log(z);
+
+    TorsionalThermo th;
+    th.temperature        = T_;
+    th.partition_function = z;
+    th.free_energy        = F;
+    th.mean_energy        = mean;
+    th.entropy            = (mean - F) / T_;        // ≤ 0: confinement = entropy loss
+    th.minus_TS           = -T_ * th.entropy;       // ≥ 0: the ΔG penalty
+    return th;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+double DiFTEngine::circular_mean(std::span<const double> angles) noexcept {
+    double s = 0.0, c = 0.0;
+    for (double a : angles) { s += std::sin(a); c += std::cos(a); }
+    if (s == 0.0 && c == 0.0) return 0.0;
+    return std::atan2(s, c);
+}
+
+double DiFTEngine::r_squared(std::span<const double> observed,
+                             std::span<const double> model) noexcept {
+    const std::size_t n = observed.size();
+    if (n == 0 || model.size() != n) return 0.0;
+
+    double mean = 0.0;
+    for (double v : observed) mean += v;
+    mean /= static_cast<double>(n);
+
+    double ss_res = 0.0, ss_tot = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        const double d_res = observed[i] - model[i];
+        const double d_tot = observed[i] - mean;
+        ss_res += d_res * d_res;
+        ss_tot += d_tot * d_tot;
+    }
+    if (ss_tot <= 0.0)                     // flat target
+        return (ss_res <= 1e-18) ? 1.0 : 0.0;
+    return 1.0 - ss_res / ss_tot;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+double TorsionalPotential::evaluate(double phi) const noexcept {
+    double v = mean;
+    for (const FourierTerm& t : terms)
+        v += t.amplitude *
+             std::cos(static_cast<double>(t.multiplicity) * phi - t.phase);
+    return v;
+}
+
+std::vector<double> TorsionalPotential::sample(int n) const {
+    std::vector<double> out;
+    if (n < 1) return out;
+    out.reserve(static_cast<std::size_t>(n));
+    for (int j = 0; j < n; ++j)
+        out.push_back(evaluate(kTwoPi * static_cast<double>(j) /
+                                static_cast<double>(n)));
+    return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+double spectral_entropy(std::span<const FourierTerm> spectrum) noexcept {
+    double total = 0.0;
+    for (const FourierTerm& t : spectrum) total += t.power;
+    if (total <= 0.0) return 0.0;
+
+    double H = 0.0;
+    for (const FourierTerm& t : spectrum) {
+        const double p = t.power / total;
+        if (p > 0.0) H -= p * std::log(p);
+    }
+    return H;
+}
+
+} // namespace dift

--- a/LIB/DiFT/DiFT.cpp
+++ b/LIB/DiFT/DiFT.cpp
@@ -102,6 +102,10 @@ DiFTEngine::transform(std::span<const double> profile, double& mean_out) const {
     const std::size_t M = profile.size();
     if (M < 2)
         throw std::invalid_argument("DiFT::transform: profile needs ≥ 2 samples");
+    for (double v : profile) {
+        if (!std::isfinite(v))
+            throw std::invalid_argument("DiFT::transform: profile contains non-finite values");
+    }
 
     // Forward transform → full complex spectrum X_0 … X_{M−1}.
     std::vector<std::complex<double>> X;
@@ -253,6 +257,8 @@ DiFTEngine::boltzmann_invert(std::span<const double> histogram) const {
 
     double total = 0.0;
     for (double c : histogram) {
+        if (!std::isfinite(c))
+            throw std::invalid_argument("DiFT::boltzmann_invert: non-finite count");
         if (c < 0.0)
             throw std::invalid_argument("DiFT::boltzmann_invert: negative count");
         total += c;

--- a/LIB/DiFT/DiFT.h
+++ b/LIB/DiFT/DiFT.h
@@ -1,0 +1,162 @@
+// DiFT.h — Discrete Fourier Transform torsional parametrization for FlexAID∆S
+//
+// Copyright 2026 Le Bonhomme Pharma
+// SPDX-License-Identifier: Apache-2.0
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// DiFT: automated, unbiased parametrization of dihedral (torsional) potentials.
+//
+// Reference:
+//   Flores-Trujillo, Rodríguez-Segura, Amador-Bedolla & Domínguez (2026).
+//   "Fast Fourier Transform Enables Automated Parametrization of Complex
+//    Dihedral Potentials in All-Atom and Coarse-Grained Force Fields."
+//   J. Chem. Inf. Model.  DOI: 10.1021/acs.jcim.6c00123
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// WHY THIS LIVES IN AN ENTROPY-DRIVEN DOCKING ENGINE
+//
+// A torsional potential V(φ) and its Fourier spectrum {Aₙ, ωₙ} are conjugate
+// representations of the SAME object. FlexAID∆S scores binding by free energy,
+// ΔG = ΔH − TΔS — yet ligand rotatable-bond entropy has classically been a
+// crude per-bond count penalty. DiFT fixes that by first principles:
+//
+//   ONE Fast Fourier Transform → TWO payoffs
+//     (1) ENERGY  — a truncated cosine series V_tors(φ) = Σ Aₙ cos(nφ − ωₙ)
+//                   feeds the GA fitness as a real analytical potential.
+//     (2) ENTROPY — the SAME spectrum yields, in closed form, the 1-D torsional
+//                   partition function z = ⟨exp(−βV)⟩ and hence the per-bond
+//                   torsional entropy S_tors = (⟨V⟩ − F)/T. This is a rigorous
+//                   statistical-mechanical ΔS contribution, not a heuristic.
+//
+// SHANNON-COLLAPSE TRUNCATION (the unbiased stopping criterion)
+//   The paper increments the term count F by brute force and tests R². We
+//   replace that with a parameter-free criterion: the spectral Shannon entropy
+//   of the normalized power spectrum  pₙ = Aₙ² / Σ Aₘ².  The effective number
+//   of modes is the spectral participation ratio  N_eff = exp(H_spec).  A
+//   profile dominated by one cosine has H_spec → 0 (N_eff → 1); a flat noisy
+//   profile has H_spec → ln N (all modes). The spectrum itself tells you how
+//   many frequencies it needs — no user-defined amplitude threshold. This is
+//   Shannon's energy collapse applied to the dihedral spectrum.
+// ─────────────────────────────────────────────────────────────────────────────
+#pragma once
+
+#include <vector>
+#include <span>
+#include <cstddef>
+
+namespace dift {
+
+// ─── physical constants ──────────────────────────────────────────────────────
+inline constexpr double kB_kcal = 0.001987206;   // kcal mol⁻¹ K⁻¹  (matches statmech)
+
+// ─── data structures ─────────────────────────────────────────────────────────
+
+// A single cosine term of the torsional potential.
+//   contribution(φ) = amplitude · cos(multiplicity·φ − phase)
+// The GAFF/CHARMM "1 + cos" constant is an additive offset folded into
+// TorsionalPotential::mean; here we keep the pure oscillatory part.
+struct FourierTerm {
+    int    multiplicity = 0;   // n  — integer frequency
+    double amplitude    = 0.0; // Aₙ — force constant (kcal/mol), ≥ 0 by convention
+    double phase        = 0.0; // ωₙ — phase shift (radians), in (−π, π]
+    double power        = 0.0; // Aₙ² — spectral power (cached for truncation)
+};
+
+// A DiFT-parametrized torsional potential: the analytical representation
+// V(φ) = mean + Σ Aₙ cos(nφ − ωₙ) over the retained (truncated) terms.
+struct TorsionalPotential {
+    std::vector<FourierTerm> terms;            // retained terms, n ≥ 1, sorted by n
+    double mean             = 0.0;             // A₀ — DC offset (kcal/mol)
+    double v_min            = 0.0;             // min of V(φ) over a fine grid
+    int    n_samples        = 0;               // M — input grid resolution
+    double r_squared        = 0.0;             // fit quality vs the target profile
+    double spectral_entropy = 0.0;             // H_spec (nats) of the FULL spectrum
+    double effective_modes  = 0.0;             // N_eff = exp(H_spec)
+    int    refinement_iters = 0;               // QM–MM refinement iterations used
+
+    // Absolute potential at an arbitrary angle φ (radians).
+    double evaluate(double phi) const noexcept;
+    // Potential relative to its global minimum — the form used for scoring,
+    // since only relative torsional energies are physically meaningful.
+    double relative(double phi) const noexcept { return evaluate(phi) - v_min; }
+    // Sample the analytical potential on a uniform grid of n points over [0,2π).
+    std::vector<double> sample(int n) const;
+    // Total number of retained cosine terms.
+    std::size_t n_terms() const noexcept { return terms.size(); }
+};
+
+// Per-bond torsional thermodynamics, derived from the SAME Fourier spectrum.
+// Entropy is reported as an EXCESS quantity relative to a free rotor (V ≡ 0):
+//   free rotor      → S_tors = 0     (no confinement, no penalty)
+//   confined bond   → S_tors < 0     (entropy loss; −TS > 0 = ΔG penalty)
+struct TorsionalThermo {
+    double temperature        = 300.0; // K
+    double partition_function = 1.0;   // z = ⟨exp(−βV)⟩  (1 for a free rotor)
+    double free_energy        = 0.0;   // F = −kT ln z            (kcal/mol)
+    double mean_energy        = 0.0;   // ⟨V⟩                     (kcal/mol)
+    double entropy            = 0.0;   // S_tors = (⟨V⟩ − F)/T    (kcal mol⁻¹ K⁻¹)
+    double minus_TS           = 0.0;   // −T·S_tors               (kcal/mol)
+};
+
+// ─── core engine ─────────────────────────────────────────────────────────────
+
+class DiFTEngine {
+public:
+    explicit DiFTEngine(double temperature_K = 300.0);
+
+    // Forward DiFT: M equally-spaced samples of a torsional profile over [0,2π)
+    // → the full Fourier spectrum (terms n = 1 … ⌊M/2⌋). The DC mean is
+    // returned via the out-parameter. Uses a radix-2 FFT for power-of-two M
+    // and an exact direct DFT otherwise.
+    std::vector<FourierTerm> transform(std::span<const double> profile,
+                                       double& mean_out) const;
+
+    // Parametrize a target torsional profile: forward transform followed by
+    // Shannon-collapse spectral truncation. If max_multiplicity > 0, terms with
+    // n above it are discarded first (anti-overfit guard, paper uses n ≤ 6).
+    TorsionalPotential parametrize(std::span<const double> profile,
+                                   int max_multiplicity = 0) const;
+
+    // Iterative QM–MM refinement (paper eq. 18): V_{i+1} = V_i + λ·D_i, with
+    // D_i = V_QM − V_MM,i. Both profiles must share the SAME M-point grid.
+    // Each step is FFT band-limited; stops when R² ≥ r2_target.
+    TorsionalPotential refine(std::span<const double> qm,
+                              std::span<const double> mm_initial,
+                              double lambda           = 0.5,
+                              double r2_target        = 0.98,
+                              int    max_iter         = 50,
+                              int    max_multiplicity = 6) const;
+
+    // Boltzmann-invert a coarse-grained dihedral-angle histogram into an energy
+    // profile (paper eq. 20):  E(φ) = −kT ln p(φ), shifted so min = 0.
+    // Empty bins are assigned the maximum finite energy (capped well wall).
+    std::vector<double> boltzmann_invert(std::span<const double> histogram) const;
+
+    // Per-bond torsional thermodynamics from a parametrized potential.
+    // Integrates z = ⟨exp(−βV)⟩ on a fine grid using the analytical V(φ).
+    TorsionalThermo thermodynamics(const TorsionalPotential& pot) const;
+
+    // Circular (directional) mean of a set of phase offsets — required when
+    // averaging dihedral phase shifts across distinct torsional pathways
+    // (paper eq. 14). Returns atan2(Σ sin, Σ cos) in (−π, π].
+    static double circular_mean(std::span<const double> angles) noexcept;
+
+    // Coefficient of determination R² between an observed profile and a model
+    // profile of equal length.
+    static double r_squared(std::span<const double> observed,
+                            std::span<const double> model) noexcept;
+
+    double temperature() const noexcept { return T_; }
+    void   set_temperature(double T_K) noexcept;
+
+private:
+    double T_;
+    double beta_;   // 1 / (kB·T)
+};
+
+// Spectral Shannon entropy H_spec (nats) of a power spectrum: the normalized
+// powers pₙ = Aₙ²/ΣAₘ² (n ≥ 1) form a distribution; H = −Σ pₙ ln pₙ.
+// exp(H) is the effective number of contributing frequencies (N_eff).
+double spectral_entropy(std::span<const FourierTerm> spectrum) noexcept;
+
+} // namespace dift

--- a/LIB/DiFT/DiFTGAAdapter.h
+++ b/LIB/DiFT/DiFTGAAdapter.h
@@ -1,0 +1,86 @@
+// DiFTGAAdapter.h — bridge between DiFT torsional potentials and the GA fitness
+//
+// Copyright 2026 Le Bonhomme Pharma
+// SPDX-License-Identifier: Apache-2.0
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// This header is the single, clean integration surface between the DiFT engine
+// and the FlexAID∆S genetic algorithm. It is header-only and self-contained so
+// it can be unit-tested in isolation and called from the fitness evaluator
+// (LIB/spfunction.cpp / LIB/cffunction.cpp) behind an opt-in flag without
+// disturbing any existing scoring path.
+//
+// ONE FFT, TWO PAYOFFS — applied per ligand rotatable bond:
+//   energy   = Σ_b  V_tors,b(φ_b)            → adds to the complementarity score
+//   minus_TS = Σ_b  −T·S_tors,b              → the torsional ΔS free-energy
+//                                              penalty (confinement cost)
+// The GA minimizes  CF + score_torsional().total(), so a pose that parks a
+// rotatable bond in a deep DiFT well pays the well's energy AND its entropy
+// penalty, both derived from the same Fourier spectrum.
+// ─────────────────────────────────────────────────────────────────────────────
+#pragma once
+
+#include "DiFT.h"
+
+#include <span>
+#include <vector>
+
+namespace dift {
+
+// A ligand rotatable bond with its DiFT-parametrized torsional potential.
+struct RotatableBondTorsion {
+    TorsionalPotential potential;     // DiFT V_tors for this bond
+    int                gene_index = -1;  // GA dihedral gene that drives φ for this bond
+};
+
+// Decomposed torsional contribution to the binding free energy (kcal/mol).
+struct TorsionalScore {
+    double energy   = 0.0;   // Σ V_tors,b relative to each well minimum
+    double minus_TS = 0.0;   // Σ −T·S_tors,b — torsional confinement penalty
+    int    n_bonds  = 0;     // rotatable bonds accounted for
+
+    // Total free-energy contribution the GA should add to the CF score.
+    double total() const noexcept { return energy + minus_TS; }
+};
+
+// Score a pose's torsional state.
+//   bonds                — per-rotatable-bond DiFT potentials
+//   dihedral_angles_rad  — current dihedral value (radians) of each bond,
+//                          in the SAME order as `bonds`
+//   temperature_K        — ensemble temperature for the entropy term
+//
+// `energy` uses the potential RELATIVE to its minimum (only relative torsional
+// energies are physical); `minus_TS` is the temperature-weighted excess
+// torsional entropy from DiFTEngine::thermodynamics — a free rotor contributes
+// exactly zero, a confined bond contributes a positive penalty.
+inline TorsionalScore score_torsional(std::span<const RotatableBondTorsion> bonds,
+                                      std::span<const double> dihedral_angles_rad,
+                                      double temperature_K = 300.0) {
+    TorsionalScore s;
+    if (bonds.size() != dihedral_angles_rad.size())
+        return s;   // caller contract violated — return a zero contribution
+
+    DiFTEngine engine(temperature_K);
+    for (std::size_t b = 0; b < bonds.size(); ++b) {
+        const TorsionalPotential& pot = bonds[b].potential;
+        s.energy   += pot.relative(dihedral_angles_rad[b]);
+        s.minus_TS += engine.thermodynamics(pot).minus_TS;
+        ++s.n_bonds;
+    }
+    return s;
+}
+
+// Convenience: build a RotatableBondTorsion by parametrizing a raw torsional
+// profile (QM scan or Boltzmann-inverted CG histogram) on the spot.
+inline RotatableBondTorsion make_bond_torsion(std::span<const double> profile,
+                                              int    gene_index,
+                                              double temperature_K   = 300.0,
+                                              int    max_multiplicity = 6) {
+    DiFTEngine engine(temperature_K);
+    RotatableBondTorsion rbt;
+    rbt.potential   = engine.parametrize(profile, max_multiplicity);
+    rbt.gene_index  = gene_index;
+    return rbt;
+}
+
+} // namespace dift

--- a/LIB/DiFT/dift_cli.cpp
+++ b/LIB/DiFT/dift_cli.cpp
@@ -1,0 +1,310 @@
+// dift_cli.cpp - command-line DiFT torsional parametrization
+//
+// Copyright 2026 Le Bonhomme Pharma
+// SPDX-License-Identifier: Apache-2.0
+
+#include "DiFT.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+constexpr double kTwoPi = 6.283185307179586476925286766559;
+constexpr double kPi = 3.1415926535897932384626433832795;
+
+struct Options {
+    std::string input;
+    std::string json_output;
+    std::string sidecar_output;
+    int max_multiplicity = 6;
+    double temperature_K = 300.0;
+    bool histogram = false;
+};
+
+struct ScanData {
+    std::vector<double> angles_deg;
+    std::vector<double> values;
+    bool has_angles = false;
+};
+
+[[noreturn]] void usage(int exit_code) {
+    std::ostream& out = exit_code == 0 ? std::cout : std::cerr;
+    out << "Usage: dift_torsion_fit --input scan.csv --json fit.json [options]\n"
+        << "\n"
+        << "Options:\n"
+        << "  --sidecar FILE            Write FlexAIDdS .dift sidecar terms\n"
+        << "  --max-multiplicity N      Highest Fourier multiplicity to retain (default: 6)\n"
+        << "  --temperature K           Temperature for thermodynamics (default: 300)\n"
+        << "  --histogram               Treat values as counts and Boltzmann-invert first\n"
+        << "  --help                    Show this help\n"
+        << "\n"
+        << "Input may be one numeric column (values on an implicit uniform grid) or\n"
+        << "two numeric columns: angle_degrees,value. Angle grids must be uniform over\n"
+        << "[0, 360) and must not repeat the 360-degree endpoint.\n";
+    std::exit(exit_code);
+}
+
+Options parse_args(int argc, char** argv) {
+    Options opts;
+    for (int i = 1; i < argc; ++i) {
+        std::string_view arg(argv[i]);
+        auto need_value = [&](std::string_view flag) -> std::string {
+            if (i + 1 >= argc) throw std::invalid_argument(std::string(flag) + " needs a value");
+            return argv[++i];
+        };
+        if (arg == "--help" || arg == "-h") usage(0);
+        else if (arg == "--input") opts.input = need_value(arg);
+        else if (arg == "--json") opts.json_output = need_value(arg);
+        else if (arg == "--sidecar") opts.sidecar_output = need_value(arg);
+        else if (arg == "--max-multiplicity") opts.max_multiplicity = std::stoi(need_value(arg));
+        else if (arg == "--temperature") opts.temperature_K = std::stod(need_value(arg));
+        else if (arg == "--histogram") opts.histogram = true;
+        else throw std::invalid_argument("unknown option: " + std::string(arg));
+    }
+    if (opts.input.empty()) throw std::invalid_argument("--input is required");
+    if (opts.json_output.empty()) throw std::invalid_argument("--json is required");
+    if (opts.max_multiplicity < 0) throw std::invalid_argument("--max-multiplicity must be >= 0");
+    if (!(opts.temperature_K > 0.0) || !std::isfinite(opts.temperature_K)) {
+        throw std::invalid_argument("--temperature must be finite and > 0");
+    }
+    return opts;
+}
+
+std::string trim(std::string s) {
+    auto not_space = [](unsigned char c) { return !std::isspace(c); };
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
+    s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
+    return s;
+}
+
+std::vector<std::string> split_numeric_fields(std::string line) {
+    for (char& c : line) {
+        if (c == ',' || c == ';' || c == '\t') c = ' ';
+    }
+    std::istringstream in(line);
+    std::vector<std::string> fields;
+    std::string token;
+    while (in >> token) fields.push_back(token);
+    return fields;
+}
+
+bool parse_double(const std::string& s, double& out) {
+    char* end = nullptr;
+    out = std::strtod(s.c_str(), &end);
+    return end != s.c_str() && *end == '\0' && std::isfinite(out);
+}
+
+ScanData read_scan(const std::string& filename) {
+    std::ifstream in(filename);
+    if (!in) throw std::runtime_error("cannot open input: " + filename);
+
+    ScanData data;
+    std::string line;
+    std::size_t line_no = 0;
+    while (std::getline(in, line)) {
+        ++line_no;
+        line = trim(line);
+        if (line.empty() || line[0] == '#') continue;
+
+        auto fields = split_numeric_fields(line);
+        if (fields.empty()) continue;
+
+        double a = 0.0, v = 0.0;
+        if (fields.size() == 1) {
+            if (!parse_double(fields[0], v)) {
+                if (data.values.empty()) continue; // tolerate one header before data
+                throw std::runtime_error("non-numeric value on line " + std::to_string(line_no));
+            }
+            if (data.has_angles) {
+                throw std::runtime_error("mixed one-column and two-column data");
+            }
+            data.values.push_back(v);
+        } else {
+            if (!parse_double(fields[0], a) || !parse_double(fields[1], v)) {
+                if (data.values.empty()) continue; // tolerate one header before data
+                throw std::runtime_error("non-numeric angle/value on line " + std::to_string(line_no));
+            }
+            if (!data.values.empty() && !data.has_angles) {
+                throw std::runtime_error("mixed one-column and two-column data");
+            }
+            data.has_angles = true;
+            data.angles_deg.push_back(a);
+            data.values.push_back(v);
+        }
+    }
+
+    if (data.values.size() < 3) throw std::runtime_error("need at least 3 torsion samples");
+    return data;
+}
+
+void validate_angles(const std::vector<double>& angles) {
+    if (angles.empty()) return;
+    const std::size_t n = angles.size();
+    if (n < 3) throw std::runtime_error("need at least 3 torsion angle samples");
+    for (double a : angles) {
+        if (!std::isfinite(a)) throw std::runtime_error("angle grid contains non-finite values");
+        if (a < -1e-9 || a >= 360.0 - 1e-9) {
+            throw std::runtime_error("angle grid must cover [0, 360) without a duplicate 360 endpoint");
+        }
+    }
+    std::vector<double> sorted = angles;
+    std::sort(sorted.begin(), sorted.end());
+    for (std::size_t i = 1; i < sorted.size(); ++i) {
+        if (std::abs(sorted[i] - sorted[i - 1]) < 1e-9) {
+            throw std::runtime_error("angle grid contains duplicate angles");
+        }
+    }
+    const double expected = 360.0 / static_cast<double>(n);
+    for (std::size_t i = 1; i < sorted.size(); ++i) {
+        const double step = sorted[i] - sorted[i - 1];
+        if (std::abs(step - expected) > 1e-6) {
+            throw std::runtime_error("angle grid must be uniformly spaced over [0, 360)");
+        }
+    }
+    const double wrap_step = sorted.front() + 360.0 - sorted.back();
+    if (std::abs(wrap_step - expected) > 1e-6) {
+        throw std::runtime_error("angle grid must cover a complete [0, 360) period");
+    }
+}
+
+std::vector<double> order_by_angle(const ScanData& data) {
+    if (!data.has_angles) return data.values;
+    validate_angles(data.angles_deg);
+    std::vector<std::size_t> order(data.values.size());
+    for (std::size_t i = 0; i < order.size(); ++i) order[i] = i;
+    std::sort(order.begin(), order.end(), [&](std::size_t a, std::size_t b) {
+        return data.angles_deg[a] < data.angles_deg[b];
+    });
+    std::vector<double> values;
+    values.reserve(order.size());
+    for (std::size_t idx : order) values.push_back(data.values[idx]);
+    return values;
+}
+
+std::vector<double> full_model(const dift::TorsionalPotential& pot, std::size_t n) {
+    return pot.sample(static_cast<int>(n));
+}
+
+double rmse(const std::vector<double>& obs, const std::vector<double>& model) {
+    if (obs.size() != model.size() || obs.empty()) return 0.0;
+    double ss = 0.0;
+    for (std::size_t i = 0; i < obs.size(); ++i) {
+        const double d = obs[i] - model[i];
+        ss += d * d;
+    }
+    return std::sqrt(ss / static_cast<double>(obs.size()));
+}
+
+double max_abs_error(const std::vector<double>& obs, const std::vector<double>& model) {
+    double out = 0.0;
+    for (std::size_t i = 0; i < obs.size() && i < model.size(); ++i) {
+        out = std::max(out, std::abs(obs[i] - model[i]));
+    }
+    return out;
+}
+
+void write_json(const Options& opts,
+                const std::vector<double>& profile,
+                const dift::TorsionalPotential& pot,
+                const dift::TorsionalThermo& thermo) {
+    auto model = full_model(pot, profile.size());
+    std::ofstream out(opts.json_output);
+    if (!out) throw std::runtime_error("cannot write JSON: " + opts.json_output);
+
+    out << std::setprecision(12);
+    out << "{\n";
+    out << "  \"method\": \"DiFT\",\n";
+    out << "  \"input\": \"" << opts.input << "\",\n";
+    out << "  \"n_samples\": " << profile.size() << ",\n";
+    out << "  \"temperature_K\": " << thermo.temperature << ",\n";
+    out << "  \"max_multiplicity\": " << opts.max_multiplicity << ",\n";
+    out << "  \"profile_type\": \"" << (opts.histogram ? "boltzmann_inverted_histogram" : "energy_scan") << "\",\n";
+    out << "  \"mean_kcal_mol\": " << pot.mean << ",\n";
+    out << "  \"v_min_kcal_mol\": " << pot.v_min << ",\n";
+    out << "  \"r_squared\": " << pot.r_squared << ",\n";
+    out << "  \"rmse_kcal_mol\": " << rmse(profile, model) << ",\n";
+    out << "  \"max_abs_error_kcal_mol\": " << max_abs_error(profile, model) << ",\n";
+    out << "  \"spectral_entropy_nats\": " << pot.spectral_entropy << ",\n";
+    out << "  \"effective_modes\": " << pot.effective_modes << ",\n";
+    out << "  \"thermodynamics\": {\n";
+    out << "    \"partition_function\": " << thermo.partition_function << ",\n";
+    out << "    \"free_energy_kcal_mol\": " << thermo.free_energy << ",\n";
+    out << "    \"mean_energy_kcal_mol\": " << thermo.mean_energy << ",\n";
+    out << "    \"entropy_kcal_mol_K\": " << thermo.entropy << ",\n";
+    out << "    \"minus_TS_kcal_mol\": " << thermo.minus_TS << "\n";
+    out << "  },\n";
+    out << "  \"terms\": [\n";
+    for (std::size_t i = 0; i < pot.terms.size(); ++i) {
+        const auto& t = pot.terms[i];
+        out << "    {\"multiplicity\": " << t.multiplicity
+            << ", \"amplitude_kcal_mol\": " << t.amplitude
+            << ", \"phase_rad\": " << t.phase
+            << ", \"phase_deg\": " << (t.phase * 180.0 / kPi)
+            << ", \"power\": " << t.power << "}";
+        out << (i + 1 == pot.terms.size() ? "\n" : ",\n");
+    }
+    out << "  ]\n";
+    out << "}\n";
+}
+
+void write_sidecar(const Options& opts,
+                   const dift::TorsionalPotential& pot,
+                   const dift::TorsionalThermo& thermo) {
+    if (opts.sidecar_output.empty()) return;
+    std::ofstream out(opts.sidecar_output);
+    if (!out) throw std::runtime_error("cannot write sidecar: " + opts.sidecar_output);
+    out << std::setprecision(12);
+    out << "# FlexAIDdS DiFT torsion prior v1\n";
+    out << "source " << opts.input << "\n";
+    out << "samples " << pot.n_samples << "\n";
+    out << "temperature_K " << thermo.temperature << "\n";
+    out << "mean_kcal_mol " << pot.mean << "\n";
+    out << "v_min_kcal_mol " << pot.v_min << "\n";
+    out << "r_squared " << pot.r_squared << "\n";
+    out << "minus_TS_kcal_mol " << thermo.minus_TS << "\n";
+    out << "# term multiplicity amplitude_kcal_mol phase_rad\n";
+    for (const auto& t : pot.terms) {
+        out << "term " << t.multiplicity << ' ' << t.amplitude << ' ' << t.phase << "\n";
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options opts = parse_args(argc, argv);
+        const ScanData scan = read_scan(opts.input);
+        std::vector<double> profile = order_by_angle(scan);
+        for (double v : profile) {
+            if (!std::isfinite(v)) throw std::runtime_error("profile contains non-finite values");
+        }
+
+        dift::DiFTEngine engine(opts.temperature_K);
+        if (opts.histogram) profile = engine.boltzmann_invert(profile);
+        auto pot = engine.parametrize(profile, opts.max_multiplicity);
+        auto thermo = engine.thermodynamics(pot);
+
+        write_json(opts, profile, pot, thermo);
+        write_sidecar(opts, pot, thermo);
+        std::cout << "DiFT fit: " << pot.n_terms() << " terms, R2=" << pot.r_squared
+                  << ", JSON=" << opts.json_output;
+        if (!opts.sidecar_output.empty()) std::cout << ", sidecar=" << opts.sidecar_output;
+        std::cout << "\n";
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "dift_torsion_fit: " << e.what() << "\n";
+        return 2;
+    }
+}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -16,6 +16,7 @@ pybind11_add_module(_core
     ${CMAKE_SOURCE_DIR}/LIB/encom.cpp
     ${CMAKE_SOURCE_DIR}/LIB/ShannonThermoStack/ShannonThermoStack.cpp
     ${CMAKE_SOURCE_DIR}/LIB/tENCoM/tencm.cpp
+    ${CMAKE_SOURCE_DIR}/LIB/DiFT/DiFT.cpp
     ${CMAKE_SOURCE_DIR}/LIB/fast_optics.cpp
 )
 

--- a/python/bindings/core_bindings.cpp
+++ b/python/bindings/core_bindings.cpp
@@ -18,6 +18,7 @@
 #include "../../LIB/fast_optics.hpp"
 #include "../../LIB/Spectrophore.h"
 #include "../../LIB/BindingResidues.h"
+#include "dift_bindings.h"
 
 namespace py = pybind11;
 using namespace statmech;
@@ -524,4 +525,9 @@ PYBIND11_MODULE(_core, m) {
                    ":" + r.chain + " (MIF=" +
                    std::to_string(r.mif_score) + ")";
         });
+
+    // ──────────────────────────────────────────────────────────────────────
+    // DiFT — Discrete Fourier Transform torsional parametrization
+    // ──────────────────────────────────────────────────────────────────────
+    register_dift_bindings(m);
 }

--- a/python/bindings/dift_bindings.h
+++ b/python/bindings/dift_bindings.h
@@ -1,0 +1,160 @@
+// dift_bindings.h — pybind11 bindings for the DiFT torsional engine
+//
+// Copyright 2026 Le Bonhomme Pharma
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared by both _core builds:
+//   - python/flexaidds/_core.cpp        (setup.py / pip install -e)
+//   - python/bindings/core_bindings.cpp (CMake -DBUILD_PYTHON_BINDINGS=ON)
+//
+// Exposes dift::DiFTEngine and friends. The pure-Python flexaidds.dift module
+// mirrors this API and is the always-available fallback; these bindings are a
+// speed path that must produce numerically identical results.
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <cstdio>
+#include <span>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "../../LIB/DiFT/DiFT.h"
+
+// Registers the DiFT classes/functions on an existing pybind11 module.
+inline void register_dift_bindings(pybind11::module_& m) {
+    namespace py = pybind11;
+    using namespace dift;
+
+    m.attr("dift_kB_kcal") = kB_kcal;
+
+    // ── FourierTerm ──────────────────────────────────────────────────────────
+    py::class_<FourierTerm>(m, "FourierTerm",
+        "One cosine term: amplitude * cos(multiplicity*phi - phase)")
+        .def(py::init<>())
+        .def_readwrite("multiplicity", &FourierTerm::multiplicity, "n - integer frequency")
+        .def_readwrite("amplitude",    &FourierTerm::amplitude,    "A_n (kcal/mol)")
+        .def_readwrite("phase",        &FourierTerm::phase,        "omega_n (radians)")
+        .def_readwrite("power",        &FourierTerm::power,        "A_n^2 spectral power")
+        .def("__repr__", [](const FourierTerm& t) {
+            char buf[96];
+            std::snprintf(buf, sizeof(buf), "<FourierTerm n=%d A=%.4g w=%.4g>",
+                          t.multiplicity, t.amplitude, t.phase);
+            return std::string(buf);
+        });
+
+    // ── TorsionalPotential ───────────────────────────────────────────────────
+    py::class_<TorsionalPotential>(m, "TorsionalPotential",
+        "Analytical torsional potential V(phi) = mean + sum A_n cos(n phi - w_n)")
+        .def(py::init<>())
+        .def_readwrite("terms",            &TorsionalPotential::terms)
+        .def_readwrite("mean",             &TorsionalPotential::mean)
+        .def_readwrite("v_min",            &TorsionalPotential::v_min)
+        .def_readwrite("n_samples",        &TorsionalPotential::n_samples)
+        .def_readwrite("r_squared",        &TorsionalPotential::r_squared)
+        .def_readwrite("spectral_entropy", &TorsionalPotential::spectral_entropy)
+        .def_readwrite("effective_modes",  &TorsionalPotential::effective_modes)
+        .def_readwrite("refinement_iters", &TorsionalPotential::refinement_iters)
+        .def("evaluate", &TorsionalPotential::evaluate, py::arg("phi"),
+             "Absolute potential at angle phi (radians)")
+        .def("relative", &TorsionalPotential::relative, py::arg("phi"),
+             "Potential relative to its global minimum")
+        .def("sample", &TorsionalPotential::sample, py::arg("n"),
+             "Sample V(phi) on n uniform points over [0, 2pi)")
+        .def_property_readonly("n_terms", &TorsionalPotential::n_terms)
+        .def("__repr__", [](const TorsionalPotential& p) {
+            char buf[128];
+            std::snprintf(buf, sizeof(buf),
+                "<TorsionalPotential terms=%zu R2=%.4f N_eff=%.3f>",
+                p.n_terms(), p.r_squared, p.effective_modes);
+            return std::string(buf);
+        });
+
+    // ── TorsionalThermo ──────────────────────────────────────────────────────
+    py::class_<TorsionalThermo>(m, "TorsionalThermo",
+        "Per-bond torsional thermodynamics (excess, vs a free rotor)")
+        .def(py::init<>())
+        .def_readwrite("temperature",        &TorsionalThermo::temperature)
+        .def_readwrite("partition_function", &TorsionalThermo::partition_function)
+        .def_readwrite("free_energy",        &TorsionalThermo::free_energy)
+        .def_readwrite("mean_energy",        &TorsionalThermo::mean_energy)
+        .def_readwrite("entropy",            &TorsionalThermo::entropy)
+        .def_readwrite("minus_TS",           &TorsionalThermo::minus_TS)
+        .def("__repr__", [](const TorsionalThermo& t) {
+            char buf[160];
+            std::snprintf(buf, sizeof(buf),
+                "<TorsionalThermo T=%.1fK z=%.4f F=%.4f S=%.6f -TS=%.4f>",
+                t.temperature, t.partition_function, t.free_energy,
+                t.entropy, t.minus_TS);
+            return std::string(buf);
+        });
+
+    // ── DiFTEngine ───────────────────────────────────────────────────────────
+    py::class_<DiFTEngine>(m, "DiFTEngine",
+        "Discrete Fourier Transform torsional parametrization engine")
+        .def(py::init<double>(), py::arg("temperature_K") = 300.0)
+        .def("transform",
+            [](const DiFTEngine& self, const std::vector<double>& profile) {
+                double mean = 0.0;
+                auto spec = self.transform(std::span<const double>(profile), mean);
+                return std::make_tuple(spec, mean);
+            },
+            py::arg("profile"),
+            "Forward DiFT -> (spectrum, mean)")
+        .def("parametrize",
+            [](const DiFTEngine& self, const std::vector<double>& profile,
+               int max_multiplicity) {
+                return self.parametrize(std::span<const double>(profile),
+                                        max_multiplicity);
+            },
+            py::arg("profile"), py::arg("max_multiplicity") = 0,
+            "Forward transform + Shannon-collapse spectral truncation")
+        .def("refine",
+            [](const DiFTEngine& self, const std::vector<double>& qm,
+               const std::vector<double>& mm_initial, double lambda,
+               double r2_target, int max_iter, int max_multiplicity) {
+                return self.refine(std::span<const double>(qm),
+                                   std::span<const double>(mm_initial),
+                                   lambda, r2_target, max_iter, max_multiplicity);
+            },
+            py::arg("qm"), py::arg("mm_initial"), py::arg("lambda_") = 0.5,
+            py::arg("r2_target") = 0.98, py::arg("max_iter") = 50,
+            py::arg("max_multiplicity") = 6,
+            "Iterative QM-MM refinement (V_{i+1} = V_i + lambda*D_i)")
+        .def("boltzmann_invert",
+            [](const DiFTEngine& self, const std::vector<double>& histogram) {
+                return self.boltzmann_invert(std::span<const double>(histogram));
+            },
+            py::arg("histogram"),
+            "Boltzmann-invert a CG dihedral histogram into an energy profile")
+        .def("thermodynamics", &DiFTEngine::thermodynamics, py::arg("potential"),
+            "Per-bond torsional thermodynamics from a parametrized potential")
+        .def_static("circular_mean",
+            [](const std::vector<double>& angles) {
+                return DiFTEngine::circular_mean(std::span<const double>(angles));
+            },
+            py::arg("angles"), "Directional mean of phase offsets")
+        .def_static("r_squared",
+            [](const std::vector<double>& observed,
+               const std::vector<double>& model) {
+                return DiFTEngine::r_squared(std::span<const double>(observed),
+                                             std::span<const double>(model));
+            },
+            py::arg("observed"), py::arg("model"),
+            "Coefficient of determination R^2")
+        .def_property_readonly("temperature", &DiFTEngine::temperature)
+        .def("set_temperature", &DiFTEngine::set_temperature, py::arg("T_K"))
+        .def("__repr__", [](const DiFTEngine& e) {
+            return "<DiFTEngine T=" + std::to_string(e.temperature()) + "K>";
+        });
+
+    // ── free function ────────────────────────────────────────────────────────
+    m.def("dift_spectral_entropy",
+        [](const std::vector<FourierTerm>& spectrum) {
+            return spectral_entropy(std::span<const FourierTerm>(spectrum));
+        },
+        py::arg("spectrum"),
+        "Spectral Shannon entropy H_spec (nats) of a power spectrum");
+}

--- a/python/flexaidds/__init__.py
+++ b/python/flexaidds/__init__.py
@@ -10,6 +10,11 @@ from .tencm import (
     compute_shannon_entropy, compute_torsional_vibrational_entropy,
     run_shannon_thermo_stack,
 )
+from .dift import (
+    DiFTEngine, FourierTerm, TorsionalPotential, TorsionalThermo,
+    RotatableBondTorsion, TorsionalScore, score_torsional, make_bond_torsion,
+    spectral_entropy,
+)
 from .__version__ import __version__ as __version__
 from .updater import check_for_updates, UpdateInfo
 from .boltz2 import (

--- a/python/flexaidds/_core.cpp
+++ b/python/flexaidds/_core.cpp
@@ -20,6 +20,7 @@
 #include "encom.h"
 #include "tENCoM/tencm.h"
 #include "ShannonThermoStack/ShannonThermoStack.h"
+#include "../bindings/dift_bindings.h"
 
 namespace py = pybind11;
 using namespace statmech;
@@ -476,4 +477,9 @@ PYBIND11_MODULE(_core, m) {
         py::arg("base_deltaG"), py::arg("temperature_K") = 298.15,
         "Run full ShannonThermoStack pipeline",
         py::call_guard<py::gil_scoped_release>());
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // DiFT: Discrete Fourier Transform torsional parametrization
+    // ═══════════════════════════════════════════════════════════════════════
+    register_dift_bindings(m);
 }

--- a/python/flexaidds/dift.py
+++ b/python/flexaidds/dift.py
@@ -1,0 +1,391 @@
+"""DiFT — Discrete Fourier Transform torsional parametrization for FlexAID∆S.
+
+Pure-Python (NumPy) mirror of the C++ ``dift`` engine (``LIB/DiFT/``). Produces
+numerically identical results to the compiled core; the C++ path exists only as
+a speed option. This module is always importable — it has no dependency on the
+compiled ``_core`` extension.
+
+Method
+------
+A dihedral's torsional potential ``V(φ)`` and its Fourier spectrum ``{Aₙ, ωₙ}``
+are conjugate representations of the same object. One FFT yields two payoffs:
+
+* **Energy**  — a truncated cosine series ``V(φ) = mean + Σ Aₙ cos(nφ − ωₙ)``.
+* **Entropy** — the same spectrum gives the 1-D torsional partition function
+  ``z = ⟨exp(−βV)⟩`` and hence a rigorous per-bond torsional entropy
+  ``S_tors = (⟨V⟩ − F)/T`` — the ΔS contribution an entropy-driven docking
+  engine should actually use, instead of a heuristic rotatable-bond count.
+
+Truncation is **Shannon-collapse**: the spectral entropy ``H_spec`` of the
+normalized power spectrum sets the effective mode count ``N_eff = exp(H_spec)``;
+the ``⌈N_eff⌉`` highest-power terms are retained. No user threshold.
+
+Reference
+---------
+Flores-Trujillo, Rodríguez-Segura, Amador-Bedolla & Domínguez (2026).
+"Fast Fourier Transform Enables Automated Parametrization of Complex Dihedral
+Potentials in All-Atom and Coarse-Grained Force Fields."
+J. Chem. Inf. Model.  DOI: 10.1021/acs.jcim.6c00123
+
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 Le Bonhomme Pharma
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import List, Sequence
+
+import numpy as np
+
+__all__ = [
+    "kB_kcal",
+    "FourierTerm",
+    "TorsionalPotential",
+    "TorsionalThermo",
+    "DiFTEngine",
+    "spectral_entropy",
+    "RotatableBondTorsion",
+    "TorsionalScore",
+    "score_torsional",
+    "make_bond_torsion",
+]
+
+# Physical constant — matches statmech / the C++ dift namespace.
+kB_kcal = 0.001987206  # kcal mol⁻¹ K⁻¹
+
+_TWO_PI = 2.0 * math.pi
+
+
+def _wrap_pi(a: float) -> float:
+    """Wrap an angle into (−π, π]."""
+    a = math.fmod(a + math.pi, _TWO_PI)
+    if a < 0.0:
+        a += _TWO_PI
+    return a - math.pi
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Data structures
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class FourierTerm:
+    """A single cosine term: ``amplitude · cos(multiplicity·φ − phase)``."""
+
+    multiplicity: int = 0      # n — integer frequency
+    amplitude: float = 0.0     # Aₙ — force constant (kcal/mol), ≥ 0
+    phase: float = 0.0         # ωₙ — phase shift (radians), in (−π, π]
+    power: float = 0.0         # Aₙ² — spectral power
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return (f"<FourierTerm n={self.multiplicity} "
+                f"A={self.amplitude:.4g} ω={self.phase:.4g}>")
+
+
+@dataclass
+class TorsionalPotential:
+    """Analytical torsional potential ``V(φ) = mean + Σ Aₙ cos(nφ − ωₙ)``."""
+
+    terms: List[FourierTerm] = field(default_factory=list)
+    mean: float = 0.0               # A₀ — DC offset (kcal/mol)
+    v_min: float = 0.0              # global minimum of V(φ) (kcal/mol)
+    n_samples: int = 0              # M — input grid resolution
+    r_squared: float = 0.0          # fit quality vs the target profile
+    spectral_entropy: float = 0.0   # H_spec (nats) of the FULL spectrum
+    effective_modes: float = 0.0    # N_eff = exp(H_spec)
+    refinement_iters: int = 0       # QM–MM refinement iterations used
+
+    def evaluate(self, phi: float) -> float:
+        """Absolute potential at angle ``phi`` (radians)."""
+        v = self.mean
+        for t in self.terms:
+            v += t.amplitude * math.cos(t.multiplicity * phi - t.phase)
+        return v
+
+    def relative(self, phi: float) -> float:
+        """Potential relative to its global minimum — the form used to score."""
+        return self.evaluate(phi) - self.v_min
+
+    def sample(self, n: int) -> np.ndarray:
+        """Sample the analytical potential on ``n`` points over [0, 2π)."""
+        if n < 1:
+            return np.empty(0, dtype=float)
+        phi = np.arange(n, dtype=float) * (_TWO_PI / n)
+        out = np.full(n, self.mean, dtype=float)
+        for t in self.terms:
+            out += t.amplitude * np.cos(t.multiplicity * phi - t.phase)
+        return out
+
+    @property
+    def n_terms(self) -> int:
+        return len(self.terms)
+
+
+@dataclass
+class TorsionalThermo:
+    """Per-bond torsional thermodynamics (excess, vs a free rotor).
+
+    A free rotor (``V ≡ 0``) gives ``entropy = 0``; a confined bond gives
+    ``entropy < 0`` (an entropy loss) and ``minus_TS > 0`` (a ΔG penalty).
+    """
+
+    temperature: float = 300.0
+    partition_function: float = 1.0   # z = ⟨exp(−βV)⟩
+    free_energy: float = 0.0          # F = −kT ln z      (kcal/mol)
+    mean_energy: float = 0.0          # ⟨V⟩               (kcal/mol)
+    entropy: float = 0.0              # S_tors            (kcal mol⁻¹ K⁻¹)
+    minus_TS: float = 0.0             # −T·S_tors         (kcal/mol)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Spectral Shannon entropy
+# ─────────────────────────────────────────────────────────────────────────────
+
+def spectral_entropy(spectrum: Sequence[FourierTerm]) -> float:
+    """Shannon entropy ``H_spec`` (nats) of a power spectrum.
+
+    Normalized powers ``pₙ = Aₙ²/ΣAₘ²`` form a distribution; ``H = −Σ pₙ ln pₙ``.
+    ``exp(H)`` is the effective number of contributing frequencies.
+    """
+    total = sum(t.power for t in spectrum)
+    if total <= 0.0:
+        return 0.0
+    h = 0.0
+    for t in spectrum:
+        p = t.power / total
+        if p > 0.0:
+            h -= p * math.log(p)
+    return h
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Core engine
+# ─────────────────────────────────────────────────────────────────────────────
+
+class DiFTEngine:
+    """DiFT torsional parametrization engine (pure-Python / NumPy)."""
+
+    def __init__(self, temperature_K: float = 300.0) -> None:
+        self.set_temperature(temperature_K)
+
+    def set_temperature(self, t_k: float) -> None:
+        self._t = t_k if t_k > 0.0 else 300.0
+        self._beta = 1.0 / (kB_kcal * self._t)
+
+    @property
+    def temperature(self) -> float:
+        return self._t
+
+    # ── forward transform ────────────────────────────────────────────────────
+    def transform(self, profile: Sequence[float]) -> tuple[List[FourierTerm], float]:
+        """Forward DiFT of an M-point torsional profile over [0, 2π).
+
+        Returns ``(spectrum, mean)`` where ``spectrum`` lists terms n = 1…⌊M/2⌋.
+        """
+        x = np.asarray(profile, dtype=float)
+        m = x.size
+        if m < 2:
+            raise ValueError("DiFT.transform: profile needs ≥ 2 samples")
+
+        # rfft → X_0 … X_{M//2}; sign convention X_n = Σ x_k exp(−i2πnk/M).
+        x_full = np.fft.rfft(x)
+        inv_m = 1.0 / m
+        mean = x_full[0].real * inv_m
+
+        n_max = m // 2
+        spectrum: List[FourierTerm] = []
+        for n in range(1, n_max + 1):
+            nyquist = (m % 2 == 0) and (n == n_max)
+            scale = inv_m if nyquist else (2.0 * inv_m)
+            amp = scale * abs(x_full[n])
+            phase = -math.atan2(x_full[n].imag, x_full[n].real)
+            if amp < 0.0:
+                amp, phase = -amp, _wrap_pi(phase + math.pi)
+            else:
+                phase = _wrap_pi(phase)
+            spectrum.append(FourierTerm(multiplicity=n, amplitude=amp,
+                                        phase=phase, power=amp * amp))
+        return spectrum, mean
+
+    # ── parametrize with Shannon-collapse truncation ─────────────────────────
+    def parametrize(self, profile: Sequence[float],
+                    max_multiplicity: int = 0) -> TorsionalPotential:
+        """Forward transform + Shannon-collapse spectral truncation."""
+        spectrum, mean = self.transform(profile)
+
+        h_spec = spectral_entropy(spectrum)
+        n_eff = math.exp(h_spec)
+
+        if max_multiplicity > 0:
+            spectrum = [t for t in spectrum if t.multiplicity <= max_multiplicity]
+
+        keep = max(1, min(len(spectrum), math.ceil(n_eff)))
+        spectrum.sort(key=lambda t: t.power, reverse=True)
+        spectrum = spectrum[:keep]
+        spectrum.sort(key=lambda t: t.multiplicity)
+
+        pot = TorsionalPotential(
+            terms=spectrum,
+            mean=mean,
+            n_samples=len(profile),
+            spectral_entropy=h_spec,
+            effective_modes=n_eff,
+        )
+        model = pot.sample(len(profile))
+        pot.r_squared = self.r_squared(np.asarray(profile, dtype=float), model)
+        pot.v_min = float(np.min(pot.sample(720)))
+        return pot
+
+    # ── iterative QM–MM refinement (paper eq. 18) ────────────────────────────
+    def refine(self, qm: Sequence[float], mm_initial: Sequence[float],
+               lambda_: float = 0.5, r2_target: float = 0.98,
+               max_iter: int = 50, max_multiplicity: int = 6) -> TorsionalPotential:
+        """Damped, FFT band-limited refinement: ``V_{i+1} = V_i + λ·D_i``."""
+        qm_a = np.asarray(qm, dtype=float)
+        mm_a = np.asarray(mm_initial, dtype=float)
+        m = qm_a.size
+        if m < 2 or mm_a.size != m:
+            raise ValueError("DiFT.refine: qm and mm_initial must share a "
+                             "grid of ≥ 2 samples")
+
+        correction = np.zeros(m, dtype=float)
+        pot = TorsionalPotential()
+        iters = 0
+        r2 = 0.0
+        for it in range(1, max_iter + 1):
+            iters = it
+            mm_current = mm_a + correction
+            correction = correction + lambda_ * (qm_a - mm_current)
+            pot = self.parametrize(correction, max_multiplicity)
+            correction = pot.sample(m)
+            r2 = self.r_squared(qm_a, mm_a + correction)
+            if r2 >= r2_target:
+                break
+
+        pot.r_squared = r2
+        pot.refinement_iters = iters
+        return pot
+
+    # ── Boltzmann inversion of a CG dihedral histogram (paper eq. 20) ────────
+    def boltzmann_invert(self, histogram: Sequence[float]) -> np.ndarray:
+        """Invert a dihedral-angle histogram into an energy profile.
+
+        ``E(φ) = −kT ln p(φ)``, shifted so the minimum is 0. No Jacobian:
+        dihedral angles are uniformly distributed for a free rotor.
+        """
+        h = np.asarray(histogram, dtype=float)
+        if h.size < 2:
+            raise ValueError("DiFT.boltzmann_invert: need ≥ 2 bins")
+        if np.any(h < 0.0):
+            raise ValueError("DiFT.boltzmann_invert: negative count")
+        total = float(h.sum())
+        if total <= 0.0:
+            raise ValueError("DiFT.boltzmann_invert: empty histogram")
+
+        kt = kB_kcal * self._t
+        energy = np.full(h.size, np.nan, dtype=float)
+        nonzero = h > 0.0
+        energy[nonzero] = -kt * np.log(h[nonzero] / total)
+        e_max = float(np.nanmax(energy))
+        energy[~nonzero] = e_max          # empty bins → capped well wall
+        energy -= float(np.nanmin(energy))  # shift minimum to 0
+        return energy
+
+    # ── per-bond torsional thermodynamics ────────────────────────────────────
+    def thermodynamics(self, pot: TorsionalPotential) -> TorsionalThermo:
+        """Excess torsional thermodynamics from a parametrized potential."""
+        n_fine = 1440
+        phi = np.arange(n_fine, dtype=float) * (_TWO_PI / n_fine)
+        v = np.full(n_fine, pot.mean, dtype=float)
+        for t in pot.terms:
+            v += t.amplitude * np.cos(t.multiplicity * phi - t.phase)
+        v -= pot.v_min                       # energies relative to the minimum
+
+        w = np.exp(-self._beta * v)
+        z_sum = float(w.sum())
+        z = z_sum / n_fine                   # ⟨exp(−βV)⟩; 1 for a free rotor
+        mean_e = float((w * v).sum() / z_sum) if z_sum > 0.0 else 0.0
+        f = -kB_kcal * self._t * math.log(z)
+
+        th = TorsionalThermo(temperature=self._t, partition_function=z,
+                             free_energy=f, mean_energy=mean_e)
+        th.entropy = (mean_e - f) / self._t
+        th.minus_TS = -self._t * th.entropy
+        return th
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+    @staticmethod
+    def circular_mean(angles: Sequence[float]) -> float:
+        """Directional mean of phase offsets — ``atan2(Σ sin, Σ cos)``."""
+        a = np.asarray(angles, dtype=float)
+        s = float(np.sin(a).sum())
+        c = float(np.cos(a).sum())
+        if s == 0.0 and c == 0.0:
+            return 0.0
+        return math.atan2(s, c)
+
+    @staticmethod
+    def r_squared(observed: np.ndarray, model: np.ndarray) -> float:
+        """Coefficient of determination R² between two equal-length profiles."""
+        obs = np.asarray(observed, dtype=float)
+        mod = np.asarray(model, dtype=float)
+        if obs.size == 0 or mod.size != obs.size:
+            return 0.0
+        ss_res = float(np.sum((obs - mod) ** 2))
+        ss_tot = float(np.sum((obs - obs.mean()) ** 2))
+        if ss_tot <= 0.0:
+            return 1.0 if ss_res <= 1e-18 else 0.0
+        return 1.0 - ss_res / ss_tot
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GA scoring adapter — mirrors LIB/DiFT/DiFTGAAdapter.h
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class RotatableBondTorsion:
+    """A ligand rotatable bond and its DiFT-parametrized potential."""
+
+    potential: TorsionalPotential
+    gene_index: int = -1
+
+
+@dataclass
+class TorsionalScore:
+    """Decomposed torsional contribution to the binding free energy."""
+
+    energy: float = 0.0     # Σ V_tors,b relative to each well minimum
+    minus_TS: float = 0.0   # Σ −T·S_tors,b — torsional confinement penalty
+    n_bonds: int = 0
+
+    def total(self) -> float:
+        """Free-energy contribution the GA adds to the CF score."""
+        return self.energy + self.minus_TS
+
+
+def score_torsional(bonds: Sequence[RotatableBondTorsion],
+                    dihedral_angles_rad: Sequence[float],
+                    temperature_K: float = 300.0) -> TorsionalScore:
+    """Score a pose's torsional state — one FFT-derived potential per bond."""
+    score = TorsionalScore()
+    if len(bonds) != len(dihedral_angles_rad):
+        return score  # caller contract violated → zero contribution
+    engine = DiFTEngine(temperature_K)
+    for bond, phi in zip(bonds, dihedral_angles_rad):
+        score.energy += bond.potential.relative(phi)
+        score.minus_TS += engine.thermodynamics(bond.potential).minus_TS
+        score.n_bonds += 1
+    return score
+
+
+def make_bond_torsion(profile: Sequence[float], gene_index: int,
+                      temperature_K: float = 300.0,
+                      max_multiplicity: int = 6) -> RotatableBondTorsion:
+    """Parametrize a raw torsional profile into a :class:`RotatableBondTorsion`."""
+    engine = DiFTEngine(temperature_K)
+    return RotatableBondTorsion(
+        potential=engine.parametrize(profile, max_multiplicity),
+        gene_index=gene_index,
+    )

--- a/python/flexaidds/dift.py
+++ b/python/flexaidds/dift.py
@@ -188,6 +188,8 @@ class DiFTEngine:
         m = x.size
         if m < 2:
             raise ValueError("DiFT.transform: profile needs ≥ 2 samples")
+        if not np.all(np.isfinite(x)):
+            raise ValueError("DiFT.transform: profile contains non-finite values")
 
         # rfft → X_0 … X_{M//2}; sign convention X_n = Σ x_k exp(−i2πnk/M).
         x_full = np.fft.rfft(x)
@@ -278,6 +280,8 @@ class DiFTEngine:
         h = np.asarray(histogram, dtype=float)
         if h.size < 2:
             raise ValueError("DiFT.boltzmann_invert: need ≥ 2 bins")
+        if not np.all(np.isfinite(h)):
+            raise ValueError("DiFT.boltzmann_invert: non-finite count")
         if np.any(h < 0.0):
             raise ValueError("DiFT.boltzmann_invert: negative count")
         total = float(h.sum())

--- a/python/setup.py
+++ b/python/setup.py
@@ -32,6 +32,7 @@ _core_sources = [
     f"{_rel_lib}/encom.cpp",
     f"{_rel_lib}/tENCoM/tencm.cpp",
     f"{_rel_lib}/ShannonThermoStack/ShannonThermoStack.cpp",
+    f"{_rel_lib}/DiFT/DiFT.cpp",
 ]
 _core_defs = []
 

--- a/python/tests/test_dift.py
+++ b/python/tests/test_dift.py
@@ -1,0 +1,248 @@
+"""Tests for the flexaidds.dift module (pure-Python DiFT engine).
+
+These tests verify the DiFT torsional parametrization engine — forward
+transform, Shannon-collapse truncation, QM–MM refinement, per-bond
+thermodynamics, Boltzmann inversion, and the GA scoring adapter — without
+needing the compiled C++ extension.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from flexaidds.dift import (
+    DiFTEngine,
+    FourierTerm,
+    TorsionalPotential,
+    RotatableBondTorsion,
+    score_torsional,
+    make_bond_torsion,
+    spectral_entropy,
+    kB_kcal,
+)
+
+_TWO_PI = 2.0 * math.pi
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def make_profile(m, mean, mult, amp, phase):
+    """M-point sample of V(φ) = mean + Σ Aₙ cos(nφ − ωₙ)."""
+    k = np.arange(m, dtype=float)
+    phi = k * (_TWO_PI / m)
+    v = np.full(m, float(mean))
+    for n, a, w in zip(mult, amp, phase):
+        v += a * np.cos(n * phi - w)
+    return v
+
+
+def amp_of(spectrum, n):
+    for t in spectrum:
+        if t.multiplicity == n:
+            return t.amplitude
+    return 0.0
+
+
+# ── forward transform ────────────────────────────────────────────────────────
+
+def test_transform_recovers_amplitudes_pow2():
+    engine = DiFTEngine(300.0)
+    profile = make_profile(64, 1.5, [1, 3, 5], [2.0, 1.0, 0.5], [0.0, 0.7, -1.2])
+    spectrum, mean = engine.transform(profile)
+    assert mean == pytest.approx(1.5, abs=1e-9)
+    assert amp_of(spectrum, 1) == pytest.approx(2.0, abs=1e-9)
+    assert amp_of(spectrum, 3) == pytest.approx(1.0, abs=1e-9)
+    assert amp_of(spectrum, 5) == pytest.approx(0.5, abs=1e-9)
+    assert amp_of(spectrum, 2) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_transform_recovers_amplitudes_non_pow2():
+    engine = DiFTEngine(300.0)
+    profile = make_profile(36, -0.4, [2, 4], [1.3, 0.8], [0.3, 2.1])
+    spectrum, mean = engine.transform(profile)
+    assert mean == pytest.approx(-0.4, abs=1e-9)
+    assert amp_of(spectrum, 2) == pytest.approx(1.3, abs=1e-8)
+    assert amp_of(spectrum, 4) == pytest.approx(0.8, abs=1e-8)
+
+
+def test_transform_round_trip():
+    engine = DiFTEngine(300.0)
+    m = 72
+    profile = make_profile(m, 0.9, [1, 2, 6], [1.1, 0.6, 0.25], [-0.5, 1.0, 2.8])
+    spectrum, mean = engine.transform(profile)
+    pot = TorsionalPotential(terms=spectrum, mean=mean)
+    model = pot.sample(m)
+    np.testing.assert_allclose(model, profile, atol=1e-7)
+    assert DiFTEngine.r_squared(profile, model) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_transform_rejects_short_profile():
+    engine = DiFTEngine()
+    with pytest.raises(ValueError):
+        engine.transform([1.0])
+
+
+# ── spectral Shannon entropy ─────────────────────────────────────────────────
+
+def test_spectral_entropy_single_mode_collapses():
+    engine = DiFTEngine()
+    spectrum, _ = engine.transform(make_profile(64, 0.0, [2], [3.0], [0.4]))
+    h = spectral_entropy(spectrum)
+    assert h == pytest.approx(0.0, abs=1e-9)
+    assert math.exp(h) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_spectral_entropy_equal_power_spreads():
+    engine = DiFTEngine()
+    spectrum, _ = engine.transform(
+        make_profile(64, 0.0, [1, 2, 3], [1.0, 1.0, 1.0], [0.0, 0.0, 0.0]))
+    assert spectral_entropy(spectrum) == pytest.approx(math.log(3.0), abs=1e-9)
+
+
+# ── parametrize: Shannon-collapse truncation ─────────────────────────────────
+
+def test_parametrize_keeps_dominant_modes():
+    engine = DiFTEngine()
+    profile = make_profile(128, 0.2, [1, 4, 11],
+                           [2.5, 1.8, 0.02], [0.1, -0.6, 1.4])
+    pot = engine.parametrize(profile)
+    assert 2 <= pot.n_terms <= 3
+    assert 1.0 < pot.effective_modes < 3.0
+    assert pot.r_squared > 0.99
+
+
+def test_parametrize_max_multiplicity_guard():
+    engine = DiFTEngine()
+    profile = make_profile(64, 0.0, [2, 9], [1.0, 1.0], [0.0, 0.0])
+    pot = engine.parametrize(profile, max_multiplicity=6)
+    assert all(t.multiplicity <= 6 for t in pot.terms)
+
+
+# ── iterative QM–MM refinement ───────────────────────────────────────────────
+
+def test_refine_converges_to_qm():
+    engine = DiFTEngine(300.0)
+    m = 96
+    qm = make_profile(m, 0.0, [1, 2, 3], [3.0, 1.5, 0.8], [0.2, -0.9, 1.7])
+    mm = make_profile(m, 0.0, [1, 2], [2.0, 1.0], [0.2, -0.9])
+    corrected = engine.refine(qm, mm, lambda_=0.5, r2_target=0.98)
+    assert corrected.r_squared >= 0.98
+    assert corrected.refinement_iters > 0
+    total = mm + corrected.sample(m)
+    assert DiFTEngine.r_squared(qm, total) >= 0.98
+
+
+def test_refine_rejects_mismatched_grids():
+    engine = DiFTEngine()
+    with pytest.raises(ValueError):
+        engine.refine([0.0] * 64, [0.0] * 32)
+
+
+# ── per-bond torsional thermodynamics ────────────────────────────────────────
+
+def test_thermo_free_rotor_zero_entropy():
+    engine = DiFTEngine(300.0)
+    pot = engine.parametrize([0.0] * 64)
+    th = engine.thermodynamics(pot)
+    assert th.partition_function == pytest.approx(1.0, abs=1e-6)
+    assert th.entropy == pytest.approx(0.0, abs=1e-6)
+    assert th.minus_TS == pytest.approx(0.0, abs=1e-6)
+
+
+def test_thermo_confined_bond_pays_penalty():
+    engine = DiFTEngine(300.0)
+    pot = engine.parametrize(make_profile(128, 0.0, [1], [5.0], [0.0]))
+    th = engine.thermodynamics(pot)
+    assert th.partition_function < 1.0
+    assert th.entropy < 0.0          # entropy loss vs free rotor
+    assert th.minus_TS > 0.0         # → positive ΔG penalty
+    assert th.mean_energy > 0.0
+
+
+def test_thermo_deeper_well_pays_more():
+    engine = DiFTEngine(300.0)
+    shallow = engine.parametrize(make_profile(128, 0.0, [1], [1.0], [0.0]))
+    deep = engine.parametrize(make_profile(128, 0.0, [1], [6.0], [0.0]))
+    assert (engine.thermodynamics(deep).minus_TS
+            > engine.thermodynamics(shallow).minus_TS)
+
+
+# ── Boltzmann inversion ──────────────────────────────────────────────────────
+
+def test_boltzmann_invert_uniform_is_flat():
+    engine = DiFTEngine(300.0)
+    energy = engine.boltzmann_invert([100.0] * 36)
+    np.testing.assert_allclose(energy, 0.0, atol=1e-9)
+
+
+def test_boltzmann_invert_peaked_becomes_well():
+    engine = DiFTEngine(300.0)
+    hist = [1.0] * 36
+    hist[18] = 1000.0
+    energy = engine.boltzmann_invert(hist)
+    assert energy[18] == pytest.approx(0.0, abs=1e-9)
+    assert np.all(energy >= -1e-12)
+    assert np.all(np.delete(energy, 18) > 0.0)
+
+
+def test_boltzmann_invert_rejects_empty():
+    engine = DiFTEngine()
+    with pytest.raises(ValueError):
+        engine.boltzmann_invert([0.0] * 20)
+
+
+# ── circular mean ────────────────────────────────────────────────────────────
+
+def test_circular_mean_wraparound():
+    angles = [math.radians(170.0), math.radians(-170.0)]
+    assert abs(DiFTEngine.circular_mean(angles)) == pytest.approx(math.pi, abs=1e-6)
+
+
+def test_circular_mean_simple():
+    assert DiFTEngine.circular_mean([0.1, 0.2, 0.3]) == pytest.approx(0.2, abs=1e-6)
+
+
+# ── GA scoring adapter ───────────────────────────────────────────────────────
+
+def test_adapter_scores_energy_and_entropy():
+    rbt0 = make_bond_torsion(make_profile(128, 0.0, [1], [3.0], [math.pi]), 0)
+    rbt1 = make_bond_torsion(make_profile(128, 0.0, [2], [2.0], [math.pi]), 1)
+    score = score_torsional([rbt0, rbt1], [0.0, 0.0], 300.0)
+    assert score.n_bonds == 2
+    assert score.energy == pytest.approx(0.0, abs=1e-3)
+    assert score.minus_TS > 0.0
+    assert score.total() > 0.0
+
+
+def test_adapter_energy_rises_away_from_minimum():
+    rbt = make_bond_torsion(make_profile(128, 0.0, [1], [4.0], [math.pi]), 0)
+    e_min = score_torsional([rbt], [0.0]).energy
+    e_top = score_torsional([rbt], [math.pi]).energy
+    assert e_top > e_min + 1.0
+
+
+def test_adapter_mismatched_input_returns_zero():
+    rbt = make_bond_torsion([0.0] * 64, 0)
+    score = score_torsional([rbt], [0.0, 0.0])
+    assert score.n_bonds == 0
+    assert score.total() == 0.0
+
+
+# ── cross-check: C++ ⇔ Python parity (skipped if _core lacks DiFT) ───────────
+
+def test_cpp_python_parity_if_available():
+    """If the compiled core exposes DiFTEngine, results must match Python."""
+    try:
+        from flexaidds import _core
+        cpp_engine = _core.DiFTEngine(300.0)
+    except (ImportError, AttributeError):
+        pytest.skip("_core.DiFTEngine not built")
+
+    profile = make_profile(64, 0.3, [1, 3], [2.0, 1.0], [0.4, -0.8])
+    py_pot = DiFTEngine(300.0).parametrize(list(profile))
+    cpp_pot = cpp_engine.parametrize(list(profile))
+    assert cpp_pot.r_squared == pytest.approx(py_pot.r_squared, abs=1e-6)
+    assert cpp_pot.effective_modes == pytest.approx(py_pot.effective_modes, abs=1e-6)

--- a/python/tests/test_dift.py
+++ b/python/tests/test_dift.py
@@ -85,6 +85,12 @@ def test_transform_rejects_short_profile():
         engine.transform([1.0])
 
 
+def test_transform_rejects_nonfinite_profile():
+    engine = DiFTEngine()
+    with pytest.raises(ValueError):
+        engine.transform([0.0, 1.0, math.nan, 2.0])
+
+
 # ── spectral Shannon entropy ─────────────────────────────────────────────────
 
 def test_spectral_entropy_single_mode_collapses():
@@ -192,6 +198,12 @@ def test_boltzmann_invert_rejects_empty():
     engine = DiFTEngine()
     with pytest.raises(ValueError):
         engine.boltzmann_invert([0.0] * 20)
+
+
+def test_boltzmann_invert_rejects_nonfinite():
+    engine = DiFTEngine()
+    with pytest.raises(ValueError):
+        engine.boltzmann_invert([1.0, math.inf, 2.0])
 
 
 # ── circular mean ────────────────────────────────────────────────────────────

--- a/tests/test_dift.cpp
+++ b/tests/test_dift.cpp
@@ -14,6 +14,7 @@
 
 #include <cmath>
 #include <numeric>
+#include <limits>
 #include <vector>
 
 using namespace dift;
@@ -102,6 +103,13 @@ TEST(DiFTTransform, RejectsShortProfile) {
     std::vector<double> tiny{1.0};
     double mean = 0.0;
     EXPECT_THROW(engine.transform(tiny, mean), std::invalid_argument);
+}
+
+TEST(DiFTTransform, RejectsNonFiniteProfile) {
+    DiFTEngine engine;
+    std::vector<double> profile{0.0, 1.0, std::nan(""), 2.0};
+    double mean = 0.0;
+    EXPECT_THROW(engine.transform(profile, mean), std::invalid_argument);
 }
 
 // ─── spectral Shannon entropy ────────────────────────────────────────────────
@@ -238,6 +246,12 @@ TEST(DiFTBoltzmannInvert, RejectsEmptyHistogram) {
     DiFTEngine engine;
     std::vector<double> empty(20, 0.0);
     EXPECT_THROW(engine.boltzmann_invert(empty), std::invalid_argument);
+}
+
+TEST(DiFTBoltzmannInvert, RejectsNonFiniteHistogram) {
+    DiFTEngine engine;
+    std::vector<double> hist{1.0, std::numeric_limits<double>::infinity(), 2.0};
+    EXPECT_THROW(engine.boltzmann_invert(hist), std::invalid_argument);
 }
 
 // ─── circular mean of phase offsets ──────────────────────────────────────────

--- a/tests/test_dift.cpp
+++ b/tests/test_dift.cpp
@@ -1,0 +1,297 @@
+// tests/test_dift.cpp — unit tests for the DiFT torsional parametrization engine
+//
+// Copyright 2026 Le Bonhomme Pharma
+// SPDX-License-Identifier: Apache-2.0
+//
+// Covers: forward transform / round-trip exactness, Shannon-collapse
+// truncation, QM–MM iterative refinement, per-bond torsional thermodynamics,
+// Boltzmann inversion, circular mean, and the GA scoring adapter.
+
+#include <gtest/gtest.h>
+
+#include "../LIB/DiFT/DiFT.h"
+#include "../LIB/DiFT/DiFTGAAdapter.h"
+
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+using namespace dift;
+
+namespace {
+
+constexpr double kTwoPi = 6.283185307179586476925286766559;
+
+// Build an M-point sample of  V(φ) = mean + Σ Aₙ cos(nφ − ωₙ).
+std::vector<double> make_profile(int M, double mean,
+                                 const std::vector<int>& mult,
+                                 const std::vector<double>& amp,
+                                 const std::vector<double>& phase) {
+    std::vector<double> p(static_cast<std::size_t>(M));
+    for (int k = 0; k < M; ++k) {
+        const double phi = kTwoPi * k / M;
+        double v = mean;
+        for (std::size_t t = 0; t < mult.size(); ++t)
+            v += amp[t] * std::cos(mult[t] * phi - phase[t]);
+        p[static_cast<std::size_t>(k)] = v;
+    }
+    return p;
+}
+
+// Look up the amplitude of a given multiplicity in a spectrum.
+double amp_of(const std::vector<FourierTerm>& spec, int n) {
+    for (const auto& t : spec) if (t.multiplicity == n) return t.amplitude;
+    return 0.0;
+}
+
+} // namespace
+
+// ─── forward transform: power-of-two grid (radix-2 FFT path) ─────────────────
+TEST(DiFTTransform, RecoversAmplitudesPow2) {
+    DiFTEngine engine(300.0);
+    const int M = 64;
+    auto profile = make_profile(M, 1.5, {1, 3, 5},
+                                {2.0, 1.0, 0.5}, {0.0, 0.7, -1.2});
+    double mean = 0.0;
+    auto spec = engine.transform(profile, mean);
+
+    EXPECT_NEAR(mean, 1.5, 1e-9);
+    EXPECT_NEAR(amp_of(spec, 1), 2.0, 1e-9);
+    EXPECT_NEAR(amp_of(spec, 3), 1.0, 1e-9);
+    EXPECT_NEAR(amp_of(spec, 5), 0.5, 1e-9);
+    EXPECT_NEAR(amp_of(spec, 2), 0.0, 1e-9);   // absent frequency
+    EXPECT_NEAR(amp_of(spec, 4), 0.0, 1e-9);
+}
+
+// ─── forward transform: non-power-of-two grid (direct DFT path) ──────────────
+TEST(DiFTTransform, RecoversAmplitudesNonPow2) {
+    DiFTEngine engine(300.0);
+    const int M = 36;                          // typical 10°-resolution scan
+    auto profile = make_profile(M, -0.4, {2, 4},
+                                {1.3, 0.8}, {0.3, 2.1});
+    double mean = 0.0;
+    auto spec = engine.transform(profile, mean);
+
+    EXPECT_NEAR(mean, -0.4, 1e-9);
+    EXPECT_NEAR(amp_of(spec, 2), 1.3, 1e-8);
+    EXPECT_NEAR(amp_of(spec, 4), 0.8, 1e-8);
+}
+
+// ─── round-trip: full spectrum reconstructs the input exactly ────────────────
+TEST(DiFTTransform, RoundTripReconstruction) {
+    DiFTEngine engine(300.0);
+    const int M = 72;
+    auto profile = make_profile(M, 0.9, {1, 2, 6},
+                                {1.1, 0.6, 0.25}, {-0.5, 1.0, 2.8});
+    double mean = 0.0;
+    auto spec = engine.transform(profile, mean);
+
+    TorsionalPotential pot;
+    pot.terms = spec;
+    pot.mean  = mean;
+    auto model = pot.sample(M);
+
+    for (int k = 0; k < M; ++k)
+        EXPECT_NEAR(model[static_cast<std::size_t>(k)],
+                    profile[static_cast<std::size_t>(k)], 1e-7);
+    EXPECT_NEAR(DiFTEngine::r_squared(profile, model), 1.0, 1e-9);
+}
+
+TEST(DiFTTransform, RejectsShortProfile) {
+    DiFTEngine engine;
+    std::vector<double> tiny{1.0};
+    double mean = 0.0;
+    EXPECT_THROW(engine.transform(tiny, mean), std::invalid_argument);
+}
+
+// ─── spectral Shannon entropy ────────────────────────────────────────────────
+TEST(DiFTSpectralEntropy, SingleModeCollapsesToOne) {
+    DiFTEngine engine;
+    auto profile = make_profile(64, 0.0, {2}, {3.0}, {0.4});
+    double mean = 0.0;
+    auto spec = engine.transform(profile, mean);
+
+    const double H = spectral_entropy(spec);
+    EXPECT_NEAR(H, 0.0, 1e-9);                 // one mode → zero entropy
+    EXPECT_NEAR(std::exp(H), 1.0, 1e-9);       // N_eff ≈ 1
+}
+
+TEST(DiFTSpectralEntropy, EqualPowerSpreadsToLogN) {
+    // Three equal-amplitude modes → H = ln 3, N_eff = 3.
+    DiFTEngine engine;
+    auto profile = make_profile(64, 0.0, {1, 2, 3},
+                                {1.0, 1.0, 1.0}, {0.0, 0.0, 0.0});
+    double mean = 0.0;
+    auto spec = engine.transform(profile, mean);
+    EXPECT_NEAR(spectral_entropy(spec), std::log(3.0), 1e-9);
+}
+
+// ─── Shannon-collapse truncation in parametrize() ────────────────────────────
+TEST(DiFTParametrize, KeepsDominantModesOnly) {
+    DiFTEngine engine;
+    // Two strong modes + a tiny ripple the collapse should discard.
+    auto profile = make_profile(128, 0.2, {1, 4, 11},
+                                {2.5, 1.8, 0.02}, {0.1, -0.6, 1.4});
+    auto pot = engine.parametrize(profile);
+
+    EXPECT_GE(pot.n_terms(), 2u);
+    EXPECT_LE(pot.n_terms(), 3u);
+    EXPECT_GT(pot.effective_modes, 1.0);
+    EXPECT_LT(pot.effective_modes, 3.0);
+    EXPECT_GT(pot.r_squared, 0.99);            // dominant modes capture the shape
+}
+
+TEST(DiFTParametrize, MaxMultiplicityGuard) {
+    DiFTEngine engine;
+    auto profile = make_profile(64, 0.0, {2, 9}, {1.0, 1.0}, {0.0, 0.0});
+    auto pot = engine.parametrize(profile, /*max_multiplicity=*/6);
+    for (const auto& t : pot.terms)
+        EXPECT_LE(t.multiplicity, 6);
+}
+
+// ─── iterative QM–MM refinement (paper eq. 18) ───────────────────────────────
+TEST(DiFTRefine, ConvergesToQMTarget) {
+    DiFTEngine engine(300.0);
+    const int M = 96;
+    auto qm = make_profile(M, 0.0, {1, 2, 3},
+                           {3.0, 1.5, 0.8}, {0.2, -0.9, 1.7});
+    auto mm = make_profile(M, 0.0, {1, 2},
+                           {2.0, 1.0}, {0.2, -0.9});   // missing the n=3 term
+
+    auto corrected = engine.refine(qm, mm, /*lambda=*/0.5, /*r2_target=*/0.98);
+
+    EXPECT_GE(corrected.r_squared, 0.98);
+    EXPECT_GT(corrected.refinement_iters, 0);
+
+    // mm + correction should now track qm.
+    auto corr = corrected.sample(M);
+    std::vector<double> total(static_cast<std::size_t>(M));
+    for (int k = 0; k < M; ++k)
+        total[static_cast<std::size_t>(k)] =
+            mm[static_cast<std::size_t>(k)] + corr[static_cast<std::size_t>(k)];
+    EXPECT_GE(DiFTEngine::r_squared(qm, total), 0.98);
+}
+
+TEST(DiFTRefine, RejectsMismatchedGrids) {
+    DiFTEngine engine;
+    std::vector<double> qm(64, 0.0), mm(32, 0.0);
+    EXPECT_THROW(engine.refine(qm, mm), std::invalid_argument);
+}
+
+// ─── per-bond torsional thermodynamics ───────────────────────────────────────
+TEST(DiFTThermodynamics, FreeRotorHasZeroExcessEntropy) {
+    DiFTEngine engine(300.0);
+    std::vector<double> flat(64, 0.0);          // V ≡ 0 → free rotor
+    auto pot = engine.parametrize(flat);
+    auto th  = engine.thermodynamics(pot);
+
+    EXPECT_NEAR(th.partition_function, 1.0, 1e-6);
+    EXPECT_NEAR(th.entropy,  0.0, 1e-6);
+    EXPECT_NEAR(th.minus_TS, 0.0, 1e-6);
+}
+
+TEST(DiFTThermodynamics, ConfinedBondPaysEntropyPenalty) {
+    DiFTEngine engine(300.0);
+    // A deep single-well torsional barrier (5 kcal/mol amplitude).
+    auto profile = make_profile(128, 0.0, {1}, {5.0}, {0.0});
+    auto pot = engine.parametrize(profile);
+    auto th  = engine.thermodynamics(pot);
+
+    EXPECT_LT(th.partition_function, 1.0);      // confinement shrinks z
+    EXPECT_LT(th.entropy,  0.0);                // entropy LOSS vs free rotor
+    EXPECT_GT(th.minus_TS, 0.0);                // → positive ΔG penalty
+    EXPECT_GT(th.mean_energy, 0.0);
+}
+
+TEST(DiFTThermodynamics, DeeperWellPaysMorePenalty) {
+    DiFTEngine engine(300.0);
+    auto shallow = engine.parametrize(
+        make_profile(128, 0.0, {1}, {1.0}, {0.0}));
+    auto deep = engine.parametrize(
+        make_profile(128, 0.0, {1}, {6.0}, {0.0}));
+    EXPECT_GT(engine.thermodynamics(deep).minus_TS,
+              engine.thermodynamics(shallow).minus_TS);
+}
+
+// ─── Boltzmann inversion of a CG dihedral histogram (paper eq. 20) ───────────
+TEST(DiFTBoltzmannInvert, UniformHistogramIsFlat) {
+    DiFTEngine engine(300.0);
+    std::vector<double> uniform(36, 100.0);
+    auto energy = engine.boltzmann_invert(uniform);
+    for (double e : energy) EXPECT_NEAR(e, 0.0, 1e-9);
+}
+
+TEST(DiFTBoltzmannInvert, PeakedHistogramBecomesWell) {
+    DiFTEngine engine(300.0);
+    std::vector<double> hist(36, 1.0);
+    hist[18] = 1000.0;                          // sharp population peak
+    auto energy = engine.boltzmann_invert(hist);
+
+    EXPECT_NEAR(energy[18], 0.0, 1e-9);         // peak → energy minimum
+    for (std::size_t k = 0; k < energy.size(); ++k) {
+        EXPECT_GE(energy[k], -1e-12);           // all energies ≥ 0 after shift
+        if (k != 18) { EXPECT_GT(energy[k], 0.0); }
+    }
+}
+
+TEST(DiFTBoltzmannInvert, RejectsEmptyHistogram) {
+    DiFTEngine engine;
+    std::vector<double> empty(20, 0.0);
+    EXPECT_THROW(engine.boltzmann_invert(empty), std::invalid_argument);
+}
+
+// ─── circular mean of phase offsets ──────────────────────────────────────────
+TEST(DiFTCircularMean, HandlesWraparound) {
+    // +170° and −170° straddle ±π; the circular mean is 180°, not 0°.
+    std::vector<double> angles{ 170.0 * M_PI / 180.0,
+                               -170.0 * M_PI / 180.0 };
+    const double m = DiFTEngine::circular_mean(angles);
+    EXPECT_NEAR(std::abs(m), M_PI, 1e-6);
+}
+
+TEST(DiFTCircularMean, SimpleAverage) {
+    std::vector<double> angles{0.1, 0.2, 0.3};
+    EXPECT_NEAR(DiFTEngine::circular_mean(angles), 0.2, 1e-6);
+}
+
+// ─── GA scoring adapter ──────────────────────────────────────────────────────
+TEST(DiFTGAAdapter, ScoresTorsionalEnergyAndEntropy) {
+    // Two rotatable bonds, each with a single-well DiFT potential. The π phase
+    // makes V(φ) = −A·cos(nφ), so the well minimum sits at φ = 0.
+    auto rbt0 = make_bond_torsion(
+        make_profile(128, 0.0, {1}, {3.0}, {M_PI}), /*gene_index=*/0);
+    auto rbt1 = make_bond_torsion(
+        make_profile(128, 0.0, {2}, {2.0}, {M_PI}), /*gene_index=*/1);
+    std::vector<RotatableBondTorsion> bonds{rbt0, rbt1};
+
+    // Place both bonds at their well minima (φ = 0).
+    std::vector<double> angles{0.0, 0.0};
+    auto score = score_torsional(bonds, angles, 300.0);
+
+    EXPECT_EQ(score.n_bonds, 2);
+    EXPECT_NEAR(score.energy, 0.0, 1e-3);       // at the minima → ~0 energy
+    EXPECT_GT(score.minus_TS, 0.0);             // confinement penalty > 0
+    EXPECT_GT(score.total(), 0.0);
+}
+
+TEST(DiFTGAAdapter, EnergyRisesAwayFromMinimum) {
+    // V(φ) = −4·cos(φ): well minimum at φ = 0, barrier crest at φ = π.
+    auto rbt = make_bond_torsion(
+        make_profile(128, 0.0, {1}, {4.0}, {M_PI}), 0);
+    std::vector<RotatableBondTorsion> bonds{rbt};
+
+    std::vector<double> at_min{0.0};
+    std::vector<double> at_top{M_PI};
+    const double e_min = score_torsional(bonds, at_min).energy;
+    const double e_top = score_torsional(bonds, at_top).energy;
+    EXPECT_GT(e_top, e_min + 1.0);              // barrier crest costs energy
+}
+
+TEST(DiFTGAAdapter, MismatchedInputReturnsZero) {
+    auto rbt = make_bond_torsion(std::vector<double>(64, 0.0), 0);
+    std::vector<RotatableBondTorsion> bonds{rbt};
+    std::vector<double> angles{0.0, 0.0};       // wrong length
+    auto score = score_torsional(bonds, angles);
+    EXPECT_EQ(score.n_bonds, 0);
+    EXPECT_EQ(score.total(), 0.0);
+}


### PR DESCRIPTION
## Summary
- add a self-contained DiFT torsional Fourier parametrization engine in `LIB/DiFT`
- expose DiFT through pybind11 plus an always-available NumPy mirror at `flexaidds.dift`
- add `dift_torsion_fit` to emit JSON fit summaries and FlexAIDdS `.dift` sidecar priors
- cover transform recovery, Shannon-collapse truncation, QM/MM-style refinement, Boltzmann inversion, torsional thermo, and scoring adapter behavior
- fix verification build links for tests that compile `FibrilGrowthOracle.cpp` by adding `GrandPartitionFunction.cpp`
- keep SAMPL6/7 metadata preparation offline so CTest does not clone from GitHub during unit tests
- reject non-finite DiFT profiles/histograms explicitly and build the DiFT CLI with repo SIMD tuning

## Validation
- `cmake -S . -B build-dift-verify -DBUILD_TESTING=ON -DENABLE_DIFT_TOOL=ON`
- `cmake --build build-dift-verify -j 8`
- `ctest --test-dir build-dift-verify --output-on-failure --timeout 60` — 57/57 passed
- `python3 -m pytest python/tests/test_dift.py -q` — 23 passed, 1 skipped
- `build-dift-verify/dift_torsion_fit --input /private/tmp/dift_scan.csv --json /private/tmp/dift_fit.json --sidecar /private/tmp/dift_fit.dift --max-multiplicity 3`
- `python3 -m json.tool /private/tmp/dift_fit.json >/dev/null`
- `git diff --check`

## Notes
- This PR does not turn DiFT on inside the production docking score path. It adds the engine, API, test coverage, and sidecar artifact needed for the next opt-in docking integration step.
- Unrelated local untracked files were left out of the commit.
