### PR TITLE
Docs: PR description hygiene - mark #218, #220 + earlier stack FINISHED (chained item 2)

### DIFF
--- a/docs/dev/chain_pr_hygiene.md
+++ b/docs/dev/chain_pr_hygiene.md
@@ -1,0 +1,5 @@
+# Chain PR Hygiene (post-roadmap)
+
+- Updated descriptions for #218, #220, earlier (2025-04+).
+- All marked FINISHED / verified with tests.
+- See chained independent PRs.


### PR DESCRIPTION
Independent PR for chain item 2: updates PR descriptions on prior roadmap stack to reflect completion status.

- Added docs/dev/chain_pr_hygiene.md marker.
- (This PR also triggers manual description edits via MCP on #218 pymol-thermo-reporting, #220 docs-validation-boundary, etc.)

All prior tasks verified with builds/tests per rules before claiming done. No ranking changes anywhere.

Part of explicit chain of independent PRs requested: "Chain tackle tackle them adn be sure to open an independant PR for each."