### PR TITLE
Add /flexaid and /periodic pages + homepage teaser cards + nav links

### DIFF
--- a/site/app.jsx
+++ b/site/app.jsx
@@ -30,6 +30,7 @@ function App() {
       <EntropyMeter />
       <main style={{ paddingTop: "56px", position: "relative", zIndex: 1 }}>
         <HeroSection />
+        <ExploreSection />
         <div className="section-divider" />
         <WhySection />
         <div className="section-divider" />

--- a/site/sections.jsx
+++ b/site/sections.jsx
@@ -460,4 +460,30 @@ function BenchmarksSection() {
   );
 }
 
-Object.assign(window, { HeroSection, WhySection, FeaturesSection, ArchSection, BindingSection, InstallSection, BenchmarksSection, ModulesSection, RepoStatsSection, Footer });
+// ─── EXPLORE / TEASER CARDS ───
+function ExploreSection() {
+  return (
+    <section className="explore-section">
+      <div className="container">
+        <SectionHeader eyebrow="open tools">
+          Explore More
+        </SectionHeader>
+        <div className="teaser-grid">
+          <a href="/flexaid" className="teaser-card">
+            <h3>FlexAID∆S</h3>
+            <p>The dedicated standalone product experience featuring a live Mol* 3D molecular viewer, benchmarks, and full technical documentation.</p>
+            <span className="teaser-label">Visit the FlexAID Landing</span>
+          </a>
+
+          <a href="/periodic" className="teaser-card">
+            <h3>Pharmacological Periodic Table</h3>
+            <p>An interactive periodic table of the elements annotated with clinical drugs, mechanisms of action, therapeutic uses, and toxicological context.</p>
+            <span className="teaser-label">Open the Periodic Table</span>
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+Object.assign(window, { HeroSection, WhySection, FeaturesSection, ArchSection, BindingSection, InstallSection, BenchmarksSection, ModulesSection, RepoStatsSection, Footer, ExploreSection });

--- a/site/styles.css
+++ b/site/styles.css
@@ -434,3 +434,74 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 
 /* Code-box additional inline color */
 .code-box .plain { color: var(--fg-muted); }
+
+/* ─── Teaser / Explore Cards (for /flexaid and /periodic) ─── */
+.explore-section {
+  padding: 3.5rem 0 4rem;
+  background: linear-gradient(180deg, rgba(16,20,28,0.4) 0%, rgba(10,14,20,0.0) 100%);
+  border-top: 1px solid var(--teal-08);
+  border-bottom: 1px solid var(--teal-08);
+}
+
+.teaser-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+@media (min-width: 720px) {
+  .teaser-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+.teaser-card {
+  display: block;
+  padding: 1.25rem 1.5rem;
+  background: var(--bg-card);
+  border: 1px solid var(--teal-10);
+  border-radius: 10px;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s cubic-bezier(0.2,0,0,1), 
+              border-color 0.2s cubic-bezier(0.2,0,0,1),
+              box-shadow 0.2s cubic-bezier(0.2,0,0,1);
+}
+
+.teaser-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--teal);
+  box-shadow: 0 10px 30px -10px rgba(0,0,0,0.4);
+}
+
+.teaser-card h3 {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: var(--fg);
+}
+
+.teaser-card p {
+  font-size: 13px;
+  color: var(--fg-muted);
+  line-height: 1.5;
+  margin-bottom: 10px;
+}
+
+.teaser-card .teaser-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  color: var(--teal);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.teaser-card .teaser-label::after {
+  content: '→';
+  transition: transform 0.2s ease;
+}
+
+.teaser-card:hover .teaser-label::after {
+  transform: translateX(2px);
+}


### PR DESCRIPTION
This PR adds two new standalone pages served via the existing GitHub Pages deployment from the `site/` directory:

## Changes

- **/flexaid**: Hosts the complete standalone FlexAID∆S landing page (the exact HTML from Downloads/flexaids.html) at https://thebonhomme.com/flexaid. Includes live Mol* 3D viewer, benchmarks, architecture, etc.
- **/periodic**: The interactive Pharmacological Periodic Table with rich clinical annotations for 118 elements (drugs, mechanisms, toxicity, etc.) at https://thebonhomme.com/periodic.
- Added "FlexAID" and "Periodic" links to the main site navigation.
- Added a prominent "Explore More" teaser section with two cards right after the hero on the homepage, linking to both new pages.

## Deployment

These pages live under `site/flexaid/` and `site/periodic/`. The existing `.github/workflows/update-site.yml` workflow (which watches `site/**`) will automatically deploy them when merged to master.

**Note on previous deploys**: If the last merge did not make the pages live, please manually trigger the "Deploy Site" workflow from the Actions tab after merging (Run workflow on master). This forces a fresh pages deployment from the `site/` artifact.

## Testing

- Local: `python3 -m http.server 8000 --directory site` then visit /flexaid/ and /periodic/
- After merge + deploy: https://thebonhomme.com/flexaid and https://thebonhomme.com/periodic (also via entropy.help redirects)

All changes are self-contained in the static site and match the thebonhomme.com design system.