### PR TITLE
Fix: PyPI + Homebrew package install refresh (tap docs, caveats, release check)

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -53,8 +53,27 @@ jobs:
           python -c "import flexaidds as fd; print('flexaidds', fd.__version__, 'HAS_CORE=', getattr(fd, 'HAS_CORE_BINDINGS', False))"
           python -m flexaidds --help
           python -m flexaidds --check-update || true
-          test "$(python -c 'import flexaidds; print(flexaidds.__version__)')" = "2.0.0" \
-            || python -c "import flexaidds as fd; assert fd.__version__, fd.__version__"
+          # Version must be non-empty and match the static PEP 621 field in pyproject.toml
+          # (do not hardcode — that drifted when we shipped 2.0.1/2.0.2).
+          python -c "
+import re
+from pathlib import Path
+import flexaidds as fd
+assert fd.__version__, fd.__version__
+text = Path('python/pyproject.toml').read_text(encoding='utf-8')
+in_project = False
+found = None
+for line in text.splitlines():
+    s = line.strip()
+    if s.startswith('[') and s.endswith(']'):
+        in_project = s == '[project]'
+        continue
+    if in_project and s.startswith('version') and '=' in s:
+        found = s.split('=', 1)[1].strip().strip('\"\'')
+        break
+assert found == fd.__version__, (found, fd.__version__)
+print('version_ok', fd.__version__)
+"
 
       - name: Upload sdist artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/Formula/flexaidds.rb
+++ b/Formula/flexaidds.rb
@@ -128,21 +128,29 @@ class Flexaidds < Formula
 
   def caveats
     <<~EOS
-      The FlexAIDdS native tools (FlexAIDdS, tENCoM, FlexAID) have been installed.
+      This formula installs the *native* docking tools only:
+        FlexAIDdS, FlexAID, tENCoM, tencom_entropy_diff
+
+      It does *not* install the Python analysis package. Those are separate:
+        # Python CLI + load_results / StatMech (GitHub until public PyPI):
+        pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
+        # After the first PyPI release: pip install flexaidds
+        # Then: flexaidds --help   or   python -m flexaidds --help
 
       Wrappers under #{bin} set FLEXAIDDS_DATA_DIR=#{libexec}/share so PATH
       symlinks still find MC matrices and AMINO.def.
 
       Stable v2.0.2+ includes the production docking matrix (atom typing works
       out of the box). Upgrade from broken v2.0.0 installs with:
-        brew update && brew reinstall flexaidds
+        brew update && brew reinstall lebonhommepharma/flexaidds/flexaidds
 
-      Python package:
-        pip install flexaidds
-        # or from git: pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
+      Install / reinstall path (Homebrew 6+ requires a real tap; raw URL installs
+      are rejected):
+        brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
+        brew install lebonhommepharma/flexaidds/flexaidds
 
       Default brew build uses CPU + OpenMP (no Metal).
-      Metal: brew install --with-metal flexaidds
+      Metal: brew install --with-metal lebonhommepharma/flexaidds/flexaidds
 
       Example:
         FlexAIDdS receptor.pdb ligand.sdf --rigid -o /tmp/out

--- a/README.md
+++ b/README.md
@@ -92,19 +92,20 @@ print(fd.__version__)
 run = fd.load_results("path/to/results")
 ```
 
-### macOS: Homebrew (native CLI tools)
+### macOS: Homebrew (native docking tools)
 
 ```bash
-# Tap the monorepo (Homebrew 6+ requires formulae to live in a tap with a git remote)
+# Tap the monorepo (Homebrew 6+ requires formulae to live in a tap with a git remote;
+# raw formula URL installs are rejected)
 brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
