### PR TITLE
Fix: deterministic regex in source validator (longest-extension-first)

### DIFF
--- a/scripts/validate_sources.py
+++ b/scripts/validate_sources.py
@@ -185,12 +185,16 @@ def collect_referenced_names(root: Path) -> Set[str]:
     # Remove duplicates
     search_files = list({p.resolve() for p in search_files if p.is_file()})
 
-    # Regex that matches typical source file references
+    # Regex that matches typical source file references. Extension alternatives
+    # are sorted longest-first so short prefixes like .c cannot match before
+    # .cpp (set iteration order is non-deterministic across Python hash seeds,
+    # so without sorting this validator is randomly flaky in CI).
     # Examples matched:
     #   Foo.cpp   LIB/Bar.cu   "something/Widget.mm"   MyKernel.cuh
+    _sorted_exts = sorted(SOURCE_EXTENSIONS, key=lambda ext: (-len(ext), ext))
     source_regex = re.compile(
         r'["\']?([A-Za-z0-9_./\\-]+\.(?:' +
-        "|".join(re.escape(ext.lstrip(".")) for ext in SOURCE_EXTENSIONS) +
+        "|".join(re.escape(ext.lstrip(".")) for ext in _sorted_exts) +
         r'))["\']?'
     )
 


### PR DESCRIPTION
## Summary
- `collect_referenced_names` in `scripts/validate_sources.py` iterated `SOURCE_EXTENSIONS` (a `set`) in hash-randomized order when building the alternation, so PYTHONHASHSEED values that put `.c` before `.cpp` made the regex match `foo.c` inside `foo.cpp` and store the wrong name. Every `.cpp` listed in CMakeLists.txt then looked unreferenced.
- This is the root cause of the flaky `FlexAID CI`, `Sanitizers`, `tsan`, and `C++ core (*)` failures on master and on **every open PR** (17 of them) — same tree sometimes passes, sometimes fails.
- Fix: sort the extension alternation longest-first before joining (`.cpp` binds before `.c`, `.hpp` before `.h`, `.cuh` before `.cu`, etc.).

## Test plan
- [x] Verified locally with `PYTHONHASHSEED=0..7` — clean every time (375 sources scanned, 0 orphans).
- [x] Verified with `PYTHONHASHSEED=random` — clean.
- [ ] CI must turn green on this PR.

Unblocks: #211 #212 #213 #214 #215 #216 #217 #218 #220 #221 #222 #223 #224 #225 #226 #227 #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)