### PR TITLE
Fix: Homebrew --with-metal link (Metal bridges on flexaid_core)

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -53,8 +53,27 @@ jobs:
           python -c "import flexaidds as fd; print('flexaidds', fd.__version__, 'HAS_CORE=', getattr(fd, 'HAS_CORE_BINDINGS', False))"
           python -m flexaidds --help
           python -m flexaidds --check-update || true
-          test "$(python -c 'import flexaidds; print(flexaidds.__version__)')" = "2.0.0" \
-            || python -c "import flexaidds as fd; assert fd.__version__, fd.__version__"
+          # Version must be non-empty and match the static PEP 621 field in pyproject.toml
+          # (do not hardcode — that drifted when we shipped 2.0.1/2.0.2).
+          python -c "
+import re
+from pathlib import Path
+import flexaidds as fd
+assert fd.__version__, fd.__version__
+text = Path('python/pyproject.toml').read_text(encoding='utf-8')
+in_project = False
+found = None
+for line in text.splitlines():
+    s = line.strip()
+    if s.startswith('[') and s.endswith(']'):
+        in_project = s == '[project]'
+        continue
+    if in_project and s.startswith('version') and '=' in s:
+        found = s.split('=', 1)[1].strip().strip('\"\'')
+        break
+assert found == fd.__version__, (found, fd.__version__)
+print('version_ok', fd.__version__)
+"
 
       - name: Upload sdist artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,47 +268,42 @@ if(FLEXAIDS_USE_ROCM)
     message(STATUS "ROCm/HIP enabled — CF batch + runtime detection")
 endif()
 
-# ─── Metal sources ──────────────────────────────────────────────────────
+# ─── Metal sources (attach to flexaid_core once) ─────────────────────────
+# hardware_detect.cpp, UnifiedHardwareDispatch.cpp, gaboom.cpp, FOPTICS.cpp and
+# other flexaid_core TUs reference metal_eval / metal_rmsd when FLEXAIDS_USE_METAL
+# is on. Implementations MUST live on flexaid_core (or a library it pulls in),
+# not only on individual executables. Attaching .mm files solely to FlexAID /
+# FlexAIDdS left undefined symbols under LTO / multi-target links (Homebrew
+# --with-metal). All consumers of flexaid_core inherit the OBJCXX objects and
+# Metal frameworks via PUBLIC linkage below.
 if(FLEXAIDS_USE_METAL)
