### PR TITLE
Fix: Blocking macOS CPU ctest + Metal CI release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
           python/tests/test_dift.py
           benchmarks/tests/test_itc_calibration.py
 
+  # Linux C++ matrix only. macOS CPU build+ctest is the dedicated blocking job
+  # macos_cpu_tests (no continue-on-error). See docs/CI_RELEASE_GATES.md.
   cxx_core_build:
     name: C++ core (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
@@ -68,11 +70,6 @@ jobs:
             os: ubuntu-latest
             cc: clang-18
             cxx: clang++-18
-          - name: macos-clang
-            os: macos-15
-            cc: clang
-            cxx: clang++
-            allow_failure: true
           - name: linux-gcc-avx512
             os: ubuntu-latest
             cc: gcc-14
@@ -92,6 +89,7 @@ jobs:
               -DCMAKE_CXX_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer -g'
               -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address,undefined'
           # windows-msvc excluded: deep MSVC C++20/C++26 incompatibilities in legacy sources
+          # macos-clang removed from soft-fail matrix → see macos_cpu_tests (blocking)
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
@@ -108,13 +106,6 @@ jobs:
             PKGS="$PKGS libopenmpi-dev openmpi-bin"
           fi
           sudo apt-get install -y $PKGS
-      - name: Install macOS dependencies
-        if: runner.os == 'macOS'
-        run: |
-          # Apple Clang ≥ 16 (Xcode 16) is required for C++26.
-          # Eigen3: system install via brew; vendored submodule skipped in CI.
-          sudo xcode-select -s /Applications/Xcode_16.app || true
-          brew install cmake ninja libomp eigen
       - name: Install Windows dependencies
         if: runner.os == 'Windows'
         run: |
@@ -135,18 +126,84 @@ jobs:
             -DFLEXAIDS_STRICT_SOURCE_VALIDATION=ON
             ${{ matrix.cmake_extra }}
           )
-          # Homebrew on Apple Silicon installs to /opt/homebrew
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            CMAKE_ARGS+=(-DCMAKE_PREFIX_PATH="$(brew --prefix)")
-            CMAKE_ARGS+=(-DBUILD_TESTING=OFF)
-            CMAKE_ARGS+=(-DOpenMP_ROOT="$(brew --prefix libomp)")
-          fi
           cmake "${CMAKE_ARGS[@]}"
       - name: Build
         run: cmake --build build --parallel
       - name: Test
         if: matrix.name == 'linux-gcc' || matrix.name == 'linux-clang' || matrix.name == 'linux-gcc-mpi' || matrix.name == 'linux-gcc-asan'
         run: ctest --test-dir build --output-on-failure
+
+  # Blocking macOS CPU gate (audit: was allow_failure + BUILD_TESTING=OFF).
+  # No continue-on-error. Metal is intentionally OFF here; shader smoke and
+  # self-hosted full Metal gate are separate (docs/CI_RELEASE_GATES.md).
+  macos_cpu_tests:
+    name: macOS CPU tests (blocking)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          submodules: false
+      - name: Install macOS dependencies
+        run: |
+          # Apple Clang ≥ 16 (Xcode 16) is required for C++26.
+          # Eigen3: system install via brew; vendored submodule skipped in CI.
+          sudo xcode-select -s /Applications/Xcode_16.app || true
+          brew install cmake ninja libomp eigen
+      - name: Configure (CPU, tests ON, Metal OFF)
+        run: |
+          CMAKE_ARGS=(
+            -S . -B build
+            -G Ninja
+            -DCMAKE_BUILD_TYPE=Release
+            -DFLEXAIDS_USE_CUDA=OFF
+            -DFLEXAIDS_USE_METAL=OFF
+            -DBUILD_PYTHON_BINDINGS=OFF
+            -DBUILD_TESTING=ON
+            -DFLEXAIDS_STRICT_SOURCE_VALIDATION=ON
+            -DCMAKE_PREFIX_PATH="$(brew --prefix)"
+            -DOpenMP_ROOT="$(brew --prefix libomp)"
+          )
+          cmake "${CMAKE_ARGS[@]}"
+      - name: Build
+        run: cmake --build build --parallel
+      - name: Test (ctest blocking)
+        run: ctest --test-dir build --output-on-failure --timeout 120
+
+  # Hosted Metal compile smoke: .metal → .air only (no full OBJCXX link).
+  # Exit 2 from the script = toolchain missing → soft-skip with notice.
+  # Full Metal link/runtime: workflow_dispatch metal-self-hosted.yml (self-hosted-m3).
+  macos_metal_compile_smoke:
+    name: Metal shader compile smoke
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          submodules: false
+      - name: Prefer recent Xcode (Metal toolchain)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_16.app || true
+          xcodebuild -version || true
+          xcrun -f metal || true
+      - name: Compile Metal shaders (smoke)
+        id: metal_smoke
+        run: |
+          set +e
+          bash scripts/ci/metal_compile_smoke.sh "${{ github.workspace }}/build-metal-smoke"
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$rc" -eq 2 ]; then
+            echo "status=skipped" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Metal toolchain absent::Hosted runner has no metal compiler; full Metal release gate is metal-self-hosted.yml (label self-hosted-m3). See docs/CI_RELEASE_GATES.md"
+            exit 0
+          fi
+          echo "status=failed" >> "$GITHUB_OUTPUT"
+          exit "$rc"
+      - name: Record smoke outcome
+        run: echo "Metal smoke status=${{ steps.metal_smoke.outputs.status }}"
 
   python_bindings_smoke:
     name: Python bindings smoke (${{ matrix.name }})