-brew install flexaidds
-# Tip-of-tree: brew install --HEAD flexaidds
-# Python package (not yet on public PyPI — install from GitHub):
+brew install lebonhommepharma/flexaidds/flexaidds
+# Tip-of-tree: brew install --HEAD lebonhommepharma/flexaidds/flexaidds
+# Python analysis package is separate (not yet on public PyPI — install from GitHub):
 pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
 # later: python -m flexaidds --self-update
 ```
 
-See [docs/INSTALLATION.md](docs/INSTALLATION.md) for conda, GitHub/PyPI, Windows, and full platform instructions. The Python package and native tools can be installed independently.
+Homebrew installs **native** binaries (`FlexAIDdS`, `tENCoM`, …). pip installs the **Python** package (`import flexaidds`, `flexaidds` CLI). Install both when you need docking *and* analysis. See [docs/INSTALLATION.md](docs/INSTALLATION.md) for conda, GitHub/PyPI, Windows, and full platform instructions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ run = fd.load_results("path/to/results")
 ### macOS: Homebrew (native CLI tools)
 
 ```bash
-# Stable release, or add --HEAD for tip-of-tree
-brew install --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+# Tap the monorepo (Homebrew 6+ requires formulae to live in a tap with a git remote)
+brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
+brew install flexaidds
+# Tip-of-tree: brew install --HEAD flexaidds
 # Python package (not yet on public PyPI — install from GitHub):
 pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
 # later: python -m flexaidds --self-update

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -122,17 +122,25 @@ cmake --build build --parallel
 
 #### Easy install via Homebrew (recommended for native CLI tools)
 
+Homebrew 6+ rejects one-off raw formula URLs and path installs. Install from a
+proper tap (with `origin`) so `brew update` / `brew doctor` stay clean — do
+**not** use `brew tap-new test/...` temporary taps without a remote (they leave
+orphan-tap doctor warnings).
+
 ```bash
+# One-time: tap the monorepo (Formula/flexaidds.rb lives at repo root)
+brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
+
 # Stable tagged release (v2.0.0+)
-brew install --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+brew install flexaidds
 
 # Or latest development tip
-brew install --HEAD --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+brew install --HEAD flexaidds
 
 # Update later
-brew reinstall --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+brew update && brew reinstall flexaidds
 # or, for HEAD builds:
-brew reinstall --HEAD --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+brew reinstall --HEAD flexaidds
 ```
 
 This installs `FlexAIDdS`, `tENCoM`, `FlexAID` + required data files.
@@ -194,11 +202,14 @@ See also `python/README.md`.
 The formula provides the high-performance native executables with data files staged correctly:
 
 ```bash
+# One-time tap (required on Homebrew 6+; raw URL / bare path installs are rejected)
+brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
+
 # Stable release
-brew install --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+brew install flexaidds
 
 # Development / latest
-brew install --HEAD --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+brew install --HEAD flexaidds
 
 # After install, add the Python package (GitHub until PyPI publish):
 pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
@@ -206,6 +217,18 @@ pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=
 ```
 
 The formula lives at `Formula/flexaidds.rb`. It supports both a stable `url`/`sha256` (tagged release) and `head` for tip-of-tree. Bottles may be added later.
+
+**Local formula testing (maintainers):** if you must exercise a local formula edit
+before push, either `brew install --build-from-source lebonhommepharma/flexaidds/flexaidds`
+after syncing the tap, or use a temporary tap **with cleanup**:
+
+```bash
+# Prefer this over leaving orphan test taps
+TAP="test/flexaidds-local-$$"
+brew tap-new --no-git "$TAP"   # or set origin if you init git
+# copy Formula/flexaidds.rb into the tap Formula/ dir, install, then:
+brew untap --force "$TAP"      # always clean up; never leave test/* without origin
+```
 
 When cutting a new stable release, update the formula’s `url`, `sha256`, and version together:
 ```bash
@@ -251,8 +274,7 @@ curl -sL "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/${TAG}
   python -c "import flexaidds as fd; print(fd.__version__, fd.HAS_CORE_BINDINGS)"
   ```
 
