### PR TITLE
Add: consume DiFT torsional free-energy/entropy in BindingMode

### DIFF
--- a/docs/IMPLEMENTATION_ROADMAP.md
+++ b/docs/IMPLEMENTATION_ROADMAP.md
@@ -607,6 +607,13 @@ modes). No user threshold — the spectrum itself decides.
   `score_torsional()` returns `{energy, minus_TS, n_bonds}` per pose.
 - `python/flexaidds/dift.py` — bit-identical pure-Python (NumPy) mirror; the
   always-available path even without `_core`.
+- `python/flexaidds/docking.py` — **consumer**: `BindingMode.set_torsional_\
+potentials()` / `set_torsional_profiles()` attach per-bond DiFT potentials, and
+  the torsional `energy + (−TΔS)` folds additively into the mode's
+  `free_energy`, `enthalpy`, and `entropy` (and `get_thermodynamics()`). Opt-in
+  and zero-cost when no potentials are attached — a mode is otherwise a pure
+  configurational ensemble. This is where the entropy-driven engine finally
+  spends the ΔS payoff instead of a heuristic rotatable-bond count.
 - `python/bindings/dift_bindings.h` — pybind11 bindings, registered into both
   `_core.cpp` (setup.py) and `core_bindings.cpp` (CMake).
 - `tests/test_dift.cpp` — 23 GoogleTest cases (round-trip, Shannon collapse,
@@ -615,7 +622,9 @@ modes). No user threshold — the spectrum itself decides.
 - `python/tests/test_dift.py` — 23 pytest cases mirroring the C++ suite + a
   C++/Python parity check that runs whenever `_core.DiFTEngine` is available.
 
-**Status**: ✅ Complete (engine, bindings, tests, CMake/CI wiring, docs).
+**Status**: ✅ Complete (engine, bindings, tests, CMake/CI wiring, docs) and
+now consumed by the docking thermodynamics layer via `BindingMode` (opt-in
+torsional ΔG/ΔS folding, `python/tests/test_docking.py::TestBindingModeTorsional`).
 
 ### PTM Attachment (`LIB/PTMAttachment/`)
 

--- a/python/flexaidds/docking.py
+++ b/python/flexaidds/docking.py
@@ -8,10 +8,17 @@ import shutil
 import re
 import numpy as np
 from pathlib import Path
-from typing import List, Optional, Dict, Any
-from dataclasses import dataclass
+from typing import List, Optional, Dict, Any, Sequence
+from dataclasses import dataclass, replace
 
 from .thermodynamics import Thermodynamics, StatMechEngine, kB_kcal
+from .dift import (
+    DiFTEngine,
+    RotatableBondTorsion,
+    TorsionalScore,
+    make_bond_torsion,
+    score_torsional,
+)
 
 try:
     from . import _core
@@ -58,11 +65,25 @@ class BindingMode:
     A binding mode represents a distinct local minimum on the binding energy
     landscape, characterized by an ensemble of similar poses.
 
+    The configurational thermodynamics come from the pose-energy ensemble. In
+    addition, a binding mode can carry the DiFT (Discrete Fourier Transform)
+    torsional potentials of the ligand's rotatable bonds; when attached, the
+    per-bond torsional free-energy contribution ``V_tors(φ) − T·S_tors`` folds
+    into ``free_energy``, ``enthalpy``, and ``entropy``. This replaces the
+    classical crude per-rotatable-bond count penalty with a first-principles
+    statistical-mechanical ΔS term derived from the same Fourier spectrum that
+    parametrizes the torsional energy. See :mod:`flexaidds.dift`.
+
     Example:
         >>> mode = results.binding_modes[0]  # top-ranked mode
         >>> thermo = mode.get_thermodynamics()
         >>> print(f"ΔG = {thermo.free_energy:.2f} kcal/mol")
         >>> print(f"ΔH = {thermo.mean_energy:.2f}, TΔS = {thermo.entropy_term:.2f}")