--- a/.github/workflows/metal-self-hosted.yml
+++ b/.github/workflows/metal-self-hosted.yml
@@ -1,0 +1,117 @@
+# Full Metal build + link gate for Apple Silicon self-hosted runners.
+#
+# GitHub-hosted macOS runners can compile .metal shaders (see ci.yml
+# macos_metal_compile_smoke) but cannot reliably provide a production
+# Metal link/runtime environment for release claims.
+#
+# Fail-closed: when this workflow is dispatched, jobs require a runner
+# labeled `self-hosted-m3`. Missing toolchain or build/link failure fails
+# the job (no continue-on-error).
+#
+# Register a runner with labels: self-hosted, self-hosted-m3
+# Docs: docs/CI_RELEASE_GATES.md
+
+name: Metal full gate (self-hosted M3)
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_ctest:
+        description: "Run ctest after Metal-enabled build (slower)"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+concurrency:
+  group: metal-self-hosted-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  metal_full_gate:
+    name: Metal build + smoke (self-hosted-m3)
+    runs-on: [self-hosted, self-hosted-m3]
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          submodules: false
+
+      - name: Fail-closed Metal toolchain preflight
+        run: |
+          set -euo pipefail
+          echo "Runner: $(uname -a)"
+          echo "Labels expected: self-hosted, self-hosted-m3"
+          if ! command -v xcrun >/dev/null 2>&1; then
+            echo "FATAL: xcrun missing on self-hosted-m3 runner"
+            exit 1
+          fi
+          METALC="$(xcrun -f metal 2>/dev/null || true)"
+          if [[ -z "${METALC}" || ! -x "${METALC}" ]]; then
+            echo "FATAL: Metal compiler not found. Install Xcode Metal toolchain:"
+            echo "  xcodebuild -downloadComponent MetalToolchain"
+            exit 1
+          fi
+          echo "Metal compiler: ${METALC}"
+          xcodebuild -version || true
+          # Hosted CI only smokes shaders; this gate requires frameworks too.
+          python3 - <<'PY'
+          import ctypes, sys
+          try:
+              ctypes.CDLL("/System/Library/Frameworks/Metal.framework/Metal")
+          except OSError as e:
+              print("FATAL: Metal.framework not loadable:", e)
+              sys.exit(1)
+          print("Metal.framework: OK")
+          PY
+
+      - name: Install deps (Homebrew if available)
+        run: |
+          set -euo pipefail
+          if command -v brew >/dev/null 2>&1; then
+            brew install cmake ninja libomp eigen || true
+          else
+            echo "NOTE: brew not found; assuming cmake/ninja/eigen already on PATH"
+          fi
+          command -v cmake
+          command -v ninja
+
+      - name: Configure (Metal ON, tests ON)
+        run: |
+          set -euo pipefail
+          CMAKE_ARGS=(
+            -S . -B build-metal
+            -G Ninja
+            -DCMAKE_BUILD_TYPE=Release
+            -DFLEXAIDS_USE_CUDA=OFF
+            -DFLEXAIDS_USE_METAL=ON
+            -DBUILD_PYTHON_BINDINGS=OFF
+            -DBUILD_TESTING=ON
+            -DFLEXAIDS_STRICT_SOURCE_VALIDATION=ON
+          )
+          if command -v brew >/dev/null 2>&1; then
+            CMAKE_ARGS+=(-DCMAKE_PREFIX_PATH="$(brew --prefix)")
+            if [[ -d "$(brew --prefix libomp 2>/dev/null || true)" ]]; then
+              CMAKE_ARGS+=(-DOpenMP_ROOT="$(brew --prefix libomp)")
+            fi
+          fi
+          cmake "${CMAKE_ARGS[@]}"
+
+      - name: Build FlexAID (Metal-linked)
+        run: cmake --build build-metal --parallel --target FlexAID
+
+      - name: Metal shader compile smoke
+        run: bash scripts/ci/metal_compile_smoke.sh build-metal/metal-smoke
+
+      - name: Unit tests (optional)
+        if: inputs.run_ctest == 'true'
+        run: ctest --test-dir build-metal --output-on-failure --timeout 120
+
+      - name: Summarize gate
+        run: |
+          echo "Metal full gate PASSED on self-hosted-m3"
+          echo "Binary: build-metal/FlexAID (or FlexAIDdS)"
+          ls -la build-metal/FlexAID build-metal/FlexAIDdS 2>/dev/null || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,23 @@ This document explains how to contribute while keeping the codebase fast, scient
    - Call out any API changes, new config options, or new dependencies.
    - Mention any licensing or build-system impact.
 