-- **Homebrew**: Update `Formula/flexaidds.rb` (`url` + `sha256` for stable; `head` tracks `master`) when cutting releases. Users install via the raw formula URL (or a personal tap).
-
+- **Homebrew**: Update `Formula/flexaidds.rb` (`url` + `sha256` for stable; `head` tracks `master`) when cutting releases. Users install via `brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS` then `brew install flexaidds` (Homebrew 6+ requires a real tap with `origin`; raw formula URLs are rejected).
 - **Native binaries**: Existing release workflow attaches platform archives on tag.
 
 - **In-package updater**: `python -m flexaidds --check-update` / `--self-update` uses the GitHub Releases API and `pip install --upgrade flexaidds` (falls back to the GitHub VCS URL when the package is not yet on the default index).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -131,19 +131,20 @@ orphan-tap doctor warnings).
 # One-time: tap the monorepo (Formula/flexaidds.rb lives at repo root)
 brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
 
-# Stable tagged release (v2.0.0+)
-brew install flexaidds
+# Stable tagged release (v2.0.2+). Qualified name always works.
+brew install lebonhommepharma/flexaidds/flexaidds
+# short form after tap: brew install flexaidds
 
 # Or latest development tip
-brew install --HEAD flexaidds
+brew install --HEAD lebonhommepharma/flexaidds/flexaidds
 
 # Update later
-brew update && brew reinstall flexaidds
+brew update && brew reinstall lebonhommepharma/flexaidds/flexaidds
 # or, for HEAD builds:
-brew reinstall --HEAD flexaidds
+brew reinstall --HEAD lebonhommepharma/flexaidds/flexaidds
 ```
 
-This installs `FlexAIDdS`, `tENCoM`, `FlexAID` + required data files.
+This installs **native** tools only (`FlexAIDdS`, `tENCoM`, `FlexAID` + MC matrices / `AMINO.def`). The Python package is separate (see pip section below).
 
 Then (recommended — GitHub until PyPI publish):
 ```bash
@@ -199,17 +200,27 @@ See also `python/README.md`.
 
 ## Homebrew (macOS native tools)
 
+### What each installer provides
+
+| Installer | Provides | Does **not** provide |
+|:----------|:---------|:---------------------|
+| **Homebrew** (`flexaidds` formula) | Native C++ tools: `FlexAIDdS`, `FlexAID`, `tENCoM`, `tencom_entropy_diff` + production MC matrices / `AMINO.def` | Python package, `flexaidds` CLI, `load_results`, pure-Python StatMech |
+| **pip / PyPI** (`flexaidds` package) | Python API + CLIs (`flexaidds`, `flexaidds-benchmark`), optional `_core` acceleration | Full docking engine binary / cavity search campaign binary |
+
+Install both if you want native docking **and** Python analysis. Versions are aligned at **2.0.2** (`Formula/flexaidds.rb` ↔ `python/pyproject.toml` ↔ `python/flexaidds/__version__.py`).
+
 The formula provides the high-performance native executables with data files staged correctly:
 
 ```bash
 # One-time tap (required on Homebrew 6+; raw URL / bare path installs are rejected)
 brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
 
-# Stable release
-brew install flexaidds
+# Stable release (qualified name always works)
+brew install lebonhommepharma/flexaidds/flexaidds
+# short form after tap: brew install flexaidds
 
 # Development / latest
-brew install --HEAD flexaidds
+brew install --HEAD lebonhommepharma/flexaidds/flexaidds
 
 # After install, add the Python package (GitHub until PyPI publish):
 pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
@@ -230,12 +241,14 @@ brew tap-new --no-git "$TAP"   # or set origin if you init git
 brew untap --force "$TAP"      # always clean up; never leave test/* without origin
 ```
 
-When cutting a new stable release, update the formula’s `url`, `sha256`, and version together:
+When cutting a new stable release, update the formula’s `url`, `sha256`, and version together
+(and keep `python/pyproject.toml` + `python/flexaidds/__version__.py` in sync):
 ```bash
 # Example maintainer steps
-TAG=v2.0.1
+TAG=v2.0.2
 curl -sL "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/${TAG}.tar.gz" | shasum -a 256
 # paste sha256 into Formula/flexaidds.rb, commit, push
+# users: brew update && brew reinstall lebonhommepharma/flexaidds/flexaidds
 ```
 
 ---

