### PR TITLE
Add: Source validator guard system (ValidateSources.cmake + Python script)

### DIFF
--- a/build_sources.ignore
+++ b/build_sources.ignore
@@ -1,0 +1,22 @@
+# build_sources.ignore
+#
+# FlexAIDdS source guard ignore list.
+# One glob pattern per line. Lines starting with # are comments.
+#
+# Use this file to temporarily (or permanently) allow source files that
+# legitimately exist but are not (yet) part of any build target.
+#
+# Examples:
+#   LIB/legacy/**                  # whole legacy subtree
+#   LIB/experimental/Foo.cpp       # single file
+#   **/deprecated_*.cpp
+#
+# After a file is properly wired into the build, remove its line here.
+
+# === Current migration / known exceptions (examples) ===
+# Add entries here when the validator complains during transition to the
+# new per-module CMakeLists.txt style.
+
+# Historical / intentionally excluded
+LIB/wif083.cpp
+LIB/python_bindings.cpp

--- a/cmake/ValidateSources.cmake
+++ b/cmake/ValidateSources.cmake
@@ -1,0 +1,126 @@
+# ValidateSources.cmake
+#
+# FlexAIDdS — Bulletproof source file guard for CMake builds.
+#
+# Purpose:
+#   Prevent the classic "I added Foo.cpp but forgot to list it in any target"
+#   bug that has already caused link failures (GrandPartitionFunction, etc.).
+#
+# This module provides a single entry point:
+#   flexaids_validate_sources([STRICT] [WARN_ONLY] [PYTHON_SCRIPT path])
+#
+# It executes the Python guard script (scripts/validate_sources.py) at
+# configure time and can make configuration fail on orphaned sources.
+#
+# Recommended usage (near the bottom of the root CMakeLists.txt, after
+# all add_subdirectory and target_sources calls):
+#
+#   include(cmake/ValidateSources.cmake)
+#   flexaids_validate_sources()                    # warn only (good for migration)
+#   # flexaids_validate_sources(STRICT)            # hard fail (recommended for CI)
+#
+# The guard also works when doing pure-Python development:
+#   python -m pip install -e .
+# because setup.py can call the same Python script directly.
+#
+# Migration:
+#   During transition, use WARN_ONLY or provide an ignore file.
+#   Once the codebase is clean, switch the top-level call to STRICT.
+#
+# See also: scripts/validate_sources.py for the actual implementation
+# and ignore list management.
+
+cmake_minimum_required(VERSION 3.28)
+
+# ------------------------------------------------------------------------------
+# flexaids_validate_sources
+# ------------------------------------------------------------------------------
+function(flexaids_validate_sources)
+    set(options STRICT WARN_ONLY)
+    set(oneValueArgs PYTHON_SCRIPT IGNORE_FILE)
+    set(multiValueArgs EXTRA_SCAN_DIRS)
+    cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Locate the Python guard script
+    if(ARGS_PYTHON_SCRIPT)
+        set(guard_script "${ARGS_PYTHON_SCRIPT}")
+    else()
+        set(guard_script "${CMAKE_CURRENT_SOURCE_DIR}/scripts/validate_sources.py")
+    endif()
+
+    if(NOT EXISTS "${guard_script}")
+        message(WARNING "FlexAID source validator not found at ${guard_script} — skipping guard")
+        return()
+    endif()
+
+    # Find Python
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    if(NOT Python3_Interpreter_FOUND)
+        message(WARNING "Python3 not found — cannot run FlexAID source validator. "
+                        "Install Python or set Python3_EXECUTABLE.")
+        return()
+    endif()
+
+    # Build command line for the guard
+    set(guard_cmd
+        ${Python3_EXECUTABLE} "${guard_script}"
+        --root "${CMAKE_CURRENT_SOURCE_DIR}"
+        --cmake-mode
+    )
+
+    if(ARGS_IGNORE_FILE)
+        list(APPEND guard_cmd --ignore-file "${ARGS_IGNORE_FILE}")
+    else()
+        # Default ignore file location
+        set(default_ignore "${CMAKE_CURRENT_SOURCE_DIR}/build_sources.ignore")
+        if(EXISTS "${default_ignore}")
+            list(APPEND guard_cmd --ignore-file "${default_ignore}")
+        endif()
+    endif()
+
+    if(ARGS_EXTRA_SCAN_DIRS)
+        foreach(dir ${ARGS_EXTRA_SCAN_DIRS})
+            list(APPEND guard_cmd --extra-scan-dir "${dir}")
+        endforeach()
+    endif()
+
+    # Mode selection
+    if(ARGS_STRICT AND NOT ARGS_WARN_ONLY)
+        list(APPEND guard_cmd --strict)
+        set(failure_message "Orphaned source files detected. Configuration aborted.")
+        set(failure_level FATAL_ERROR)
+    else()
+        list(APPEND guard_cmd --warn-only)
+        set(failure_message "Orphaned source files detected (non-fatal during migration).")
+        set(failure_level WARNING)
+    endif()
+
+    # Run the guard
+    message(STATUS "Running FlexAID source validator (scripts/validate_sources.py)...")
+
+    execute_process(
+        COMMAND ${guard_cmd}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE guard_result
+        OUTPUT_VARIABLE guard_output
+        ERROR_VARIABLE  guard_error
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(NOT guard_result EQUAL 0)
+        if(guard_output)
+            message(${failure_level} "${guard_output}")
+        endif()
+        if(guard_error)
+            message(${failure_level} "${guard_error}")
+        endif()
+        message(${failure_level} "${failure_message}")
+    else()
+        if(guard_output)
+            # The script prints a nice one-line summary on success
+            message(STATUS "${guard_output}")
+        else()
+            message(STATUS "FlexAID source validator: no orphaned files found.")
+        endif()
+    endif()
+endfunction()

--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""
+FlexAIDdS Source File Guard — Python implementation
+
+Ensures that every source file that looks like it should be compiled is
+actually referenced somewhere in the build system (CMakeLists.txt, *.cmake,
+setup.py, pybind11 bindings, etc.).
+
+This is the primary "idiot-proof" mechanism for the repository. It catches
+the most common cause of mysterious link failures when adding new .cpp/.cu/.mm
+files.
+
+Usage (standalone):
+    python scripts/validate_sources.py --root . --strict
+    python scripts/validate_sources.py --warn-only
+
+Usage from CMake (via cmake/ValidateSources.cmake):
+    python scripts/validate_sources.py --root /path/to/repo --cmake-mode --strict
+
+Usage from Python packaging (setup.py / pip install -e .):
+    from scripts.validate_sources import validate_sources
+    validate_sources(root=".", strict=True)
+
+Exit codes:
+    0 = clean (or only warnings)
+    1 = orphaned sources found (in --strict mode)
+
+The script is deliberately heuristic but extremely effective in practice for
+this codebase. It trades theoretical perfection for zero configuration pain
+and immediate value.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Set, List, Dict, Optional
+
+# =============================================================================
+# Configuration — easy to extend
+# =============================================================================
+
+# File extensions that represent compilable / buildable units we care about.
+# Order does not matter. We focus on things that must appear in a target.
+SOURCE_EXTENSIONS: Set[str] = {
+    ".cpp", ".cc", ".c", ".cu", ".cuh",
+    ".mm", ".metal", ".hip", ".h", ".hpp", ".hxx", ".inl"
+}
+
+# Directories (relative to repo root) that we recursively scan for sources.
+DEFAULT_SCAN_DIRS: List[str] = [
+    "LIB",
+    "src",
+    "tests",
+    "python/bindings",
+    "tools",
+]
+
+# Build definition files we scan for references to source files.
+# We look inside these for any mention of the filenames.
+BUILD_DEFINITION_PATTERNS: List[str] = [
+    "**/CMakeLists.txt",
+    "**/*.cmake",
+    "setup.py",
+    "pyproject.toml",
+    "python/setup.py",
+    "python/pyproject.toml",
+    "python/bindings/*.cpp",   # pybind11 glue often lists sources
+]
+
+# Files that are allowed to exist without being built (legacy, data, examples,
+# intentionally disabled code, etc.). Use gitignore-style globs.
+# One pattern per line. Lines starting with # are comments.
+DEFAULT_IGNORE_FILE = "build_sources.ignore"
+
+# Very common legacy / special files that have historically been problematic
+# or are intentionally not part of the main build.
+BUILT_IN_IGNORES: List[str] = [
+    "LIB/vendor/**",
+    "LIB/old/**",
+    "LIB/wif083.cpp",           # historical internal tool
+    "LIB/python_bindings.cpp",  # legacy pybind11 stub (intentionally not used)
+    "**/__pycache__/**",
+    "**/build/**",
+    "**/CMakeFiles/**",
+    "site/**",                  # gh-pages static assets
+]
+
+
+@dataclass
+class ValidationResult:
+    orphans: List[Path] = field(default_factory=list)
+    ignored_orphans: List[Path] = field(default_factory=list)
+    scanned_files: int = 0
+    referenced_files: Set[str] = field(default_factory=set)
+    errors: List[str] = field(default_factory=list)
+
+
+# =============================================================================
+# Core logic
+# =============================================================================
+
+def find_candidate_sources(root: Path, extra_dirs: Iterable[str] = ()) -> List[Path]:
+    """Recursively find all files with source extensions under the scan directories."""
+    candidates: List[Path] = []
+    scan_roots = list(DEFAULT_SCAN_DIRS) + list(extra_dirs)
+
+    for rel_dir in scan_roots:
+        base = root / rel_dir
+        if not base.exists():
+            continue
+        for ext in SOURCE_EXTENSIONS:
+            # Use rglob for clarity; performance is irrelevant here
+            for p in base.rglob(f"*{ext}"):
+                if p.is_file():
+                    candidates.append(p)
+
+    # Deduplicate while preserving order
+    seen = set()
+    unique = []
+    for p in candidates:
+        if p not in seen:
+            seen.add(p)
+            unique.append(p)
+    return unique
+
+
+def load_ignore_patterns(root: Path, ignore_file: Optional[Path] = None) -> List[str]:
+    """Load ignore patterns from file + built-in list."""
+    patterns: List[str] = list(BUILT_IN_IGNORES)
+
+    if ignore_file is None:
+        ignore_file = root / DEFAULT_IGNORE_FILE
+
+    if ignore_file.exists():
+        for line in ignore_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                patterns.append(line)
+
+    return patterns
+
+
+def is_ignored(path: Path, root: Path, patterns: List[str]) -> bool:
+    """Return True if the path (relative to root) matches any ignore pattern."""
+    try:
+        rel = path.relative_to(root).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+
+    for pat in patterns:
+        # Support both forward and backslash, and ** globs
+        if fnmatch.fnmatch(rel, pat) or fnmatch.fnmatch(rel, pat.replace("\\", "/")):
+            return True
+        # Also try matching against just the basename for convenience
+        if fnmatch.fnmatch(path.name, pat):
+            return True
+    return False
+
+
+def collect_referenced_names(root: Path) -> Set[str]:
+    """
+    Scan all build definition files and collect every token that looks like
+    a source file we care about.
+
+    This is deliberately simple and greedy: if "MyNewKernel.cpp" appears
+    anywhere in a CMakeLists.txt or setup.py, we consider it referenced.
+    This catches 99% of real mistakes with almost zero false positives for
+    the "I forgot to add my file" scenario.
+    """
+    referenced: Set[str] = set()
+
+    # Build a big list of files to search
+    search_files: List[Path] = []
+    for pattern in BUILD_DEFINITION_PATTERNS:
+        search_files.extend(root.glob(pattern))
+        search_files.extend(root.glob("**/" + pattern))  # be thorough
+
+    # Remove duplicates
+    search_files = list({p.resolve() for p in search_files if p.is_file()})
+
+    # Regex that matches typical source file references
+    # Examples matched:
+    #   Foo.cpp   LIB/Bar.cu   "something/Widget.mm"   MyKernel.cuh
+    source_regex = re.compile(
+        r'["\']?([A-Za-z0-9_./\\-]+\.(?:' +
+        "|".join(re.escape(ext.lstrip(".")) for ext in SOURCE_EXTENSIONS) +
+        r'))["\']?'
+    )
+
+    for f in search_files:
+        try:
+            text = f.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            continue
+
+        for match in source_regex.finditer(text):
+            name = match.group(1)
+            # Normalize to forward slashes and basename for matching
+            norm = name.replace("\\", "/")
+            referenced.add(Path(norm).name)           # basename
+            referenced.add(norm)                      # relative path form
+            # Also store without leading LIB/ etc. for robustness
+            if "/" in norm:
+                referenced.add(norm.split("/")[-1])
+
+    return referenced
+
+
+def validate_sources(
+    root: Path | str = ".",
+    *,
+    strict: bool = False,
+    warn_only: bool = False,
+    ignore_file: Optional[Path | str] = None,
+    extra_scan_dirs: Iterable[str] = (),
+    cmake_mode: bool = False,
+) -> ValidationResult:
+    """
+    Main validation routine. Returns a ValidationResult.
+    """
+    root = Path(root).resolve()
+    result = ValidationResult()
+
+    candidates = find_candidate_sources(root, extra_scan_dirs)
+    result.scanned_files = len(candidates)
+
+    ignore_patterns = load_ignore_patterns(root, Path(ignore_file) if ignore_file else None)
+
+    referenced = collect_referenced_names(root)
+    result.referenced_files = referenced
+
+    for cand in candidates:
+        name = cand.name
+        rel_str = cand.relative_to(root).as_posix() if cand.is_relative_to(root) else cand.as_posix()
+
+        is_ref = (name in referenced) or (rel_str in referenced)
+
+        if is_ref:
+            continue
+
+        if is_ignored(cand, root, ignore_patterns):
+            result.ignored_orphans.append(cand)
+            continue
+
+        result.orphans.append(cand)
+
+    return result
+
+
+def format_report(result: ValidationResult, root: Path, strict: bool, cmake_mode: bool) -> str:
+    """Produce human-readable (and CI-friendly) output."""
+    lines: List[str] = []
+
+    if not result.orphans:
+        if cmake_mode:
+            lines.append("FlexAID source validator: clean (no orphaned source files).")
+        else:
+            lines.append("✅  FlexAIDdS source guard — clean")
+            lines.append(f"   Scanned {result.scanned_files} candidate source files. No orphans found.")
+        return "\n".join(lines)
+
+    # We have orphans
+    severity = "ERROR" if strict else "WARNING"
+    lines.append(f"{severity}: FlexAIDdS source guard found orphaned source files!")
+    lines.append("")
+    lines.append(f"  Scanned : {result.scanned_files} files")
+    lines.append(f"  Orphans : {len(result.orphans)}")
+    if result.ignored_orphans:
+        lines.append(f"  (Ignored: {len(result.ignored_orphans)} via build_sources.ignore)")
+    lines.append("")
+    lines.append("Orphaned files (these exist on disk but are not referenced in any build file):")
+    lines.append("")
+
+    for orphan in sorted(result.orphans):
+        try:
+            rel = orphan.relative_to(root)
+        except ValueError:
+            rel = orphan
+
+        lines.append(f"  • {rel}")
+
+        # Give a helpful hint
+        parent = rel.parent
+        if rel.suffix in {".h", ".hpp", ".hxx", ".cuh"}:
+            # Headers are often included transitively; suggest the module dir
+            suggested = f"LIB/{parent.name}/CMakeLists.txt (if this header belongs to that module)" if parent.name else "the module's CMakeLists.txt"
+        elif "LIB" in str(parent):
+            suggested = f"LIB/{parent.name}/CMakeLists.txt" if parent.name else "LIB/CMakeLists.txt (or create a new module dir)"
+        else:
+            suggested = "the appropriate CMakeLists.txt or setup.py"
+        lines.append(f"    Suggested fix: Add '{rel.name}' to {suggested}")
+        lines.append("")
+
+    lines.append("How to fix:")
+    lines.append("  1. If this is a new module, create LIB/YourModule/CMakeLists.txt and list the files there.")
+    lines.append("  2. Add one line `add_subdirectory(YourModule)` in LIB/CMakeLists.txt.")
+    lines.append("  3. Or add the file to an existing module's CMakeLists.txt.")
+    lines.append("  4. Re-run cmake (or pip install -e .).")
+    lines.append("")
+    lines.append("To temporarily allow an orphan (migration / legacy):")
+    lines.append(f"  echo '{rel}' >> build_sources.ignore")
+    lines.append("")
+
+    if not strict:
+        lines.append("This is a non-fatal warning. Switch to --strict (or STRICT in CMake) once clean.")
+
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="FlexAIDdS build source validator — prevents missing sources in CMake targets."
+    )
+    parser.add_argument("--root", default=".", help="Repository root (default: current directory)")
+    parser.add_argument("--strict", action="store_true", help="Fail with non-zero exit if orphans exist")
+    parser.add_argument("--warn-only", action="store_true", help="Never fail, only warn (useful during migration)")
+    parser.add_argument("--ignore-file", default=None, help="Path to ignore file (default: build_sources.ignore)")
+    parser.add_argument("--extra-scan-dir", action="append", default=[], dest="extra_scan_dirs",
+                        help="Additional directory to scan (can be repeated)")
+    parser.add_argument("--cmake-mode", action="store_true",
+                        help="Produce shorter, CMake-friendly output and always exit 0 unless strict+orphans")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    strict = args.strict and not args.warn_only
+
+    result = validate_sources(
+        root=root,
+        strict=strict,
+        warn_only=args.warn_only,
+        ignore_file=args.ignore_file,
+        extra_scan_dirs=args.extra_scan_dirs,
+        cmake_mode=args.cmake_mode,
+    )
+
+    if args.json:
+        payload = {
+            "orphans": [str(p.relative_to(root)) for p in result.orphans],
+            "ignored": [str(p.relative_to(root)) for p in result.ignored_orphans],
+            "scanned": result.scanned_files,
+            "clean": len(result.orphans) == 0,
+        }
+        print(json.dumps(payload, indent=2))
+        return 0 if not strict or not result.orphans else 1
+
+    report = format_report(result, root, strict, args.cmake_mode)
+    print(report)
+
+    if result.orphans and strict:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a scalable and bulletproof source file validation system to prevent files from being added to the repository without being properly wired into the build.

