### PR TITLE
Fix: Complete P0 source validator improvements (setup.py + CMake + CI + reporting)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
             -DFLEXAIDS_USE_METAL=OFF
             -DBUILD_PYTHON_BINDINGS=OFF
             -DBUILD_TESTING=ON
+            -DFLEXAIDS_STRICT_SOURCE_VALIDATION=ON
             ${{ matrix.cmake_extra }}
           )
           # Homebrew on Apple Silicon installs to /opt/homebrew

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3002,3 +3002,21 @@ if(BUILD_SWIFT_BRIDGE)
     set_tests_properties(DockingPipelineTests PROPERTIES LABELS "integration")
 
 endif()
+
+# =============================================================================
+# FlexAID source validator guard (MUST be the last thing in this file)
+# =============================================================================
+#
+# This runs after every add_subdirectory / target_sources / add_test etc.
+# so it sees the complete declared source set.
+#
+# P0 integration: Supports FLEXAIDS_STRICT_SOURCE_VALIDATION for CI.
+# Developers get the safe WARN_ONLY default.
+# =============================================================================
+include(cmake/ValidateSources.cmake)
+
+if(FLEXAIDS_STRICT_SOURCE_VALIDATION)
+    flexaids_validate_sources(STRICT)
+else()
+    flexaids_validate_sources(WARN_ONLY)
+endif()

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,6 +13,23 @@ except ImportError as exc:
         "Install it with `pip install pybind11` and retry."
     ) from exc
 
+# --- P0: Wire source validator guard (python path) ---
+# Runs early so developers doing `pip install -e .` (or equivalent) get
+# immediate feedback if they added sources without wiring them.
+try:
+    import sys
+    repo_root = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(repo_root))
+    from scripts.validate_sources import validate_sources
+
+    # Respect env var for CI / strict local runs. Default is lenient for
+    # normal developer `pip install -e` usage.
+    strict = os.environ.get("FLEXAIDS_STRICT_SOURCE_VALIDATION", "0").lower() not in ("0", "false", "")
+    validate_sources(root=str(repo_root), strict=strict)
+except Exception as exc:
+    # Never break the build due to the guard during normal development.
+    print(f"[source-guard] Warning: validator skipped ({exc})", file=sys.stderr)
+
 ROOT = Path(__file__).resolve().parent
 LIB_DIR = ROOT.parent / "LIB"
 

--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -278,24 +278,37 @@ def format_report(result: ValidationResult, root: Path, strict: bool, cmake_mode
     lines.append("Orphaned files (these exist on disk but are not referenced in any build file):")
     lines.append("")
 
-    for orphan in sorted(result.orphans):
-        try:
-            rel = orphan.relative_to(root)
-        except ValueError:
-            rel = orphan
+    # P0 tightening: Separate compilable units from headers for clearer output
+    compilable = [o for o in result.orphans if o.suffix.lower() not in {".h", ".hpp", ".hxx", ".cuh", ".inl"}]
+    headers = [o for o in result.orphans if o.suffix.lower() in {".h", ".hpp", ".hxx", ".cuh", ".inl"}]
 
-        lines.append(f"  • {rel}")
+    if compilable:
+        lines.append("  Compilable units (highest priority):")
+        for orphan in sorted(compilable):
+            try:
+                rel = orphan.relative_to(root)
+            except ValueError:
+                rel = orphan
+            lines.append(f"    • {rel}")
+            parent = rel.parent
+            if "LIB" in str(parent):
+                suggested = f"LIB/{parent.name}/CMakeLists.txt" if parent.name else "LIB/CMakeLists.txt (or create a new module dir)"
+            else:
+                suggested = "the appropriate CMakeLists.txt or setup.py"
+            lines.append(f"      Suggested fix: Add '{rel.name}' to {suggested}")
+        lines.append("")
 
-        # Give a helpful hint
-        parent = rel.parent
-        if rel.suffix in {".h", ".hpp", ".hxx", ".cuh"}:
-            # Headers are often included transitively; suggest the module dir
-            suggested = f"LIB/{parent.name}/CMakeLists.txt (if this header belongs to that module)" if parent.name else "the module's CMakeLists.txt"
-        elif "LIB" in str(parent):
-            suggested = f"LIB/{parent.name}/CMakeLists.txt" if parent.name else "LIB/CMakeLists.txt (or create a new module dir)"
-        else:
-            suggested = "the appropriate CMakeLists.txt or setup.py"
-        lines.append(f"    Suggested fix: Add '{rel.name}' to {suggested}")
+    if headers:
+        lines.append("  Headers (often transitively included — lower priority):")
+        for orphan in sorted(headers)[:20]:  # cap noise
+            try:
+                rel = orphan.relative_to(root)
+            except ValueError:
+                rel = orphan
+            lines.append(f"    • {rel}")
+        if len(headers) > 20:
+            lines.append(f"    ... and {len(headers) - 20} more headers")
+        lines.append("      (Consider adding the corresponding .cpp/.cu to the module's CMakeLists.txt first)")
         lines.append("")
 
     lines.append("How to fix:")


### PR DESCRIPTION
## Summary

Completes the three P0 recommendations from the manual code review of the source validator system (PR #209) that recently landed on master.

### P0 Items Delivered

1. **Wired validator into `python/setup.py`**  
   Early call during pybind11 extension build. Respects `FLEXAIDS_STRICT_SOURCE_VALIDATION` env var. Non-fatal by default for normal developer installs.

2. **Wired validator into root `CMakeLists.txt`** (most critical)  
   Added at the absolute end of the file so it observes every declared source. Supports the CMake variable `FLEXAIDS_STRICT_SOURCE_VALIDATION=ON` for CI while keeping `WARN_ONLY` as the safe default for developers.

3. **Enabled STRICT mode in CI** (`cxx_core_build` job)  
   The main multi-platform C++ build now runs the guard in strict mode. Future source files added without proper wiring will fail CI.

4. **Bonus tightening** (while addressing the P0 list)  
   Improved reporting to clearly separate "Compilable units (highest priority)" from "Headers (lower priority)" and cap header noise.

### Context

These changes address the gaps identified after the initial merge of the source validator guard in #209. The guard is now actually active in both the main CMake path and the pure-Python development path, and it is enforced in CI.

Branch: `codex/fix-source-validator-p0`