### PR TITLE
Fix: v2.0.2 Homebrew build (const path resolution)

### DIFF
--- a/Formula/flexaidds.rb
+++ b/Formula/flexaidds.rb
@@ -1,10 +1,10 @@
 class Flexaidds < Formula
   desc "Entropy-driven molecular docking engine (FlexAID + ΔS thermodynamic analysis)"
   homepage "https://github.com/LeBonhommePharma/FlexAIDdS"
-  # v2.0.1 ships production MC_st0r5.2_6.dat (md5 9dc93717…) at repo root and
+  # v2.0.2 ships production MC_st0r5.2_6.dat (md5 9dc93717…) at repo root and
   # WRK/. v2.0.0 only had an outdated WRK matrix (md5 204b75ef…) that broke typing.
-  url "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/v2.0.1.tar.gz"
-  sha256 "08b0d3aecb71a8960f25396a48dd8facc76696b51072f78679e39ad198ebb971"
+  url "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/v2.0.2.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
   license "Apache-2.0"
   head "https://github.com/LeBonhommePharma/FlexAIDdS.git", branch: "master"
 
@@ -72,7 +72,7 @@ class Flexaidds < Formula
     install_runtime_data!(libexec/"bin")
     install_runtime_data!(libexec/"share")
 
-    # Prefer root matrix over WRK/ when both exist (v2.0.1+ ships production both).
+    # Prefer root matrix over WRK/ when both exist (v2.0.2+ ships production both).
     write_wrappers!
   end
 
@@ -133,7 +133,7 @@ class Flexaidds < Formula
       Wrappers under #{bin} set FLEXAIDDS_DATA_DIR=#{libexec}/share so PATH
       symlinks still find MC matrices and AMINO.def.
 
-      Stable v2.0.1+ includes the production docking matrix (atom typing works
+      Stable v2.0.2+ includes the production docking matrix (atom typing works
       out of the box). Upgrade from broken v2.0.0 installs with:
         brew update && brew reinstall flexaidds
 

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -603,15 +603,19 @@ int main(int argc, char **argv){
 		if (rp != NULL) {
 			src = resolved;
 		}
-		pch = strrchr(src, '/');
-		if (pch != NULL) {
-			size_t n = (size_t)(pch - src);
+		// strrchr(const char*) returns const char* — keep a local const pointer
+		// instead of assigning into the legacy char* pch variable.
+		const char* slash = strrchr(src, '/');
+		if (slash != NULL) {
+			size_t n = (size_t)(slash - src);
 			if (n >= MAX_PATH__) n = MAX_PATH__ - 1;
 			memcpy(FA->base_path, src, n);
 			FA->base_path[n] = '\0';
+			pch = FA->base_path; // satisfy any later uses of pch
 		} else {
 			strncpy(FA->base_path, ".", MAX_PATH__ - 1);
 			FA->base_path[MAX_PATH__ - 1] = '\0';
+			pch = NULL;
 		}
 	}
 #else

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,8 +1,8 @@
 # FlexAID∆S Version History
 
-**Current Version**: 2.0.1
+**Current Version**: 2.0.2
 **Release Date**: 2026-07-12
-**Python Package**: 2.0.1 (`python/flexaidds/__version__.py`)
+**Python Package**: 2.0.2 (`python/flexaidds/__version__.py`)
 **Repository**: [github.com/LeBonhommePharma/FlexAIDdS](https://github.com/LeBonhommePharma/FlexAIDdS)
 **License**: Apache-2.0
 
@@ -29,6 +29,10 @@ Selected changes that landed on `master` this week.
 - **Tooling and site surface** — [#231](https://github.com/LeBonhommePharma/FlexAIDdS/pull/231), [#232](https://github.com/LeBonhommePharma/FlexAIDdS/pull/232), [#233](https://github.com/LeBonhommePharma/FlexAIDdS/pull/233)
 
 ---
+
+## v2.0.2 (2026-07-12) — Homebrew build fix
+
+Hotfix on top of v2.0.1: fix `const char*` / `char*` mismatch in `LIB/top.cpp` path resolution so Apple Clang builds (Homebrew) succeed. Matrix shipping and installer changes from v2.0.1 unchanged.
 
 ## v2.0.1 (2026-07-12) — Homebrew + packaging hotfix
 

--- a/python/flexaidds/__version__.py
+++ b/python/flexaidds/__version__.py
@@ -1,7 +1,7 @@
 """Version information for FlexAID∆S Python package."""
 
-__version__ = "2.0.1"
-__version_info__ = (2, 0, 1, "final", 0)
+__version__ = "2.0.2"
+__version_info__ = (2, 0, 2, "final", 0)
 
 # Build metadata
 __author__ = "Louis-Philippe Morency"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ name = "flexaidds"
 # that path executes flexaidds/__init__.py, which needs numpy — and numpy is
 # not a build-system dependency. That produced UNKNOWN-0.0.0 wheels on clean
 # / older pip builds (the classic PyPI installer failure mode).
-version = "2.0.1"
+version = "2.0.2"
 description = "Python bindings and analysis tools for the FlexAID∆S thermodynamic docking engine"
 authors = [
   { name = "Louis-Philippe Morency" },


### PR DESCRIPTION
## Summary
- Fix compile error on Apple Clang: `assigning to 'char *' from 'const char *' discards qualifiers` in `LIB/top.cpp` (v2.0.1 path-resolution change).
- Bump package/VERSION/Formula to **v2.0.2**. Production matrix shipping from v2.0.1 unchanged.

## Test plan
- [x] `clang++ -c LIB/top.cpp` succeeds with Eigen includes
- [ ] Merge → tag `v2.0.2` → Formula sha256
- [ ] `brew install` stable succeeds; matrix md5 `9dc93717…`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released FlexAIDDS version 2.0.2 with updated package and distribution metadata.
  * Updated Homebrew packaging to use the v2.0.2 release artifact and checksum.
  * Refined production docking matrix guidance for v2.0.2 and later.

* **Bug Fixes**
  * Fixed an Apple Clang/Homebrew build issue affecting executable path resolution.

* **Documentation**
  * Added v2.0.2 release notes describing the Homebrew build fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->