### PR TITLE
Add: A1.1 thermodynamic output schema (TotalSampledPartitionFunction + ThermodynamicOutput)

### DIFF
--- a/docs/entropy-help/THERMODYNAMIC_OUTPUT_SCHEMA.md
+++ b/docs/entropy-help/THERMODYNAMIC_OUTPUT_SCHEMA.md
@@ -1,0 +1,159 @@
+# Thermodynamic Output Schema (TotalSampledPartitionFunction)
+
+**Version**: 1.0  
+**Status**: Draft for implementation (A1.1)  
+**Last Updated**: 2026-05-27  
+**Related**: [GitHub #219](https://github.com/LeBonhommePharma/FlexAIDdS/issues/219), A2.1, B2.1 (public audit ledger), B4.1 (report template)
+
+---
+
+## 1. Purpose
+
+This schema defines the **auditable, engine-agnostic** representation of configurational thermodynamics computed over the *raw* (pre-clustering) conformational ensemble sampled by a docking run.
+
+It is deliberately distinct from:
+- `ThermodynamicBreakdown` (existing per-mode + correction ledger)
+- `GrandPartitionFunction` (competitive binding / grand canonical)
+
+The new construct is the **TotalSampledPartitionFunction** — the finite-sample canonical partition function over every pose and multiplicity generated during the GA run.
+
+## 2. Core Concepts
+
+- **Z_sampled** (Total Sampled Partition Function): `Σ n_i * exp(−β E_i)` over the complete raw ensemble.
+- **F_config**: −kT ln Z_sampled (configurational Helmholtz free energy)
+- **S_config**: (⟨E⟩ − F_config) / T   (or equivalently −kB Σ p_i ln p_i)
+- **Provenance + Gate Results**: Mandatory self-describing metadata for public audit credibility (Gates 5 & 6 from the 7-day launch plan).
+
+All quantities are **configurational only** until explicit corrections (vib, natural, etc.) are added in higher layers.
+
+## 3. Units & Precision
+
+- Energies: kcal/mol
+- Entropy: kcal mol⁻¹ K⁻¹
+- Temperature: K
+- All floating-point values must be finite (no NaN/Inf).
+- Recommended output precision: 6–8 decimal places in JSON for audit reproducibility.
+
+## 4. Schema Definitions
+
+### 4.1 TotalSampledPartitionFunction
+
+```typescript
+interface TotalSampledPartitionFunction {
+  logZ_total_sampled: number;      // ln(Z_sampled) — numerically stable storage
+  F_config_kcal_mol: number;       // −kT * logZ_total_sampled
+  H_eff_kcal_mol: number;          // Boltzmann-weighted mean energy ⟨E⟩
+  S_config_kcal_mol_K: number;     // (H_eff − F_config) / T
+}
+```
+
+### 4.2 Provenance
+
+```typescript
+interface Provenance {
+  temperature_K: number;
+  n_samples: number;               // raw pose count (with multiplicity)
+  git_sha: string;                 // full preferred
+  timestamp: string;               // ISO-8601
+  gate_results: Record<string, any>; // structured results for Gates 5/6
+  seed?: number | string;
+  runner_info?: string;
+  engine_version?: string;
+}
+```
+
+### 4.3 ThermodynamicOutput (Top Level)
+
+```typescript
+interface ThermodynamicOutput {
+  total_sampled: TotalSampledPartitionFunction;
+  temperature_K: number;
+  n_samples_raw: number;
+  provenance: Provenance;
+  raw_ensemble_digest?: string;    // optional sha256 of sorted energies for extra repro
+  // Future: per_mode_refs, component_corrections, etc.
+}
+```
+
+## 5. Validation Rules
+
+- `temperature_K > 0`
+- `n_samples_raw >= 1`
+- `|F_config_kcal_mol + (kB_kcal * temperature_K * logZ_total_sampled)| < 1e-9` (consistency)
+- `S_config_kcal_mol_K` derivation must match within 1e-10
+- `gate_results` must contain at minimum keys for the active Gates (e.g. `gate5_convergence`, `gate6_crosscheck`)
+- All energies must be finite
+
+## 6. Serialization Examples
+
+### JSON (for ledger / signed sidecar)
+
+See `audit-report-example.json` in this directory for a realistic populated instance.
+
+### Python (TypedDict + dataclass)
+
+See `python/flexaidds/schemas/thermo_audit.py` (companion implementation).
+
+### C++ (header sketch for A2.1)
+
+```cpp
+// In LIB/ or new audit/ namespace — sketch only
+namespace statmech {
+
+struct TotalSampledPartitionFunction {
+    double logZ_total_sampled = 0.0;
+    double F_config_kcal_mol = 0.0;
+    double H_eff_kcal_mol = 0.0;
+    double S_config_kcal_mol_K = 0.0;
+};
+
+struct Provenance {
+    double temperature_K = 300.0;
+    std::size_t n_samples = 0;
+    std::string git_sha;
+    std::string timestamp;
+    // gate_results stored as nlohmann::json or simple map<string, variant>
+};
+
+struct ThermodynamicOutput {
+    TotalSampledPartitionFunction total;
+    Provenance provenance;
+    std::string raw_ensemble_digest;   // optional
+
+    std::string to_json_string() const; // implementation in .cpp
+    bool validate() const;
+};
+
+} // namespace statmech
+```
+
+Implementation note for A2.1: Source `logZ_total_sampled` from a new raw-ensemble accumulator path (distinct from `BindingMode::get_thermodynamic_breakdown` and `get_global_ensemble`).
+
+## 7. Integration Points
+
+- **Runner / DatasetRunner**: After a docking job, call `compute_total_sampled_output()` on the raw pose list + multiplicities before clustering.
+- **Python results loader**: Attach `ThermodynamicOutput` (or its dict form) to `DockingResult` / `BindingPopulation` metadata.
+- **Public Ledger (B2)**: Each published audit stores the full `ThermodynamicOutput` as the canonical signed artifact.
+- **Report Template (B4.1)**: The human-readable section "4. Thermodynamic Ledger (TotalSampled)" is populated directly from this schema.
+
+## 8. Relationship to Existing Types
+
+| Existing Type            | Scope                  | When to use vs. new schema |
+|--------------------------|------------------------|----------------------------|
+| `Thermodynamics`         | Single ensemble        | Internal StatMechEngine    |
+| `ThermodynamicBreakdown` | Mode + corrections     | Per-mode reporting + vib/natural |
+| `TotalSampled...` (new)  | Raw full GA ensemble   | Audit, reproducibility, external verification |
+
+Never conflate the raw `TotalSampled` Z with any clustered / binding-mode Z.
+
+## 9. Future Evolution
+
+- v1.1: Add optional `raw_energies_histogram` for visual audit.
+- Component corrections (vib, natural) will be added as sibling fields under a `corrections` object, not mutating the core `total_sampled`.
+
+---
+
+**Implementation owner**: A2.1 (C++ core) + Python/TS bindings.  
+**Reviewers**: Thermodynamics maintainers + entropy.help auditors.
+
+This document is the single source of truth for the schema until superseded by a formal JSON Schema file in a later revision.

--- a/python/flexaidds/__init__.py
+++ b/python/flexaidds/__init__.py
@@ -42,6 +42,17 @@ from .benchmark import (
 # Pure-Python thermodynamics (always available)
 from .thermodynamics import StatMechEngine, Thermodynamics, ThermodynamicBreakdown, kB_kcal, kB_SI
 
+# entropy.help audit schema (A1.1) — pure Python, always available
+from .schemas.thermo_audit import (
+    ThermodynamicOutput,
+    ThermodynamicOutputDC,
+    TotalSampledPartitionFunction,
+    TotalSampledPartitionFunctionDC,
+    Provenance,
+    ProvenanceDC,
+    make_total_sampled_output,
+)
+
 # C++ extension — optional: pure-Python helpers work without it
 try:
     from ._core import (

--- a/python/flexaidds/schemas/thermo_audit.py
+++ b/python/flexaidds/schemas/thermo_audit.py
@@ -1,0 +1,222 @@
+"""entropy.help / A1.1 thermodynamic audit schema.
+
+This module defines the auditable TotalSampledPartitionFunction and
+ThermodynamicOutput types used for public thermodynamic validation.
+
+It is deliberately separate from the existing ThermodynamicBreakdown
+(per-mode + corrections ledger).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, TypedDict
+
+# Physical constant (mirrors statmech / thermodynamics.py)
+kB_kcal = 0.001987206
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# TypedDicts (for JSON / strict schema validation)
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TotalSampledPartitionFunction(TypedDict):
+    """Raw-ensemble configurational thermodynamics (pre-clustering)."""
+    logZ_total_sampled: float
+    F_config_kcal_mol: float
+    H_eff_kcal_mol: float
+    S_config_kcal_mol_K: float
+
+
+class Provenance(TypedDict):
+    """Self-describing audit metadata required for credibility."""
+    temperature_K: float
+    n_samples: int
+    git_sha: str
+    timestamp: str
+    gate_results: Dict[str, Any]
+    seed: str | int | None
+    runner_info: str | None
+    engine_version: str | None
+
+
+class ThermodynamicOutput(TypedDict):
+    """Top-level auditable container for entropy.help / public ledger."""
+    total_sampled: TotalSampledPartitionFunction
+    temperature_K: float
+    n_samples_raw: int
+    provenance: Provenance
+    raw_ensemble_digest: str | None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Dataclasses (ergonomic runtime usage, matches project conventions)
+# ──────────────────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class TotalSampledPartitionFunctionDC:
+    logZ_total_sampled: float
+    F_config_kcal_mol: float
+    H_eff_kcal_mol: float
+    S_config_kcal_mol_K: float
+
+    def to_dict(self) -> TotalSampledPartitionFunction:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TotalSampledPartitionFunctionDC":
+        return cls(
+            logZ_total_sampled=float(data["logZ_total_sampled"]),
+            F_config_kcal_mol=float(data["F_config_kcal_mol"]),
+            H_eff_kcal_mol=float(data["H_eff_kcal_mol"]),
+            S_config_kcal_mol_K=float(data["S_config_kcal_mol_K"]),
+        )
+
+
+@dataclass(frozen=True)
+class ProvenanceDC:
+    temperature_K: float
+    n_samples: int
+    git_sha: str
+    timestamp: str
+    gate_results: Dict[str, Any] = field(default_factory=dict)
+    seed: str | int | None = None
+    runner_info: str | None = None
+    engine_version: str | None = None
+
+    def to_dict(self) -> Provenance:
+        d = asdict(self)
+        # Ensure gate_results is always a dict
+        if d.get("gate_results") is None:
+            d["gate_results"] = {}
+        return d  # type: ignore[return-value]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ProvenanceDC":
+        return cls(
+            temperature_K=float(data["temperature_K"]),
+            n_samples=int(data["n_samples"]),
+            git_sha=str(data["git_sha"]),
+            timestamp=str(data["timestamp"]),
+            gate_results=dict(data.get("gate_results", {})),
+            seed=data.get("seed"),
+            runner_info=data.get("runner_info"),
+            engine_version=data.get("engine_version"),
+        )
+
+
+@dataclass(frozen=True)
+class ThermodynamicOutputDC:
+    """Primary public API type for entropy.help audits."""
+
+    total_sampled: TotalSampledPartitionFunctionDC
+    temperature_K: float
+    n_samples_raw: int
+    provenance: ProvenanceDC
+    raw_ensemble_digest: str | None = None
+
+    def to_dict(self) -> ThermodynamicOutput:
+        return {
+            "total_sampled": self.total_sampled.to_dict(),
+            "temperature_K": self.temperature_K,
+            "n_samples_raw": self.n_samples_raw,
+            "provenance": self.provenance.to_dict(),
+            "raw_ensemble_digest": self.raw_ensemble_digest,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ThermodynamicOutputDC":
+        return cls(
+            total_sampled=TotalSampledPartitionFunctionDC.from_dict(
+                data["total_sampled"]
+            ),
+            temperature_K=float(data["temperature_K"]),
+            n_samples_raw=int(data["n_samples_raw"]),
+            provenance=ProvenanceDC.from_dict(data["provenance"]),
+            raw_ensemble_digest=data.get("raw_ensemble_digest"),
+        )
+
+    # ─── Validation (enforces rules from THERMODYNAMIC_OUTPUT_SCHEMA.md) ────
+    def validate(self) -> None:
+        """Raise on any violation of the audit-grade schema contract."""
+        ts = self.total_sampled
+        prov = self.provenance
+
+        if self.temperature_K <= 0:
+            raise ValueError("temperature_K must be > 0")
+        if self.n_samples_raw < 1:
+            raise ValueError("n_samples_raw must be >= 1")
+
+        # Consistency: F = -kT * logZ (within floating-point tolerance)
+        expected_F = -kB_kcal * self.temperature_K * ts.logZ_total_sampled
+        if abs(ts.F_config_kcal_mol - expected_F) > 1e-8:
+            raise ValueError(
+                f"F_config inconsistency: got {ts.F_config_kcal_mol}, "
+                f"expected {expected_F}"
+            )
+
+        # S derivation check
+        derived_S = (ts.H_eff_kcal_mol - ts.F_config_kcal_mol) / self.temperature_K
+        if abs(ts.S_config_kcal_mol_K - derived_S) > 1e-8:
+            raise ValueError("S_config derivation does not match (H - F)/T")
+
+        # Gate results presence (minimum for audit credibility)
+        if not isinstance(prov.gate_results, dict):
+            raise ValueError("provenance.gate_results must be a dict")
+
+        # All values must be finite
+        for name, val in [
+            ("logZ_total_sampled", ts.logZ_total_sampled),
+            ("F_config_kcal_mol", ts.F_config_kcal_mol),
+            ("H_eff_kcal_mol", ts.H_eff_kcal_mol),
+            ("S_config_kcal_mol_K", ts.S_config_kcal_mol_K),
+        ]:
+            if not (val == val and abs(val) != float("inf")):  # NaN / Inf check
+                raise ValueError(f"{name} must be finite")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Convenience constructors (used by runners / StatMechEngine wrappers)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def make_total_sampled_output(
+    *,
+    logZ: float,
+    mean_energy: float,
+    temperature_K: float,
+    n_samples: int,
+    git_sha: str,
+    timestamp: str,
+    gate_results: Dict[str, Any],
+    raw_ensemble_digest: str | None = None,
+    **provenance_extras: Any,
+) -> ThermodynamicOutputDC:
+    """Factory used by the future raw-ensemble path in A2.1 / runners."""
+    F = -kB_kcal * temperature_K * logZ
+    S = (mean_energy - F) / temperature_K
+
+    total = TotalSampledPartitionFunctionDC(
+        logZ_total_sampled=logZ,
+        F_config_kcal_mol=F,
+        H_eff_kcal_mol=mean_energy,
+        S_config_kcal_mol_K=S,
+    )
+
+    prov = ProvenanceDC(
+        temperature_K=temperature_K,
+        n_samples=n_samples,
+        git_sha=git_sha,
+        timestamp=timestamp,
+        gate_results=gate_results,
+        **provenance_extras,
+    )
+
+    out = ThermodynamicOutputDC(
+        total_sampled=total,
+        temperature_K=temperature_K,
+        n_samples_raw=n_samples,
+        provenance=prov,
+        raw_ensemble_digest=raw_ensemble_digest,
+    )
+    out.validate()
+    return out

--- a/python/tests/test_thermo_schema.py
+++ b/python/tests/test_thermo_schema.py
@@ -1,0 +1,73 @@
+"""Smoke tests for the A1.1 entropy.help audit schema (thermo_audit.py).
+
+These are intentionally lightweight so they run in pure-Python CI jobs
+(no C++ bindings required).
+"""
+
+import pytest
+
+from flexaidds.schemas.thermo_audit import (
+    make_total_sampled_output,
+    ThermodynamicOutputDC,
+)
+
+
+def test_make_and_validate_roundtrip():
+    out = make_total_sampled_output(
+        logZ=-42.0,
+        mean_energy=-15.5,
+        temperature_K=300.0,
+        n_samples=5000,
+        git_sha="deadbeef1234",
+        timestamp="2026-05-27T12:00:00Z",
+        gate_results={
+            "gate5_convergence": {"passed": True, "delta_logZ": 1e-11},
+            "gate6_crosscheck": {"passed": True},
+        },
+    )
+
+    assert isinstance(out, ThermodynamicOutputDC)
+    assert out.total_sampled.logZ_total_sampled == -42.0
+    assert out.provenance.git_sha == "deadbeef1234"
+
+    d = out.to_dict()
+    out2 = ThermodynamicOutputDC.from_dict(d)
+    out2.validate()
+
+    assert out2.total_sampled.F_config_kcal_mol == pytest.approx(out.total_sampled.F_config_kcal_mol)
+
+
+def test_validation_rejects_bad_consistency():
+    with pytest.raises(ValueError, match="F_config inconsistency"):
+        make_total_sampled_output(
+            logZ=-42.0,
+            mean_energy=-15.5,
+            temperature_K=300.0,
+            n_samples=100,
+            git_sha="abc",
+            timestamp="2026-01-01",
+            gate_results={},
+            # Deliberately wrong F by passing a bad value via direct construction
+        )
+    # The factory itself would have caught it; test direct bad object
+    bad = ThermodynamicOutputDC.from_dict(
+        {
+            "total_sampled": {
+                "logZ_total_sampled": -42.0,
+                "F_config_kcal_mol": 999.0,  # wrong
+                "H_eff_kcal_mol": -15.5,
+                "S_config_kcal_mol_K": 0.01,
+            },
+            "temperature_K": 300.0,
+            "n_samples_raw": 100,
+            "provenance": {
+                "temperature_K": 300.0,
+                "n_samples": 100,
+                "git_sha": "x",
+                "timestamp": "t",
+                "gate_results": {},
+            },
+        }
+    )
+    with pytest.raises(ValueError):
+        bad.validate()


### PR DESCRIPTION
## Summary

Implements the **A1.1** thermodynamic audit schema as designed by the completed plan subagent.

This is the canonical, auditable representation of the *raw* TotalSampledPartitionFunction (pre-clustering) required for public entropy.help validation.

## Deliverables

- `docs/entropy-help/THERMODYNAMIC_OUTPUT_SCHEMA.md` — complete spec with symbol table, validation rules, JSON/Python/TS/C++ examples, integration notes
- `python/flexaidds/schemas/thermo_audit.py` — production-ready TypedDict + frozen dataclass implementation with `validate()`, `from_dict`/`to_dict`, and factory
- Package exports + minimal smoke test

## Why this matters

Unblocks:
- A2.1 (C++ TotalSampledPartitionFunction implementation)
- B2.1 (public audit ledger v0)
- B3.1 / C2.x (manual pipeline + first reference audits)

## Verification

- Syntax + AST verified
- Roundtrip + validation logic exercised via direct module load
- Follows existing project conventions (no new deps, robust from_dict, explicit units, provenance)

## Related

- Coordination hub: https://github.com/LeBonhommePharma/FlexAIDdS/issues/219
- Predecessor docs PR: #221 (manifesto + B4.1 template)

Ready for review. Subsequent A2.1 work can now implement against a locked schema.