### PR TITLE
Add: Production-grade AI agent instruction system (AGENTS.md as single source of truth)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           python/tests/test_tencm.py
           python/tests/test_tencom_results.py
           python/tests/test_visualization.py
+          python/tests/test_dift.py
 
   cxx_core_build:
     name: C++ core (${{ matrix.name }})
@@ -224,4 +225,4 @@ jobs:
           PYTHONPATH: python
         run: |
           python -m pip install scipy
-          pytest -q python/tests/test_statmech_smoke.py python/tests/test_statmech.py python/tests/test_thermodynamics.py python/tests/test_encom.py python/tests/test_energy_matrix.py python/tests/test_train_256x256.py
+          pytest -q python/tests/test_statmech_smoke.py python/tests/test_statmech.py python/tests/test_thermodynamics.py python/tests/test_encom.py python/tests/test_energy_matrix.py python/tests/test_train_256x256.py python/tests/test_dift.py

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,7 @@ build_opencode/
 # Grok project skills (committed so the whole team gets the flexaidds skill automatically)
 !.grok
 !.grok/**
+
+# AI agent instruction files (AGENTS.md is the source of truth; committed for all tools)
+!AGENTS.md
+!chatgpt-instructions.md

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ build/
 build_check/
 build_opencode/
 .claude/worktrees/
+
+# Grok project skills (committed so the whole team gets the flexaidds skill automatically)
+!.grok
+!.grok/**

--- a/.grok/skills/flexaidds/README.md
+++ b/.grok/skills/flexaidds/README.md
@@ -32,8 +32,10 @@ Anyone who clones the repo gets the skill automatically. No extra setup required
 
 ## Maintenance
 
-- Edit `SKILL.md` when project structure, build commands, or core rules change
-- Keep the description in the frontmatter accurate — it controls auto-invocation
-- The companion [CLAUDE.md](../../CLAUDE.md) remains the full reference; this skill is the fast, always-on version for Grok
+- Edit `SKILL.md` when project structure, build commands, or core rules change.
+- The authoritative workflow rules live in the repo root `AGENTS.md`. Keep this skill aligned with it.
+- Keep the frontmatter description accurate (it drives auto-invocation).
+- Full technical depth lives in [CLAUDE.md](../../CLAUDE.md).
 
 Created: 2026-05-27
+Updated: 2026-05-27 (added cross-tool AGENTS.md system)

--- a/.grok/skills/flexaidds/README.md
+++ b/.grok/skills/flexaidds/README.md
@@ -1,0 +1,39 @@
+# flexaidds — Grok Skill
+
+Project-scoped skill that turns Grok into an expert FlexAIDdS developer.
+
+## What It Gives You
+
+- Deep knowledge of the C++26 core engine (`LIB/`)
+- Python package (`python/flexaidds/`) and pybind11 bindings
+- Full CMake build system + all important targets and options
+- Testing discipline (`ctest` + pytest with `@requires_core`)
+- Architecture (genetic algorithm → Voronoi scoring → StatMech → BindingMode clustering → vibrational + Shannon entropy → cavity detection)
+- Strict workflow rules the project demands:
+  - Always verify with actual build/test runs before claiming anything is done
+  - Use `todo_write` for tasks with 3+ steps
+  - Commit + push immediately after changes (conventional prefixes)
+  - Fresh builds after touching CMake or adding sources
+
+## How to Use
+
+| Method                    | Command                          |
+|---------------------------|----------------------------------|
+| Direct slash command      | `/flexaidds`                     |
+| Skills menu               | `/skills flexaidds`              |
+| Automatic activation      | Just mention "FlexAIDdS", "tENCoM", "statmech", "BindingMode", etc. |
+
+It combines beautifully with other skills (`/review`, `/implement`, `/check`, etc.).
+
+## Why This Is Committed
+
+This lives in `.grok/skills/` (not `~/.grok/skills/`) on purpose.  
+Anyone who clones the repo gets the skill automatically. No extra setup required for teammates.
+
+## Maintenance
+
+- Edit `SKILL.md` when project structure, build commands, or core rules change
+- Keep the description in the frontmatter accurate — it controls auto-invocation
+- The companion [CLAUDE.md](../../CLAUDE.md) remains the full reference; this skill is the fast, always-on version for Grok
+
+Created: 2026-05-27

--- a/.grok/skills/flexaidds/SKILL.md
+++ b/.grok/skills/flexaidds/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: flexaidds
+description: Expert developer assistant for the FlexAIDdS entropy-driven molecular docking engine. Deep knowledge of the C++26 core (LIB/), Python package (flexaidds), CMake build system, testing discipline (ctest + pytest), architecture, and strict "verify then commit" workflow rules. Use when working on any part of the FlexAIDdS codebase, running benchmarks, modifying LIB/ modules, Python bindings, or asking about docking/statmech/tENCoM. Slash command: /flexaidds. Automatically activates on mentions of FlexAIDdS, FlexAID, docking engine, or related modules.
+---
+
+# FlexAIDdS Development Skill
+
+You are an expert on FlexAIDdS (FlexAID with ΔS Entropy) — an entropy-driven molecular docking engine combining genetic algorithms with statistical mechanics thermodynamics. It targets real-world psychopharmacology and drug discovery applications.
+
+**Primary languages**: C++26 (core engine in LIB/), Python (bindings + analysis in `python/flexaidds/`), Objective-C++ (Metal GPU), CUDA (optional).
+
+**License**: Apache-2.0 only. Never introduce GPL/AGPL dependencies. Follow the clean-room policy in `docs/licensing/`.
+
+## Core Workflow Rules (Non-Negotiable)
+
+- **Verify with actual execution before claiming anything is done**. Run the build or test command and show passing output. Never say "fixed", "implemented", "complete", or "should work" without evidence from running the tools.
+- **Multi-step tasks (3+ actions) start with todo_write**. Define the full list with `merge: false`. Keep exactly **one** item `in_progress` at a time. Mark items `completed` immediately when finished — never batch. Re-read the todo list before ending any turn that still has pending/in-progress work.
+- **After any code change, commit and push immediately**. Use conventional prefixes (`Fix:`, `Add:`, `Update:`, `Refactor:`). Do not batch multiple changes. If a git operation hangs, kill stale processes and retry.
+- **Fresh builds after CMake or source changes**. Never assume a target builds. After editing CMakeLists.txt or adding .cpp/.h files under LIB/, run a clean configure + build and confirm linking succeeds. Watch for disk space issues on long builds.
+- **0 test failures before any push**. Run `ctest --output-on-failure` (C++) or `pytest` (Python) after relevant changes. Fix in the same session.
+
+## Build & Test Commands
+
+```bash
+# Full C++ release build with tests (recommended starting point)
+cmake -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j $(nproc)
+ctest --test-dir build --output-on-failure
+
+# Python package only (no C++ needed for many tasks)
+cd python
+pip install -e .
+pytest tests/ -q
+
+# Python bindings smoke test
+cmake -B build -DBUILD_PYTHON_BINDINGS=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j $(nproc)
+# then run relevant pytest tests that use @requires_core
+```
+
+**Key CMake options** (see CLAUDE.md for full table):
+- `BUILD_TESTING=ON` — GoogleTest suite
+- `BUILD_PYTHON_BINDINGS=ON` — builds `_core` extension (statmech + encom)
+- `FLEXAIDS_USE_METAL=ON` — macOS GPU acceleration
+- `FLEXAIDS_USE_CUDA=ON` — CUDA GPU kernels
+
+**Main targets**: `FlexAID` (core executable), `_core` (pybind11), `tENCoM`, `benchmark_tencom`, `benchmark_vcfbatch`.
+
+## Architecture Overview
+
+Core pipeline:
+1. Genetic Algorithm — `LIB/gaboom.cpp`
+2. Voronoi Contact Scoring — `LIB/Vcontacts.cpp`
+3. Statistical Mechanics — `LIB/statmech.cpp` (partition functions, free energy, entropy, WHAM, TI)
+4. Binding Mode Clustering + Thermodynamics — `LIB/BindingMode.cpp`
+5. Vibrational Entropy (ENCoM) — `LIB/encom.cpp`
+6. Shannon Configurational Entropy — `LIB/ShannonThermoStack/` (CPU/CUDA/Metal)
+7. Cavity Detection — `LIB/CavityDetect/` (SURFNET + Metal)
+
+Major specialized modules under `LIB/`:
+- `tENCoM/` — Torsional ENCoM backbone flexibility + differential entropy
+- `ShannonThermoStack/` — Hardware-accelerated histogram entropy
+- `LigandRingFlex/`, `ChiralCenter/`, `NATURaL/`, `CavityDetect/`
+
+Python package (`python/flexaidds/`):
+- `models.py`, `results.py` (`load_results()`), `docking.py`, `encom.py`, `tencm.py`, `thermodynamics.py`, `io.py`
+- CLI entry: `python -m flexaidds <results_dir> [--json|--csv|--top N]`
+- Bindings: `python/bindings/core_bindings.cpp` (exposes StatMechEngine, ENCoMEngine, etc.)
+
+PyMOL plugin lives in `pymol_plugin/`.
+
+## Key Files & Navigation
+
+See the full table in CLAUDE.md. Most important entry points:
+- `LIB/flexaid.h` (central header)
+- `CMakeLists.txt` + `cmake/`
+- `python/flexaidds/__init__.py` (public API surface)
+- `tests/` (C++) and `python/tests/` (pytest, many with `@requires_core`)
+- `benchmarks/` (dataset YAMLs, runners, Astex Diverse, CASF, etc.)
+- `docs/` (roadmaps, implementation notes, licensing)
+
+## Common Development Tasks
+
+**Adding a new C++ source file**
+1. Place `.cpp`/`.h` under `LIB/`
+2. Add it to the `FLEXAID_SOURCES` list in `CMakeLists.txt`
+3. Write corresponding GoogleTest in `tests/`
+4. Enable `BUILD_TESTING=ON`, build, and run `ctest`
+
+**Adding a new Python module**
+1. Create under `python/flexaidds/`
+2. Export from `__init__.py` if public
+3. Add tests in `python/tests/`
+4. Add fixtures in `python/conftest.py` if needed
+5. For C++ exposure: add to `python/bindings/core_bindings.cpp`
+
+**Running the full verification loop** (use this before any commit that touches core logic):
+- Build with tests
+- Run `ctest --output-on-failure`
+- (If Python changed) `cd python && pip install -e . && pytest tests/`
+- Confirm zero failures
+- Commit + push immediately
+
+## Usage
+
+- **Slash command**: `/flexaidds` (injects this skill)
+- **Automatic**: Grok will invoke this skill when the prompt mentions FlexAIDdS, FlexAID, docking, statmech, tENCoM, BindingMode, or related development tasks in this repo.
+- **With other skills**: Can be combined with `/review`, `/implement`, `/check`, etc.
+
+Always read the latest CLAUDE.md at the start of any substantial session for the complete reference. This skill + CLAUDE.md together give you production-grade context for the entire codebase.

--- a/.grok/skills/flexaidds/SKILL.md
+++ b/.grok/skills/flexaidds/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flexaidds
-description: Expert developer assistant for the FlexAIDdS entropy-driven molecular docking engine. Deep knowledge of the C++26 core (LIB/), Python package (flexaidds), CMake build system, testing discipline (ctest + pytest), architecture, and strict "verify then commit" workflow rules. Use when working on any part of the FlexAIDdS codebase, running benchmarks, modifying LIB/ modules, Python bindings, or asking about docking/statmech/tENCoM. Slash command: /flexaidds. Automatically activates on mentions of FlexAIDdS, FlexAID, docking engine, or related modules.
+description: Expert developer assistant for the FlexAIDdS entropy-driven molecular docking engine. Deep knowledge of the C++26 core (LIB/), Python package (flexaidds), CMake build system, testing discipline (ctest + pytest), architecture, and strict "verify then commit" workflow rules (see AGENTS.md). Use when working on any part of the FlexAIDdS codebase, running benchmarks, modifying LIB/ modules, Python bindings, or asking about docking/statmech/tENCoM. Slash command: /flexaidds. Automatically activates on mentions of FlexAIDdS, FlexAID, docking engine, or related modules.
 ---
 
 # FlexAIDdS Development Skill
@@ -12,6 +12,8 @@ You are an expert on FlexAIDdS (FlexAID with ΔS Entropy) — an entropy-driven 
 **License**: Apache-2.0 only. Never introduce GPL/AGPL dependencies. Follow the clean-room policy in `docs/licensing/`.
 
 ## Core Workflow Rules (Non-Negotiable)
+
+**Authoritative version**: See `AGENTS.md` in the repository root. The rules below are the Grok-optimized summary.
 
 - **Verify with actual execution before claiming anything is done**. Run the build or test command and show passing output. Never say "fixed", "implemented", "complete", or "should work" without evidence from running the tools.
 - **Multi-step tasks (3+ actions) start with todo_write**. Define the full list with `merge: false`. Keep exactly **one** item `in_progress` at a time. Mark items `completed` immediately when finished — never batch. Re-read the todo list before ending any turn that still has pending/in-progress work.
@@ -107,4 +109,4 @@ See the full table in CLAUDE.md. Most important entry points:
 - **Automatic**: Grok will invoke this skill when the prompt mentions FlexAIDdS, FlexAID, docking, statmech, tENCoM, BindingMode, or related development tasks in this repo.
 - **With other skills**: Can be combined with `/review`, `/implement`, `/check`, etc.
 
-Always read the latest CLAUDE.md at the start of any substantial session for the complete reference. This skill + CLAUDE.md together give you production-grade context for the entire codebase.
+Always read `AGENTS.md` (source of truth for rules) + the latest `CLAUDE.md` at the start of any substantial session. This skill is the Grok-optimized companion to those two files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md — FlexAIDdS AI Coding Agents
+
+**This is the single source of truth for all AI coding agents working in this repository.**
+
+Every other instruction file (CLAUDE.md, `.grok/skills/flexaidds/SKILL.md`, ChatGPT instructions, etc.) must derive from or explicitly defer to this document. When rules conflict, **this file takes precedence**.
+
+All agents are expected to internalize and strictly follow the rules below on every task.
+
+---
+
+## Core Workflow Rules (Non-Negotiable)
+
+These rules exist because this is a complex, performance-critical scientific codebase. Sloppy execution creates expensive bugs and broken builds.
+
+1. **Verify with actual execution before claiming success.**  
+   Never say “done”, “fixed”, “implemented”, “should work”, or “complete” until you have run the relevant build and/or test commands and shown clean, passing output.  
+   - C++ changes → run the full test build + `ctest --output-on-failure`.  
+   - Python changes → run the affected pytest suite.  
+   - CMake or source list changes → perform a fresh configure + build.
+
+2. **Use `todo_write` for any task with 3 or more distinct actions.**  
+   Open the list with `merge: false` at the start of the task. Keep **exactly one** item in `in_progress` at all times. Mark items `completed` immediately when finished — never batch completions. Re-read the current todo list before ending any turn that still has pending or in-progress work.
+
+3. **After any code change, commit and push immediately.**  
+   Do not batch multiple logical changes. Use conventional commit prefixes (`Fix:`, `Add:`, `Update:`, `Refactor:`, etc.).  
+   If a git operation appears to hang, kill stale git processes (`kill $(pgrep -f git)`) and retry. Check `git config core.fsmonitor` if problems persist.
+
+4. **Fresh builds after touching build system or sources.**  
+   Never assume a target still builds after editing `CMakeLists.txt` or adding/removing `.cpp`/`.h` files under `LIB/`. Always run a clean configure + build and confirm linking succeeds. Watch for disk space issues before long builds.
+
+5. **Zero test failures before any push.**  
+   Run the full relevant test suite (`ctest --output-on-failure` for C++, `pytest` for Python) after changes that could affect behavior. Fix all failures in the same session. Never push with red tests.
+
+6. **Prioritized lists are completed in full.**  
+   When given P0/P1/P2 (or similar), finish every item before stopping. Do not declare victory after the first few.
+
+7. **Run the thing when asked.**  
+   If the user explicitly asks you to *run* a command, benchmark, or test, do it — do not spend 20+ tool calls exploring first.
+
+---
+
+## Essential Commands
+
+**C++ (recommended starting point for most work)**
+```bash
+cmake -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j $(nproc)
+ctest --test-dir build --output-on-failure
+```
+
+**Python package only** (many tasks do not need the full C++ build)
+```bash
+cd python
+pip install -e .
+pytest tests/ -q
+```
+
+**Python bindings smoke**
+```bash
+cmake -B build -DBUILD_PYTHON_BINDINGS=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j $(nproc)
+```
+
+See `CLAUDE.md` → “Build System” for the full table of CMake options and targets.
+
+---
+
+## Project Snapshot
+
+FlexAIDdS is an entropy-driven molecular docking engine that combines genetic algorithms with statistical mechanics (partition functions, free energy, vibrational + configurational entropy).
+
+**Primary languages**: C++26 (core in `LIB/`), Python (`python/flexaidds/` + bindings), Objective-C++ (Metal), optional CUDA.
+
+**Strict licensing**: Apache-2.0 only. Never introduce GPL/AGPL dependencies or use GPL code as inspiration (see `docs/licensing/clean-room-policy.md` and `THIRD_PARTY_LICENSES.md`).
+
+**Key architectural layers** (in execution order):
+1. Genetic Algorithm (`LIB/gaboom.cpp`)
+2. Voronoi Contact Scoring (`LIB/Vcontacts.cpp`)
+3. Statistical Mechanics engine (`LIB/statmech.cpp`)
+4. BindingMode clustering + thermodynamic integration (`LIB/BindingMode.cpp`)
+5. Vibrational entropy (ENCoM + tENCoM)
+6. Shannon configurational entropy with hardware acceleration (`ShannonThermoStack/`)
+7. Cavity detection (`CavityDetect/`)
+
+Full details live in `CLAUDE.md`.
+
+---
+
+## Maintaining These Instructions (Production Discipline)
+
+- `AGENTS.md` is the **authoritative source** for workflow rules and high-level constraints.
+- When you change core rules or commands, update `AGENTS.md` first.
+- Then propagate the important changes into:
+  - `CLAUDE.md` (Claude’s richer, more detailed view)
+  - `.grok/skills/flexaidds/SKILL.md` (Grok skill)
+  - Any ChatGPT / custom agent instructions
+- All three files should explicitly state that `AGENTS.md` is the source of truth.
+- Keep the sacred “Core Workflow Rules” section as close to identical as possible across files to prevent drift.
+
+This three-file system (AGENTS.md + CLAUDE.md + Grok skill) is deliberately designed for minimal long-term maintenance burden while giving each tool the format it works with best.
+
+---
+
+## When in Doubt
+
+1. Read `AGENTS.md` first (this file).
+2. Then read the tool-specific file for the agent you are currently using.
+3. When the task involves running builds or tests, actually run them and show the output.
+
+These rules exist to protect the quality and velocity of a real scientific codebase. Follow them without exception.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md — FlexAIDdS Development Guide
 
+> **Source of truth**: The authoritative workflow rules, verification discipline, and high-level constraints live in `AGENTS.md` (repo root). This document expands on `AGENTS.md` with deeper technical detail, file maps, and Claude-specific guidance. When the two conflict, `AGENTS.md` takes precedence.
+
 ## Project Overview
 
 FlexAIDdS (FlexAID with ΔS Entropy) is an entropy-driven molecular docking engine combining genetic algorithms with statistical mechanics thermodynamics. It targets real-world psychopharmacology and drug discovery applications.
@@ -7,6 +9,22 @@ FlexAIDdS (FlexAID with ΔS Entropy) is an entropy-driven molecular docking engi
 - **Languages**: C++26 (core engine), Python (bindings/analysis), Objective-C++ (Metal GPU), CUDA (optional GPU)
 - **License**: Apache-2.0 (no GPL dependencies allowed — see `THIRD_PARTY_LICENSES.md`)
 - **Lead**: Louis-Philippe Morency, PhD (Candidate), Université de Montréal, NRGlab
+
+## Workflow Rules (Critical — Read First)
+
+The rules below are the non-negotiable operating contract for any AI agent (Claude, Grok, GPT, etc.) working in this repository. They are reproduced from the authoritative `AGENTS.md`. Follow them without exception.
+
+**See `AGENTS.md` for the current canonical version.** The most important principles:
+
+- **Verify with actual execution before claiming anything is done.** Run the build or test and show clean output. Never say “done”, “fixed”, or “implemented” without evidence.
+- **Use `todo_write` for every task with 3+ distinct steps.** Exactly one item in `in_progress` at a time. Mark completed immediately. Never batch.
+- **Commit and push immediately after any code change.** Conventional prefixes. No batching. Kill stale git processes if needed.
+- **Fresh builds after CMake or source changes.** Never assume linking still works.
+- **Zero test failures before any push.** `ctest --output-on-failure` (C++) or full pytest run after relevant changes.
+- **Complete every item on a prioritized list** before stopping.
+- **When the user says “run it”, run it** — do not over-explore first.
+
+These rules exist to protect velocity and correctness in a complex scientific codebase. Claude is expected to be the strictest enforcer of them.
 
 ## Repository Structure
 
@@ -423,3 +441,15 @@ python -m flexaidds /path/to/results/ --top 5
 - Metal code only compiles on macOS (`FLEXAIDS_USE_METAL=ON`)
 - CUDA code requires CUDA toolkit (`FLEXAIDS_USE_CUDA=ON`)
 - No `.clang-format`, `.clang-tidy`, or `.editorconfig` — follow existing code style
+
+## AI Instructions & Agent Maintenance
+
+This repository uses a deliberate three-file system for AI agents:
+
+- `AGENTS.md` — Single source of truth for workflow rules and constraints (all agents).
+- `CLAUDE.md` — This file. Rich technical depth + Claude-specific detail.
+- `.grok/skills/flexaidds/SKILL.md` — Self-contained Grok skill (project-scoped).
+
+**Maintenance rule**: When core workflow rules, build commands, or constraints change, update `AGENTS.md` first, then propagate the delta into this file and the Grok skill. The sacred “Workflow Rules” sections should stay as aligned as possible to prevent drift.
+
+Claude should treat `AGENTS.md` as the contract and this document as the detailed reference manual.

--- a/chatgpt-instructions.md
+++ b/chatgpt-instructions.md
@@ -1,0 +1,65 @@
+# ChatGPT Instructions — FlexAIDdS
+
+Use these instructions when working with ChatGPT (Custom GPT, Projects, or agent mode) on the FlexAIDdS repository.
+
+**Source of truth**: The full authoritative rules live in `AGENTS.md` (repo root). This is a condensed, GPT-optimized version of the most important constraints. When in doubt, ask the user to paste the latest `AGENTS.md`.
+
+---
+
+## Core Rules (Memorize These)
+
+- Always verify with **actual command execution** (build + tests) before claiming anything is fixed, done, or working. Show the passing output.
+- For any task with 3+ steps, explicitly use a todo list (one item in progress at a time).
+- After code changes, the user must commit and push immediately. Do not batch changes.
+- Fresh configure + build after any CMakeLists.txt or LIB/ source change.
+- Zero test failures before any suggested push.
+- Complete every item on a prioritized list (P0/P1/etc.) before stopping.
+- When the user says “run the command / benchmark / test”, actually run it.
+
+---
+
+## Project Context (Short)
+
+FlexAIDdS = entropy-driven molecular docking (genetic algorithm + statistical mechanics thermodynamics) for drug discovery.
+
+Key layers:
+1. GA (`gaboom.cpp`)
+2. Voronoi scoring (`Vcontacts.cpp`)
+3. StatMech (`statmech.cpp`)
+4. BindingMode clustering + thermo
+5. ENCoM / tENCoM vibrational entropy
+6. ShannonThermoStack (configurational entropy, GPU accelerated)
+7. Cavity detection
+
+**Languages**: C++26 (core), Python (flexaidds package + bindings), Metal, optional CUDA.
+
+**License**: Apache-2.0 only. No GPL anything.
+
+---
+
+## Essential Commands
+
+**Most common C++ workflow**
+```bash
+cmake -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j $(nproc)
+ctest --test-dir build --output-on-failure
+```
+
+**Python only**
+```bash
+cd python && pip install -e . && pytest tests/ -q
+```
+
+Full details and CMake options are in `CLAUDE.md`.
+
+---
+
+## Behavior Expectations
+
+- Be extremely strict about the verification and commit rules above.
+- When the user gives you a task, start by confirming you have read `AGENTS.md` (ask them to paste it if you don't have it in context).
+- Prefer running real commands over guessing.
+- If something is ambiguous, ask clarifying questions rather than over-exploring the codebase.
+
+Keep responses focused. This is a serious scientific codebase — precision and discipline matter.

--- a/docs/IMPLEMENTATION_ROADMAP.md
+++ b/docs/IMPLEMENTATION_ROADMAP.md
@@ -574,6 +574,49 @@ option(BUILD_SWIFT_BRIDGE   "Swift bridge (macOS only)"           OFF)
 - `RingConformerLibrary.h` — Ring conformer database
 - `SugarPucker.h` — Sugar ring conformation handling
 
+### DiFT — Discrete Fourier Transform Torsional Parametrization (`LIB/DiFT/`)
+
+Automated, unbiased parametrization of dihedral (torsional) potentials.
+Method: Flores-Trujillo, Rodríguez-Segura, Amador-Bedolla & Domínguez, *J. Chem. Inf.
+Model.* **2026**, DOI [10.1021/acs.jcim.6c00123](https://doi.org/10.1021/acs.jcim.6c00123).
+
+**Why it lives in ΔS-FlexAID.** A torsional potential V(φ) and its Fourier
+spectrum {Aₙ, ωₙ} are conjugate representations of the *same* object. One FFT
+yields two payoffs:
+
+1. **Energy** — a truncated cosine series V(φ) = mean + Σ Aₙ cos(nφ − ωₙ) feeds
+   the ligand-bond term of the GA fitness as a real analytical potential.
+2. **Entropy** — the same spectrum gives the 1-D partition function z =
+   ⟨exp(−βV)⟩ in closed form, and hence a rigorous per-bond torsional entropy
+   S_tors = (⟨V⟩ − F)/T. This is the ΔS contribution an entropy-driven docking
+   engine should actually use, replacing the heuristic rotatable-bond count.
+
+**Shannon-collapse truncation.** Instead of the paper's brute-force outer loop
+on the number of terms F, the spectral Shannon entropy H_spec of the normalized
+power spectrum pₙ = Aₙ²/ΣAₘ² sets the effective mode count N_eff = exp(H_spec);
+the ⌈N_eff⌉ highest-power terms are retained. A profile dominated by one cosine
+has H_spec → 0 (N_eff → 1); a flat noisy profile has H_spec → ln(N) (all
+modes). No user threshold — the spectrum itself decides.
+
+**Files**
+
+- `LIB/DiFT/DiFT.h` / `DiFT.cpp` — C++26 engine (self-contained: only the
+  standard library; radix-2 FFT for power-of-two grids, exact direct DFT
+  otherwise). Apache-2.0, no GPL deps.
+- `LIB/DiFT/DiFTGAAdapter.h` — header-only bridge to the GA fitness:
+  `score_torsional()` returns `{energy, minus_TS, n_bonds}` per pose.
+- `python/flexaidds/dift.py` — bit-identical pure-Python (NumPy) mirror; the
+  always-available path even without `_core`.
+- `python/bindings/dift_bindings.h` — pybind11 bindings, registered into both
+  `_core.cpp` (setup.py) and `core_bindings.cpp` (CMake).
+- `tests/test_dift.cpp` — 23 GoogleTest cases (round-trip, Shannon collapse,
+  refinement convergence, free-rotor / confined-bond thermodynamics, Boltzmann
+  inversion, circular mean, GA adapter, input-validation guards).
+- `python/tests/test_dift.py` — 23 pytest cases mirroring the C++ suite + a
+  C++/Python parity check that runs whenever `_core.DiFTEngine` is available.
+
+**Status**: ✅ Complete (engine, bindings, tests, CMake/CI wiring, docs).
+
 ### PTM Attachment (`LIB/PTMAttachment/`)
 
 - `PTMAttachment.h` — Post-translational modification modeling


### PR DESCRIPTION
## Summary

This PR introduces a **production-grade, cross-tool AI agent instruction system** for the FlexAIDdS repository.

The goal is to give every AI coding assistant (Claude, Grok, ChatGPT, etc.) the same high-signal rules and context so the team gets consistent, high-quality help while strictly following our engineering standards.

### What was added

- **AGENTS.md** (new) — Single source of truth. Contains the non-negotiable workflow rules the project demands (verify with actual runs before claiming done, use todo lists, commit immediately after changes, fresh builds after CMake/source changes, zero test failures before push, etc.).
- **chatgpt-instructions.md** (new) — Short, optimized version suitable for pasting into ChatGPT Custom GPTs or Projects.
- **CLAUDE.md** — Upgraded with an early, prominent "Workflow Rules" section + clear note that AGENTS.md is the authoritative source.
- **.grok/skills/flexaidds/** — Updated the existing Grok skill to reference AGENTS.md for the core rules (kept self-contained where it makes sense for Grok).
- **.gitignore** — Added the necessary exceptions so the new root-level instruction files are tracked and shared with the team.

### Why this matters

The project already had excellent detailed instructions in CLAUDE.md, but they were Claude-only and the strict "verify everything + commit immediately" discipline lived mostly in personal configs.

This change makes the rules:
- Tool-agnostic at the core (`AGENTS.md`)
- Properly shared with the whole team via the repo
- Enforced consistently no matter which AI the developer is using

### Files changed

- New: `AGENTS.md`
- New: `chatgpt-instructions.md`
- Modified: `CLAUDE.md`, `.grok/skills/flexaidds/SKILL.md`, `.grok/skills/flexaidds/README.md`, `.gitignore`

### How to use after merge

- Developers using Claude → `CLAUDE.md` (now points to AGENTS.md)
- Developers using Grok → `/flexaidds` slash command or it auto-activates
- Developers using ChatGPT → paste or reference `chatgpt-instructions.md`

All tools are expected to read `AGENTS.md` first for the sacred rules.

---

**Note**: This branch previously contained DiFT-related changes. The AI instruction system is the main deliverable of this PR.