+## 2b. CI release gates (macOS + Metal)
+
+Merge and release claims follow the blocking jobs documented in
+**[`docs/CI_RELEASE_GATES.md`](docs/CI_RELEASE_GATES.md)**. Short version:
+
+| Gate | Blocking? | Notes |
+|:--|:--|:--|
+| Linux C++ build + `ctest` | Yes | `cxx_core_build` (GCC/Clang/MPI/ASan) |
+| **macOS CPU build + `ctest`** | **Yes** | Job `macos_cpu_tests` — no `continue-on-error` |
+| Metal `.metal` shader compile | Yes if toolchain present | Job `macos_metal_compile_smoke` |
+| Metal full link / GPU runtime | Self-hosted only | `workflow_dispatch` → `metal-self-hosted.yml` (`self-hosted-m3`) |
+
+Do **not** re-add `continue-on-error: true` (or matrix `allow_failure`) to
+`macos_cpu_tests` without an issue link and an explicit temporary waiver in
+`docs/CI_RELEASE_GATES.md`. Metal production claims require a green
+self-hosted M3 full gate; hosted CI only smokes shader compilation.
+
 ## 3. Coding Guidelines
 
 - **Languages**

--- a/docs/CI_RELEASE_GATES.md
+++ b/docs/CI_RELEASE_GATES.md
@@ -1,0 +1,106 @@
+# CI Release Gates
+
+This document defines **what must be green** before claiming a platform or
+backend is release-validated. It addresses the audit finding that macOS was
+allowed to fail, C++ tests were disabled on macOS, and Metal had no blocking
+gate.
+
+## Blocking gates (required on every PR / push)
+
+| Gate | Workflow / job | Runner | Fail behavior |
+|:--|:--|:--|:--|
+| Pure Python results | `ci.yml` → `pure_python_results` | `ubuntu-latest` | Blocking |
+| C++ core Linux GCC | `ci.yml` → `cxx_core_build` (`linux-gcc`) | `ubuntu-latest` | Blocking + **ctest** |
+| C++ core Linux Clang | `ci.yml` → `cxx_core_build` (`linux-clang`) | `ubuntu-latest` | Blocking + **ctest** |
+| C++ MPI / ASan Linux | `ci.yml` → `cxx_core_build` | `ubuntu-latest` | Blocking + **ctest** |
+| **macOS CPU C++ tests** | `ci.yml` → `macos_cpu_tests` | `macos-15` | **Blocking + ctest** (no `continue-on-error`) |
+| **Metal shader compile smoke** | `ci.yml` → `macos_metal_compile_smoke` | `macos-15` | Blocking if Metal toolchain present; soft-skip (job success with notice) only if `xcrun metal` is absent |
+| Python bindings smoke (Linux) | `ci.yml` → `python_bindings_smoke` | `ubuntu-latest` | Blocking |
+| Repo hygiene + skill tests | `ci.yml` → `repo_hygiene` | `ubuntu-latest` | Blocking |
+| DatasetRunner dry-run | `ci.yml` → `flexaid_docking_datasetrunner` | `ubuntu-latest` | Blocking |
+
+### Before / after (macOS audit)
+
+| Behavior | Before | After |
+|:--|:--|:--|
+| macOS in `cxx_core_build` | Matrix entry with `allow_failure: true` | Removed from soft-fail matrix |
+| macOS `BUILD_TESTING` | Forced `OFF` in configure | Dedicated job forces **`ON`** |
+| macOS `ctest` | Not run | **`macos_cpu_tests` runs ctest** |
+| Metal | No CI gate | Hosted **shader compile smoke** + self-hosted full gate |
+
+## Soft / experimental (non-blocking)
+
+| Gate | Why soft |
+|:--|:--|
+| `linux-gcc-avx512` | Architecture may be unavailable on GHA hardware; `allow_failure: true` |
+| Windows Python bindings | Known flaky / deep MSVC issues; `allow_failure: true` |
+| Coverage, sanitizers, TSAN, perf workflows | Extra signal, not merge gates unless required by a release checklist |
+
+## Metal: hosted smoke vs self-hosted full gate
+
+### Hosted (every PR): shader compile only
+
+- Job: `macos_metal_compile_smoke` in `.github/workflows/ci.yml`
+- Script: `scripts/ci/metal_compile_smoke.sh`
+- Compiles tracked `*.metal` sources to `.air` (and `.metallib` when `metallib` exists)
+- Does **not** full-link Metal OBJCXX bridges into `FlexAID` (that path needs a stable Apple Silicon + Xcode Metal toolchain environment)
+- Runtime: seconds to a few minutes — not a docking campaign
+
+If GitHub-hosted `macos-15` lacks the Metal compiler component, the job prints a clear skip notice and exits 0 so Linux/macOS CPU gates stay green. That **does not** authorize Metal release claims.
+
+### Self-hosted full gate (Metal release claims)
+
+- Workflow: `.github/workflows/metal-self-hosted.yml`
+- Trigger: **`workflow_dispatch` only** (manual or release checklist)
+- Runner labels: **`self-hosted`**, **`self-hosted-m3`**
+- Behavior: **fail-closed**
+  - Missing Metal compiler → job fails
+  - CMake `FLEXAIDS_USE_METAL=ON` configure/build/link failure → job fails
+  - Optional `ctest` (default on) failure → job fails
+  - No `continue-on-error`
+
+Register an Apple Silicon (M-series) machine as a GitHub Actions self-hosted runner with both labels. Without a matching runner, the workflow stays queued until a runner appears or the run is cancelled — it never soft-passes.
+
+## What still needs a self-hosted M3
+
+| Claim | Hosted GHA sufficient? | Required gate |
+|:--|:--|:--|
+| macOS CPU build + unit tests | Yes (`macos_cpu_tests`) | PR CI |
+| Metal `.metal` → `.air` compile | Usually yes (when Xcode Metal toolchain present) | PR CI smoke |
+| Metal OBJCXX bridge **link** into `FlexAID` | **No** (treat as self-hosted) | `metal-self-hosted.yml` |
+| Metal **runtime** correctness / GPU kernels | **No** | self-hosted + local validation |
+| Full docking campaign on Apple Silicon | **No** | Local / fleet benchmarks (not this gate) |
+
+## Release checklist (minimum)
+
+1. Green blocking jobs on `ci.yml` for the commit/tag (including **`macos_cpu_tests`**).
+2. Linux `ctest` clean (`linux-gcc` and `linux-clang` at minimum).
+3. If advertising Metal acceleration in release notes:
+   - Green `Metal full gate (self-hosted M3)` for that commit/tag, **or**
+   - Explicitly mark Metal as experimental with no production guarantee (see `docs/SUPPORT_MATRIX.md`).
+4. No secrets / machine-absolute paths: `python3 scripts/check_repo_hygiene.py`.
+
+## Local reproduction
+
+```bash
+# macOS CPU (matches macos_cpu_tests)
+cmake -B build-macos-cpu -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DFLEXAIDS_USE_CUDA=OFF \
+  -DFLEXAIDS_USE_METAL=OFF \
+  -DBUILD_TESTING=ON \
+  -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
+  -DOpenMP_ROOT="$(brew --prefix libomp)"
+cmake --build build-macos-cpu --parallel
+ctest --test-dir build-macos-cpu --output-on-failure
+
+# Metal shader smoke (hosted-equivalent)
+bash scripts/ci/metal_compile_smoke.sh /tmp/metal-smoke
+
+# Metal full link (self-hosted-equivalent)
+cmake -B build-metal -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DFLEXAIDS_USE_METAL=ON \
+  -DBUILD_TESTING=ON
+cmake --build build-metal --parallel --target FlexAID
+```

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -35,8 +35,18 @@ Anything not listed here should be treated as experimental.
 | AVX2 | Supported | Performance optimization, not correctness dependency |
 | AVX-512 | Experimental | Optional and architecture-specific |
 | CUDA | Experimental | Not required for 1.0 support guarantees |
