### PR TITLE
Fix: finish PyPI installer release path

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -97,6 +97,15 @@ jobs:
           python -m pip install dist/*.whl
           python -c "import flexaidds as fd; print('flexaidds', fd.__version__, 'HAS_CORE=', getattr(fd, 'HAS_CORE_BINDINGS', False)); assert not fd.HAS_CORE_BINDINGS"
           python -m flexaidds --help
+          # Confirm wheel is pure py3-none-any (no platform tag).
+          python - <<'PY'
+          from pathlib import Path
+          wheels = list(Path("dist").glob("*.whl"))
+          assert wheels, "no wheel built"
+          name = wheels[0].name
+          assert name.endswith("py3-none-any.whl"), f"expected pure wheel, got {name}"
+          print("pure wheel tag OK:", name)
+          PY
 
       - name: Upload pure wheel artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -127,7 +136,7 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: List packages to publish
+      - name: List packages + trusted-publisher checklist
         run: |
           set -euo pipefail
           ls -la dist/
@@ -135,11 +144,31 @@ jobs:
           from pathlib import Path
           files = sorted(Path("dist").glob("*"))
           assert files, "no artifacts to publish"
+          sdists = list(Path("dist").glob("*.tar.gz"))
+          wheels = list(Path("dist").glob("*.whl"))
+          assert sdists, "missing sdist"
+          assert wheels, "missing wheel"
           print("\n".join(str(p) for p in files))
           PY
+          cat <<'EOF'
+          === Trusted publisher must match (pypi.org → Publishing) ===
+          Owner:             LeBonhommePharma
+          Repository:        FlexAIDdS
+          Workflow filename: pypi-release.yml
+          Environment name:  pypi
+          =======================================================================
+          Alternative: set repo secret PYPI_API_TOKEN (pypi.org API token for
+          project flexaidds). When that secret is non-empty, the publish action
+          uses token auth; otherwise it uses OIDC trusted publishing.
+          EOF
 
-      - name: Publish to PyPI (trusted publishing)
+      # password empty → OIDC trusted publishing; non-empty → API token.
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.10.3
+        with:
+          skip-existing: true
+          # Prefer trusted publishing when PYPI_API_TOKEN is unset.
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
   publish-testpypi:
     name: Publish to TestPyPI (manual or pre-release)
@@ -158,7 +187,7 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: List packages to publish
+      - name: List packages + trusted-publisher checklist
         run: |
           set -euo pipefail
           ls -la dist/
@@ -171,10 +200,30 @@ jobs:
           wheels = list(Path("dist").glob("*.whl"))
           assert sdists, "missing sdist"
           assert wheels, "missing wheel"
+          pure = [w for w in wheels if w.name.endswith("py3-none-any.whl")]
+          assert pure, f"missing pure py3-none-any wheel among {[w.name for w in wheels]}"
           print("\n".join(str(p) for p in files))
           PY
+          cat <<'EOF'
+          === Trusted publisher must match (test.pypi.org → Publishing) ===
+          If the project does not exist yet, create a *pending* publisher:
+            https://test.pypi.org/manage/account/publishing/
+          Values (must match OIDC claims exactly):
+            PyPI Project Name:   flexaidds   (pending OK)
+            Owner:               LeBonhommePharma
+            Repository:          FlexAIDdS
+            Workflow filename:   pypi-release.yml
+            Environment name:    testpypi
+          ==================================================================
+          Alternative: set repo secret TEST_PYPI_API_TOKEN (TestPyPI API token).
+          When that secret is non-empty, the publish action uses token auth;
+          otherwise it uses OIDC trusted publishing.
+          EOF
 
+      # password empty → OIDC trusted publishing; non-empty → API token.
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.10.3
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -71,7 +71,7 @@ python -m flexaidds --help || echo "CLI works via python -m"
 python -m flexaidds --check-update
 ```
 
-A GitHub Actions workflow (`.github/workflows/pypi-release.yml`) handles building wheels + sdist and publishing via trusted publishing on release (or manual `workflow_dispatch` to TestPyPI/PyPI).
+A GitHub Actions workflow (`.github/workflows/pypi-release.yml`) builds a pure `py3-none-any` wheel + sdist (smoke-tested in CI) and publishes via trusted publishing on GitHub Release, or manual `workflow_dispatch` to TestPyPI/PyPI. Accelerated platform wheels are optional and not on the first-release critical path.
 
 ### Full native tools + Python (CMake)
 
@@ -219,15 +219,43 @@ curl -sL "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/${TAG}
 
 ## Releasing & Distribution
 
-- **Python package (PyPI)**: The workflow `.github/workflows/pypi-release.yml` builds sdist + wheels (cibuildwheel) and publishes on GitHub Release using trusted publishing. Run the workflow manually (`workflow_dispatch`) for TestPyPI. The optional `_core` extension is built when possible; otherwise pure-Python wheels/sdists still publish.
-  - Required once per environment: configure PyPI / TestPyPI **trusted publishing** for the `pypi` and `testpypi` GitHub Environments.
-  - Smoke checks: sdist install + `import flexaidds` run in CI before publish.
+- **Python package (PyPI)**: The workflow `.github/workflows/pypi-release.yml` builds:
+  1. **sdist** (includes staged minimal `LIB/` so out-of-tree builds can compile `_core` when Eigen + a C++26 compiler are present)
+  2. **pure `py3-none-any` wheel** (`FLEXAIDDS_SKIP_CORE=1`) so `pip install flexaidds` always works without a compiler
+
+  Both artifacts are smoke-tested (install + `import flexaidds` + CLI) before publish. Publish runs on GitHub Release (`pypi`) or manual `workflow_dispatch` (`testpypi` / `pypi`).
+
+  **One-time trusted publisher setup** (required before the first upload — this is the usual cause of `invalid-publisher`):
+
+  | Field | TestPyPI | PyPI |
+  |:------|:---------|:-----|
+  | Project | `flexaidds` (pending OK) | `flexaidds` (pending OK) |
+  | Owner | `LeBonhommePharma` | `LeBonhommePharma` |
+  | Repository | `FlexAIDdS` | `FlexAIDdS` |
+  | Workflow filename | `pypi-release.yml` | `pypi-release.yml` |
+  | Environment name | `testpypi` | `pypi` |
+
+  - TestPyPI pending publisher: https://test.pypi.org/manage/account/publishing/
+  - PyPI pending publisher: https://pypi.org/manage/account/publishing/
+  - GitHub Environments `pypi` / `testpypi` must already exist on the repo (they do).
+  - **Token fallback** (optional): set repo secret `TEST_PYPI_API_TOKEN` or `PYPI_API_TOKEN` (API token starting with `pypi-`). When set, the workflow uses token auth instead of OIDC.
+
+  Local packaging smoke test (mirrors CI):
+  ```bash
+  python3 -m venv /tmp/flexaidds-pkg && source /tmp/flexaidds-pkg/bin/activate
+  pip install -U pip build twine
+  cd python
+  FLEXAIDDS_SKIP_CORE=1 python -m build --sdist --wheel --outdir /tmp/flexaidds-dist
+  twine check /tmp/flexaidds-dist/*
+  FLEXAIDDS_SKIP_CORE=1 pip install /tmp/flexaidds-dist/*.whl
+  python -c "import flexaidds as fd; print(fd.__version__, fd.HAS_CORE_BINDINGS)"
+  ```
 
 - **Homebrew**: Update `Formula/flexaidds.rb` (`url` + `sha256` for stable; `head` tracks `master`) when cutting releases. Users install via the raw formula URL (or a personal tap).
 
 - **Native binaries**: Existing release workflow attaches platform archives on tag.
 
-- **In-package updater**: `python -m flexaidds --check-update` / `--self-update` uses the GitHub Releases API and `pip install --upgrade flexaidds`.
+- **In-package updater**: `python -m flexaidds --check-update` / `--self-update` uses the GitHub Releases API and `pip install --upgrade flexaidds` (falls back to the GitHub VCS URL when the package is not yet on the default index).
 
 ---
 


### PR DESCRIPTION
## Summary

Finishes the PyPI installer work after pure sdist + wheel builds already green in CI.

- **Build path verified**: pure `py3-none-any` wheel + sdist with staged `LIB/` install cleanly (`HAS_CORE=False` pure-Python fallback). Local smoke: twine check, wheel install, CLI, import.
- **Release workflow**: assert pure wheel tag, `skip-existing`, optional `PYPI_API_TOKEN` / `TEST_PYPI_API_TOKEN` fallback, and print the exact trusted-publisher claim checklist before upload.
- **Docs**: replace outdated cibuildwheel-on-critical-path notes with the pure-wheel first-release path + one-time TestPyPI/PyPI publisher setup table.

## Root cause of last CI failure

Latest `workflow_dispatch` → TestPyPI failed only on publish:

`invalid-publisher` — GitHub Environments `pypi`/`testpypi` exist, but **no matching trusted publisher** is registered on test.pypi.org for:

`repo:LeBonhommePharma/FlexAIDdS:environment:testpypi` + workflow `pypi-release.yml`.

Build jobs (sdist + pure wheel) already succeeded.

## One-time action required (you)

1. https://test.pypi.org/manage/account/publishing/ → add **pending** publisher:
   - Project: `flexaidds`
   - Owner: `LeBonhommePharma`
   - Repository: `FlexAIDdS`
   - Workflow: `pypi-release.yml`
   - Environment: `testpypi`
2. Re-run **PyPI Release** with target `testpypi`.
3. Repeat on pypi.org (environment `pypi`) before the first public publish.

**Or** set repo secret `TEST_PYPI_API_TOKEN` / `PYPI_API_TOKEN` (token must start with `pypi-`).

## Test plan

- [x] Local `FLEXAIDDS_SKIP_CORE=1 python -m build` → pure wheel + sdist
- [x] twine check PASSED
- [x] pip install wheel + sdist → `import flexaidds`, CLI, `HAS_CORE_BINDINGS=False`
- [x] pytest packaging-related suite: 47 passed, 1 skipped
- [ ] After trusted publisher (or token): re-run workflow_dispatch → TestPyPI green
- [ ] `pip install -i https://test.pypi.org/simple/ flexaidds` smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release & Distribution**
  * Improved package release checks to verify pure Python wheel compatibility.
  * Added clearer publishing validation for PyPI and TestPyPI releases.
  * Documented trusted publishing setup, token fallback options, generated artifacts, and local packaging smoke tests.

* **Documentation**
  * Clarified installation and release workflows, including source distributions, pure wheels, optional platform wheels, and package update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->