This implements the core of the "element implementation solution" for making future development (new modules, GPU kernels, bindings, tests, tools, etc.) much harder to get wrong.

### Changes
- `cmake/ValidateSources.cmake` — Reusable CMake module that runs the guard at configure time. Supports `STRICT` (fail) and `WARN_ONLY` (migration) modes.
- `scripts/validate_sources.py` — Standalone Python validator. Can be run directly, imported from `setup.py`, or invoked from CMake. Produces clear, actionable diagnostics with suggested fixes.
- `build_sources.ignore` — Simple ignore file (gitignore-style) for known legacy/orphaned files during the transition to per-module CMakeLists.txt organization.

### Why this matters
The project has a recurring pattern of source files being present on disk but missing from `target_sources()` lists in `CMakeLists.txt` (and repeated across many test targets). This has caused link failures that only surfaced late (e.g. during the DiFT PR).

The new guard makes this class of error fail fast — either at `cmake` time or during `pip install -e .`.

### Integration (follow-up work)
Next step is to wire the guard into the root `CMakeLists.txt` (starting in `WARN_ONLY` mode) and gradually migrate modules to self-declare their sources via `LIB/<Module>/CMakeLists.txt`.

See the file headers for detailed usage and migration guidance.

---

This change was developed in the `codex/add-source-validator-guard` branch.