### PR TITLE
Fix: PyPI and Homebrew installers + update paths

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -38,6 +38,13 @@ jobs:
         working-directory: python
         run: python -m build --sdist --outdir ../dist
 
+      - name: Verify sdist installs (pure-Python fallback OK)
+        run: |
+          python -m pip install dist/*.tar.gz
+          python -c "import flexaidds as fd; print('flexaidds', fd.__version__, 'HAS_CORE=', getattr(fd, 'HAS_CORE_BINDINGS', False))"
+          python -m flexaidds --help
+          python -m flexaidds --check-update || true
+
       - name: Upload sdist artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -66,32 +73,37 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install --upgrade pip cibuildwheel
 
-      # Provide Eigen headers for the extension build inside the isolated environments.
-      # We download a known-good version (header-only) and point setup.py at it via env var.
-      - name: Configure Eigen + cibuildwheel environment (Linux)
-        if: runner.os == 'Linux'
+      # Provide Eigen headers before the isolated wheel builds. setup.py reads
+      # EIGEN_INCLUDE_DIR; if missing it falls back to pure-Python wheels.
+      - name: Install Eigen headers
+        shell: bash
         run: |
-          echo "CIBW_BEFORE_ALL_LINUX=curl -sL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz | tar xz -C /tmp" >> $GITHUB_ENV
-          echo "CIBW_ENVIRONMENT_LINUX=EIGEN_INCLUDE_DIR=/tmp/eigen-3.4.0" >> $GITHUB_ENV
-
-      - name: Configure Eigen + cibuildwheel environment (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          echo "CIBW_BEFORE_ALL_MACOS=curl -sL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz | tar xz -C /tmp" >> $GITHUB_ENV
-          echo "CIBW_ENVIRONMENT_MACOS=EIGEN_INCLUDE_DIR=/tmp/eigen-3.4.0" >> $GITHUB_ENV
-
-      - name: Configure Eigen + cibuildwheel environment (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $before = @'
-powershell -Command "Invoke-WebRequest -Uri https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz -OutFile $env:TEMP\eigen.tar.gz; tar -xzf $env:TEMP\eigen.tar.gz -C $env:TEMP"
-'@
-          "CIBW_BEFORE_ALL_WINDOWS=$before" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "CIBW_ENVIRONMENT_WINDOWS=EIGEN_INCLUDE_DIR=$env:TEMP\eigen-3.4.0" | Out-File -FilePath $env:GITHUB_ENV -Append
+          set -euo pipefail
+          EIGEN_ROOT="${RUNNER_TEMP}/eigen-3.4.0"
+          curl -sL "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz" \
+            | tar xz -C "${RUNNER_TEMP}"
+          test -f "${EIGEN_ROOT}/Eigen/Dense"
+          {
+            echo "EIGEN_INCLUDE_DIR=${EIGEN_ROOT}"
+            echo "CIBW_ENVIRONMENT=EIGEN_INCLUDE_DIR=${EIGEN_ROOT}"
+          } >> "$GITHUB_ENV"
 
       - name: Build wheels with cibuildwheel
         run: python -m cibuildwheel --output-dir wheelhouse python
+
+      - name: Smoke-test built wheels
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          shopt -s nullglob
+          wheels=(wheelhouse/*.whl)
+          if [ ${#wheels[@]} -eq 0 ]; then
+            echo "No wheels produced" >&2
+            exit 1
+          fi
+          python -m pip install "${wheels[0]}"
+          python -c "import flexaidds as fd; print('flexaidds', fd.__version__, 'HAS_CORE=', getattr(fd, 'HAS_CORE_BINDINGS', False))"
 
       - name: Upload wheels artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -111,7 +123,7 @@ powershell -Command "Invoke-WebRequest -Uri https://gitlab.com/libeigen/eigen/-/
       url: https://pypi.org/project/flexaidds
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           path: dist
           merge-multiple: true
@@ -129,7 +141,7 @@ powershell -Command "Invoke-WebRequest -Uri https://gitlab.com/libeigen/eigen/-/
       url: https://test.pypi.org/project/flexaidds
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -32,24 +32,77 @@ jobs:
           python-version: "3.11"
 
       - name: Install build tools
-        run: python -m pip install --upgrade pip build
+        run: python -m pip install --upgrade pip build twine
 
       - name: Build sdist
         working-directory: python
         run: python -m build --sdist --outdir ../dist
 
+      - name: Twine check sdist
+        run: python -m twine check dist/*.tar.gz
+
       - name: Verify sdist installs (pure-Python fallback OK)
         run: |
-          python -m pip install dist/*.tar.gz
+          set -euo pipefail
+          python -m venv /tmp/flexaidds-sdist-venv
+          # shellcheck disable=SC1091
+          source /tmp/flexaidds-sdist-venv/bin/activate
+          python -m pip install --upgrade pip
+          # Force pure-Python path so CI does not depend on a C++26 toolchain.
+          FLEXAIDDS_SKIP_CORE=1 python -m pip install dist/*.tar.gz
           python -c "import flexaidds as fd; print('flexaidds', fd.__version__, 'HAS_CORE=', getattr(fd, 'HAS_CORE_BINDINGS', False))"
           python -m flexaidds --help
           python -m flexaidds --check-update || true
+          test "$(python -c 'import flexaidds; print(flexaidds.__version__)')" = "2.0.0" \
+            || python -c "import flexaidds as fd; assert fd.__version__, fd.__version__"
 
       - name: Upload sdist artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sdist
           path: dist/*.tar.gz
+          retention-days: 5
+
+  # Guaranteed universal wheel so `pip install flexaidds` works without a
+  # C++ compiler on any platform (accelerated wheels are additive).
+  build-pure-wheel:
+    name: Build pure-Python wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build pure-Python wheel
+        working-directory: python
+        env:
+          FLEXAIDDS_SKIP_CORE: "1"
+        run: python -m build --wheel --outdir ../dist
+
+      - name: Twine check + smoke install
+        run: |
+          set -euo pipefail
+          python -m twine check dist/*.whl
+          python -m venv /tmp/flexaidds-pure-venv
+          # shellcheck disable=SC1091
+          source /tmp/flexaidds-pure-venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python -c "import flexaidds as fd; print('flexaidds', fd.__version__, 'HAS_CORE=', getattr(fd, 'HAS_CORE_BINDINGS', False)); assert not fd.HAS_CORE_BINDINGS"
+          python -m flexaidds --help
+
+      - name: Upload pure wheel artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: wheels-pure
+          path: dist/*.whl
           retention-days: 5
 
   build-wheels:
@@ -73,9 +126,10 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install --upgrade pip cibuildwheel
 
-      # Provide Eigen headers before the isolated wheel builds. setup.py reads
-      # EIGEN_INCLUDE_DIR; if missing it falls back to pure-Python wheels.
-      - name: Install Eigen headers
+      # Eigen for native (macOS/Windows) host builds. Linux cibuildwheel runs
+      # inside manylinux containers, so Eigen must be fetched with BEFORE_ALL.
+      - name: Install Eigen headers (host)
+        if: runner.os != 'Linux'
         shell: bash
         run: |
           set -euo pipefail
@@ -86,6 +140,16 @@ jobs:
           {
             echo "EIGEN_INCLUDE_DIR=${EIGEN_ROOT}"
             echo "CIBW_ENVIRONMENT=EIGEN_INCLUDE_DIR=${EIGEN_ROOT}"
+          } >> "$GITHUB_ENV"
+
+      - name: Configure Eigen for manylinux containers
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "CIBW_BEFORE_ALL_LINUX=curl -sL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz | tar xz -C /tmp && test -f /tmp/eigen-3.4.0/Eigen/Dense"
+            echo "CIBW_ENVIRONMENT_LINUX=EIGEN_INCLUDE_DIR=/tmp/eigen-3.4.0"
           } >> "$GITHUB_ENV"
 
       - name: Build wheels with cibuildwheel
@@ -114,7 +178,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [build-sdist, build-wheels]
+    needs: [build-sdist, build-pure-wheel, build-wheels]
     runs-on: ubuntu-latest
     # Only publish on actual releases or when manually requested for pypi
     if: (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi')
@@ -128,12 +192,23 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: List packages to publish
+        run: |
+          set -euo pipefail
+          ls -la dist/
+          python - <<'PY'
+          from pathlib import Path
+          files = sorted(Path("dist").glob("*"))
+          assert files, "no artifacts to publish"
+          print("\n".join(str(p) for p in files))
+          PY
+
       - name: Publish to PyPI (trusted publishing)
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.10.3
 
   publish-testpypi:
     name: Publish to TestPyPI (manual or pre-release)
-    needs: [build-sdist, build-wheels]
+    needs: [build-sdist, build-pure-wheel, build-wheels]
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi'
     environment:
@@ -145,6 +220,17 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+
+      - name: List packages to publish
+        run: |
+          set -euo pipefail
+          ls -la dist/
+          python - <<'PY'
+          from pathlib import Path
+          files = sorted(Path("dist").glob("*"))
+          assert files, "no artifacts to publish"
+          print("\n".join(str(p) for p in files))
+          PY
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.10.3

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ build/
 .eggs/
 *.so
 *.dylib
+# Staged by sdist only inside the release tree — never commit a local copy
+python/LIB/
 
 # C++ build artifacts
 build/

--- a/Formula/flexaidds.rb
+++ b/Formula/flexaidds.rb
@@ -1,22 +1,26 @@
 class Flexaidds < Formula
   desc "Entropy-driven molecular docking engine (FlexAID + ΔS thermodynamic analysis)"
   homepage "https://github.com/LeBonhommePharma/FlexAIDdS"
+  url "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/v2.0.0.tar.gz"
+  sha256 "31488777f361bb02cb29df7a5e65e62cea15434e451bb574a14b10e702ae21e3"
   license "Apache-2.0"
   head "https://github.com/LeBonhommePharma/FlexAIDdS.git", branch: "master"
-  # Stable releases will be added here with proper tarball + sha256 when cutting releases.
-  # For now the formula is optimized for `brew install --HEAD ...` and direct formula URLs.
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
 
   depends_on "cmake" => :build
   depends_on "ninja" => :build
   depends_on "eigen"
   depends_on "libomp" if OS.mac?
-  depends_on "python@3.11" => :recommended # for the flexaidds Python package (recommended install separately via pip too)
 
   def install
     # Build the main tools. Focus on the fast optimized FlexAIDdS binary,
     # the tENCoM tool, and legacy FlexAID for compatibility.
     args = std_cmake_args + %W[
-      -G Ninja
+      -GNinja
       -DCMAKE_BUILD_TYPE=Release
       -DBUILD_TESTING=OFF
       -DBUILD_PYTHON_BINDINGS=OFF
@@ -29,7 +33,7 @@ class Flexaidds < Formula
 
     if OS.mac?
       # Help CMake find Homebrew's libomp (keg-only)
-      libomp = Formula["libomp"].opt_prefix
+      libomp = formula_opt_prefix("libomp")
       args += %W[
         -DOpenMP_C_FLAGS=-Xpreprocessor\ -fopenmp\ -I#{libomp}/include
         -DOpenMP_C_LIB_NAMES=omp
@@ -45,11 +49,11 @@ class Flexaidds < Formula
     # The build system stages runtime data files (MC_*.dat, AMINO.def, etc.)
     # next to the built binaries via POST_BUILD rules. Install them together
     # so relative-path lookup in the executables succeeds out of the box.
-    bin.install "build/FlexAIDdS"
-    bin.install "build/tENCoM"
+    bin.install "build/FlexAIDdS" if File.exist?("build/FlexAIDdS")
+    bin.install "build/tENCoM" if File.exist?("build/tENCoM")
     bin.install "build/FlexAID" if File.exist?("build/FlexAID")
 
-    # Install co-located data files (staged by the build)
+    # Install co-located data files (staged by the build).
     # These are looked up relative to the executable directory.
     bin.install Dir["build/MC_*.dat"]
     bin.install "build/AMINO.def" if File.exist?("build/AMINO.def")
@@ -60,7 +64,7 @@ class Flexaidds < Formula
     bin.install "build/flexaids_process_ligand" if File.exist?("build/flexaids_process_ligand")
     bin.install "build/tencom_entropy_diff" if File.exist?("build/tencom_entropy_diff")
 
-    # Note: The Python package "flexaidds" is best installed via pip:
+    # NOTE: The Python package "flexaidds" is best installed via pip:
     #   pip install flexaidds
     # This formula focuses on the high-performance native CLI tools.
   end
@@ -75,8 +79,12 @@ class Flexaidds < Formula
       For the Python package (analysis, results loader, thermodynamics):
         pip install flexaidds
 
-      To use the full Python + native integration, install the Python package
-      after this formula.
+      To upgrade the Python package later:
+        pip install --upgrade flexaidds
+        # or: python -m flexaidds --self-update
+
+      To rebuild the latest development tip of this formula:
+        brew reinstall --HEAD flexaidds
 
       Example usage:
         FlexAIDdS receptor.pdb ligand.mol2
@@ -85,10 +93,8 @@ class Flexaidds < Formula
   end
 
   test do
-    # Basic smoke test - the binaries should exist and report something
-    assert_predicate bin/"FlexAIDdS", :exist?
-    # Most of these tools accept -h or --help; fall back to existence + basic run
-    system "#{bin}/FlexAIDdS", "--help" if (bin/"FlexAIDdS").exist?
-    assert_predicate bin/"tENCoM", :exist?
+    assert_path_exists bin/"FlexAIDdS"
+    system bin/"FlexAIDdS", "--help"
+    assert_path_exists bin/"tENCoM"
   end
 end

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ run = fd.load_results("path/to/results")
 ### macOS: Homebrew (native CLI tools)
 
 ```bash
-brew install --HEAD --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+# Stable release, or add --HEAD for tip-of-tree
+brew install --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
 pip install flexaidds   # Python package (recommended)
+# later: pip install --upgrade flexaidds   # or: python -m flexaidds --self-update
 ```
 
 See [docs/INSTALLATION.md](docs/INSTALLATION.md) for conda, PyPI, Windows, and full platform instructions. The Python package and native tools can be installed independently.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -34,9 +34,11 @@ Complete build and installation instructions for FlexAID∆S on all supported pl
 
 ### Python package via pip (easiest for analysis, results, thermodynamics)
 
-From a released version on PyPI (recommended once published):
+From a released version on PyPI:
 ```bash
 pip install flexaidds
+# later: pip install --upgrade flexaidds
+# or:    python -m flexaidds --self-update
 ```
 
 From source (for development or latest):
@@ -45,17 +47,23 @@ git clone https://github.com/LeBonhommePharma/FlexAIDdS.git && cd FlexAIDdS
 pip install -e ./python
 ```
 
+Direct from GitHub (when you want tip-of-tree without a local clone):
+```bash
+pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
+```
+
 - Installs the `flexaidds` package (and the `flexaidds` + `flexaidds-benchmark` CLIs).
-- The native C++ extension (`_core`) is **optional**. If build tools/Eigen are missing the package still installs and works in pure-Python mode (with fallbacks).
+- The native C++ extension (`_core`) is **optional**. If build tools/Eigen are missing **or** compilation fails, the package still installs and works in pure-Python mode (with fallbacks). Set `FLEXAIDDS_SKIP_CORE=1` to force pure-Python.
 - Works from PyPI, sdist, git, or local checkout.
 
 Verify:
 ```bash
 python -c "import flexaidds as fd; print(fd.__version__, 'HAS_CORE=', getattr(fd, 'HAS_CORE_BINDINGS', False))"
 python -m flexaidds --help || echo "CLI works via python -m"
+python -m flexaidds --check-update
 ```
 
-A GitHub Actions workflow (`.github/workflows/pypi-release.yml`) handles building wheels + sdist and publishing via trusted publishing on release.
+A GitHub Actions workflow (`.github/workflows/pypi-release.yml`) handles building wheels + sdist and publishing via trusted publishing on release (or manual `workflow_dispatch` to TestPyPI/PyPI).
 
 ### Full native tools + Python (CMake)
 
@@ -107,8 +115,16 @@ cmake --build build --parallel
 #### Easy install via Homebrew (recommended for native CLI tools)
 
 ```bash
-# Latest development version
+# Stable tagged release (v2.0.0+)
+brew install --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+
+# Or latest development tip
 brew install --HEAD --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+
+# Update later
+brew reinstall --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+# or, for HEAD builds:
+brew reinstall --HEAD --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
 ```
 
 This installs `FlexAIDdS`, `tENCoM`, `FlexAID` + required data files.
@@ -169,6 +185,9 @@ See also `python/README.md`.
 The formula provides the high-performance native executables with data files staged correctly:
 
 ```bash
+# Stable release
+brew install --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+
 # Development / latest
 brew install --HEAD --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
 
@@ -176,17 +195,29 @@ brew install --HEAD --formula https://raw.githubusercontent.com/LeBonhommePharma
 pip install flexaidds
 ```
 
-The formula lives at `Formula/flexaidds.rb`. It is currently source-based (HEAD) for the latest code. Bottles may be added later.
+The formula lives at `Formula/flexaidds.rb`. It supports both a stable `url`/`sha256` (tagged release) and `head` for tip-of-tree. Bottles may be added later.
+
+When cutting a new stable release, update the formula’s `url`, `sha256`, and version together:
+```bash
+# Example maintainer steps
+TAG=v2.0.1
+curl -sL "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/${TAG}.tar.gz" | shasum -a 256
+# paste sha256 into Formula/flexaidds.rb, commit, push
+```
 
 ---
 
 ## Releasing & Distribution
 
-- **Python package (PyPI)**: The workflow `.github/workflows/pypi-release.yml` builds sdist + wheels (cibuildwheel) and publishes on GitHub Release using trusted publishing. Run the workflow manually for TestPyPI.
+- **Python package (PyPI)**: The workflow `.github/workflows/pypi-release.yml` builds sdist + wheels (cibuildwheel) and publishes on GitHub Release using trusted publishing. Run the workflow manually (`workflow_dispatch`) for TestPyPI. The optional `_core` extension is built when possible; otherwise pure-Python wheels/sdists still publish.
+  - Required once per environment: configure PyPI / TestPyPI **trusted publishing** for the `pypi` and `testpypi` GitHub Environments.
+  - Smoke checks: sdist install + `import flexaidds` run in CI before publish.
 
-- **Homebrew**: Update `Formula/flexaidds.rb` (version/sha for stable, HEAD for dev) when cutting releases. Users install via the raw URL or a tap.
+- **Homebrew**: Update `Formula/flexaidds.rb` (`url` + `sha256` for stable; `head` tracks `master`) when cutting releases. Users install via the raw formula URL (or a personal tap).
 
 - **Native binaries**: Existing release workflow attaches platform archives on tag.
+
+- **In-package updater**: `python -m flexaidds --check-update` / `--self-update` uses the GitHub Releases API and `pip install --upgrade flexaidds`.
 
 ---
 

--- a/python/LICENSE
+++ b/python/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,32 +1,25 @@
 # MANIFEST.in for flexaidds Python package sdist
-# Ensures C++ sources for the pybind11 extension are included so that
-# `pip install` from sdist or git (without the full repo checkout layout)
-# can still compile the accelerated _core extension.
+# C++ sources for the optional _core extension are staged by setup.py's
+# sdist_with_lib command from ../LIB (or FLEXAIDDS_LIB_DIR) into LIB/ inside
+# the sdist. Paths below cover in-tree files only.
 
 include flexaidds/py.typed
-recursive-include flexaidds/dataset_runner datasets *.yaml
-
-# C++ sources and headers required to build the _core extension.
-# These live one level up in the repo (../LIB) when developing from python/.
-# When building an sdist the files are included at the expected relative paths.
-recursive-include ../LIB *.cpp *.c *.cu
-recursive-include ../LIB *.h *.hpp *.cuh *.hh
-recursive-include ../LIB tENCoM *.cpp *.h
-recursive-include ../LIB ShannonThermoStack *.cpp *.h *.metal
-recursive-include ../LIB DiFT *.cpp *.h
-recursive-include ../LIB ChiralCenter *.cpp *.h
-recursive-include ../LIB LigandRingFlex *.cpp *.h
-include ../LIB/*.dat
-include ../LIB/*.def
-
-# Also include the pybind11 wrapper source explicitly (already covered by flexaidds/_core.cpp glob above but be explicit)
 include flexaidds/_core.cpp
-include bindings/*.cpp bindings/*.h
+include README.md
+include pyproject.toml
+include setup.py
 
-# License and readme for the sdist
-include ../LICENSE
-include ../THIRD_PARTY_LICENSES.md
-global-exclude __pycache__ *.py[cod] *~ .git* .DS_Store
+recursive-include flexaidds/dataset_runner/datasets *.yaml
+recursive-include bindings *.cpp *.h *.hpp
+
+# If LIB was pre-staged next to setup.py (e.g. by a packaging script), include it.
+recursive-include LIB *.cpp *.c *.h *.hpp *.hh *.cuh
+
+# License when present next to the package (copied by some packaging flows)
+include LICENSE
+include THIRD_PARTY_LICENSES.md
+
+global-exclude __pycache__ *.py[cod] *~ .git* .DS_Store *.so *.dylib *.pyd
 prune */__pycache__
 prune */*.egg-info
 prune build

--- a/python/README.md
+++ b/python/README.md
@@ -16,14 +16,19 @@ Higher-level live docking orchestration is still intentionally staged behind the
 ### With pip (recommended for most users)
 
 ```bash
-# From the repo root
+# From PyPI (released versions)
+pip install flexaidds
+pip install --upgrade flexaidds          # later updates
+python -m flexaidds --check-update       # or --self-update
+
+# From the repo root (development)
 pip install -e ./python
 
-# Or directly (also works for git URLs):
-# pip install -e /path/to/FlexAIDdS/python
+# From GitHub tip-of-tree
+pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
 ```
 
-This installs the `flexaidds` package. The compiled acceleration (`_core`) is built if the required build dependencies (pybind11, Eigen headers, a C++ compiler) are present. Otherwise the package installs successfully in **pure-Python fallback mode** (full result loading, models, pure-Python thermodynamics, etc. still work).
+This installs the `flexaidds` package. The compiled acceleration (`_core`) is built if the required build dependencies (pybind11, Eigen headers, a C++ compiler) are present. Otherwise the package installs successfully in **pure-Python fallback mode** (full result loading, models, pure-Python thermodynamics, etc. still work). Set `FLEXAIDDS_SKIP_CORE=1` to force pure-Python.
 
 You can also do a non-editable install after building a wheel:
 ```bash

--- a/python/THIRD_PARTY_LICENSES.md
+++ b/python/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,233 @@
+# Third-Party Licenses
+
+**FlexAID∆S** incorporates and depends on the following open-source components:
+
+---
+
+## Direct Dependencies
+
+### RDKit (BSD-3-Clause)
+
+**Project:** Open-source cheminformatics and machine learning toolkit  
+**License:** BSD 3-Clause License  
+**Source:** https://github.com/rdkit/rdkit  
+**Use in FlexAID∆S:** Molecular I/O, SMILES parsing, molecular property calculations
+
+```
+Copyright (c) 2006-2024, RDKit Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
+```
+
+---
+
+### Eigen (MPL 2.0) — vendored
+
+**Project:** C++ template library for linear algebra  
+**Version:** 3.4.0  
+**License:** Mozilla Public License 2.0  
+**Source:** https://gitlab.com/libeigen/eigen  
+**Vendored at:** `LIB/vendor/eigen/` (git submodule, pinned to tag `3.4.0`)  
+**Use in FlexAID∆S:** SIMD vectorization, matrix operations, eigenvalue decomposition, numerical stability
+
+Eigen is vendored directly in the repository as a git submodule so that the build works out-of-the-box on any platform without requiring `libeigen3-dev`, `brew install eigen`, or `choco install eigen`. A fresh clone with `git clone --recurse-submodules` is all that is needed.
+
+```
+Copyright (C) 2008-2024 Eigen Contributors
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+```
+
+**Note:** MPL 2.0 is a file-level copyleft license. Modified Eigen files must remain MPL 2.0. FlexAID∆S uses Eigen as an unmodified header-only dependency, maintaining compatibility with Apache-2.0.
+
+---
+
+### PyMOL (Python Software Foundation License)
+
+**Project:** Molecular visualization system  
+**License:** Python Software Foundation License (permissive)  
+**Source:** https://github.com/schrodinger/pymol-open-source  
+**Use in FlexAID∆S:** Optional visualization backend, PyMOL plugin integration
+
+```
+Copyright (c) 2001-2024 Schrodinger, LLC
+SPDX-License-Identifier: Python-2.0
+
+Python Software Foundation License Version 2
+```
+
+---
+
+## Build & Runtime Dependencies
+
+### CMake (BSD-3-Clause)
+
+**Project:** Cross-platform build system generator  
+**License:** BSD 3-Clause License  
+**Source:** https://cmake.org/  
+**Use in FlexAID∆S:** Build configuration, hardware detection
+
+---
+
+### OpenMP (Various)
+
+**Standard:** OpenMP API Specification  
+**License:** Implementation-specific (GCC: GPL with Runtime Exception, LLVM: Apache-2.0/MIT)  
+**Source:** https://www.openmp.org/  
+**Use in FlexAID∆S:** CPU parallelization, thread management
+
+**Note:** OpenMP runtime libraries include linking exceptions that permit use in non-GPL software. FlexAID∆S uses OpenMP directives without modifying compiler sources.
+
+---
+
+### CUDA Toolkit (NVIDIA EULA - Proprietary but Free)
+
+**Project:** NVIDIA GPU computing platform  
+**License:** NVIDIA End User License Agreement (free for research and commercial use)  
+**Source:** https://developer.nvidia.com/cuda-toolkit  
+**Use in FlexAID∆S:** Optional GPU acceleration on NVIDIA hardware
+
+**Note:** Not open source, but freely available. Distribution of CUDA binaries restricted by NVIDIA EULA. FlexAID∆S ships CUDA-compatible source code; users install CUDA Toolkit separately.
+
+---
+
+### Metal Framework (Apple Inc. - Free)
+
+**Project:** Apple GPU programming framework  
+**License:** Included with macOS SDK (free)  
+**Source:** https://developer.apple.com/metal/  
+**Use in FlexAID∆S:** Optional GPU acceleration on Apple Silicon (M1/M2/M3)
+
+**Note:** Proprietary but freely available on macOS. FlexAID∆S uses public Metal APIs.
+
+---
+
+## Scientific Methods & Parameters
+
+### FlexAID Core Method (Apache-2.0)
+
+**Original Project:** NRGlab/FlexAID  
+**License:** Apache License 2.0  
+**Source:** https://github.com/NRGlab/FlexAID  
+**Papers:**
+- Gaudreault & Najmanovich (2015). *J. Chem. Inf. Model.* 55(7):1323-36.  
+  DOI: [10.1021/acs.jcim.5b00078](https://doi.org/10.1021/acs.jcim.5b00078)
+
+**Use in FlexAID∆S:** Genetic algorithm docking engine, NATURaL scoring function parameters (40-SYBYL atom type interaction matrix), side-chain flexibility framework
+
+**Notes:**
+- FlexAID∆S is derived from the Apache-2.0 licensed FlexAID
+- Energy parameters (ε_ij values) are reused from original FlexAID
+- Original docking engine architecture extended with entropy calculations
+- Full Apache-2.0 compatibility maintained
+
+---
+
+### NRGRank Method (Scientific Inspiration Only - GPL-3.0)
+
+**Project:** NRGlab/NRGRank  
+**License:** GNU General Public License v3.0  
+**Source:** https://github.com/NRGlab/NRGRank (NOT INCLUDED AS DEPENDENCY)  
+**Paper:** Gaudreault et al. (bioRxiv preprint, 2024 - citation pending publication)
+
+**Relationship to FlexAID∆S:**
+- **Scientific inspiration:** NRGRank's cube screening algorithm informed FreeNRG design
+- **No code dependency:** FlexAID∆S and FreeNRG do NOT import, link to, or incorporate NRGRank code
+- **Clean-room implementation:** Methods reimplemented from published equations under Apache-2.0
+- **License isolation:** GPL-3.0 does not propagate to FlexAID∆S (see clean-room policy)
+
+**Why NRGRank is not a dependency:**
+- Copyright protects *expression* (code), not *ideas* (algorithms)
+- Published scientific methods are not copyrightable
+- Independent implementation from mathematical descriptions avoids GPL contamination
+- FlexAID∆S maintains full Apache-2.0 permissiveness
+
+**Citation in Scientific Work:**
+> "The ultra-HTS cube screening method was inspired by NRGRank (Gaudreault et al., bioRxiv 2024). FlexAID∆S reimplements this approach from first principles with Shannon entropy extensions."
+
+---
+
+## License Compatibility Summary
+
+| Component | License | Compatibility with Apache-2.0 | Distribution Status |
+|-----------|---------|-------------------------------|---------------------|
+| **FlexAID Core** | Apache-2.0 | ✅ Same license | Incorporated |
+| **RDKit** | BSD-3-Clause | ✅ Permissive | Dependency |
+| **Eigen** | MPL 2.0 | ✅ File-level copyleft | Header-only dependency |
+| **PyMOL** | PSF | ✅ Permissive | Optional dependency |
+| **OpenMP** | Runtime exception | ✅ Linking exception | Compiler built-in |
+| **CUDA** | NVIDIA EULA | ⚠️ Proprietary (free) | User installs separately |
+| **Metal** | Apple | ⚠️ Proprietary (free) | macOS built-in |
+| **libcurl** | curl (MIT/X-inspired) | ✅ Permissive | Optional dependency (dataset runner) |
+| **NRGRank** | GPL-3.0 | ❌ **NOT A DEPENDENCY** | Cited as scientific inspiration only |
+
+**Legend:**
+- ✅ Compatible: No restrictions on Apache-2.0 distribution
+- ⚠️ Proprietary but free: Not open source, but freely available
+- ❌ Avoided: GPL code not included to maintain Apache-2.0 purity
+
+---
+
+## Compliance Notes
+
+### For Users
+
+**No GPL obligations:** FlexAID∆S can be used in proprietary software, modified freely, and relicensed under any terms. No source disclosure required for downstream works.
+
+**Optional dependencies:** CUDA and Metal are optional. FlexAID∆S includes CPU-only fallback implementations.
+
+**No viral licenses:** All included dependencies are permissive or have library exceptions. No strong copyleft propagation.
+
+### For Contributors
+
+**CLA Required:** All contributions must be submitted under Apache License 2.0 terms.
+
+**No GPL code:** Do not submit patches incorporating GPL-licensed code. See [docs/licensing/clean-room-policy.md](docs/licensing/clean-room-policy.md) for detailed GPL avoidance strategy.
+
+**Dependency review:** Proposed new dependencies must use Apache-2.0, BSD, MIT, PSF, or MPL 2.0 licenses. GPL and AGPL forbidden.
+
+### For Redistributors
+
+**Binary distribution:** Include this file and main LICENSE in all binary packages.
+
+**Source distribution:** Preserve all copyright notices in source headers.
+
+**CUDA/Metal:** If distributing binaries with GPU support, note that users must accept NVIDIA EULA (CUDA) or Apple terms (Metal) separately. Do not redistribute CUDA Toolkit itself.
+
+**FlexAID attribution:** Retain Apache-2.0 notice for FlexAID-derived components.
+
+---
+
+## Updates
+
+This file is maintained alongside FlexAID∆S releases:
+
+- **Version 1.0 (March 2026):** Initial comprehensive third-party license documentation
+- Future updates will track dependency changes and new integrations
+
+For questions about licensing compliance, see:
+- Main LICENSE file (Apache-2.0 full text)
+- [docs/licensing/clean-room-policy.md](docs/licensing/clean-room-policy.md) (GPL avoidance strategy)
+- GitHub issues: https://github.com/LeBonhommePharma/FlexAIDdS/issues
+
+---
+
+**Maintained by:** Louis-Philippe Morency, PhD (Candidate)  
+**Last Updated:** March 7, 2026  
+**Repository:** https://github.com/LeBonhommePharma/FlexAIDdS

--- a/python/flexaidds/__init__.py
+++ b/python/flexaidds/__init__.py
@@ -65,32 +65,38 @@ from .schemas.thermo_audit import (
     make_total_sampled_output,
 )
 
-# C++ extension — optional: pure-Python helpers work without it
+# Pure-Python-only types (never exported by the C++ _core extension).
+# Import these *before* the _core try block so a missing/partial extension
+# cannot take down HAS_CORE_BINDINGS for the symbols that *are* bound.
+from ._fallback_types import TemperatureScanPoint, DeltaCpFit
+
+# C++ extension — optional: pure-Python helpers work without it.
+# Important: only import symbols that _core actually exports. Importing a
+# pure-Python-only name (e.g. TemperatureScanPoint) from _core used to raise
+# ImportError and force HAS_CORE_BINDINGS=False even when the .so was present
+# and fully functional — breaking pip-installed accelerated wheels.
 try:
-    from ._core import (
+    from ._core import (  # type: ignore[attr-defined]
         BoltzmannLUT,
         Replica,
         State,
         TIPoint,
         WHAMBin,
-        TemperatureScanPoint,
-        DeltaCpFit,
         kB_kcal,  # noqa: F811  (more precise C++ value)
         kB_SI,    # noqa: F811
     )
-    # Override with C++ StatMechEngine when available
-    from ._core import StatMechEngine as _CppStatMechEngine  # noqa: F811
-    from ._core import Thermodynamics as _CppThermodynamics  # noqa: F811
-    from ._core import ThermodynamicBreakdown as _CppThermodynamicBreakdown  # noqa: F811
-    from ._core import ENCoMEngine as _CppENCoMEngine        # noqa: F811
-    from ._core import NormalMode as _CppNormalMode           # noqa: F811
-    from ._core import VibrationalEntropy as _CppVibrationalEntropy  # noqa: F811
+    # Override pure-Python engines/types with the compiled implementations.
+    from ._core import StatMechEngine as StatMechEngine  # noqa: F811
+    from ._core import Thermodynamics as Thermodynamics  # noqa: F811
+    from ._core import ThermodynamicBreakdown as ThermodynamicBreakdown  # noqa: F811
+    from ._core import ENCoMEngine as ENCoMEngine  # noqa: F811
+    from ._core import NormalMode as NormalMode  # noqa: F811
+    from ._core import VibrationalEntropy as VibrationalEntropy  # noqa: F811
     HAS_CORE_BINDINGS = True
 except ImportError:
-    # Fallback when C++ extension is not built
+    # Fallback when C++ extension is not built / fails to load
     from ._fallback_types import (
         BoltzmannLUT, Replica, State, TIPoint, WHAMBin,
-        TemperatureScanPoint, DeltaCpFit,
     )
     kB_kcal = 0.001987206   # kcal mol⁻¹ K⁻¹
     kB_SI = 1.380649e-23    # J K⁻¹

--- a/python/flexaidds/schemas/__init__.py
+++ b/python/flexaidds/schemas/__init__.py
@@ -1,0 +1,21 @@
+"""Schema helpers for FlexAID∆S thermodynamic audit / provenance payloads."""
+
+from .thermo_audit import (
+    Provenance,
+    ProvenanceDC,
+    ThermodynamicOutput,
+    ThermodynamicOutputDC,
+    TotalSampledPartitionFunction,
+    TotalSampledPartitionFunctionDC,
+    make_total_sampled_output,
+)
+
+__all__ = [
+    "Provenance",
+    "ProvenanceDC",
+    "ThermodynamicOutput",
+    "ThermodynamicOutputDC",
+    "TotalSampledPartitionFunction",
+    "TotalSampledPartitionFunctionDC",
+    "make_total_sampled_output",
+]

--- a/python/flexaidds/updater.py
+++ b/python/flexaidds/updater.py
@@ -173,20 +173,27 @@ def download_asset(
     return dest
 
 
-def update_pip(version: str = "latest") -> int:
+def update_pip(version: str = "latest", *, index_url: Optional[str] = None) -> int:
     """Update the flexaidds Python package via pip.
 
     Args:
         version: Version to install, or "latest" for the newest.
+        index_url: Optional extra index URL (e.g. TestPyPI). When the package
+            is not yet on the default index, callers can pass TestPyPI or a
+            direct VCS URL via ``version`` as ``git+https://...``.
 
     Returns:
         pip exit code.
     """
     cmd = [sys.executable, "-m", "pip", "install", "--upgrade"]
+    if index_url:
+        cmd.extend(["--index-url", index_url])
     if version == "latest":
         cmd.append("flexaidds")
+    elif version.startswith("git+") or version.startswith("https://") or version.startswith("http://"):
+        cmd.append(version)
     else:
-        cmd.append(f"flexaidds=={version}")
+        cmd.append(f"flexaidds=={version.lstrip('v')}")
 
     result = subprocess.run(cmd, capture_output=False)
     return result.returncode

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: C++",
   "Operating System :: OS Independent",
   "Topic :: Scientific/Engineering :: Bio-Informatics",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,20 +11,30 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.9"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 classifiers = [
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: C++",
-  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
   "Topic :: Scientific/Engineering :: Bio-Informatics",
   "Topic :: Scientific/Engineering :: Chemistry",
 ]
-dependencies = []
+# numpy is imported by core modules (io, docking, thermodynamics helpers, etc.)
+dependencies = [
+  "numpy>=1.22",
+]
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov"]
-benchmarks = ["numpy>=2.0.2", "pyyaml>=6.0.3"]
-benchmarks-mpi = ["numpy>=2.0.2", "pyyaml>=6.0.3", "mpi4py>=4.1.1"]
+# DatasetRunner YAML configs + extra analysis stack
+benchmarks = ["pyyaml>=6.0.3"]
+benchmarks-mpi = ["pyyaml>=6.0.3", "mpi4py>=4.1.1"]
+yaml = ["pyyaml>=6.0.3"]
 
 [project.scripts]
 flexaidds = "flexaidds.__main__:main"
@@ -34,6 +44,8 @@ flexaidds-benchmark = "flexaidds.dataset_runner.cli:main"
 Homepage = "https://github.com/LeBonhommePharma/FlexAIDdS"
 Documentation = "https://github.com/LeBonhommePharma/FlexAIDdS/tree/master/docs"
 Source = "https://github.com/LeBonhommePharma/FlexAIDdS"
+Issues = "https://github.com/LeBonhommePharma/FlexAIDdS/issues"
+Changelog = "https://github.com/LeBonhommePharma/FlexAIDdS/blob/master/VERSION.md"
 
 [tool.setuptools]
 zip-safe = false
@@ -50,3 +62,25 @@ namespaces = false
 
 [tool.setuptools.dynamic]
 version = { attr = "flexaidds.__version__.__version__" }
+
+# cibuildwheel: produce installable wheels even when the optional C++ extension
+# cannot be compiled (pure-Python fallback). setup.py never fails the install.
+[tool.cibuildwheel]
+build-frontend = "build"
+# Skip exotic / EOL targets that inflate CI without real users.
+skip = "pp* *-win32 *-manylinux_i686 *-musllinux_i686"
+test-command = "python -c \"import flexaidds as fd; print(fd.__version__)\""
+test-skip = ""
+
+[tool.cibuildwheel.linux]
+# Prefer modern manylinux images; extension may still fall back pure-Python
+# when the image compiler lacks C++26.
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+
+[tool.cibuildwheel.macos]
+environment = { MACOSX_DEPLOYMENT_TARGET = "12.0" }
+
+[tool.cibuildwheel.windows]
+# MSVC via cibuildwheel; extension optional.
+

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,9 +1,31 @@
+"""Build script for the flexaidds Python package.
+
+The accelerated ``flexaidds._core`` extension is **optional**:
+- Built when pybind11 + Eigen + C++ sources are available and compilation succeeds.
+- Skipped cleanly (pure-Python fallback) when any of those are missing or the
+  compile fails. ``pip install flexaidds`` must always succeed.
+
+Important packaging constraints:
+- ``setup()`` Extension sources must be relative paths under ``python/`` (never
+  absolute, never ``../``), otherwise setuptools rejects the sdist/wheel or
+  materializes a stray ``python/LIB/`` tree in the checkout.
+- Monorepo ``../LIB`` sources are wired in at ``build_ext`` time only.
+- The custom ``sdist`` command stages the minimal LIB files into the *release
+  tree* as ``LIB/`` so out-of-tree builds can still compile ``_core``.
+"""
+
+from __future__ import annotations
+
 import os
+import shutil
 import sys
 import warnings
 from pathlib import Path
+from typing import List, Optional, Tuple
 
 from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext as _build_ext
+from setuptools.command.sdist import sdist as _sdist
 
 # --- P0: Wire source validator guard (python path) ---
 # Runs early so developers doing `pip install -e .` (or equivalent) get
@@ -15,45 +37,101 @@ try:
 
     # Respect env var for CI / strict local runs. Default is lenient for
     # normal developer `pip install -e` usage.
-    strict = os.environ.get("FLEXAIDS_STRICT_SOURCE_VALIDATION", "0").lower() not in ("0", "false", "")
+    strict = os.environ.get("FLEXAIDS_STRICT_SOURCE_VALIDATION", "0").lower() not in (
+        "0",
+        "false",
+        "",
+    )
     validate_sources(root=str(repo_root), strict=strict)
 except Exception as exc:
     # Never break the build due to the guard during normal development.
     print(f"[source-guard] Warning: validator skipped ({exc})", file=sys.stderr)
 
 ROOT = Path(__file__).resolve().parent
-LIB_DIR = ROOT.parent / "LIB"
 
-# setuptools requires /-separated paths relative to setup.py directory
-_rel_lib = "../LIB"
+# Relative source paths (under LIB/) required to build flexaidds._core.
+# Keep in sync with python/CMakeLists.txt and the main C++ build.
+_CORE_LIB_REL_SOURCES = [
+    "statmech.cpp",
+    "TurboQuant.cpp",
+    "UnifiedHardwareDispatch.cpp",
+    "hardware_detect.cpp",
+    "encom.cpp",
+    "tENCoM/tencm.cpp",
+    "ShannonThermoStack/ShannonThermoStack.cpp",
+    "DiFT/DiFT.cpp",
+    "fast_optics.cpp",
+]
+
+# Headers / extra files staged into the sdist so out-of-tree builds can compile.
+_CORE_LIB_REL_HEADERS = [
+    "statmech.h",
+    "TurboQuant.h",
+    "UnifiedHardwareDispatch.h",
+    "hardware_detect.h",
+    "encom.h",
+    "fast_optics.hpp",
+    "tENCoM/tencm.h",
+    "ShannonThermoStack/ShannonThermoStack.h",
+    "DiFT/DiFT.h",
+]
 
 
-def _find_eigen_include_dir():
-    """Locate Eigen headers. Returns path or None.
-    Does not raise so that `pip install` can succeed in pure-Python mode
-    (the package has graceful fallbacks when the _core extension is absent).
+def _skip_core_requested() -> bool:
+    return os.environ.get("FLEXAIDDS_SKIP_CORE", "").lower() in ("1", "true", "yes")
+
+
+def _resolve_lib_dir() -> Optional[Path]:
+    """Locate LIB/ with C++ sources for the optional _core extension.
+
+    Search order:
+      1. FLEXAIDDS_LIB_DIR env override
+      2. ./LIB           (sdist layout: sources staged beside setup.py)
+      3. ../LIB          (monorepo: python/ next to LIB/)
     """
-    # Allow explicit override (very useful for cibuildwheel / CI / conda)
+    candidates: List[Path] = []
+    env = os.environ.get("FLEXAIDDS_LIB_DIR")
+    if env:
+        candidates.append(Path(env))
+    # Prefer staged in-tree LIB (sdist) over monorepo parent so isolated builds
+    # use the files that shipped with the sdist.
+    candidates.extend(
+        [
+            ROOT / "LIB",
+            ROOT.parent / "LIB",
+        ]
+    )
+    for candidate in candidates:
+        if candidate.is_dir() and (candidate / "statmech.cpp").is_file():
+            return candidate.resolve()
+    return None
+
+
+def _find_eigen_include_dir() -> Optional[str]:
+    """Locate Eigen headers. Returns path or None."""
     if os.environ.get("EIGEN_INCLUDE_DIR"):
         p = Path(os.environ["EIGEN_INCLUDE_DIR"])
         if (p / "Eigen" / "Dense").exists():
             return str(p)
-        if p.name == "eigen" or p.name.startswith("eigen-"):
-            # allow pointing at the extracted dir containing Eigen/
-            if (p / "Eigen" / "Dense").exists():
-                return str(p)
+        if (p.name == "eigen" or p.name.startswith("eigen-")) and (
+            p / "Eigen" / "Dense"
+        ).exists():
+            return str(p)
 
-    # 1. Vendored git submodule
-    vendored = LIB_DIR / "vendor" / "eigen"
-    if (vendored / "Eigen" / "Dense").exists():
-        return str(vendored)
+    lib_dir = _resolve_lib_dir()
+    if lib_dir is not None:
+        vendored = lib_dir / "vendor" / "eigen"
+        if (vendored / "Eigen" / "Dense").exists():
+            return str(vendored)
 
-    # 2. pkg-config (works for apt/dnf libeigen3-dev and Homebrew alike)
     try:
         import subprocess
+
         out = subprocess.run(
             ["pkg-config", "--cflags-only-I", "eigen3"],
-            capture_output=True, text=True, check=True,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
         for token in out.split():
             if token.startswith("-I"):
@@ -63,13 +141,12 @@ def _find_eigen_include_dir():
     except Exception:
         pass
 
-    # 3. Homebrew / common system / extracted locations (cibuildwheel friendly)
     for candidate in (
         Path("/opt/homebrew/include/eigen3"),
         Path("/usr/local/include/eigen3"),
         Path("/usr/include/eigen3"),
-        Path("/usr/local/include/eigen"),   # sometimes extracted this way
-        Path(os.environ.get("EIGEN_ROOT", "")) if os.environ.get("EIGEN_ROOT") else None,
+        Path("/usr/local/include/eigen"),
+        Path(os.environ["EIGEN_ROOT"]) if os.environ.get("EIGEN_ROOT") else None,
     ):
         if candidate and (candidate / "Eigen" / "Dense").exists():
             return str(candidate)
@@ -77,93 +154,260 @@ def _find_eigen_include_dir():
     return None
 
 
-_EIGEN_INCLUDE_DIR = _find_eigen_include_dir()
+def _core_sources_available(lib_dir: Path) -> bool:
+    for rel in _CORE_LIB_REL_SOURCES:
+        if not (lib_dir / rel).is_file():
+            return False
+    if not (ROOT / "flexaidds" / "_core.cpp").is_file():
+        return False
+    return True
 
-# Keep in sync with python/CMakeLists.txt and the main C++ build.
-_core_sources = [
-    "flexaidds/_core.cpp",
-    f"{_rel_lib}/statmech.cpp",
-    f"{_rel_lib}/TurboQuant.cpp",
-    f"{_rel_lib}/UnifiedHardwareDispatch.cpp",
-    f"{_rel_lib}/hardware_detect.cpp",
-    f"{_rel_lib}/encom.cpp",
-    f"{_rel_lib}/tENCoM/tencm.cpp",
-    f"{_rel_lib}/ShannonThermoStack/ShannonThermoStack.cpp",
-    f"{_rel_lib}/DiFT/DiFT.cpp",
-    f"{_rel_lib}/fast_optics.cpp",
-]
-_core_defs = [("FLEXAIDS_HAS_EIGEN", "1")]
 
-# 256×256 soft contact matrix bindings (added when file exists)
-_matrix_bindings = Path("bindings/bindings_matrix.cpp")
-if _matrix_bindings.exists():
-    _core_sources.append(str(_matrix_bindings))
-    _core_defs.append(("FLEXAIDS_USE_256_MATRIX", "1"))
-
-ext_modules = []
-build_core = True
-
-try:
-    import pybind11
-except ImportError:
-    warnings.warn(
-        "pybind11 not found. The accelerated _core extension will be skipped. "
-        "Install with `pip install pybind11` (or use conda) for full performance. "
-        "Pure-Python fallbacks will be used.",
-        stacklevel=2,
-    )
-    build_core = False
-
-if build_core and _EIGEN_INCLUDE_DIR is None:
-    warnings.warn(
-        "Eigen3 headers not found. The accelerated _core C++ extension will be "
-        "skipped.\n"
-        "  macOS:   brew install eigen\n"
-        "  Linux:   sudo apt install libeigen3-dev\n"
-        "  Windows: choco install eigen\n"
-        "  Or vendor: git submodule update --init LIB/vendor/eigen\n\n"
-        "The flexaidds package will still install and work in pure-Python fallback mode "
-        "(results loading, models, pure StatMech, etc.).",
-        stacklevel=2,
-    )
-    build_core = False
-
-if build_core:
+def _can_attempt_core() -> bool:
+    if _skip_core_requested():
+        return False
     try:
-        ext = Extension(
-            "flexaidds._core",
-            sources=_core_sources,
-            include_dirs=[
-                str(LIB_DIR),
-                str(LIB_DIR / "tENCoM"),
-                str(LIB_DIR / "ShannonThermoStack"),
-                _EIGEN_INCLUDE_DIR,
-                pybind11.get_include(),
-            ],
-            define_macros=_core_defs + (
-                [
-                    ("_CRT_SECURE_NO_WARNINGS", "1"),
-                    ("_USE_MATH_DEFINES", "1"),
-                    ("NOMINMAX", "1"),
-                ]
-                if os.name == "nt"
-                else []
-            ),
-            language="c++",
-            extra_compile_args=(
+        import pybind11  # noqa: F401
+    except ImportError:
+        return False
+    lib_dir = _resolve_lib_dir()
+    if lib_dir is None or not _core_sources_available(lib_dir):
+        return False
+    if _find_eigen_include_dir() is None:
+        return False
+    return True
+
+
+class optional_build_ext(_build_ext):
+    """Build extensions, but never fail the whole install if compile breaks.
+
+    Real LIB/ sources (monorepo ``../LIB`` or sdist ``LIB/``) are attached here
+    so ``setup()`` only ever sees in-tree relative paths.
+    """
+
+    def build_extensions(self) -> None:
+        if not self.extensions:
+            return
+        try:
+            super().build_extensions()
+        except Exception as exc:  # pragma: no cover - platform/compiler dependent
+            warnings.warn(
+                f"Failed to build flexaidds._core extension ({exc}). "
+                "Installing pure-Python fallback only. "
+                "Install a C++26 compiler + Eigen + pybind11 for the accelerated path.",
+                stacklevel=2,
+            )
+            self.extensions = []
+
+    def build_extension(self, ext: Extension) -> None:
+        if ext.name == "flexaidds._core":
+            if not self._prepare_core_extension(ext):
+                self.announce(
+                    "skipping flexaidds._core (sources/deps unavailable)",
+                    level=2,
+                )
+                return
+        try:
+            super().build_extension(ext)
+        except Exception as exc:  # pragma: no cover
+            warnings.warn(
+                f"Failed to build extension {ext.name}: {exc}. Skipping.",
+                stacklevel=2,
+            )
+
+    def _prepare_core_extension(self, ext: Extension) -> bool:
+        if _skip_core_requested():
+            warnings.warn(
+                "FLEXAIDDS_SKIP_CORE set — installing pure-Python package only.",
+                stacklevel=2,
+            )
+            return False
+
+        try:
+            import pybind11
+        except ImportError:
+            warnings.warn(
+                "pybind11 not found. The accelerated _core extension will be skipped.",
+                stacklevel=2,
+            )
+            return False
+
+        lib_dir = _resolve_lib_dir()
+        if lib_dir is None or not _core_sources_available(lib_dir):
+            warnings.warn(
+                "C++ sources for flexaidds._core not found. "
+                "Installing pure-Python fallback only.",
+                stacklevel=2,
+            )
+            return False
+
+        eigen = _find_eigen_include_dir()
+        if eigen is None:
+            warnings.warn(
+                "Eigen3 headers not found. The accelerated _core extension will be "
+                "skipped.\n"
+                "  macOS:   brew install eigen\n"
+                "  Linux:   sudo apt install libeigen3-dev\n"
+                "  Or set:  EIGEN_INCLUDE_DIR=/path/to/eigen",
+                stacklevel=2,
+            )
+            return False
+
+        # Compile-time sources may be absolute (monorepo). Packaging never sees these.
+        sources = [str((ROOT / "flexaidds" / "_core.cpp").resolve())]
+        for rel in _CORE_LIB_REL_SOURCES:
+            sources.append(str((lib_dir / rel).resolve()))
+
+        matrix_bindings = ROOT / "bindings" / "bindings_matrix.cpp"
+        define_macros: List[Tuple[str, Optional[str]]] = list(ext.define_macros or [])
+        if not any(k == "FLEXAIDS_HAS_EIGEN" for k, _ in define_macros):
+            define_macros.append(("FLEXAIDS_HAS_EIGEN", "1"))
+        if matrix_bindings.is_file():
+            sources.append(str(matrix_bindings.resolve()))
+            if not any(k == "FLEXAIDS_USE_256_MATRIX" for k, _ in define_macros):
+                define_macros.append(("FLEXAIDS_USE_256_MATRIX", "1"))
+
+        if os.name == "nt":
+            for macro in (
+                ("_CRT_SECURE_NO_WARNINGS", "1"),
+                ("_USE_MATH_DEFINES", "1"),
+                ("NOMINMAX", "1"),
+            ):
+                if not any(k == macro[0] for k, _ in define_macros):
+                    define_macros.append(macro)
+
+        ext.sources = sources
+        ext.include_dirs = [
+            str(lib_dir),
+            str(lib_dir / "tENCoM"),
+            str(lib_dir / "ShannonThermoStack"),
+            eigen,
+            pybind11.get_include(),
+        ]
+        ext.define_macros = define_macros
+        ext.language = "c++"
+        if not ext.extra_compile_args:
+            ext.extra_compile_args = (
                 ["/O2", "/std:c++latest", "/EHsc"]
                 if os.name == "nt"
                 else ["-std=c++26", "-O3", "-ffast-math"]
-            ),
-        )
-        ext_modules = [ext]
-    except Exception as exc:  # pragma: no cover
-        warnings.warn(f"Failed to prepare _core extension, installing without it: {exc}", stacklevel=2)
-        ext_modules = []
+            )
+        return True
 
-# IMPORTANT: most metadata (name, version from dynamic, description, packages,
-# package_data, scripts, etc.) lives in pyproject.toml for modern builds.
-# We only pass what is needed for the compiled extension here.
+
+class sdist_with_lib(_sdist):
+    """Stage required LIB/ sources into the sdist so wheels can compile _core.
+
+    Only the files needed by ``flexaidds._core`` are copied into the *release
+    tree* (``base_dir/LIB``). Never write into the source checkout.
+    """
+
+    def make_release_tree(self, base_dir, files):  # type: ignore[no-untyped-def]
+        super().make_release_tree(base_dir, files)
+
+        # Prefer monorepo LIB/ so we do not re-stage a leftover python/LIB.
+        monorepo_lib = ROOT.parent / "LIB"
+        if monorepo_lib.is_dir() and (monorepo_lib / "statmech.cpp").is_file():
+            lib_dir = monorepo_lib.resolve()
+        else:
+            lib_dir = _resolve_lib_dir()
+
+        if lib_dir is None:
+            self.announce(
+                "sdist: LIB/ not found — sdist will be pure-Python only",
+                level=2,
+            )
+            return
+
+        dest_lib = Path(base_dir) / "LIB"
+        staged = 0
+        wanted = list(_CORE_LIB_REL_SOURCES) + list(_CORE_LIB_REL_HEADERS)
+
+        for sub, patterns in (
+            ("tENCoM", ("*.h", "*.hpp", "*.hh")),
+            ("ShannonThermoStack", ("*.h", "*.hpp", "*.hh")),
+            ("DiFT", ("*.h", "*.hpp", "*.hh")),
+        ):
+            src_sub = lib_dir / sub
+            if not src_sub.is_dir():
+                continue
+            for pattern in patterns:
+                for src in src_sub.glob(pattern):
+                    wanted.append(f"{sub}/{src.name}")
+
+        seen = set()
+        for rel in wanted:
+            if rel in seen:
+                continue
+            seen.add(rel)
+            src = lib_dir / rel
+            if not src.is_file():
+                continue
+            dst = dest_lib / rel
+            self.mkpath(str(dst.parent))
+            shutil.copy2(src, dst)
+            staged += 1
+
+        self.announce(f"sdist: staged {staged} LIB files for _core builds", level=2)
+
+
+def _placeholder_extension_modules() -> List[Extension]:
+    """Declare _core with only in-tree relative sources for setup()/sdist.
+
+    Real sources are filled in by ``optional_build_ext`` at compile time.
+    """
+    if _skip_core_requested():
+        warnings.warn(
+            "FLEXAIDDS_SKIP_CORE set — installing pure-Python package only.",
+            stacklevel=2,
+        )
+        return []
+
+    if not _can_attempt_core():
+        # Emit a single informative warning for the common missing-deps cases.
+        if not (ROOT / "flexaidds" / "_core.cpp").is_file():
+            return []
+        try:
+            import pybind11  # noqa: F401
+        except ImportError:
+            warnings.warn(
+                "pybind11 not found. The accelerated _core extension will be skipped. "
+                "Pure-Python fallbacks will be used.",
+                stacklevel=2,
+            )
+            return []
+        if _resolve_lib_dir() is None:
+            warnings.warn(
+                "C++ sources for flexaidds._core not found (expected LIB/ next to "
+                "python/ or staged as python/LIB/ in the sdist). "
+                "Installing pure-Python fallback only.",
+                stacklevel=2,
+            )
+            return []
+        if _find_eigen_include_dir() is None:
+            warnings.warn(
+                "Eigen3 headers not found. The accelerated _core C++ extension will be "
+                "skipped. Pure-Python fallbacks will be used.",
+                stacklevel=2,
+            )
+            return []
+        return []
+
+    # Placeholder only — absolute/parent paths are forbidden in setup().
+    return [
+        Extension(
+            "flexaidds._core",
+            sources=["flexaidds/_core.cpp"],
+            language="c++",
+        )
+    ]
+
+
+# IMPORTANT: most metadata lives in pyproject.toml for modern builds.
 setup(
-    ext_modules=ext_modules,
+    ext_modules=_placeholder_extension_modules(),
+    cmdclass={
+        "build_ext": optional_build_ext,
+        "sdist": sdist_with_lib,
+    },
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -7,9 +7,10 @@ The accelerated ``flexaidds._core`` extension is **optional**:
 
 Important packaging constraints:
 - ``setup()`` Extension sources must be relative paths under ``python/`` (never
-  absolute, never ``../``), otherwise setuptools rejects the sdist/wheel or
-  materializes a stray ``python/LIB/`` tree in the checkout.
-- Monorepo ``../LIB`` sources are wired in at ``build_ext`` time only.
+  absolute, never ``../``). Modern setuptools rejects absolute paths even when
+  assigned later in ``build_ext``.
+- Monorepo ``../LIB`` sources are **staged** into the gitignored ``python/LIB/``
+  tree at ``build_ext`` time so every source path stays relative to ``setup.py``.
 - The custom ``sdist`` command stages the minimal LIB files into the *release
   tree* as ``LIB/`` so out-of-tree builds can still compile ``_core``.
 """
@@ -178,26 +179,118 @@ def _can_attempt_core() -> bool:
     return True
 
 
+def _path_is_under_root(path: Path) -> bool:
+    """True if *path* is the same as ROOT or a descendant (not via ``..``)."""
+    try:
+        path.resolve().relative_to(ROOT.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _stage_lib_under_root(lib_dir: Path) -> Optional[Path]:
+    """Ensure LIB sources live under ``python/`` as relative paths.
+
+    setuptools rejects absolute paths and ``../`` in ``Extension.sources``.
+    When the monorepo has sources at ``../LIB``, we copy the minimal set into
+    the gitignored ``python/LIB/`` tree (same layout as the sdist).
+    """
+    if _path_is_under_root(lib_dir) and _core_sources_available(lib_dir):
+        return lib_dir.resolve()
+
+    dest = (ROOT / "LIB").resolve()
+    dest.mkdir(parents=True, exist_ok=True)
+
+    # Sources + headers + transitive headers from known subdirs.
+    wanted = list(_CORE_LIB_REL_SOURCES) + list(_CORE_LIB_REL_HEADERS)
+    for sub, patterns in (
+        ("tENCoM", ("*.h", "*.hpp", "*.hh")),
+        ("ShannonThermoStack", ("*.h", "*.hpp", "*.hh")),
+        ("DiFT", ("*.h", "*.hpp", "*.hh")),
+    ):
+        src_sub = lib_dir / sub
+        if not src_sub.is_dir():
+            continue
+        for pattern in patterns:
+            for src in src_sub.glob(pattern):
+                wanted.append(f"{sub}/{src.name}")
+
+    seen = set()
+    staged = 0
+    for rel in wanted:
+        if rel in seen:
+            continue
+        seen.add(rel)
+        src = lib_dir / rel
+        if not src.is_file():
+            continue
+        dst = dest / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        # Copy when missing or source is newer (cheap mtime check).
+        if (
+            not dst.is_file()
+            or src.stat().st_mtime > dst.stat().st_mtime
+            or src.stat().st_size != dst.stat().st_size
+        ):
+            shutil.copy2(src, dst)
+        staged += 1
+
+    if not _core_sources_available(dest):
+        return None
+    return dest
+
+
+def _relpath_from_root(path: Path) -> str:
+    """Return a POSIX-style path relative to setup.py's directory."""
+    rel = path.resolve().relative_to(ROOT.resolve())
+    return rel.as_posix()
+
+
 class optional_build_ext(_build_ext):
     """Build extensions, but never fail the whole install if compile breaks.
 
-    Real LIB/ sources (monorepo ``../LIB`` or sdist ``LIB/``) are attached here
-    so ``setup()`` only ever sees in-tree relative paths.
+    Real LIB/ sources (monorepo ``../LIB`` or sdist ``LIB/``) are staged under
+    ``python/`` here so every ``Extension.sources`` entry is a relative path
+    (required by modern setuptools).
+
+    Extensions that are skipped or fail to compile are removed from
+    ``self.extensions`` so setuptools does not try to package a missing
+    ``.so`` / ``.pyd`` (which would otherwise fail the wheel build).
     """
 
     def build_extensions(self) -> None:
         if not self.extensions:
             return
-        try:
-            super().build_extensions()
-        except Exception as exc:  # pragma: no cover - platform/compiler dependent
+        requested = list(self.extensions)
+        kept: List[Extension] = []
+        for ext in requested:
+            try:
+                self.build_extension(ext)
+            except Exception as exc:  # pragma: no cover - platform/compiler dependent
+                warnings.warn(
+                    f"Failed to build extension {ext.name} ({exc}). Skipping.",
+                    stacklevel=2,
+                )
+                continue
+            # Only keep extensions that actually produced a binary.
+            try:
+                built = Path(self.get_ext_fullpath(ext.name))
+            except Exception:
+                built = None
+            if built is not None and built.is_file():
+                kept.append(ext)
+            else:
+                self.announce(
+                    f"skipping package of {ext.name} (no binary produced)",
+                    level=2,
+                )
+        self.extensions = kept
+        if not kept and any(getattr(e, "name", "") == "flexaidds._core" for e in requested):
             warnings.warn(
-                f"Failed to build flexaidds._core extension ({exc}). "
-                "Installing pure-Python fallback only. "
+                "flexaidds._core was not built. Installing pure-Python fallback only. "
                 "Install a C++26 compiler + Eigen + pybind11 for the accelerated path.",
                 stacklevel=2,
             )
-            self.extensions = []
 
     def build_extension(self, ext: Extension) -> None:
         if ext.name == "flexaidds._core":
@@ -232,10 +325,19 @@ class optional_build_ext(_build_ext):
             )
             return False
 
-        lib_dir = _resolve_lib_dir()
-        if lib_dir is None or not _core_sources_available(lib_dir):
+        lib_src = _resolve_lib_dir()
+        if lib_src is None or not _core_sources_available(lib_src):
             warnings.warn(
                 "C++ sources for flexaidds._core not found. "
+                "Installing pure-Python fallback only.",
+                stacklevel=2,
+            )
+            return False
+
+        lib_dir = _stage_lib_under_root(lib_src)
+        if lib_dir is None:
+            warnings.warn(
+                "Failed to stage LIB sources under python/ for setuptools. "
                 "Installing pure-Python fallback only.",
                 stacklevel=2,
             )
@@ -253,17 +355,17 @@ class optional_build_ext(_build_ext):
             )
             return False
 
-        # Compile-time sources may be absolute (monorepo). Packaging never sees these.
-        sources = [str((ROOT / "flexaidds" / "_core.cpp").resolve())]
+        # Relative paths only — absolute / parent paths are rejected by setuptools.
+        sources = ["flexaidds/_core.cpp"]
         for rel in _CORE_LIB_REL_SOURCES:
-            sources.append(str((lib_dir / rel).resolve()))
+            sources.append(_relpath_from_root(lib_dir / rel))
 
         matrix_bindings = ROOT / "bindings" / "bindings_matrix.cpp"
         define_macros: List[Tuple[str, Optional[str]]] = list(ext.define_macros or [])
         if not any(k == "FLEXAIDS_HAS_EIGEN" for k, _ in define_macros):
             define_macros.append(("FLEXAIDS_HAS_EIGEN", "1"))
         if matrix_bindings.is_file():
-            sources.append(str(matrix_bindings.resolve()))
+            sources.append("bindings/bindings_matrix.cpp")
             if not any(k == "FLEXAIDS_USE_256_MATRIX" for k, _ in define_macros):
                 define_macros.append(("FLEXAIDS_USE_256_MATRIX", "1"))
 
@@ -277,6 +379,7 @@ class optional_build_ext(_build_ext):
                     define_macros.append(macro)
 
         ext.sources = sources
+        # include_dirs may be absolute (headers only; setuptools allows this).
         ext.include_dirs = [
             str(lib_dir),
             str(lib_dir / "tENCoM"),

--- a/python/tests/test_import_fallback.py
+++ b/python/tests/test_import_fallback.py
@@ -136,3 +136,38 @@ def test_load_results_works_without_core(tmp_path: Path):
     result = load_results(tmp_path)
     assert result.n_modes == 1
     assert result.binding_modes[0].best_cf == -5.0
+
+
+def test_has_core_true_when_extension_loads():
+    """HAS_CORE_BINDINGS must be True whenever flexaidds._core is importable.
+
+    Regression guard: pure-Python-only symbols (TemperatureScanPoint,
+    DeltaCpFit) must not be imported from _core — that used to raise
+    ImportError and force HAS_CORE_BINDINGS=False even with a working .so,
+    breaking accelerated pip wheels.
+    """
+    try:
+        import flexaidds._core  # noqa: F401
+    except ImportError:
+        import pytest
+
+        pytest.skip("_core extension not built in this environment")
+
+    # Fresh import so we exercise the package's own try/except path.
+    saved = {k: sys.modules.pop(k, None) for k in list(sys.modules) if k == "flexaidds" or k.startswith("flexaidds.")}
+    try:
+        import flexaidds
+
+        assert flexaidds.HAS_CORE_BINDINGS is True
+        # Pure-Python-only types must still be available.
+        assert flexaidds.TemperatureScanPoint is not None
+        assert flexaidds.DeltaCpFit is not None
+        # Compiled engines should be the ones from _core.
+        assert flexaidds.StatMechEngine is flexaidds._core.StatMechEngine
+    finally:
+        for k in list(sys.modules):
+            if k == "flexaidds" or k.startswith("flexaidds."):
+                sys.modules.pop(k, None)
+        for k, v in saved.items():
+            if v is not None:
+                sys.modules[k] = v


### PR DESCRIPTION
## Summary

Fixes the broken PyPI release workflow and Homebrew formula, and makes `pip install flexaidds` reliably succeed (pure-Python fallback when the optional `_core` extension cannot build).

### PyPI / pip
- **Root cause**: `pypi-release.yml` had invalid YAML (Windows Eigen PowerShell here-string at column 0), so the workflow never ran. Sdist also failed installs because extension sources used `../LIB` incorrectly and `numpy` was not declared despite hard imports.
- Repaired workflow: valid YAML, Eigen downloaded in a portable bash step, `download-artifact` v5, sdist/wheel smoke tests before publish.
- `setup.py`: optional `_core` prepared at `build_ext` time; soft-fail on compile errors; sdist stages only the minimal LIB files into the release tree; `FLEXAIDDS_SKIP_CORE=1` force pure-Python.
- `pyproject.toml`: `numpy>=1.22` runtime dep, cibuildwheel config, SPDX license string.
- `flexaidds.schemas` package init for clean discovery.
- Updater: `--check-update` / `--self-update` verified against GitHub Releases (`v2.0.0` up to date).

### Homebrew
- Stable `url`/`sha256` for `v2.0.0` + `head` for tip-of-tree.
- `livecheck`, style fixes (`formula_opt_prefix`, `assert_path_exists`).
- Removed deprecated `python@3.11 => :recommended`.
- Upgrade caveats for brew reinstall + pip upgrade.

## Verification (run locally)
- `python -m build --sdist` → sdist with 29 staged LIB files, no `python/LIB` pollution
- `FLEXAIDDS_SKIP_CORE=1 pip install sdist` → pure-Python wheel, `import flexaidds` works
- `python -m flexaidds --check-update` → up to date at 2.0.0
- `pytest tests/test_updater.py tests/test_version.py tests/test_import_fallback.py` → 34 passed
- `brew style Formula/flexaidds.rb` → no offenses
- YAML parse of `pypi-release.yml` → OK

## Follow-up for maintainers
1. Configure GitHub Environments `pypi` / `testpypi` with trusted publishing on PyPI/TestPyPI.
2. Run workflow_dispatch → TestPyPI, then publish a GitHub Release (or dispatch → pypi) to ship `flexaidds` on PyPI.
3. When cutting a new tag, update `Formula/flexaidds.rb` `url` + `sha256`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded self-updater to support pinned versions, direct Git/VCS URLs, and custom package indexes.
  - Added public exports for thermodynamic/provenance schema outputs.
- **Bug Fixes**
  - Strengthened pure-Python fallback behavior when native core/Eigen isn’t available; improved core availability detection and resilience.
  - Improved cross-platform native/Eigen discovery and wheel build smoke testing.
- **Documentation**
  - Updated installation, verification, Homebrew guidance, and PyPI/test publishing notes; added third-party licensing documentation.
- **Packaging**
  - Improved sdist/wheel validation and publish flow with smoke checks; refined sdist contents and wheel build configuration.
- **Tests**
  - Added a regression test for correct core-binding detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->