-| Metal | Experimental | Not required for 1.0 support guarantees |
+| Metal | Experimental | Hosted CI: shader compile smoke only. Full link/runtime gate: self-hosted `self-hosted-m3` (`metal-self-hosted.yml`). Not required for 1.0 CPU support guarantees. See `docs/CI_RELEASE_GATES.md`. |
 | ROCm/HIP | Experimental | Not required for 1.0 support guarantees |
+
+### Platform CI gates (summary)
+
+| Platform | Blocking PR gate | What is still self-hosted |
+|:--|:--|:--|
+| Linux CPU | `cxx_core_build` + `ctest` | Full docking campaigns |
+| macOS CPU | `macos_cpu_tests` + `ctest` (no soft-fail) | Full docking campaigns |
+| Metal GPU | `macos_metal_compile_smoke` (shaders) | Link + runtime via `self-hosted-m3` |
+
+Full table and release checklist: **`docs/CI_RELEASE_GATES.md`**.
 
 ## Python support
 

--- a/scripts/ci/metal_compile_smoke.sh
+++ b/scripts/ci/metal_compile_smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Metal shader compile smoke — no full docking, no OBJCXX link.
+# Exit codes:
+#   0  shaders compiled (or metallib linked when available)
+#   2  Metal toolchain not available (caller may treat as skip)
+#   1  compile failure
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${1:-${ROOT}/build-metal-smoke}"
+mkdir -p "${OUT_DIR}"
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+METALC=""
+if require_cmd xcrun; then
+  if METALC="$(xcrun -f metal 2>/dev/null)" && [[ -n "${METALC}" && -x "${METALC}" ]]; then
+    :
+  else
+    METALC=""
+  fi
+fi
+
+if [[ -z "${METALC}" ]]; then
+  echo "SKIP: Metal shader compiler not found (xcrun -f metal)."
+  echo "Full Metal link/runtime gate requires a self-hosted runner labeled self-hosted-m3."
+  echo "See docs/CI_RELEASE_GATES.md and .github/workflows/metal-self-hosted.yml"
+  exit 2
+fi
+
+METALLIB=""
+METAL_DIR="$(dirname "${METALC}")"
+if [[ -x "${METAL_DIR}/metallib" ]]; then
+  METALLIB="${METAL_DIR}/metallib"
+elif require_cmd metallib; then
+  METALLIB="$(command -v metallib)"
+fi
+
+echo "Metal compiler: ${METALC}"
+echo "metallib: ${METALLIB:-<not found — .air only>}"
+echo "Output: ${OUT_DIR}"
+
+SHADERS=(
+  "LIB/CavityDetect/CavityDetect.metal"
+  "LIB/ShannonThermoStack/shannon_metal.metal"
+  "LIB/TurboQuant.metal"
+  "LIB/MetalRMSD.metal"
+  "LIB/gpu_fast_optics_metal.metal"
+)
+
+AIR_FILES=()
+failed=0
+for rel in "${SHADERS[@]}"; do
+  src="${ROOT}/${rel}"
+  if [[ ! -f "${src}" ]]; then
+    echo "WARN: missing shader ${rel} — skipping"
+    continue
+  fi
+  base="$(basename "${rel}" .metal)"
+  air="${OUT_DIR}/${base}.air"
+  echo "=== metal -c ${rel} ==="
+  if ! "${METALC}" -c "${src}" -o "${air}"; then
+    echo "FAIL: compile ${rel}"
+    failed=1
+    continue
+  fi
+  AIR_FILES+=("${air}")
+  echo "OK: ${air}"
+done
+
+if [[ "${failed}" -ne 0 ]]; then
+  echo "Metal compile smoke FAILED"
+  exit 1
+fi
+
+if [[ ${#AIR_FILES[@]} -eq 0 ]]; then
+  echo "FAIL: no Metal shaders found to compile"
+  exit 1
+fi
+
+if [[ -n "${METALLIB}" ]]; then
+  lib="${OUT_DIR}/flexaidds_smoke.metallib"
+  echo "=== metallib -> ${lib} ==="
+  "${METALLIB}" -o "${lib}" "${AIR_FILES[@]}"
+  echo "OK: ${lib}"
+else
+  echo "NOTE: metallib not available; .air compile-only smoke is sufficient for hosted CI."
+fi
+
+echo "Metal compile smoke: SUCCESS (${#AIR_FILES[@]} shaders)"
+exit 0


### PR DESCRIPTION
## Summary

Addresses GPT audit: **macOS CI allowed to fail; C++ tests disabled; Metal lacks blocking release gate**.

### Before (`ci.yml`)
| Item | Behavior |
|:--|:--|
| `macos-clang` in `cxx_core_build` | `allow_failure: true` → soft-fail |
| macOS configure | Forced `BUILD_TESTING=OFF` |
| macOS `ctest` | Not run |
| Metal | No CI job |

### After
| Item | Behavior |
|:--|:--|
| `macos-clang` soft-fail matrix entry | **Removed** |
| **`macos_cpu_tests`** (new) | `macos-15`, **no** `continue-on-error`, `BUILD_TESTING=ON`, **blocking `ctest`** |
| **`macos_metal_compile_smoke`** (new) | Hosted shader compile (`.metal` → `.air`/`.metallib`); soft-skip only if `xcrun metal` missing |
| **`metal-self-hosted.yml`** (new) | `workflow_dispatch` + labels `self-hosted`, `self-hosted-m3`; fail-closed full Metal link gate |
| Docs | `docs/CI_RELEASE_GATES.md`, `CONTRIBUTING.md` §2b, `SUPPORT_MATRIX.md` |

Linux jobs unchanged (still blocking GCC/Clang/MPI/ASan + `ctest`). Experimental `linux-gcc-avx512` and Windows Python bindings remain soft-fail only.

## What still needs self-hosted M3

| Claim | Hosted GHA | Self-hosted M3 |
|:--|:--|:--|
| macOS CPU build + unit tests | ✅ `macos_cpu_tests` | — |
| Metal shader compile | ✅ smoke when toolchain present | — |
| Metal OBJCXX **link** into FlexAID | ❌ | ✅ `metal-self-hosted.yml` |
| Metal **runtime** / GPU kernels | ❌ | ✅ + local validation |
| Full docking campaigns | ❌ | Local / fleet (out of scope) |

Register a runner with labels **`self-hosted`** and **`self-hosted-m3`**, then dispatch **Metal full gate (self-hosted M3)** for Metal release claims.

## Verification (this session)
- YAML parse: `ci.yml` + `metal-self-hosted.yml` OK
- `python3 scripts/check_repo_hygiene.py` OK
- Local `bash scripts/ci/metal_compile_smoke.sh` → **SUCCESS (5 shaders)** including metallib

## Out of scope (per mission)
- Full Metal link/Homebrew fix
- DatasetRunner split, ProtocolConfig, CF naming

## Test plan
- [ ] PR CI: Linux `cxx_core_build` still green
- [ ] PR CI: `macos_cpu_tests` runs and is **required** (not soft-fail)
- [ ] PR CI: `macos_metal_compile_smoke` compiles or skips with notice (not silent fail)
- [ ] Manual: dispatch `metal-self-hosted.yml` when `self-hosted-m3` runner is available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS CPU test coverage as a blocking release check.
  * Added hosted Metal shader compilation checks and a dedicated Apple Silicon full Metal validation workflow.
  * Added clearer platform support and release-gate status information.

* **Documentation**
  * Expanded contributor guidance for macOS and Metal release validation.
  * Added release checklists, local reproduction steps, and clarified hosted versus self-hosted Metal coverage.

* **Bug Fixes**
  * Improved CI handling for unavailable Metal toolchains by reporting a clear skip instead of an unexplained failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->