-    target_sources(FlexAID PRIVATE LIB/metal_eval.mm)
-    target_compile_definitions(FlexAID PRIVATE FLEXAIDS_USE_METAL)
-    target_compile_options(FlexAID PRIVATE -fno-objc-arc)
-    target_link_libraries(FlexAID PRIVATE
+    set(_FLEXAIDS_METAL_BRIDGES
+        LIB/metal_eval.mm
+        LIB/MetalRMSDBridge.mm
+        LIB/ShannonThermoStack/ShannonMetalBridge.mm
+        LIB/tENCoM/tencm_metal.mm
+        LIB/gpu_fast_optics_metal.mm
+        LIB/CavityDetect/CavityDetectMetalBridge.mm
+        LIB/TurboQuantMetalBridge.mm
+    )
+    target_sources(flexaid_core PRIVATE ${_FLEXAIDS_METAL_BRIDGES})
+    target_compile_options(flexaid_core PRIVATE -fno-objc-arc)
+    target_link_libraries(flexaid_core PUBLIC
         ${METAL_LIBRARY}
         ${FOUNDATION_LIBRARY}
         ${METALKIT_LIBRARY}
     )
-    set_source_files_properties(LIB/metal_eval.mm PROPERTIES
+    set_source_files_properties(${_FLEXAIDS_METAL_BRIDGES} PROPERTIES
         LANGUAGE OBJCXX
         COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
     )
-    # Shannon Metal GPU bridge (Apple Silicon Shannon entropy histogram)
-    target_sources(FlexAID PRIVATE LIB/ShannonThermoStack/ShannonMetalBridge.mm)
-    target_compile_definitions(FlexAID PRIVATE FLEXAIDS_HAS_METAL_SHANNON)
-    set_source_files_properties(LIB/ShannonThermoStack/ShannonMetalBridge.mm PROPERTIES
-        LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
+    target_compile_definitions(flexaid_core PUBLIC
+        FLEXAIDS_USE_METAL
+        FLEXAIDS_HAS_METAL_SHANNON
+        FLEXAIDS_HAS_METAL_TENCM
     )
-    # TENCoM Metal bridge (GPU contact discovery + Hessian assembly)
-    target_sources(FlexAID PRIVATE LIB/tENCoM/tencm_metal.mm)
-    target_compile_definitions(FlexAID PRIVATE FLEXAIDS_HAS_METAL_TENCM)
-    set_source_files_properties(LIB/tENCoM/tencm_metal.mm PROPERTIES
-        LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-    )
-    # FastOPTICS Metal kNN (GPU-accelerated neighbor discovery)
-    target_sources(FlexAID PRIVATE LIB/gpu_fast_optics_metal.mm)
-    set_source_files_properties(LIB/gpu_fast_optics_metal.mm PROPERTIES
-        LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-    )
-    # CavityDetect Metal bridge (Task 1.4: GPU probe-sphere generation)
-    target_sources(FlexAID PRIVATE LIB/CavityDetect/CavityDetectMetalBridge.mm)
-    set_source_files_properties(LIB/CavityDetect/CavityDetectMetalBridge.mm PROPERTIES
-        LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-    )
-    # Compile CavityDetect.metal shader → .metallib
+
+    # ── Compile .metal shaders → .metallib (single shared set) ────────────
     set(CAVITY_METAL_SRC  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/CavityDetect/CavityDetect.metal")
     set(CAVITY_AIR        "${CMAKE_CURRENT_BINARY_DIR}/CavityDetect.air")
     set(CAVITY_METALLIB   "${CMAKE_CURRENT_BINARY_DIR}/CavityDetect.metallib")
@@ -327,17 +322,7 @@ if(FLEXAIDS_USE_METAL)
         VERBATIM
     )
     add_custom_target(CavityDetectMetal DEPENDS "${CAVITY_METALLIB}")
-    add_dependencies(FlexAID CavityDetectMetal)
-    target_compile_definitions(FlexAID PRIVATE
-        CAVITY_METALLIB_PATH="${CAVITY_METALLIB}"
-    )
-    # TurboQuant Metal bridge (TurboQuant.metal batch quantize/dequantize)
-    target_sources(FlexAID PRIVATE LIB/TurboQuantMetalBridge.mm)
-    set_source_files_properties(LIB/TurboQuantMetalBridge.mm PROPERTIES
-        LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-    )
-    # Compile TurboQuant.metal shader → .metallib
+
     set(TQ_METAL_SRC  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/TurboQuant.metal")
     set(TQ_AIR        "${CMAKE_CURRENT_BINARY_DIR}/TurboQuant.air")
     set(TQ_METALLIB   "${CMAKE_CURRENT_BINARY_DIR}/TurboQuant.metallib")
@@ -356,17 +341,7 @@ if(FLEXAIDS_USE_METAL)
         VERBATIM
     )
     add_custom_target(TurboQuantMetal DEPENDS "${TQ_METALLIB}")
-    add_dependencies(FlexAID TurboQuantMetal)
-    target_compile_definitions(FlexAID PRIVATE
-        TURBOQUANT_METALLIB_PATH="${TQ_METALLIB}"
-    )
-    # MetalRMSD bridge (GPU pairwise RMSD for FOPTICS clustering)
-    target_sources(FlexAID PRIVATE LIB/MetalRMSDBridge.mm)
-    set_source_files_properties(LIB/MetalRMSDBridge.mm PROPERTIES
-        LANGUAGE OBJCXX
-        COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-    )
-    # Compile MetalRMSD.metal shader → .metallib
+
     set(RMSD_METAL_SRC  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/MetalRMSD.metal")
     set(RMSD_AIR        "${CMAKE_CURRENT_BINARY_DIR}/MetalRMSD.air")
     set(RMSD_METALLIB   "${CMAKE_CURRENT_BINARY_DIR}/MetalRMSD.metallib")
@@ -385,10 +360,55 @@ if(FLEXAIDS_USE_METAL)
         VERBATIM
     )
     add_custom_target(MetalRMSDMetal DEPENDS "${RMSD_METALLIB}")
-    add_dependencies(FlexAID MetalRMSDMetal)
-    target_compile_definitions(FlexAID PRIVATE
-        METALRMSD_METALLIB_PATH="${RMSD_METALLIB}"
+
+    set(SHANNON_METAL_SRC  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/ShannonThermoStack/shannon_metal.metal")
+    set(SHANNON_AIR        "${CMAKE_CURRENT_BINARY_DIR}/ShannonEntropy.air")
+    set(SHANNON_METALLIB   "${CMAKE_CURRENT_BINARY_DIR}/ShannonEntropy.metallib")
+    add_custom_command(
+        OUTPUT  "${SHANNON_AIR}"
+        COMMAND "${FLEXAIDS_METALC}" "-fmodules-cache-path=${FLEXAIDS_METAL_MODULE_CACHE}" -c "${SHANNON_METAL_SRC}" -o "${SHANNON_AIR}"
+        DEPENDS "${SHANNON_METAL_SRC}"
+        COMMENT "Compiling ShannonEntropy Metal shader"
+        VERBATIM
     )
+    add_custom_command(
+        OUTPUT  "${SHANNON_METALLIB}"
+        COMMAND "${FLEXAIDS_METALLIB}" "${SHANNON_AIR}" -o "${SHANNON_METALLIB}"
+        DEPENDS "${SHANNON_AIR}"
+        COMMENT "Linking ShannonEntropy.metallib"
+        VERBATIM
+    )
+    add_custom_target(ShannonEntropyMetal DEPENDS "${SHANNON_METALLIB}")
+
+    # Path macros for bridges that load metallibs at runtime.
+    # PUBLIC so every TU that includes the bridges sees the same paths.
+    target_compile_definitions(flexaid_core PUBLIC
+        CAVITY_METALLIB_PATH="${CAVITY_METALLIB}"
+        TURBOQUANT_METALLIB_PATH="${TQ_METALLIB}"
+        METALRMSD_METALLIB_PATH="${RMSD_METALLIB}"
+        SHANNON_METALLIB_PATH="${SHANNON_METALLIB}"
+    )
+    add_dependencies(flexaid_core
+        CavityDetectMetal
+        TurboQuantMetal
+        MetalRMSDMetal
+        ShannonEntropyMetal
+    )
+    # Convenience aliases for older custom-target names referenced by helpers.
+    if(NOT TARGET CavityDetectMetalDS)
+        add_custom_target(CavityDetectMetalDS DEPENDS CavityDetectMetal)
+    endif()
+    if(NOT TARGET MetalRMSDMetalDS)
+        add_custom_target(MetalRMSDMetalDS DEPENDS MetalRMSDMetal)
+    endif()
+    if(NOT TARGET TurboQuantMetalDS)
+        add_custom_target(TurboQuantMetalDS DEPENDS TurboQuantMetal)
+    endif()
+    # Back-compat path vars used by benchmark_datasets / attach helpers.
+    set(CAVITY_METALLIB_DS "${CAVITY_METALLIB}")
+    set(RMSD_METALLIB_DS "${RMSD_METALLIB}")
+    set(TQ_METALLIB_DS "${TQ_METALLIB}")
+    message(STATUS "Metal bridges attached to flexaid_core (all executables inherit them)")
 endif()
 
 # ─── Python bindings (pybind11 module) ─────────────────────────────────────────
@@ -710,156 +730,25 @@ if(BUILD_FLEXAIDDS_FAST)
         set_property(TARGET FlexAIDdS PROPERTY HIP_ARCHITECTURES ${FLEXAIDS_HIP_ARCHITECTURES})
     endif()
 
-    # ─── Metal sources for FlexAIDdS ────────────────────────────────────────
+    # Metal OBJCXX bridges + frameworks come from flexaid_core when
+    # FLEXAIDS_USE_METAL=ON (see "Metal sources (attach to flexaid_core once)").
     if(FLEXAIDS_USE_METAL)
-        # Metal batch Voronoi evaluation bridge
-        target_sources(FlexAIDdS PRIVATE LIB/metal_eval.mm)
-        target_compile_definitions(FlexAIDdS PRIVATE FLEXAIDS_USE_METAL)
-        target_compile_options(FlexAIDdS PRIVATE -fno-objc-arc)
-        target_link_libraries(FlexAIDdS PRIVATE
-            ${METAL_LIBRARY}
-            ${FOUNDATION_LIBRARY}
-            ${METALKIT_LIBRARY}
-        )
-        set_source_files_properties(LIB/metal_eval.mm PROPERTIES
-            LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-        )
-        # Shannon Metal GPU bridge (histogram binning on Apple Silicon)
-        target_sources(FlexAIDdS PRIVATE LIB/ShannonThermoStack/ShannonMetalBridge.mm)
-        target_compile_definitions(FlexAIDdS PRIVATE FLEXAIDS_HAS_METAL_SHANNON)
-        set_source_files_properties(LIB/ShannonThermoStack/ShannonMetalBridge.mm PROPERTIES
-            LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-        )
-        # Shannon Metal shader → .metallib
-        set(SHANNON_METAL_SRC  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/ShannonThermoStack/shannon_metal.metal")
-        set(SHANNON_AIR        "${CMAKE_CURRENT_BINARY_DIR}/ShannonEntropy.air")
-        set(SHANNON_METALLIB   "${CMAKE_CURRENT_BINARY_DIR}/ShannonEntropy.metallib")
-        add_custom_command(
-            OUTPUT  "${SHANNON_AIR}"
-            COMMAND "${FLEXAIDS_METALC}" "-fmodules-cache-path=${FLEXAIDS_METAL_MODULE_CACHE}" -c "${SHANNON_METAL_SRC}" -o "${SHANNON_AIR}"
-            DEPENDS "${SHANNON_METAL_SRC}"
-            COMMENT "Compiling ShannonEntropy Metal shader"
-            VERBATIM
-        )
-        add_custom_command(
-            OUTPUT  "${SHANNON_METALLIB}"
-            COMMAND "${FLEXAIDS_METALLIB}" "${SHANNON_AIR}" -o "${SHANNON_METALLIB}"
-            DEPENDS "${SHANNON_AIR}"
-            COMMENT "Linking ShannonEntropy.metallib"
-            VERBATIM
-        )
-        add_custom_target(ShannonEntropyMetal DEPENDS "${SHANNON_METALLIB}")
-        add_dependencies(FlexAIDdS ShannonEntropyMetal)
-        target_compile_definitions(FlexAIDdS PRIVATE
-            SHANNON_METALLIB_PATH="${SHANNON_METALLIB}"
-        )
-        # TENCoM Metal bridge (GPU contact discovery + Hessian assembly)
-        target_sources(FlexAIDdS PRIVATE LIB/tENCoM/tencm_metal.mm)
-        target_compile_definitions(FlexAIDdS PRIVATE FLEXAIDS_HAS_METAL_TENCM)
-        set_source_files_properties(LIB/tENCoM/tencm_metal.mm PROPERTIES
-            LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-        )
-        # FastOPTICS Metal kNN (GPU-accelerated neighbor discovery)
-        target_sources(FlexAIDdS PRIVATE LIB/gpu_fast_optics_metal.mm)
-        set_source_files_properties(LIB/gpu_fast_optics_metal.mm PROPERTIES
-            LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-        )
-        # CavityDetect Metal bridge + shader
-        target_sources(FlexAIDdS PRIVATE LIB/CavityDetect/CavityDetectMetalBridge.mm)
-        set_source_files_properties(LIB/CavityDetect/CavityDetectMetalBridge.mm PROPERTIES
-            LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-        )
-        set(CAVITY_METAL_SRC_DS  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/CavityDetect/CavityDetect.metal")
-        set(CAVITY_AIR_DS         "${CMAKE_CURRENT_BINARY_DIR}/CavityDetect_ds.air")
-        set(CAVITY_METALLIB_DS    "${CMAKE_CURRENT_BINARY_DIR}/CavityDetect_ds.metallib")
-        add_custom_command(
-            OUTPUT  "${CAVITY_AIR_DS}"
-            COMMAND "${FLEXAIDS_METALC}" "-fmodules-cache-path=${FLEXAIDS_METAL_MODULE_CACHE}" -c "${CAVITY_METAL_SRC_DS}" -o "${CAVITY_AIR_DS}"
-            DEPENDS "${CAVITY_METAL_SRC_DS}"
-            COMMENT "Compiling CavityDetect Metal shader (FlexAIDdS)"
-            VERBATIM
-        )
-        add_custom_command(
-            OUTPUT  "${CAVITY_METALLIB_DS}"
-            COMMAND "${FLEXAIDS_METALLIB}" "${CAVITY_AIR_DS}" -o "${CAVITY_METALLIB_DS}"
-            DEPENDS "${CAVITY_AIR_DS}"
-            COMMENT "Linking CavityDetect_ds.metallib"
-            VERBATIM
-        )
-        add_custom_target(CavityDetectMetalDS DEPENDS "${CAVITY_METALLIB_DS}")
-        add_dependencies(FlexAIDdS CavityDetectMetalDS)
-        target_compile_definitions(FlexAIDdS PRIVATE
-            CAVITY_METALLIB_PATH="${CAVITY_METALLIB_DS}"
-        )
-        # TurboQuant Metal bridge + shader
-        target_sources(FlexAIDdS PRIVATE LIB/TurboQuantMetalBridge.mm)
-        set_source_files_properties(LIB/TurboQuantMetalBridge.mm PROPERTIES
-            LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-        )
-        set(TQ_METAL_SRC_DS  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/TurboQuant.metal")
-        set(TQ_AIR_DS         "${CMAKE_CURRENT_BINARY_DIR}/TurboQuant_ds.air")
-        set(TQ_METALLIB_DS    "${CMAKE_CURRENT_BINARY_DIR}/TurboQuant_ds.metallib")
-        add_custom_command(
-            OUTPUT  "${TQ_AIR_DS}"
-            COMMAND "${FLEXAIDS_METALC}" "-fmodules-cache-path=${FLEXAIDS_METAL_MODULE_CACHE}" -c "${TQ_METAL_SRC_DS}" -o "${TQ_AIR_DS}"
-            DEPENDS "${TQ_METAL_SRC_DS}"
-            COMMENT "Compiling TurboQuant Metal shader (FlexAIDdS)"
-            VERBATIM
-        )
-        add_custom_command(
-            OUTPUT  "${TQ_METALLIB_DS}"
-            COMMAND "${FLEXAIDS_METALLIB}" "${TQ_AIR_DS}" -o "${TQ_METALLIB_DS}"
-            DEPENDS "${TQ_AIR_DS}"
-            COMMENT "Linking TurboQuant_ds.metallib"
-            VERBATIM
-        )
-        add_custom_target(TurboQuantMetalDS DEPENDS "${TQ_METALLIB_DS}")
-        add_dependencies(FlexAIDdS TurboQuantMetalDS)
-        target_compile_definitions(FlexAIDdS PRIVATE
-            TURBOQUANT_METALLIB_PATH="${TQ_METALLIB_DS}"
-        )
-        # MetalRMSD bridge + shader (GPU pairwise RMSD for FOPTICS clustering)
-        target_sources(FlexAIDdS PRIVATE LIB/MetalRMSDBridge.mm)
-        set_source_files_properties(LIB/MetalRMSDBridge.mm PROPERTIES
-            LANGUAGE OBJCXX
-            COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-        )
-        set(RMSD_METAL_SRC_DS  "${CMAKE_CURRENT_SOURCE_DIR}/LIB/MetalRMSD.metal")
-        set(RMSD_AIR_DS         "${CMAKE_CURRENT_BINARY_DIR}/MetalRMSD_ds.air")
-        set(RMSD_METALLIB_DS    "${CMAKE_CURRENT_BINARY_DIR}/MetalRMSD_ds.metallib")
-        add_custom_command(
-            OUTPUT  "${RMSD_AIR_DS}"
-            COMMAND "${FLEXAIDS_METALC}" "-fmodules-cache-path=${FLEXAIDS_METAL_MODULE_CACHE}" -c "${RMSD_METAL_SRC_DS}" -o "${RMSD_AIR_DS}"
-            DEPENDS "${RMSD_METAL_SRC_DS}"
-            COMMENT "Compiling MetalRMSD Metal shader (FlexAIDdS)"
-            VERBATIM
-        )
-        add_custom_command(
-            OUTPUT  "${RMSD_METALLIB_DS}"
-            COMMAND "${FLEXAIDS_METALLIB}" "${RMSD_AIR_DS}" -o "${RMSD_METALLIB_DS}"
-            DEPENDS "${RMSD_AIR_DS}"
-            COMMENT "Linking MetalRMSD_ds.metallib"
-            VERBATIM
-        )
-        add_custom_target(MetalRMSDMetalDS DEPENDS "${RMSD_METALLIB_DS}")
-        add_dependencies(FlexAIDdS MetalRMSDMetalDS)
-        target_compile_definitions(FlexAIDdS PRIVATE
-            METALRMSD_METALLIB_PATH="${RMSD_METALLIB_DS}"
-        )
-        message(STATUS "FlexAIDdS: Metal GPU acceleration enabled (Shannon + CavityDetect + TurboQuant + MetalRMSD)")
+        message(STATUS "FlexAIDdS: Metal GPU acceleration via flexaid_core")
     endif()
 
     message(STATUS "FlexAIDdS fast executable enabled")
 endif()
 
+# Attach Metal dispatch runtime to targets that compile hardware_detect /
+# UnifiedHardwareDispatch themselves WITHOUT linking flexaid_core.
+# Targets that already link flexaid_core already get metal_eval.mm etc.
 function(flexaids_attach_metal_dispatch_runtime target_name)
     if(NOT FLEXAIDS_USE_METAL)
+        return()
+    endif()
+    # Avoid duplicate-symbol if the target already pulls flexaid_core objects.
+    get_target_property(_flexaids_metal_link_libs ${target_name} LINK_LIBRARIES)
+    if(_flexaids_metal_link_libs MATCHES "flexaid_core")
         return()
     endif()
     target_sources(${target_name} PRIVATE
@@ -1019,29 +908,9 @@ if(ENABLE_CAVITY_DETECT_CLI)
     if(FLEXAIDS_USE_OPENMP AND OpenMP_CXX_FOUND)
         target_link_libraries(cavity_detect_cli PRIVATE OpenMP::OpenMP_CXX)
     endif()
-    if(FLEXAIDS_USE_METAL)
-        target_sources(cavity_detect_cli PRIVATE
-            LIB/CavityDetect/CavityDetectMetalBridge.mm
-        )
-        target_compile_definitions(cavity_detect_cli PRIVATE FLEXAIDS_USE_METAL)
-        target_compile_options(cavity_detect_cli PRIVATE -fno-objc-arc)
-        target_link_libraries(cavity_detect_cli PRIVATE
-            ${METAL_LIBRARY}
-            ${FOUNDATION_LIBRARY}
-            ${METALKIT_LIBRARY}
-        )
-        set_source_files_properties(
-            LIB/CavityDetect/CavityDetectMetalBridge.mm
-            PROPERTIES LANGUAGE OBJCXX COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-        )
-        if(TARGET CavityDetectMetalDS)
-            add_dependencies(cavity_detect_cli CavityDetectMetalDS)
-        endif()
-        if(DEFINED CAVITY_METALLIB_DS)
-            target_compile_definitions(cavity_detect_cli PRIVATE
-                CAVITY_METALLIB_PATH="${CAVITY_METALLIB_DS}"
-            )
-        endif()
+    # Metal CavityDetect bridge + frameworks come from flexaid_core.
+    if(FLEXAIDS_USE_METAL AND TARGET CavityDetectMetal)
+        add_dependencies(cavity_detect_cli CavityDetectMetal)
     endif()
     message(STATUS "Native CavityDetector CLI enabled -- build target: cavity_detect_cli")
 endif()
@@ -1097,43 +966,13 @@ if(ENABLE_BENCHMARK_DATASETS)
     if(FLEXAIDS_USE_OPENMP AND OpenMP_CXX_FOUND)
         target_link_libraries(benchmark_datasets PRIVATE OpenMP::OpenMP_CXX)
     endif()
-    # Metal bridge sources — required when flexaid_core was compiled with Metal.
+    # Metal bridges/frameworks are on flexaid_core when FLEXAIDS_USE_METAL=ON.
     if(FLEXAIDS_USE_METAL)
-        target_sources(benchmark_datasets PRIVATE
-            LIB/metal_eval.mm
-            LIB/MetalRMSDBridge.mm
-            LIB/CavityDetect/CavityDetectMetalBridge.mm
-            LIB/ShannonThermoStack/ShannonMetalBridge.mm
-            LIB/gpu_fast_optics_metal.mm
-        )
-        target_compile_definitions(benchmark_datasets PRIVATE
-            FLEXAIDS_USE_METAL
-            FLEXAIDS_HAS_METAL_SHANNON
-        )
-        target_compile_options(benchmark_datasets PRIVATE -fno-objc-arc)
-        target_link_libraries(benchmark_datasets PRIVATE
-            ${METAL_LIBRARY}
-            ${FOUNDATION_LIBRARY}
-            ${METALKIT_LIBRARY}
-        )
-        set_source_files_properties(
-            LIB/metal_eval.mm
-            LIB/MetalRMSDBridge.mm
-            LIB/CavityDetect/CavityDetectMetalBridge.mm
-            LIB/ShannonThermoStack/ShannonMetalBridge.mm
-            LIB/gpu_fast_optics_metal.mm
-            PROPERTIES LANGUAGE OBJCXX COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
-        )
         add_dependencies(benchmark_datasets
-            CavityDetectMetalDS
+            CavityDetectMetal
             ShannonEntropyMetal
-            MetalRMSDMetalDS
-        )
-        target_compile_definitions(benchmark_datasets PRIVATE
-            SHANNON_METALLIB_PATH="${SHANNON_METALLIB}"
-            METALRMSD_METALLIB_PATH="${RMSD_METALLIB_DS}"
-            CAVITY_METALLIB_PATH="${CAVITY_METALLIB_DS}"
-            TURBOQUANT_METALLIB_PATH="${TQ_METALLIB_DS}"
+            MetalRMSDMetal
+            TurboQuantMetal
         )
     endif()
     message(STATUS "Benchmark dataset runner enabled — build target: benchmark_datasets")

--- a/Formula/flexaidds.rb
+++ b/Formula/flexaidds.rb
@@ -22,8 +22,9 @@ class Flexaidds < Formula
   depends_on "libomp" if OS.mac?
 
   def install
-    # Metal OFF by default: HEAD can fail to link metal_eval/metal_rmsd under
-    # pure Command Line Tools SDKs. CPU + OpenMP is the portable brew path.
+    # Metal OFF by default for CLT-only SDKs without a working metalc; use
+    # --with-metal when Xcode/Metal toolchain is present. Metal OBJCXX bridges
+    # are linked via flexaid_core (not only the executable) so the link succeeds.
     metal = build.with?("metal") ? "ON" : "OFF"
 
     args = std_cmake_args + %W[

--- a/Formula/flexaidds.rb
+++ b/Formula/flexaidds.rb
@@ -6,7 +6,9 @@ class Flexaidds < Formula
   url "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/v2.0.2.tar.gz"
   sha256 "11109a3eb6cac4185cee10390be7bf09be2520e89f13064a524e984be1366cc0"
   license "Apache-2.0"
-  head "https://github.com/LeBonhommePharma/FlexAIDdS.git", branch: "master"
+  # HEAD carries the flexaid_core Metal OBJCXX link fix (stable v2.0.2 does not).
+  # Track this fix branch until it lands on master; after merge, flip back to master.
+  head "https://github.com/LeBonhommePharma/FlexAIDdS.git", branch: "fix/homebrew-metal-link"
 
   livecheck do
     url :stable
@@ -14,7 +16,10 @@ class Flexaidds < Formula
   end
 
   # Optional Metal GPU path (macOS only). Off by default — see install notes.
-  option "with-metal", "Build with Metal GPU acceleration (macOS; may fail on pure CLT SDKs)"
+  # Requires a working Metal toolchain (Xcode + MetalToolchain). Stable v2.0.2
+  # lacks the flexaid_core OBJCXX membership fix; use --HEAD --with-metal until
+  # the next release tag that includes that CMake change (PR #260).
+  option "with-metal", "Build with Metal GPU acceleration (macOS; needs Metal toolchain)"
 
   depends_on "cmake" => :build
   depends_on "ninja" => :build
@@ -23,9 +28,28 @@ class Flexaidds < Formula
 
   def install
     # Metal OFF by default for CLT-only SDKs without a working metalc; use
-    # --with-metal when Xcode/Metal toolchain is present. Metal OBJCXX bridges
-    # are linked via flexaid_core (not only the executable) so the link succeeds.
+    # --with-metal when Xcode/Metal toolchain is present. On sources that include
+    # the flexaid_core Metal fix, OBJCXX bridges + frameworks are linked via
+    # flexaid_core so every consumer (FlexAID, FlexAIDdS, cavity tools) links.
     metal = build.with?("metal") ? "ON" : "OFF"
+
+    # Stable v2.0.2 tarball still attaches Metal .mm only to some executables;
+    # targets that link flexaid_core alone (e.g. cavity_detect_cli) then fail with
+    # undefined metal_eval_* / metal_rmsd::*. Prefer HEAD for Metal until the next
+    # release ships the core membership fix.
+    if build.with?("metal") && !build.head?
+      odie <<~EOS
+        --with-metal requires source that links Metal bridges via flexaid_core.
+        Stable v2.0.2 still fails that link (undefined metal_eval_* from gaboom /
+        hardware_detect / FOPTICS when building auxiliary targets).
+
+        Until the next release tag, install Metal from HEAD:
+          brew reinstall --build-from-source --HEAD --with-metal lebonhommepharma/flexaidds/flexaidds
+
+        Default (CPU + OpenMP, no Metal) still works on stable:
+          brew reinstall lebonhommepharma/flexaidds/flexaidds
+      EOS
+    end
 
     args = std_cmake_args + %W[
       -GNinja
@@ -37,6 +61,10 @@ class Flexaidds < Formula
       -DFLEXAIDS_USE_OPENMP=ON
       -DBUILD_FLEXAIDDS_FAST=ON
       -DENABLE_TENCOM_TOOL=ON
+      -DENABLE_CAVITY_DETECT_CLI=OFF
+      -DENABLE_BENCHMARK_DATASETS=OFF
+      -DENABLE_DUAL_ASSEMBLY_TOOL=OFF
+      -DENABLE_DIFT_TOOL=OFF
     ]
 
     if OS.mac?
@@ -150,8 +178,13 @@ class Flexaidds < Formula
         brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
         brew install lebonhommepharma/flexaidds/flexaidds
 
-      Default brew build uses CPU + OpenMP (no Metal).
-      Metal: brew install --with-metal lebonhommepharma/flexaidds/flexaidds
+      Default brew build uses CPU + OpenMP (no Metal) and is the portable path.
+
+      Metal GPU (macOS + Xcode Metal toolchain). Stable v2.0.2 cannot link Metal
+      into every flexaid_core consumer; use HEAD until the next release:
+        brew reinstall --build-from-source --HEAD --with-metal lebonhommepharma/flexaidds/flexaidds
+      After a post-v2.0.2 tag with the flexaid_core Metal fix:
+        brew install --with-metal lebonhommepharma/flexaidds/flexaidds
 
       Example:
         FlexAIDdS receptor.pdb ligand.sdf --rigid -o /tmp/out

--- a/Formula/flexaidds.rb
+++ b/Formula/flexaidds.rb
@@ -128,21 +128,29 @@ class Flexaidds < Formula
 
   def caveats
     <<~EOS
-      The FlexAIDdS native tools (FlexAIDdS, tENCoM, FlexAID) have been installed.
+      This formula installs the *native* docking tools only:
+        FlexAIDdS, FlexAID, tENCoM, tencom_entropy_diff
+
+      It does *not* install the Python analysis package. Those are separate:
+        # Python CLI + load_results / StatMech (GitHub until public PyPI):
+        pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
+        # After the first PyPI release: pip install flexaidds
+        # Then: flexaidds --help   or   python -m flexaidds --help
 
       Wrappers under #{bin} set FLEXAIDDS_DATA_DIR=#{libexec}/share so PATH
       symlinks still find MC matrices and AMINO.def.
 
       Stable v2.0.2+ includes the production docking matrix (atom typing works
       out of the box). Upgrade from broken v2.0.0 installs with:
-        brew update && brew reinstall flexaidds
+        brew update && brew reinstall lebonhommepharma/flexaidds/flexaidds
 
-      Python package:
-        pip install flexaidds
-        # or from git: pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
+      Install / reinstall path (Homebrew 6+ requires a real tap; raw URL installs
+      are rejected):
+        brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
+        brew install lebonhommepharma/flexaidds/flexaidds
 
       Default brew build uses CPU + OpenMP (no Metal).
-      Metal: brew install --with-metal flexaidds
+      Metal: brew install --with-metal lebonhommepharma/flexaidds/flexaidds
 
       Example:
         FlexAIDdS receptor.pdb ligand.sdf --rigid -o /tmp/out

--- a/Formula/flexaidds.rb
+++ b/Formula/flexaidds.rb
@@ -43,8 +43,10 @@ class Flexaidds < Formula
         Stable v2.0.2 still fails that link (undefined metal_eval_* from gaboom /
         hardware_detect / FOPTICS when building auxiliary targets).
 
-        Until the next release tag, install Metal from HEAD:
-          brew reinstall --build-from-source --HEAD --with-metal lebonhommepharma/flexaidds/flexaidds
+        Until the next release tag, install Metal from HEAD. Homebrew 6 accepts
+        --HEAD on install (not reinstall):
+          brew uninstall flexaidds 2>/dev/null
+          brew install -s --HEAD --with-metal lebonhommepharma/flexaidds/flexaidds
 
         Default (CPU + OpenMP, no Metal) still works on stable:
           brew reinstall lebonhommepharma/flexaidds/flexaidds
@@ -181,8 +183,10 @@ class Flexaidds < Formula
       Default brew build uses CPU + OpenMP (no Metal) and is the portable path.
 
       Metal GPU (macOS + Xcode Metal toolchain). Stable v2.0.2 cannot link Metal
-      into every flexaid_core consumer; use HEAD until the next release:
-        brew reinstall --build-from-source --HEAD --with-metal lebonhommepharma/flexaidds/flexaidds
+      into every flexaid_core consumer; use HEAD until the next release.
+      Homebrew 6: --HEAD is an install flag (reinstall --HEAD is invalid):
+        brew uninstall flexaidds 2>/dev/null
+        brew install -s --HEAD --with-metal lebonhommepharma/flexaidds/flexaidds
       After a post-v2.0.2 tag with the flexaid_core Metal fix:
         brew install --with-metal lebonhommepharma/flexaidds/flexaidds
 

--- a/Formula/flexaidds.rb
+++ b/Formula/flexaidds.rb
@@ -7,8 +7,8 @@ class Flexaidds < Formula
   sha256 "11109a3eb6cac4185cee10390be7bf09be2520e89f13064a524e984be1366cc0"
   license "Apache-2.0"
   # HEAD carries the flexaid_core Metal OBJCXX link fix (stable v2.0.2 does not).
-  # Track this fix branch until it lands on master; after merge, flip back to master.
-  head "https://github.com/LeBonhommePharma/FlexAIDdS.git", branch: "fix/homebrew-metal-link"
+  # Default branch is main (Git 3.0 / repo rename); brew install -s --HEAD uses this.
+  head "https://github.com/LeBonhommePharma/FlexAIDdS.git", branch: "main"
 
   livecheck do
     url :stable

--- a/LIB/CMakeLists.txt
+++ b/LIB/CMakeLists.txt
@@ -235,10 +235,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 # ─── Metal (optional) ───────────────────────────────────────────────────
-# Propagate FLEXAIDS_USE_METAL so hardware_detect.cpp and
-# UnifiedHardwareDispatch.cpp compile in their Metal detection paths.
-# metal_eval.mm is compiled directly into FlexAIDdS (not flexaid_core) to
-# keep Obj-C++ runtime isolated; the linker resolves the symbol at link time.
+# Propagate FLEXAIDS_USE_METAL so hardware_detect.cpp / UnifiedHardwareDispatch
+# / gaboom / FOPTICS compile their Metal call sites. The OBJCXX bridges
+# (metal_eval.mm, MetalRMSDBridge.mm, …) and Metal frameworks are attached to
+# flexaid_core in the root CMakeLists.txt after this subdirectory returns —
+# see "Metal sources (attach to flexaid_core once)". Do NOT leave Metal
+# implementations only on executables: that breaks multi-target and LTO links
+# (Homebrew --with-metal undefined-symbol failures).
 if(FLEXAIDS_USE_METAL)
     target_compile_definitions(flexaid_core PUBLIC FLEXAIDS_USE_METAL)
 endif()

--- a/README.md
+++ b/README.md
@@ -92,19 +92,20 @@ print(fd.__version__)
 run = fd.load_results("path/to/results")
 ```
 
-### macOS: Homebrew (native CLI tools)
+### macOS: Homebrew (native docking tools)
 
 ```bash
-# Tap the monorepo (Homebrew 6+ requires formulae to live in a tap with a git remote)
+# Tap the monorepo (Homebrew 6+ requires formulae to live in a tap with a git remote;
+# raw formula URL installs are rejected)
 brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
-brew install flexaidds
-# Tip-of-tree: brew install --HEAD flexaidds
-# Python package (not yet on public PyPI — install from GitHub):
+brew install lebonhommepharma/flexaidds/flexaidds
+# Tip-of-tree: brew install --HEAD lebonhommepharma/flexaidds/flexaidds
+# Python analysis package is separate (not yet on public PyPI — install from GitHub):
 pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
 # later: python -m flexaidds --self-update
 ```
 
-See [docs/INSTALLATION.md](docs/INSTALLATION.md) for conda, GitHub/PyPI, Windows, and full platform instructions. The Python package and native tools can be installed independently.
+Homebrew installs **native** binaries (`FlexAIDdS`, `tENCoM`, …). pip installs the **Python** package (`import flexaidds`, `flexaidds` CLI). Install both when you need docking *and* analysis. See [docs/INSTALLATION.md](docs/INSTALLATION.md) for conda, GitHub/PyPI, Windows, and full platform instructions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ run = fd.load_results("path/to/results")
 ### macOS: Homebrew (native CLI tools)
 
 ```bash
-# Stable release, or add --HEAD for tip-of-tree
-brew install --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+# Tap the monorepo (Homebrew 6+ requires formulae to live in a tap with a git remote)
+brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
+brew install flexaidds
+# Tip-of-tree: brew install --HEAD flexaidds
 # Python package (not yet on public PyPI — install from GitHub):
 pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
 # later: python -m flexaidds --self-update

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -122,17 +122,25 @@ cmake --build build --parallel
 
 #### Easy install via Homebrew (recommended for native CLI tools)
 
+Homebrew 6+ rejects one-off raw formula URLs and path installs. Install from a
+proper tap (with `origin`) so `brew update` / `brew doctor` stay clean — do
+**not** use `brew tap-new test/...` temporary taps without a remote (they leave
+orphan-tap doctor warnings).
+
 ```bash
+# One-time: tap the monorepo (Formula/flexaidds.rb lives at repo root)
+brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
+
 # Stable tagged release (v2.0.0+)
-brew install --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+brew install flexaidds
 
 # Or latest development tip
-brew install --HEAD --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+brew install --HEAD flexaidds
 
 # Update later
-brew reinstall --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+brew update && brew reinstall flexaidds
 # or, for HEAD builds:
-brew reinstall --HEAD --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+brew reinstall --HEAD flexaidds
 ```
 
 This installs `FlexAIDdS`, `tENCoM`, `FlexAID` + required data files.
@@ -194,11 +202,14 @@ See also `python/README.md`.
 The formula provides the high-performance native executables with data files staged correctly:
 
 ```bash
+# One-time tap (required on Homebrew 6+; raw URL / bare path installs are rejected)
+brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
+
 # Stable release
-brew install --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+brew install flexaidds
 
 # Development / latest
-brew install --HEAD --formula https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/master/Formula/flexaidds.rb
+brew install --HEAD flexaidds
 
 # After install, add the Python package (GitHub until PyPI publish):
 pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
@@ -206,6 +217,18 @@ pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=
 ```
 
 The formula lives at `Formula/flexaidds.rb`. It supports both a stable `url`/`sha256` (tagged release) and `head` for tip-of-tree. Bottles may be added later.
+
+**Local formula testing (maintainers):** if you must exercise a local formula edit
+before push, either `brew install --build-from-source lebonhommepharma/flexaidds/flexaidds`
+after syncing the tap, or use a temporary tap **with cleanup**:
+
+```bash
+# Prefer this over leaving orphan test taps
+TAP="test/flexaidds-local-$$"
+brew tap-new --no-git "$TAP"   # or set origin if you init git
+# copy Formula/flexaidds.rb into the tap Formula/ dir, install, then:
+brew untap --force "$TAP"      # always clean up; never leave test/* without origin
+```
 
 When cutting a new stable release, update the formula’s `url`, `sha256`, and version together:
 ```bash
@@ -251,8 +274,7 @@ curl -sL "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/${TAG}
   python -c "import flexaidds as fd; print(fd.__version__, fd.HAS_CORE_BINDINGS)"
   ```
 
-- **Homebrew**: Update `Formula/flexaidds.rb` (`url` + `sha256` for stable; `head` tracks `master`) when cutting releases. Users install via the raw formula URL (or a personal tap).
-
+- **Homebrew**: Update `Formula/flexaidds.rb` (`url` + `sha256` for stable; `head` tracks `master`) when cutting releases. Users install via `brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS` then `brew install flexaidds` (Homebrew 6+ requires a real tap with `origin`; raw formula URLs are rejected).
 - **Native binaries**: Existing release workflow attaches platform archives on tag.
 
 - **In-package updater**: `python -m flexaidds --check-update` / `--self-update` uses the GitHub Releases API and `pip install --upgrade flexaidds` (falls back to the GitHub VCS URL when the package is not yet on the default index).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -131,19 +131,20 @@ orphan-tap doctor warnings).
 # One-time: tap the monorepo (Formula/flexaidds.rb lives at repo root)
 brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
 
-# Stable tagged release (v2.0.0+)
-brew install flexaidds
+# Stable tagged release (v2.0.2+). Qualified name always works.
+brew install lebonhommepharma/flexaidds/flexaidds
+# short form after tap: brew install flexaidds
 
 # Or latest development tip
-brew install --HEAD flexaidds
+brew install --HEAD lebonhommepharma/flexaidds/flexaidds
 
 # Update later
-brew update && brew reinstall flexaidds
+brew update && brew reinstall lebonhommepharma/flexaidds/flexaidds
 # or, for HEAD builds:
-brew reinstall --HEAD flexaidds
+brew reinstall --HEAD lebonhommepharma/flexaidds/flexaidds
 ```
 
-This installs `FlexAIDdS`, `tENCoM`, `FlexAID` + required data files.
+This installs **native** tools only (`FlexAIDdS`, `tENCoM`, `FlexAID` + MC matrices / `AMINO.def`). The Python package is separate (see pip section below).
 
 Then (recommended — GitHub until PyPI publish):
 ```bash
@@ -199,17 +200,27 @@ See also `python/README.md`.
 
 ## Homebrew (macOS native tools)
 
+### What each installer provides
+
+| Installer | Provides | Does **not** provide |
+|:----------|:---------|:---------------------|
+| **Homebrew** (`flexaidds` formula) | Native C++ tools: `FlexAIDdS`, `FlexAID`, `tENCoM`, `tencom_entropy_diff` + production MC matrices / `AMINO.def` | Python package, `flexaidds` CLI, `load_results`, pure-Python StatMech |
+| **pip / PyPI** (`flexaidds` package) | Python API + CLIs (`flexaidds`, `flexaidds-benchmark`), optional `_core` acceleration | Full docking engine binary / cavity search campaign binary |
+
+Install both if you want native docking **and** Python analysis. Versions are aligned at **2.0.2** (`Formula/flexaidds.rb` ↔ `python/pyproject.toml` ↔ `python/flexaidds/__version__.py`).
+
 The formula provides the high-performance native executables with data files staged correctly:
 
 ```bash
 # One-time tap (required on Homebrew 6+; raw URL / bare path installs are rejected)
 brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
 
-# Stable release
-brew install flexaidds
+# Stable release (qualified name always works)
+brew install lebonhommepharma/flexaidds/flexaidds
+# short form after tap: brew install flexaidds
 
 # Development / latest
-brew install --HEAD flexaidds
+brew install --HEAD lebonhommepharma/flexaidds/flexaidds
 
 # After install, add the Python package (GitHub until PyPI publish):
 pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
@@ -230,12 +241,14 @@ brew tap-new --no-git "$TAP"   # or set origin if you init git
 brew untap --force "$TAP"      # always clean up; never leave test/* without origin
 ```
 
-When cutting a new stable release, update the formula’s `url`, `sha256`, and version together:
+When cutting a new stable release, update the formula’s `url`, `sha256`, and version together
+(and keep `python/pyproject.toml` + `python/flexaidds/__version__.py` in sync):
 ```bash
 # Example maintainer steps
-TAG=v2.0.1
+TAG=v2.0.2
 curl -sL "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/${TAG}.tar.gz" | shasum -a 256
 # paste sha256 into Formula/flexaidds.rb, commit, push
+# users: brew update && brew reinstall lebonhommepharma/flexaidds/flexaidds
 ```
 
 ---

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -140,8 +140,8 @@ brew install --HEAD lebonhommepharma/flexaidds/flexaidds
 
 # Update later
 brew update && brew reinstall lebonhommepharma/flexaidds/flexaidds
-# or, for HEAD builds:
-brew reinstall --HEAD lebonhommepharma/flexaidds/flexaidds
+# or, for HEAD builds (Homebrew 6+: --HEAD is install-only; reinstall --HEAD is invalid):
+brew install -s --HEAD lebonhommepharma/flexaidds/flexaidds
 ```
 
 This installs **native** tools only (`FlexAIDdS`, `tENCoM`, `FlexAID` + MC matrices / `AMINO.def`). The Python package is separate (see pip section below).

--- a/python/README.md
+++ b/python/README.md
@@ -19,6 +19,7 @@ Higher-level live docking orchestration is still intentionally staged behind the
 # Recommended today (package not yet on public PyPI):
 pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
 python -m flexaidds --check-update       # or --self-update
+# Console scripts after install: flexaidds, flexaidds-benchmark
 
 # From the repo root (development)
 pip install -e ./python
@@ -28,7 +29,13 @@ pip install flexaidds
 pip install --upgrade flexaidds
 ```
 
-This installs the `flexaidds` package. The compiled acceleration (`_core`) is built if the required build dependencies (pybind11, Eigen headers, a C++ compiler) are present. Otherwise the package installs successfully in **pure-Python fallback mode** (full result loading, models, pure-Python thermodynamics, etc. still work). Set `FLEXAIDDS_SKIP_CORE=1` to force pure-Python.
+This installs the **Python analysis package** only (not the native `FlexAIDdS` docking binary — use Homebrew or a CMake build for that). The compiled acceleration (`_core`) is built if the required build dependencies (pybind11, Eigen headers, a C++ compiler) are present. Otherwise the package installs successfully in **pure-Python fallback mode** (full result loading, models, pure-Python thermodynamics, etc. still work). Set `FLEXAIDDS_SKIP_CORE=1` to force pure-Python.
+
+**Native docking tools (separate):**
+```bash
+brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
+brew install lebonhommepharma/flexaidds/flexaidds
+```
 
 You can also do a non-editable install after building a wheel:
 ```bash


### PR DESCRIPTION
## Summary
- **Root cause**: Metal OBJCXX bridges (`metal_eval.mm`, `MetalRMSDBridge.mm`, Shannon/Cavity/TurboQuant bridges) were only attached to the `FlexAID` / `FlexAIDdS` executables, while `flexaid_core` object files (`gaboom.cpp`, `FOPTICS.cpp`, `hardware_detect.cpp`, `UnifiedHardwareDispatch.cpp`) reference those symbols when `FLEXAIDS_USE_METAL=ON`. Under LTO / multi-target links this produced `ld: symbol(s) not found for architecture arm64` for Homebrew `brew reinstall --with-metal`.
- **Fix**: Attach all Metal `.mm` bridges + Metal/Foundation/MetalKit frameworks **PUBLIC** on `flexaid_core`, compile metallibs once, and remove per-executable duplicate Metal `target_sources` lists so every consumer of core inherits the implementations.
- Formula comment updated to note the correct linkage path (no Homebrew-only hack).

## Verification
```bash
cmake -S . -B build_metal_fix -DCMAKE_BUILD_TYPE=Release \
  -DFLEXAIDS_USE_METAL=ON -DBUILD_TESTING=OFF -DBUILD_PYTHON_BINDINGS=OFF -GNinja
cmake --build build_metal_fix -j$(sysctl -n hw.ncpu) --target FlexAIDdS FlexAID
# Success: both link; nm shows metal_eval_get_capabilities / metal_rmsd::*
```

`brew reinstall --with-metal` not re-run here (disk ~14 GiB free); in-repo CMake with the same flags is the equivalent check.

## Test plan
- [x] Configure + build `FlexAIDdS` and `FlexAID` with `-DFLEXAIDS_USE_METAL=ON`
- [x] Confirm Metal symbols present in `FlexAIDdS` via `nm -gU`
- [ ] Optional: `brew reinstall --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds` once formula points at this branch/HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Release Improvements**
  * Centralized macOS Metal build wiring so multiple native docking tools share consistent Metal shader/runtime setup and macOS metallib paths.
* **Documentation**
  * Updated macOS/Homebrew installation to use tap-based `stable` vs `--HEAD` workflows, clarified native docking tools vs the separate Python analysis package, and refreshed maintainer release/testing guidance.
  * Updated Python docs to explain console scripts and the pure-Python fallback vs native docking tools.
* **Bug Fixes**
  * PyPI release workflow now verifies the source distribution version matches the package’s declared version metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->