+
+        >>> # Fold in ligand torsional entropy from QM/CG dihedral profiles:
+        >>> mode.set_torsional_profiles([qm_scan_bond0, qm_scan_bond1],
+        ...                             dihedral_angles_rad=[phi0, phi1])
+        >>> mode.torsional_free_energy  # kcal/mol (energy + confinement −TΔS)
     """
 
     def __init__(self, cpp_binding_mode=None, temperature: float = 300.0):
@@ -79,9 +100,19 @@ class BindingMode:
         # Receptor-bound ions and cofactors present in the complex.
         # Each entry is a string "RESNAME:CHAIN:RESNUM", e.g. "MG:A:101".
         self.receptor_cofactors: List[str] = []
+        # DiFT torsional potentials of the ligand's rotatable bonds (optional).
+        # When empty, torsional contributions are exactly zero and the binding
+        # mode behaves as a pure configurational ensemble.
+        self._torsional_bonds: List[RotatableBondTorsion] = []
+        # Representative dihedral state (radians) used for the torsional energy
+        # term. May be None: the confinement −TΔS penalty is state-independent
+        # and is still applied, while the energy term contributes zero.
+        self._torsional_dihedrals: Optional[List[float]] = None
+        self._cached_torsional: Optional[TorsionalScore] = None
 
     def _invalidate_cache(self) -> None:
         self._cached_thermo = None
+        self._cached_torsional = None
 
     def _compute_python_thermo(self) -> Thermodynamics:
         """Compute thermodynamics from pose energies using StatMechEngine."""
@@ -100,15 +131,125 @@ class BindingMode:
         self._cached_thermo = engine.compute()
         return self._cached_thermo
 
+    # ── DiFT torsional contribution ─────────────────────────────────────────
+
+    def set_torsional_potentials(
+            self,
+            bonds: Sequence[RotatableBondTorsion],
+            dihedral_angles_rad: Optional[Sequence[float]] = None) -> None:
+        """Attach DiFT torsional potentials for the ligand's rotatable bonds.
+
+        Each bond carries a DiFT-parametrized :class:`~flexaidds.dift.\
+TorsionalPotential` (from a QM scan or a Boltzmann-inverted coarse-grained
+        dihedral histogram). Once attached, this binding mode's ``free_energy``,
+        ``enthalpy``, and ``entropy`` include the torsional contribution.
+
+        Args:
+            bonds: Per-rotatable-bond DiFT potentials.
+            dihedral_angles_rad: Representative dihedral value (radians) of each
+                bond, in the same order as *bonds* — typically the dihedral
+                state of the mode's best pose. Drives the torsional *energy*
+                term; if *None*, only the state-independent confinement −TΔS
+                penalty is applied (the energy term is zero). Must match the
+                length of *bonds* to be used.
+        """
+        self._torsional_bonds = list(bonds)
+        self._torsional_dihedrals = (
+            list(dihedral_angles_rad) if dihedral_angles_rad is not None else None)
+        self._cached_torsional = None
+
+    def set_torsional_profiles(
+            self,
+            profiles: Sequence[Sequence[float]],
+            dihedral_angles_rad: Optional[Sequence[float]] = None,
+            temperature_K: Optional[float] = None,
+            max_multiplicity: int = 6) -> None:
+        """Attach torsional potentials by DiFT-parametrizing raw profiles.
+
+        Convenience wrapper over :func:`~flexaidds.dift.make_bond_torsion`:
+        each entry of *profiles* is an M-point torsional energy profile over
+        [0, 2π) (a QM scan or a Boltzmann-inverted CG histogram) which is
+        transformed and Shannon-collapse truncated on the spot.
+
+        Args:
+            profiles: One torsional profile per rotatable bond.
+            dihedral_angles_rad: Representative dihedral of each bond (radians);
+                see :meth:`set_torsional_potentials`.
+            temperature_K: Temperature for the DiFT fit; defaults to this
+                mode's temperature.
+            max_multiplicity: Anti-overfit cap on Fourier multiplicity.
+        """
+        temp = self._temperature if temperature_K is None else temperature_K
+        bonds = [
+            make_bond_torsion(profile, gene_index=i, temperature_K=temp,
+                              max_multiplicity=max_multiplicity)
+            for i, profile in enumerate(profiles)
+        ]
+        self.set_torsional_potentials(bonds, dihedral_angles_rad)
+
+    @property
+    def torsional_score(self) -> TorsionalScore:
+        """Decomposed torsional contribution (kcal/mol) of the attached bonds.
+
+        ``energy`` is Σ V_tors,b(φ_b) relative to each well minimum (zero unless
+        representative dihedral angles were supplied); ``minus_TS`` is the
+        confinement −TΔS penalty, well-defined from the potentials alone.
+        Returns an all-zero score when no potentials are attached.
+        """
+        if self._cached_torsional is not None:
+            return self._cached_torsional
+
+        bonds = self._torsional_bonds
+        angles = self._torsional_dihedrals
+        if not bonds:
+            score = TorsionalScore()
+        elif angles is not None and len(angles) == len(bonds):
+            # Full energy + entropy from the representative dihedral state.
+            score = score_torsional(bonds, angles, self._temperature)
+        else:
+            # No (or mismatched) dihedral state: apply only the state-independent
+            # confinement −TΔS penalty; leave the energy term at zero.
+            engine = DiFTEngine(self._temperature)
+            score = TorsionalScore()
+            for bond in bonds:
+                score.minus_TS += engine.thermodynamics(bond.potential).minus_TS
+                score.n_bonds += 1
+        self._cached_torsional = score
+        return score
+
+    @property
+    def torsional_free_energy(self) -> float:
+        """Torsional free-energy contribution ΔG_tors (kcal/mol).
+
+        ``Σ_b [V_tors,b(φ_b) − T·S_tors,b]`` — energy at the representative
+        dihedral state plus the confinement entropy penalty. Zero when no
+        DiFT potentials are attached.
+        """
+        return self.torsional_score.total()
+
+    @property
+    def torsional_entropy(self) -> float:
+        """Torsional entropy S_tors (kcal mol⁻¹ K⁻¹), ≤ 0 (a confinement loss).
+
+        Derived from the same Fourier spectra as the torsional energy; zero
+        when no DiFT potentials are attached.
+        """
+        # minus_TS = −T·S_tors  ⇒  S_tors = −minus_TS / T.
+        return -self.torsional_score.minus_TS / self._temperature
+
     def get_thermodynamics(self) -> Thermodynamics:
         """Get full thermodynamic properties of this binding mode.
