### PR TITLE
Fix: PyPI installer no longer emits UNKNOWN-0.0.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flexaidds"
-dynamic = ["version"]
+# Static version (keep in sync with flexaidds/__version__.py).
+# Do NOT use dynamic attr = "flexaidds.__version__.__version__": importing
+# that path executes flexaidds/__init__.py, which needs numpy — and numpy is
+# not a build-system dependency. That produced UNKNOWN-0.0.0 wheels on clean
+# / older pip builds (the classic PyPI installer failure mode).
+version = "2.0.0"
 description = "Python bindings and analysis tools for the FlexAID∆S thermodynamic docking engine"
 authors = [
   { name = "Louis-Philippe Morency" },
@@ -60,9 +65,6 @@ namespaces = false
 [tool.setuptools.package-data]
 "flexaidds" = ["py.typed"]
 "flexaidds.dataset_runner" = ["datasets/*.yaml"]
-
-[tool.setuptools.dynamic]
-version = { attr = "flexaidds.__version__.__version__" }
 
 # cibuildwheel: produce installable wheels even when the optional C++ extension
 # cannot be compiled (pure-Python fallback). setup.py never fails the install.

--- a/python/setup.py
+++ b/python/setup.py
@@ -512,8 +512,27 @@ def _placeholder_extension_modules() -> List[Extension]:
     ]
 
 
-# IMPORTANT: most metadata lives in pyproject.toml for modern builds.
+def _read_version() -> str:
+    """Parse version from flexaidds/__version__.py without importing the package.
+
+    Importing ``flexaidds`` pulls numpy (via ``__init__.py``). Build isolation
+    does not install numpy, so ``import flexaidds.__version__`` fails and older
+    tooling falls back to ``UNKNOWN-0.0.0`` wheels.
+    """
+    version_file = ROOT / "flexaidds" / "__version__.py"
+    for line in version_file.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("__version__") and "=" in stripped:
+            rhs = stripped.split("=", 1)[1].strip()
+            return rhs.strip().strip("\"'")
+    return "0.0.0"
+
+
+# Metadata primarily lives in pyproject.toml. Explicit name/version here are a
+# hard fallback for legacy pip/setuptools that do not fully apply PEP 621.
 setup(
+    name="flexaidds",
+    version=_read_version(),
     ext_modules=_placeholder_extension_modules(),
     cmdclass={
         "build_ext": optional_build_ext,

--- a/python/tests/test_version.py
+++ b/python/tests/test_version.py
@@ -42,6 +42,30 @@ class TestVersion:
         import flexaidds
         assert flexaidds.__version__ == __version__
 
+    def test_pyproject_version_matches_version_module(self):
+        """Static pyproject.toml version must match flexaidds/__version__.py.
+
+        Packaging uses a static PEP 621 version (not dynamic attr) so clean
+        builds never import flexaidds/__init__.py (which needs numpy).
+        """
+        from pathlib import Path
+
+        pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        text = pyproject.read_text(encoding="utf-8")
+        # Minimal parse: first bare `version = "..."` under [project].
+        found = None
+        in_project = False
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("[") and stripped.endswith("]"):
+                in_project = stripped == "[project]"
+                continue
+            if in_project and stripped.startswith("version") and "=" in stripped:
+                found = stripped.split("=", 1)[1].strip().strip("\"'")
+                break
+        assert found is not None, "version field missing from pyproject.toml [project]"
+        assert found == __version__, f"pyproject {found!r} != __version__ {__version__!r}"
+
     def test_statmech_in_all(self):
         """StatMechEngine and Thermodynamics should always be in __all__."""
         import flexaidds


### PR DESCRIPTION
## Summary
- Stop using dynamic `attr = flexaidds.__version__.__version__` for package version (that import loads `flexaidds/__init__.py` → numpy, which is not a build dependency and produced `UNKNOWN-0.0.0` wheels on clean/older pip).
- Set static PEP 621 `version = "2.0.0"` and pass explicit `name`/`version` in `setup.py` (parsed from `__version__.py` without importing the package).
- Add a test that keeps `pyproject.toml` and `__version__.py` in sync.

## Verification
- `python -m build` → `flexaidds-2.0.0.tar.gz` + `flexaidds-2.0.0-py3-none-any.whl`
- `twine check` PASSED
- Fresh venv install + `import flexaidds` + `python -m flexaidds --help`
- `pytest tests/test_version.py` → 11 passed

## Test plan
- [x] Local pure-wheel build/install smoke
- [ ] CI `pypi-release.yml` workflow_dispatch to TestPyPI after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package version handling during builds, avoiding unnecessary package imports and dependencies.
  * Added a fallback version for cases where version metadata cannot be read.

* **Tests**
  * Added validation to ensure the declared package version matches the runtime version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->