### PR TITLE
Fix: restore classic FlexAID soft-β entropy ranking (keep vib)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1615,6 +1615,60 @@ if(BUILD_TESTING)
     flexaids_configure_msvc_test(test_binding_mode_statmech)
     add_test(NAME BindingModeStatMechTests COMMAND test_binding_mode_statmech)
 
+    # test_classic_entropy_ranking — classic FlexAID soft-β / ACF rank-0 (rollback: force_cf_rank_emission)
+    add_executable(test_classic_entropy_ranking
+        tests/test_classic_entropy_ranking.cpp
+        tests/stubs.cpp
+        LIB/gaboom.cpp
+        LIB/coarse_init.cpp
+        LIB/ThermodynamicEngine.cpp
+        LIB/LigandRingFlex/RingConformerLibrary.cpp
+        LIB/LigandRingFlex/SugarPucker.cpp
+        LIB/VibEntropy.cpp
+        LIB/InStreamClustering.cpp
+        LIB/GAContext.cpp
+        LIB/Vcontacts.cpp
+        LIB/statmech.cpp
+        LIB/TurboQuant.cpp
+        LIB/geometry.cpp
+        LIB/tENCoM/tencm.cpp
+        LIB/encom.cpp
+        LIB/BindingMode.cpp
+        LIB/fast_optics.cpp
+        LIB/ShannonThermoStack/ShannonThermoStack.cpp
+        LIB/CleftDetector.cpp
+        LIB/NATURaL/NATURaLDualAssembly.cpp
+        LIB/NATURaL/RibosomeElongation.cpp
+        LIB/NATURaL/TransloconInsertion.cpp
+        LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/NascentChainScheduler.cpp
+        LIB/NATURaL/FibrilGrowthOracle.cpp
+        LIB/GrandPartitionFunction.cpp
+        LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/UnifiedHardwareDispatch.cpp
+        LIB/hardware_detect.cpp
+    )
+    target_include_directories(test_classic_entropy_ranking PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB/tENCoM
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB/ShannonThermoStack
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB/NATURaL
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB/CavityDetect
+    )
+    target_link_libraries(test_classic_entropy_ranking PRIVATE GTest::gtest_main)
+    if(MSVC)
+        target_compile_options(test_classic_entropy_ranking PRIVATE /O2)
+    else()
+        target_compile_options(test_classic_entropy_ranking PRIVATE -O2)
+    endif()
+    if(FLEXAIDS_USE_OPENMP AND OpenMP_CXX_FOUND)
+        target_link_libraries(test_classic_entropy_ranking PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+    target_link_libraries(test_classic_entropy_ranking PRIVATE Eigen3::Eigen)
+    target_compile_definitions(test_classic_entropy_ranking PRIVATE FLEXAIDS_HAS_EIGEN)
+    flexaids_configure_msvc_test(test_classic_entropy_ranking)
+    add_test(NAME ClassicEntropyRankingTests COMMAND test_classic_entropy_ranking)
+
     # test_ccbm — Conformer-Coupled Binding Modes (CCBM) unit tests
     add_executable(test_ccbm
         tests/test_ccbm.cpp

--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -257,6 +257,7 @@ void BindingMode::add_Pose(Pose& pose)
 /// === Cache rebuild infrastructure (Phase 1 + CCBM) ===
 /// Uses pose.total_energy() (= CF + receptor_strain) for the true
 /// multi-conformer free energy: F = -kT ln Σ_{r,i} exp(-β(E_CF(r,i) + E_strain(r)))
+/// Physical-kB path used for diagnostic ledger + force_cf_rank_emission ranking.
 void BindingMode::rebuild_engine() const
 {
 	if (thermo_cache_valid_)
@@ -273,25 +274,80 @@ void BindingMode::rebuild_engine() const
 }
 
 
+bool BindingMode::use_classic_entropy_ranking() const noexcept
+{
+	// Classic FlexAID: soft-β global-Z free energy elects modes when T>0.
+	// force_cf_rank_emission restores physical per-mode StatMech ranking (rollback).
+	if (!Population || Population->Temperature == 0)
+		return false;
+	if (Population->FA && Population->FA->force_cf_rank_emission)
+		return false;
+	return true;
+}
+
+
 double BindingMode::compute_enthalpy() const
 {
-	rebuild_engine();
-	return engine_.compute().mean_energy;
+	if (!use_classic_entropy_ranking())
+	{
+		rebuild_engine();
+		return engine_.compute().mean_energy;
+	}
+	// Classic FlexAID: H = Σ_{i in mode} p_i E_i with p_i = w_i / Z_global
+	double enthalpy = 0.0;
+	const double Z = Population->PartitionFunction;
+	if (Z <= 0.0 || Poses.empty())
+		return 0.0;
+	for (const auto& pose : Poses)
+	{
+		const double p = pose.boltzmann_weight / Z;
+		enthalpy += p * static_cast<double>(pose.CF);
+	}
+	return enthalpy;
 }
 
 
 double BindingMode::compute_entropy() const
 {
-	rebuild_engine();
-	return engine_.compute().entropy;
+	if (!use_classic_entropy_ranking())
+	{
+		rebuild_engine();
+		return engine_.compute().entropy;
+	}
+	// Classic FlexAID: S = −Σ_{i in mode} p_i ln p_i  (Shannon, global p_i)
+	double entropy = 0.0;
+	const double Z = Population->PartitionFunction;
+	if (Z <= 0.0 || Poses.empty())
+		return 0.0;
+	for (const auto& pose : Poses)
+	{
+		const double p = pose.boltzmann_weight / Z;
+		if (p > 0.0)
+			entropy += p * std::log(p);
+	}
+	return -entropy;
 }
 
 
 double BindingMode::compute_energy() const
 {
-	rebuild_engine();
-	double nat_dg = (Population && Population->FA) ? Population->FA->natural_deltaG : 0.0;
-	return engine_.compute().free_energy + compute_vibrational_correction() + nat_dg;
+	if (!use_classic_entropy_ranking())
+	{
+		rebuild_engine();
+		double nat_dg = (Population && Population->FA) ? Population->FA->natural_deltaG : 0.0;
+		return engine_.compute().free_energy + compute_vibrational_correction() + nat_dg;
+	}
+	// Classic FlexAID configurational free energy: F_conf = H − T·S
+	// (soft-β, global Z, T without kB) — this is what elects modes.
+	// FlexAIDdS keeps vibrational entropy on the ranking path as well:
+	// F = F_conf + (−T·S_vib) [ENCoM/tENCoM] + optional NATURaL ΔG.
+	// Vib is additive; it does not replace classic soft-β ranking.
+	const double nat_dg =
+		(Population && Population->FA) ? Population->FA->natural_deltaG : 0.0;
+	return compute_enthalpy()
+		- (static_cast<double>(Population->Temperature) * compute_entropy())
+		+ compute_vibrational_correction()
+		+ nat_dg;
 }
 
 
@@ -691,7 +747,16 @@ Pose::Pose(chromosome* chrom, int index, int iorder, float dist, uint temperatur
 	energy_components.metal = chrom->cf.metal_coord;
 	energy_components.water = chrom->cf.gist;
 	energy_components.complete = false;
-	this->boltzmann_weight = std::exp(-chrom->app_evalue / (statmech::kB_kcal * static_cast<double>(temperature)));
+	// Classic FlexAID soft-β: w = exp(−E/T). Physical 1/(kB·T) collapsed ranking
+	// entropy to zero on CF magnitudes. PartitionFunction + classic BindingMode F
+	// use these weights. Physical ledger uses StatMechEngine (unchanged).
+	// Rollback of ranking product is FA->force_cf_rank_emission, not this weight.
+	if (temperature > 0) {
+		this->boltzmann_weight = std::exp(
+			-static_cast<double>(chrom->app_evalue) / static_cast<double>(temperature));
+	} else {
+		this->boltzmann_weight = 0.0;
+	}
 }
 
 

--- a/LIB/BindingMode.h
+++ b/LIB/BindingMode.h
@@ -158,6 +158,9 @@ class BindingMode // aggregation of poses (Cluster)
 		void	set_energy();                         // updates cached energy value
 		void	rebuild_engine() const;               // populates engine_ from Poses (called on-demand)
 		double	compute_vibrational_correction() const; // Phase 3: -T*S_vib from ENCoM modes
+		// Classic FlexAID soft-β ranking when T>0 && !FA->force_cf_rank_emission.
+		// Ranking F also adds ENCoM vib correction (FlexAIDdS). Rollback: force_cf_rank_emission.
+		bool	use_classic_entropy_ranking() const noexcept;
 
 	private:
 		void 	output_BindingMode(int num_result, char* end_strfile, char* tmp_end_strfile, char* dockinp, char* gainp, int minPoints);

--- a/LIB/cluster.cpp
+++ b/LIB/cluster.cpp
@@ -213,31 +213,45 @@ void cluster(FA_Global* FA, GB_Global* GB, VC_Global* VC, chromosome* chrom, gen
 	if(FA->temperature)
 	{
 		// Reordering the clusters properly by lowest ACF values first (after considering cluster's entropy !)
+		// Classic FlexAID contract: this ACF order IS emission order when T>0.
 		QuickSort_Clusters(Clus_TOP, Clus_FRE, Clus_TCF, Clus_ACF, Clus_GAPOP, 0, num_of_results-1);
 	}
 
-	// ── Emit rank-0 = lowest-CF representative ───────────────────────────────
-	// The ACF ordering above is the entropy-augmented cluster free energy, which
-	// can rank a densely-populated cluster at WORSE representative CF ahead of a
-	// sparse cluster at BETTER CF (e.g. 1KZK: emitted _0.pdb = -390.45 while a
-	// -420.62 representative existed in another cluster). DatasetRunner measures
-	// both the RMSD and best_score on the lowest "REMARK CF=" pose, and that
-	// REMARK is chrom[Clus_TOP[j]].evalue (see emission below). Re-sort the
-	// clusters by representative evalue ascending (most negative first) so the
-	// emitted _0.pdb is always the lowest-CF cluster representative the GA found.
-	// Selection sort over num_of_results (≤ max_results, small) reusing
-	// swap_clusters to keep all five parallel arrays consistent.
-	for(int a=0; a<num_of_results-1; ++a)
+	// ── Rank-0 emission policy ───────────────────────────────────────────────
+	// Classic FlexAID (default when T>0 && !force_cf_rank_emission): keep ACF
+	// order so dense entropy-favored basins can beat sparse lowest-CF clusters.
+	// P3b rollback (force_cf_rank_emission or T==0): re-sort by representative
+	// evalue so _0.pdb is always lowest CF (commit cd9004d behavior).
+	// Single gate — flip FA->force_cf_rank_emission to restore old product path.
+	const bool classic_entropy_emit =
+		(FA->temperature > 0) && !FA->force_cf_rank_emission;
+	if (!classic_entropy_emit)
 	{
-		int best_idx = a;
-		for(int b=a+1; b<num_of_results; ++b)
+		for(int a=0; a<num_of_results-1; ++a)
 		{
-			if(chrom[Clus_TOP[b]].evalue < chrom[Clus_TOP[best_idx]].evalue)
-				best_idx = b;
+			int best_idx = a;
+			for(int b=a+1; b<num_of_results; ++b)
+			{
+				if(chrom[Clus_TOP[b]].evalue < chrom[Clus_TOP[best_idx]].evalue)
+					best_idx = b;
+			}
+			if(best_idx != a)
+				swap_clusters(&Clus_TOP[a], &Clus_FRE[a], &Clus_TCF[a], &Clus_ACF[a], &Clus_GAPOP[a],
+				              &Clus_TOP[best_idx], &Clus_FRE[best_idx], &Clus_TCF[best_idx], &Clus_ACF[best_idx], &Clus_GAPOP[best_idx]);
 		}
-		if(best_idx != a)
-			swap_clusters(&Clus_TOP[a], &Clus_FRE[a], &Clus_TCF[a], &Clus_ACF[a], &Clus_GAPOP[a],
-			              &Clus_TOP[best_idx], &Clus_FRE[best_idx], &Clus_TCF[best_idx], &Clus_ACF[best_idx], &Clus_GAPOP[best_idx]);
+	}
+	else if (num_of_results > 0)
+	{
+		// Debuggable proof that rank-0 is ACF, not necessarily min CF.
+		double best_cf = chrom[Clus_TOP[0]].evalue;
+		for (int a = 1; a < num_of_results; ++a) {
+			if (chrom[Clus_TOP[a]].evalue < best_cf)
+				best_cf = chrom[Clus_TOP[a]].evalue;
+		}
+		fprintf(stdout,
+			"[ENTROPY_RANK] classic FlexAID: rank-0 by ACF (ACF=%.4f CF=%.4f freq=%d); "
+			"best_CF_among_emitted=%.4f (CF re-sort off; set force_cf_rank_emission to restore P3b)\n",
+			Clus_ACF[0], chrom[Clus_TOP[0]].evalue, Clus_FRE[0], best_cf);
 	}
 
 	// print cluster information

--- a/LIB/config_defaults.h
+++ b/LIB/config_defaults.h
@@ -80,9 +80,14 @@ inline json::Value flexaid_default_config() {
 
         // ── Thermodynamics ───────────────────────────────────────
         {"thermodynamics", V(O{
-            {"temperature",           V(300)},   // Kelvin (0 = entropy off)
-            {"clustering_algorithm",  V("CF")},  // CF, DP, or FO
-            {"cluster_rmsd",          V(2.0)},   // RMSD threshold for clustering
+            {"temperature",               V(300)},   // Kelvin (0 = entropy off)
+            {"clustering_algorithm",      V("CF")},  // CF, DP, or FO
+            {"cluster_rmsd",              V(2.0)},   // RMSD threshold for clustering
+            // Classic FlexAID soft-β ACF / BindingMode F elects rank-0 (default).
+            // Set force_cf_rank_emission true (or classic_entropy_ranking false) to
+            // restore P3b lowest-CF emission without reverting the branch.
+            {"classic_entropy_ranking",   V(true)},
+            {"force_cf_rank_emission",    V(false)},
         })},
 
         // ── Genetic Algorithm ────────────────────────────────────

--- a/LIB/config_parser.cpp
+++ b/LIB/config_parser.cpp
@@ -144,6 +144,26 @@ void apply_config(const json::Value& config, FA_Global* FA, GB_Global* GB) {
         }
         FA->cluster_rmsd = jflt(config, "thermodynamics", "cluster_rmsd", 2.0f);
         FA->use_super_cluster = jbool(config, "thermodynamics", "use_super_cluster", false);
+        // Classic FlexAID entropy ranking is the default product when T>0.
+        // force_cf_rank_emission restores P3b lowest-CF emission (easy rollback).
+        // classic_entropy_ranking=false is an alias that also forces CF emission.
+        FA->force_cf_rank_emission = jbool(config, "thermodynamics", "force_cf_rank_emission", false);
+        if (!jbool(config, "thermodynamics", "classic_entropy_ranking", true)) {
+            FA->force_cf_rank_emission = true;
+        }
+        if (const char* e = std::getenv("FLEXAIDDS_FORCE_CF_RANK_EMISSION")) {
+            if (e[0] == '1' || e[0] == 't' || e[0] == 'T' || e[0] == 'y' || e[0] == 'Y')
+                FA->force_cf_rank_emission = true;
+            else if (e[0] == '0' || e[0] == 'f' || e[0] == 'F' || e[0] == 'n' || e[0] == 'N')
+                FA->force_cf_rank_emission = false;
+        }
+        if (const char* e = std::getenv("FLEXAIDDS_CLASSIC_ENTROPY_RANKING")) {
+            // 0/false → CF emission (rollback); 1/true → classic entropy (default)
+            if (e[0] == '0' || e[0] == 'f' || e[0] == 'F' || e[0] == 'n' || e[0] == 'N')
+                FA->force_cf_rank_emission = true;
+            else if (e[0] == '1' || e[0] == 't' || e[0] == 'T' || e[0] == 'y' || e[0] == 'Y')
+                FA->force_cf_rank_emission = false;
+        }
         FA->use_tqcm  = jbool(config, "turboquant", "compressed_contact_matrix", false);
         FA->use_tqens = jbool(config, "turboquant", "ensemble_compression", false);
         FA->use_tqnn  = jbool(config, "turboquant", "compressed_nn", false);

--- a/LIB/flexaid.h
+++ b/LIB/flexaid.h
@@ -399,6 +399,10 @@ struct FA_Global_struct{
 	bool  use_tqnn;                      // TurboQuant compressed NN for FastOPTICS
 	uint temperature;					 // temperature parameter
 	double beta;						 // Metropolis ß parament == 1/T *may be worth trying 1/kT*
+	// When true: restore pre-classic-entropy emission (P3b cd9004d) — rank-0 = lowest CF.
+	// When false (default) and temperature > 0: classic FlexAID ACF / BindingMode F ranking.
+	// Revert product path: set force_cf_rank_emission = true (JSON or FLEXAIDDS_FORCE_CF_RANK_EMISSION=1).
+	bool  force_cf_rank_emission;
 	double dsf_Tm_K;                     // DSF/TSA melting temperature (K); 0.0 = not provided
 	double dsf_delta_Hm;                 // enthalpy at Tm from ITC/DSF (kcal/mol); 0.0 = not provided
 	float permeability;                  // allow permeability or not between atoms

--- a/docs/classic_entropy_ranking.md
+++ b/docs/classic_entropy_ranking.md
@@ -1,0 +1,75 @@
+# Classic FlexAID entropy ranking
+
+**Product:** When `temperature > 0`, rank-0 is elected by classic FlexAID **soft-β free energy** (ACF / BindingMode `H − T·S`), not by raw CF and not by physical kcal “binding affinity” ledgers.
+
+**Vibrational entropy stays.** FlexAIDdS still adds the ENCoM/tENCoM correction (`−T·S_vib`) on the BindingMode ranking energy. Classic soft-β configurational ranking is restored *and* vib remains an additive FlexAIDdS term — vib is not stripped for “classic purity.”
+
+**Search** still optimizes the CF/contact-function scoring proxy. **Election** is entropy-aware (configurational soft-β + optional vib).
+
+## Contract (original FlexAID)
+
+| Piece | Classic FlexAID | FlexAIDdS default ranking |
+|--------|-----------------|---------------------------|
+| β | `1/T` (not `1/(kB T)`) | same for configurational weights |
+| Cluster free energy (ACF) | soft-β cluster free energy | same; elects CF-path emission |
+| BindingMode F | `H − T·S` (global Z) | `H − T·S_conf + (−T·S_vib) [+ NATURaL]` |
+| Rank-0 | lowest ACF / lowest F | same product role |
+
+| Layer | Elects rank-0? |
+|-------|----------------|
+| Soft-β ACF / classic BindingMode F (+ vib) | **Yes** |
+| Physical kB StatMech “affinity” / Shannon CSV / G_bind logs | **No** (diagnostic) |
+
+`compute_vibrational_correction()` is unchanged; classic ranking **calls it**. Disable vib via existing FA normal-modes / weight knobs, not by forcing CF emission.
+
+## Config
+
+```json
+"thermodynamics": {
+  "temperature": 300,
+  "clustering_algorithm": "CF",
+  "classic_entropy_ranking": true,
+  "force_cf_rank_emission": false
+}
+```
+
+| Knob | Default | Effect |
+|------|---------|--------|
+| `temperature` | 300 | `0` disables entropy ranking |
+| `classic_entropy_ranking` | **true** | soft-β ACF / BindingMode F elects rank-0 |
+| `force_cf_rank_emission` | **false** | if **true**, restores P3b lowest-CF emission |
+
+Env overrides:
+
+- `FLEXAIDDS_FORCE_CF_RANK_EMISSION=1` → CF emission (rollback)
+- `FLEXAIDDS_CLASSIC_ENTROPY_RANKING=0` → same rollback
+
+## Easy rollback (do not need git revert for product path)
+
+1. Set `thermodynamics.force_cf_rank_emission: true`, **or**
+2. `export FLEXAIDDS_FORCE_CF_RANK_EMISSION=1`, **or**
+3. `classic_entropy_ranking: false`
+
+That restores commit `cd9004d` behavior: emit rank-0 by lowest representative CF after optional ACF sort.
+
+Full code revert of this feature: revert the PR / branch that touches:
+
+- `LIB/cluster.cpp` (CF re-sort gate)
+- `LIB/BindingMode.cpp` / `.h` (classic F + soft-β Pose weight)
+- `LIB/flexaid.h` (`force_cf_rank_emission`)
+- `LIB/config_parser.cpp` / `config_defaults.h`
+- `tests/test_classic_entropy_ranking.cpp`
+
+## Code map
+
+| File | Change |
+|------|--------|
+| `LIB/cluster.cpp` | Skip post-ACF CF re-sort unless `force_cf` or `T==0` |
+| `LIB/BindingMode.cpp` | Classic global-Z F for ranking; physical ledger unchanged |
+| `LIB/flexaid.h` | `force_cf_rank_emission` |
+
+## Success metric
+
+Pose success = RMSD / PoseBusters — **not** lowest CF and not claimed true ΔG.
+
+Live exhibit (pre-fix 1HNN): ACF-best cluster (freq 29) was emitted as rank 3; CF champion was rank 0. Classic ranking puts ACF-best first.

--- a/tests/test_binding_mode_advanced.cpp
+++ b/tests/test_binding_mode_advanced.cpp
@@ -36,6 +36,8 @@ protected:
         std::memset(fa, 0, sizeof(FA_Global));
 #pragma clang diagnostic pop
         fa->temperature = static_cast<uint>(TEMP);
+        // Advanced thermo/profile tests use physical per-mode F.
+        fa->force_cf_rank_emission = true;
 
         gb = new GB_Global();
         std::memset(gb, 0, sizeof(GB_Global));

--- a/tests/test_binding_mode_statmech.cpp
+++ b/tests/test_binding_mode_statmech.cpp
@@ -89,12 +89,20 @@ protected:
         delete mock_fa;
     }
     
-    // Helper: Create mock pose with specific CF
+    // Helper: Create mock pose with specific CF (also sets app_evalue so soft-β
+    // Pose::boltzmann_weight matches CF — required for classic global-Z ranking).
     Pose create_mock_pose(double cf_value, int index) {
+        mock_chroms[index].app_evalue = cf_value;
+        mock_chroms[index].evalue = cf_value;
         std::vector<float> empty_vec;
         Pose p(&mock_chroms[index], index, 0, 0.0f, static_cast<uint>(TEST_TEMPERATURE), empty_vec);
         p.CF = cf_value;
         return p;
+    }
+
+    // Physical per-mode StatMech ranking path (pre-classic-entropy product).
+    void enable_force_cf_ranking() {
+        mock_fa->force_cf_rank_emission = true;
     }
 };
 
@@ -127,6 +135,9 @@ TEST_F(BindingModeStatMechTest, LazyEngineRebuild) {
 }
 
 TEST_F(BindingModeStatMechTest, ConsistencyWithLegacy) {
+    // Physical ranking path: ranking F must match StatMech ledger.
+    // Classic path intentionally diverges (soft-β global Z vs kB per-mode).
+    enable_force_cf_ranking();
     BindingMode mode(test_population);
     
     // Add diverse CF distribution
@@ -150,6 +161,8 @@ TEST_F(BindingModeStatMechTest, ConsistencyWithLegacy) {
 }
 
 TEST_F(BindingModeStatMechTest, ThermodynamicBreakdownPreservesLegacyRankingEnergy) {
+    // Breakdown ledger is physical-kB; ranking under force_cf matches it.
+    enable_force_cf_ranking();
     BindingMode mode(test_population);
 
     std::vector<double> cf_values = {-14.0, -11.0, -9.0};
@@ -200,6 +213,8 @@ TEST_F(BindingModeStatMechTest, BoltzmannWeightsNormalization) {
 }
 
 TEST_F(BindingModeStatMechTest, EntropyBehavior) {
+    // Physical β: ground-state collapse on broad CF spreads.
+    enable_force_cf_ranking();
     BindingMode mode_sharp(test_population);
     BindingMode mode_broad(test_population);
     
@@ -230,6 +245,8 @@ TEST_F(BindingModeStatMechTest, EntropyBehavior) {
 // ===========================================================================
 
 TEST_F(BindingModeStatMechTest, DeltaGCalculation) {
+    // Per-mode physical F without global Z (modes not yet in population PF).
+    enable_force_cf_ranking();
     BindingMode mode1(test_population);
     BindingMode mode2(test_population);
     
@@ -297,6 +314,7 @@ TEST_F(BindingModeStatMechTest, CacheInvalidationOnClear) {
 }
 
 TEST_F(BindingModeStatMechTest, MultipleRebuilds) {
+    enable_force_cf_ranking();
     BindingMode mode(test_population);
     
     // First batch of poses

--- a/tests/test_binding_mode_vibrational.cpp
+++ b/tests/test_binding_mode_vibrational.cpp
@@ -45,6 +45,9 @@ protected:
         mock_fa = new FA_Global();
         mock_fa->temperature = static_cast<uint>(TEST_TEMPERATURE);
         mock_fa->normal_modes = 0;  // No vibrational correction by default
+        // Vibrational correction lives on the physical ranking/ledger path.
+        // Classic soft-β global-Z ranking is covered in test_classic_entropy_ranking.
+        mock_fa->force_cf_rank_emission = true;
 
         mock_gb = new GB_Global();
         mock_gb->num_genes = 6;

--- a/tests/test_ccbm.cpp
+++ b/tests/test_ccbm.cpp
@@ -53,6 +53,8 @@ protected:
         mock_fa->n_models = 1;
         mock_fa->model_gene_index = -1;
         mock_fa->normal_modes = 0;  // no ENCoM modes for these tests
+        // CCBM free-energy assertions use per-mode physical StatMech (incl. strain).
+        mock_fa->force_cf_rank_emission = true;
 
         mock_gb = new GB_Global();
         std::memset(mock_gb, 0, sizeof(GB_Global));

--- a/tests/test_classic_entropy_ranking.cpp
+++ b/tests/test_classic_entropy_ranking.cpp
@@ -1,0 +1,240 @@
+// tests/test_classic_entropy_ranking.cpp
+// Classic FlexAID entropy ranking (soft-β, global Z, ACF elects rank-0).
+// Rollback: FA->force_cf_rank_emission = true (P3b CF emission / physical F).
+// Apache-2.0 © 2026 Le Bonhomme Pharma
+
+#include <gtest/gtest.h>
+#include "../LIB/BindingMode.h"
+#include "../LIB/statmech.h"
+#include "../LIB/gaboom.h"
+#include <cmath>
+#include <cstring>
+#include <vector>
+#include <algorithm>
+
+namespace {
+
+// Minimal ACF-vs-CF election policy (mirrors cluster.cpp gate, pure logic).
+// Returns index of rank-0 under classic entropy vs force_cf.
+int elect_rank0(const std::vector<double>& acf,
+                const std::vector<double>& cf,
+                bool force_cf_rank_emission,
+                unsigned temperature)
+{
+    const int n = static_cast<int>(acf.size());
+    if (n == 0) return -1;
+    std::vector<int> order(n);
+    for (int i = 0; i < n; ++i) order[i] = i;
+
+    if (temperature > 0) {
+        std::stable_sort(order.begin(), order.end(),
+            [&](int a, int b) { return acf[a] < acf[b]; });
+    }
+    const bool classic = (temperature > 0) && !force_cf_rank_emission;
+    if (!classic) {
+        std::stable_sort(order.begin(), order.end(),
+            [&](int a, int b) { return cf[a] < cf[b]; });
+    }
+    return order[0];
+}
+
+}  // namespace
+
+class ClassicEntropyRankingTest : public ::testing::Test {
+protected:
+    FA_Global* mock_fa = nullptr;
+    GB_Global* mock_gb = nullptr;
+    VC_Global* mock_vc = nullptr;
+    chromosome* mock_chroms = nullptr;
+    genlim* mock_gene_lim = nullptr;
+    atom* mock_atoms = nullptr;
+    resid* mock_residue = nullptr;
+    gridpoint* mock_cleftgrid = nullptr;
+    BindingPopulation* pop = nullptr;
+    static constexpr double T = 300.0;
+    static constexpr double EPS = 1e-6;
+    static constexpr int N_CHROM = 40;
+
+    void SetUp() override {
+        mock_fa = new FA_Global();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnontrivial-memcall"
+        std::memset(mock_fa, 0, sizeof(FA_Global));
+#pragma clang diagnostic pop
+        mock_fa->temperature = static_cast<uint>(T);
+        mock_fa->force_cf_rank_emission = false;  // classic product default
+        mock_fa->beta = 1.0 / T;
+
+        mock_gb = new GB_Global();
+        std::memset(mock_gb, 0, sizeof(GB_Global));
+        mock_gb->num_genes = 6;
+
+        mock_vc = new VC_Global();
+        std::memset(mock_vc, 0, sizeof(VC_Global));
+
+        mock_chroms = new chromosome[N_CHROM];
+        for (int i = 0; i < N_CHROM; ++i) {
+            mock_chroms[i].genes = new gene[mock_gb->num_genes];
+            std::memset(mock_chroms[i].genes, 0, sizeof(gene) * mock_gb->num_genes);
+            mock_chroms[i].evalue = 0.0;
+            mock_chroms[i].app_evalue = 0.0;
+            mock_chroms[i].fitnes = 0.0;
+            mock_chroms[i].status = 'n';
+        }
+        mock_gene_lim = new genlim[mock_gb->num_genes];
+        std::memset(mock_gene_lim, 0, sizeof(genlim) * mock_gb->num_genes);
+        mock_atoms = new atom[10];
+        std::memset(mock_atoms, 0, sizeof(atom) * 10);
+        mock_residue = new resid[2];
+        std::memset(mock_residue, 0, sizeof(resid) * 2);
+        mock_cleftgrid = new gridpoint[100];
+        std::memset(mock_cleftgrid, 0, sizeof(gridpoint) * 100);
+
+        pop = new BindingPopulation(
+            mock_fa, mock_gb, mock_vc,
+            mock_chroms, mock_gene_lim,
+            mock_atoms, mock_residue, mock_cleftgrid,
+            N_CHROM);
+    }
+
+    void TearDown() override {
+        delete pop;
+        delete[] mock_cleftgrid;
+        delete[] mock_residue;
+        delete[] mock_atoms;
+        delete[] mock_gene_lim;
+        for (int i = 0; i < N_CHROM; ++i) delete[] mock_chroms[i].genes;
+        delete[] mock_chroms;
+        delete mock_vc;
+        delete mock_gb;
+        delete mock_fa;
+    }
+
+    Pose make_pose(double cf, int index) {
+        mock_chroms[index].app_evalue = cf;
+        mock_chroms[index].evalue = cf;
+        std::vector<float> empty;
+        Pose p(&mock_chroms[index], index, 0, 0.0f, static_cast<uint>(T), empty);
+        p.CF = static_cast<float>(cf);
+        return p;
+    }
+};
+
+// ─── 1HNN-class emission policy (pure logic, no full GA) ───────────────────
+// Live .cad: cluster ACF=-263.4 (freq 29, CF weak) vs ACF=-49.3 (CF=-189.9).
+TEST(ClassicEntropyEmissionPolicy, DefaultElectsLowestACF) {
+    // indices: 0 = CF champion, 3 = ACF champion (1HNN-like)
+    std::vector<double> acf = {-49.3, -83.4, -48.9, -263.4, -221.2};
+    std::vector<double> cf  = {-189.9, -120.0, -100.0, -72.1, -80.0};
+    EXPECT_EQ(elect_rank0(acf, cf, /*force_cf=*/false, 300), 3);
+}
+
+TEST(ClassicEntropyEmissionPolicy, ForceCFRestoresP3bLowestCF) {
+    std::vector<double> acf = {-49.3, -83.4, -48.9, -263.4, -221.2};
+    std::vector<double> cf  = {-189.9, -120.0, -100.0, -72.1, -80.0};
+    EXPECT_EQ(elect_rank0(acf, cf, /*force_cf=*/true, 300), 0);
+}
+
+TEST(ClassicEntropyEmissionPolicy, TemperatureZeroForcesCF) {
+    std::vector<double> acf = {-49.3, -263.4};
+    std::vector<double> cf  = {-189.9, -72.1};
+    EXPECT_EQ(elect_rank0(acf, cf, /*force_cf=*/false, 0), 0);
+}
+
+// ─── Dense basin beats singleton best CF (classic BindingMode F) ───────────
+TEST_F(ClassicEntropyRankingTest, DenseModeBeatsSingletonBestCF) {
+    ASSERT_FALSE(mock_fa->force_cf_rank_emission);
+
+    BindingMode dense(pop);
+    // 25 poses at middling CF ≈ -100
+    for (int i = 0; i < 25; ++i) {
+        Pose p = make_pose(-100.0 - 0.1 * (i % 5), i);
+        dense.add_Pose(p);
+    }
+
+    BindingMode singleton(pop);
+    // One deep false minimum at CF = -190
+    Pose best = make_pose(-190.0, 30);
+    singleton.add_Pose(best);
+
+    // Register both into global Z (classic contract)
+    pop->add_BindingMode(dense);
+    pop->add_BindingMode(singleton);
+
+    // Re-fetch after Entropize path via set_energy on add
+    const BindingMode& m0 = pop->get_binding_mode(0);
+    const BindingMode& m1 = pop->get_binding_mode(1);
+
+    // Rank-0 after Entropize must be the dense mode (classic entropy).
+    // get_binding_mode sorts by classic F.
+    EXPECT_GT(m0.get_BindingMode_size(), m1.get_BindingMode_size());
+    EXPECT_LT(m0.get_cached_energy(), m1.get_cached_energy());
+    EXPECT_GT(m0.compute_entropy(), 0.0);
+}
+
+TEST_F(ClassicEntropyRankingTest, ForceCFPrefersLowestCFSingleton) {
+    mock_fa->force_cf_rank_emission = true;
+
+    BindingMode dense(pop);
+    for (int i = 0; i < 25; ++i) {
+        Pose p = make_pose(-100.0, i);
+        dense.add_Pose(p);
+    }
+    BindingMode singleton(pop);
+    Pose best = make_pose(-190.0, 30);
+    singleton.add_Pose(best);
+
+    pop->add_BindingMode(dense);
+    pop->add_BindingMode(singleton);
+
+    const BindingMode& m0 = pop->get_binding_mode(0);
+    // Physical per-mode F collapses toward min energy → singleton wins.
+    EXPECT_EQ(m0.get_BindingMode_size(), 1);
+}
+
+TEST_F(ClassicEntropyRankingTest, SoftBetaPoseWeightNotPhysicalKB) {
+    Pose p = make_pose(-90.0, 0);
+    // Classic: exp(90/300) = exp(0.3) ≈ 1.34986
+    const double classic_w = std::exp(90.0 / 300.0);
+    EXPECT_NEAR(p.boltzmann_weight, classic_w, 1e-9);
+    // Physical would be exp(90/(kB*300)) with kB≈0.001987 → huge
+    const double physical_w = std::exp(90.0 / (statmech::kB_kcal * 300.0));
+    EXPECT_GT(physical_w / classic_w, 10.0);
+}
+
+TEST_F(ClassicEntropyRankingTest, PhysicalLedgerStillCallableUnderClassicRanking) {
+    BindingMode mode(pop);
+    for (int i = 0; i < 5; ++i) {
+        Pose p = make_pose(-50.0 - i, i);
+        mode.add_Pose(p);
+    }
+    pop->add_BindingMode(mode);
+
+    // Ranking energy is classic; diagnostic ledger remains physical StatMech.
+    auto thermo = pop->get_binding_mode(0).get_thermodynamics();
+    EXPECT_TRUE(std::isfinite(thermo.free_energy));
+    EXPECT_TRUE(std::isfinite(thermo.entropy));
+}
+
+// Vibrational correction stays on classic ranking F (FlexAIDdS, not stripped).
+// With normal_modes == 0 the correction is 0 — API still composes F_conf + vib.
+TEST_F(ClassicEntropyRankingTest, ClassicRankingIncludesVibCorrectionTerm) {
+    ASSERT_FALSE(mock_fa->force_cf_rank_emission);
+    mock_fa->normal_modes = 0;  // vib term evaluates to 0, but path is exercised
+
+    BindingMode mode(pop);
+    for (int i = 0; i < 4; ++i) {
+        Pose p = make_pose(-80.0 - i, i);
+        mode.add_Pose(p);
+    }
+    pop->add_BindingMode(mode);
+
+    const BindingMode& ranked = pop->get_binding_mode(0);
+    const double F = ranked.compute_energy();
+    const double H = ranked.compute_enthalpy();
+    const double S = ranked.compute_entropy();
+    const double F_conf = H - T * S;
+    // No modes → vib = 0; ranking F must match classic conf free energy.
+    EXPECT_NEAR(F, F_conf, EPS);
+    EXPECT_GT(S, 0.0);
+}


### PR DESCRIPTION
Default product when T>0 elects rank-0 by ACF / BindingMode F = H − T·S (global Z, β=1/T), not by P3b lowest-CF re-sort. ENCoM vibrational correction remains on the ranking free energy as an additive FlexAIDdS term. Rollback without git revert: force_cf_rank_emission=true or FLEXAIDDS_FORCE_CF_RANK_EMISSION=1.

## Summary

What changed and why.

## Scope

- [ ] Core 1.0 supported surface
- [ ] Experimental surface only
- [ ] Documentation only
- [ ] CI / release engineering
- [ ] Security hardening
- [ ] Benchmark / reproducibility

## Release impact

- [ ] affects CLI behavior
- [ ] affects Python package behavior
- [ ] affects configuration schema or defaults
- [ ] affects benchmark or metric reporting
- [ ] affects installation instructions
- [ ] no user-facing release impact

## Validation

Describe how this was validated.

- [ ] unit tests
- [ ] integration tests
- [ ] smoke benchmark
- [ ] documentation review
- [ ] manual validation

## Security and safety

- [ ] no new third-party dependency
- [ ] third-party dependency added and documented
- [ ] no known security-sensitive parsing change
- [ ] security-sensitive parsing change reviewed

## Reproducibility

- [ ] no benchmark claim involved
- [ ] benchmark claim updated with reproducibility artifact
- [ ] benchmark language remains preliminary

## Notes

Anything reviewers should pay attention to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added classic entropy-aware ranking for selecting top binding results at positive temperatures.
  - Added thermodynamics settings to control classic ranking and optionally restore CF-based emission ordering.
  - Added environment-variable overrides for ranking behavior.
  - Preserved vibrational corrections in classic free-energy ranking.

- **Documentation**
  - Added guidance describing ranking behavior, configuration options, and rollback settings.

- **Tests**
  - Added coverage for classic entropy ranking, CF overrides, temperature-zero behavior, weighting, and vibrational corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->