+
+        When DiFT torsional potentials are attached, the returned free energy,
+        enthalpy (``mean_energy``), and entropy include the torsional
+        contribution on top of the configurational ensemble.
 
         Returns:
             Thermodynamics object with F, S, H, Cv, etc.
         """
         if self._cpp_mode is not None:
             thermo_cpp = self._cpp_mode.get_thermodynamics()
-            return Thermodynamics(
+            base = Thermodynamics(
                 temperature=thermo_cpp.temperature,
                 log_Z=thermo_cpp.log_Z,
                 free_energy=thermo_cpp.free_energy,
@@ -118,28 +259,52 @@ class BindingMode:
                 entropy=thermo_cpp.entropy,
                 std_energy=thermo_cpp.std_energy,
             )
-        return self._compute_python_thermo()
+        else:
+            base = self._compute_python_thermo()
+        return self._with_torsional(base)
+
+    def _with_torsional(self, base: Thermodynamics) -> Thermodynamics:
+        """Fold the torsional contribution into a configurational Thermodynamics.
+
+        Returns *base* unchanged when no torsional potentials are attached, so
+        the pure-configurational path is untouched.
+        """
+        score = self.torsional_score
+        if score.n_bonds == 0:
+            return base
+        return replace(
+            base,
+            free_energy=base.free_energy + score.total(),
+            mean_energy=base.mean_energy + score.energy,
+            entropy=base.entropy + self.torsional_entropy,
+        )
 
     @property
     def free_energy(self) -> float:
-        """Helmholtz free energy F = -kT ln Z (kcal/mol)."""
+        """Helmholtz free energy F = -kT ln Z (kcal/mol), incl. torsional term."""
         if self._cpp_mode:
-            return self._cpp_mode.get_free_energy()
-        return self._compute_python_thermo().free_energy
+            base = self._cpp_mode.get_free_energy()
+        else:
+            base = self._compute_python_thermo().free_energy
+        return base + self.torsional_free_energy
 
     @property
     def enthalpy(self) -> float:
-        """Boltzmann-weighted average energy ⟨E⟩ (kcal/mol)."""
+        """Boltzmann-weighted average energy ⟨E⟩ (kcal/mol), incl. torsional."""
         if self._cpp_mode:
-            return self._cpp_mode.compute_enthalpy()
-        return self._compute_python_thermo().mean_energy
+            base = self._cpp_mode.compute_enthalpy()
+        else:
+            base = self._compute_python_thermo().mean_energy
+        return base + self.torsional_score.energy
 
     @property
     def entropy(self) -> float:
-        """Configurational entropy S (kcal mol⁻¹ K⁻¹)."""
+        """Entropy S (kcal mol⁻¹ K⁻¹) — configurational plus torsional."""
         if self._cpp_mode:
-            return self._cpp_mode.compute_entropy()
-        return self._compute_python_thermo().entropy
+            base = self._cpp_mode.compute_entropy()
+        else:
+            base = self._compute_python_thermo().entropy
+        return base + self.torsional_entropy
 
     @property
     def n_poses(self) -> int:

--- a/python/tests/test_docking.py
+++ b/python/tests/test_docking.py
@@ -507,3 +507,102 @@ class TestComputeGlobalThermodynamics:
         result = pop.compute_global_thermodynamics()
         # Ensemble F ≤ min(E) for canonical ensemble
         assert result.free_energy <= -9.0
+
+
+# ── DiFT torsional integration into BindingMode ────────────────────────────────
+
+class TestBindingModeTorsional:
+    """The DiFT torsional free-energy / entropy contribution folds into a
+    BindingMode additively and opt-in: absent attached potentials the mode is a
+    pure configurational ensemble; attaching them adds a first-principles ΔS."""
+
+    @staticmethod
+    def _cosine_profile(n=128, k=1, amp=3.0, phase=math.pi):
+        """A single-cosine torsional profile over [0, 2π): a confined bond."""
+        return [amp * math.cos(k * (2.0 * math.pi * j / n) - phase)
+                for j in range(n)]
+
+    def _confined_mode(self):
+        mode = BindingMode(cpp_binding_mode=None)
+        mode._poses = [Pose(0, -10.0), Pose(1, -9.0)]
+        return mode
+
+    def test_no_torsional_by_default(self):
+        mode = self._confined_mode()
+        assert mode.torsional_free_energy == 0.0
+        assert mode.torsional_entropy == 0.0
+        assert mode.torsional_score.n_bonds == 0
+
+    def test_free_energy_unchanged_without_potentials(self):
+        mode = self._confined_mode()
+        f_config = mode.free_energy
+        # Attaching an empty list keeps it a pure configurational ensemble.
+        mode.set_torsional_potentials([])
+        assert mode.free_energy == f_config
+
+    def test_confinement_penalty_is_positive(self):
+        mode = self._confined_mode()
+        f_config = mode.free_energy
+        mode.set_torsional_profiles([self._cosine_profile()])
+        # A confined bond loses entropy → −TΔS > 0 → free energy rises.
+        assert mode.torsional_free_energy > 0.0
+        assert mode.torsional_entropy < 0.0
+        assert mode.free_energy > f_config
+
+    def test_energy_term_needs_dihedral_state(self):
+        mode = self._confined_mode()
+        # Without dihedral angles: only the state-independent −TΔS penalty.
+        mode.set_torsional_profiles([self._cosine_profile()])
+        assert mode.torsional_score.energy == 0.0
+        assert mode.torsional_score.minus_TS > 0.0
+
+    def test_energy_rises_away_from_well_minimum(self):
+        # Profile amp·cos(φ − π) = −amp·cos φ: minimum at φ = 0, maximum at φ = π.
+        prof = self._cosine_profile(amp=4.0, phase=math.pi)
+        m_min = self._confined_mode()
+        m_min.set_torsional_profiles([prof], dihedral_angles_rad=[0.0])
+        m_top = self._confined_mode()
+        m_top.set_torsional_profiles([prof], dihedral_angles_rad=[math.pi])
+        assert m_top.torsional_score.energy > m_min.torsional_score.energy + 1.0
+
+    def test_get_thermodynamics_includes_torsional(self):
+        mode = self._confined_mode()
+        base = mode.get_thermodynamics()
+        mode.set_torsional_profiles([self._cosine_profile()])
+        withtors = mode.get_thermodynamics()
+        assert withtors.free_energy > base.free_energy
+        assert withtors.entropy < base.entropy  # torsional entropy is a loss
+        assert withtors.temperature == base.temperature
+
+    def test_free_rotor_adds_nothing(self):
+        mode = self._confined_mode()
+        f_config = mode.free_energy
+        # A flat profile (V ≡ const) is a free rotor: zero excess entropy.
+        mode.set_torsional_profiles([[0.0] * 64])
+        assert abs(mode.torsional_free_energy) < 1e-9
+        assert abs(mode.free_energy - f_config) < 1e-9
+
+    def test_two_bonds_penalize_more_than_one(self):
+        prof = self._cosine_profile()
+        one = self._confined_mode()
+        one.set_torsional_profiles([prof])
+        two = self._confined_mode()
+        two.set_torsional_profiles([prof, prof])
+        assert two.torsional_free_energy > one.torsional_free_energy
+        assert two.torsional_score.n_bonds == 2
+
+    def test_set_potentials_directly(self):
+        from flexaidds.dift import make_bond_torsion
+        mode = self._confined_mode()
+        rbt = make_bond_torsion(self._cosine_profile(), gene_index=0)
+        mode.set_torsional_potentials([rbt], dihedral_angles_rad=[0.0])
+        assert mode.torsional_score.n_bonds == 1
+        assert mode.torsional_score.minus_TS > 0.0
+
+    def test_result_is_cached_until_reset(self):
+        mode = self._confined_mode()
+        mode.set_torsional_profiles([self._cosine_profile()])
+        first = mode.torsional_score
+        assert mode.torsional_score is first  # cached identity
+        mode.set_torsional_profiles([self._cosine_profile(), self._cosine_profile()])
+        assert mode.torsional_score is not first  # reset on re-attach


### PR DESCRIPTION
## Summary

The DiFT (Discrete Fourier Transform torsional parametrization) module was already complete and tested — engine (`LIB/DiFT/`), GA adapter, CLI, pybind11 bindings, pure-Python mirror, CMake/CI wiring — but **nothing in the docking pipeline actually consumed it**. This PR integrates DiFT where it is scientifically valid: the entropy accounting of `BindingMode`.

`BindingMode` previously reported only *configurational* thermodynamics from the pose-energy ensemble and ignored ligand torsional entropy — the classical "crude per-rotatable-bond count" penalty DiFT was written to replace. Now a binding mode can carry per-bond DiFT torsional potentials, and their `energy + (−TΔS)` folds additively into the reported free energy, enthalpy, and entropy — a first-principles 1-D torsional ΔS derived from the same Fourier spectrum that parametrizes the torsional energy.

- `BindingMode.set_torsional_potentials(bonds, dihedral_angles_rad=None)` — attach DiFT `RotatableBondTorsion` potentials.
- `BindingMode.set_torsional_profiles(profiles, dihedral_angles_rad=None, ...)` — convenience: parametrize raw torsional profiles (QM scans or Boltzmann-inverted coarse-grained dihedral histograms) on the spot.
- New `torsional_score`, `torsional_free_energy`, `torsional_entropy` accessors; the term folds into `free_energy`, `enthalpy`, `entropy`, and `get_thermodynamics()`.

**Graceful / opt-in:** with no potentials attached the torsional terms are exactly zero and a mode remains a pure configurational ensemble, so existing behavior is unchanged. The energy term uses the representative pose's dihedral state; the confinement −TΔS penalty is state-independent and applied even without dihedral angles.

## Scope

- [x] Core 1.0 supported surface
- [ ] Experimental surface only
- [ ] Documentation only
- [ ] CI / release engineering
- [ ] Security hardening
- [ ] Benchmark / reproducibility

## Release impact

- [ ] affects CLI behavior
- [x] affects Python package behavior
- [ ] affects configuration schema or defaults
- [ ] affects benchmark or metric reporting
- [ ] affects installation instructions

New additive Python API on `BindingMode`; no change to defaults or to modes that do not attach torsional potentials.

## Validation

- [x] unit tests
- [ ] integration tests
- [ ] smoke benchmark
- [x] documentation review
- [ ] manual validation

Added `TestBindingModeTorsional` (10 cases) covering: default no-op behavior, confinement penalty sign, energy rising away from the well minimum, free-rotor zero contribution, two-bond additivity, caching/reset, and `get_thermodynamics()` folding. Full Python suite: **941 passed, 72 skipped** (skips are the `@requires_core` C++-binding tests). Targeted `test_docking.py` + `test_dift.py`: 102 passed, 1 skipped. Repo hygiene check clean.

## Security and safety

- [x] no new third-party dependency
- [ ] third-party dependency added and documented
- [x] no known security-sensitive parsing change
- [ ] security-sensitive parsing change reviewed

## Reproducibility

- [x] no benchmark claim involved
- [ ] benchmark claim updated with reproducibility artifact
- [ ] benchmark language remains preliminary

## Notes

Integration is deliberately at the Python thermodynamics layer rather than the C++ GA inner loop: DiFT needs a real per-bond torsional profile (QM/CG), which the Python `docking` layer lets a caller supply, whereas the C++ fitness path has no profile source at docking time and `score_torsional` integrates a 1440-point partition function per bond per call — unsuitable for the GA hot loop. No C++ files were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuDr6w56vN9B7p4W6wUXZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuDr6w56vN9B7p4W6wUXZx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional torsional potential support to binding-mode thermodynamics.
  * Torsional profiles can now be attached directly or generated from torsional data.
  * Exposed torsional free-energy, entropy, and scoring results.
  * Thermodynamic calculations now include torsional contributions when configured, while remaining unchanged by default.

* **Documentation**
  * Updated DiFT documentation to describe its integration with docking thermodynamics and opt-in behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->