--- a/python/README.md
+++ b/python/README.md
@@ -19,6 +19,7 @@ Higher-level live docking orchestration is still intentionally staged behind the
 # Recommended today (package not yet on public PyPI):
 pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
 python -m flexaidds --check-update       # or --self-update
+# Console scripts after install: flexaidds, flexaidds-benchmark
 
 # From the repo root (development)
 pip install -e ./python
@@ -28,7 +29,13 @@ pip install flexaidds
 pip install --upgrade flexaidds
 ```
 
-This installs the `flexaidds` package. The compiled acceleration (`_core`) is built if the required build dependencies (pybind11, Eigen headers, a C++ compiler) are present. Otherwise the package installs successfully in **pure-Python fallback mode** (full result loading, models, pure-Python thermodynamics, etc. still work). Set `FLEXAIDDS_SKIP_CORE=1` to force pure-Python.
+This installs the **Python analysis package** only (not the native `FlexAIDdS` docking binary — use Homebrew or a CMake build for that). The compiled acceleration (`_core`) is built if the required build dependencies (pybind11, Eigen headers, a C++ compiler) are present. Otherwise the package installs successfully in **pure-Python fallback mode** (full result loading, models, pure-Python thermodynamics, etc. still work). Set `FLEXAIDDS_SKIP_CORE=1` to force pure-Python.
+
+**Native docking tools (separate):**
+```bash
+brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
+brew install lebonhommepharma/flexaidds/flexaidds
+```
 
 You can also do a non-editable install after building a wheel:
 ```bash


### PR DESCRIPTION
## Summary
- Verified the **Python package** (v2.0.2) builds as sdist + pure `py3-none-any` wheel, passes `twine check`, installs cleanly, and pure-Python tests pass (268 passed / 2 skipped).
- Verified the **Homebrew formula** (v2.0.2): sha256 matches the GitHub tag tarball, `brew audit --strict --online` clean, `brew style` clean, `brew test` clean; installed binaries smoke-test OK with production matrix.
- Updated install docs for **Homebrew 6+ tap-only** install (raw formula URLs rejected).
- Clarified that **Homebrew = native docking tools** and **pip = Python analysis package/CLI** (they do not replace each other).
- Formula caveats now point at the GitHub pip install until public PyPI is published.
- `pypi-release.yml` no longer hardcodes package version `2.0.0` in the sdist smoke check.

## User-facing install commands

```bash
# Native tools (macOS)
brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
brew install lebonhommepharma/flexaidds/flexaidds

# Python package (analysis / CLI — not yet on public PyPI)
pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
```

## Test plan
- [x] `FLEXAIDDS_SKIP_CORE=1 python -m build` + `twine check`
- [x] Clean venv wheel + sdist install; `import flexaidds`; CLI help
- [x] `pytest` pure-Python subset: 268 passed, 2 skipped
- [x] `brew audit --strict --online lebonhommepharma/flexaidds/flexaidds`
- [x] `brew style` / `brew test` / binary `--help` + matrix md5
- [x] Confirmed raw formula URL install is rejected on Homebrew 6
- [ ] (optional) Trigger `pypi-release.yml` → TestPyPI when publisher is ready
- [ ] (optional) Full `brew reinstall --build-from-source` when disk allows

## Notes
- Versions aligned at **2.0.2** (formula ↔ pyproject ↔ `__version__.py` ↔ `VERSION.md`).
- No PyPI upload in this PR (no policy/credentials exercised).
- Unrelated local WIP was stashed and not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified macOS installation options using Homebrew taps and Python package installation.
  - Explained the separate native docking tools and Python analysis package.
  - Documented available command-line tools, build modes, environment settings, and upgrade steps.
  - Added Homebrew testing and release guidance.

- **Bug Fixes**
  - Release verification now checks the installed package version dynamically against the project version, avoiding outdated hardcoded checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->