### PR TITLE
Add: ProtocolConfig typed env adapter (audit getenv chunk 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1075,6 +1075,14 @@ if(BUILD_TESTING)
         TEST_NAME JsonConfigTests
     )
 
+    # test_protocol_config — typed ProtocolConfig env adapter + JSON round-trip
+    flexaids_add_unit_test(test_protocol_config
+        SOURCES
+            tests/test_protocol_config.cpp
+            LIB/ProtocolConfig.cpp
+        TEST_NAME ProtocolConfigTests
+    )
+
     # test_posebust — NativePoseQC clean-room + BustCli (real Astex 1G9V artifacts)
     flexaids_add_unit_test(test_posebust
         SOURCES

--- a/LIB/CMakeLists.txt
+++ b/LIB/CMakeLists.txt
@@ -139,6 +139,8 @@ set(FLEXAID_CORE_SOURCES
     PTMAttachment/PTMAttachment.cpp
     # ── JSON config parser ──
     config_parser.cpp
+    # ── Typed protocol knobs (env adapter; audit getenv consolidation) ──
+    ProtocolConfig.cpp
     # ── ThermodynamicEngine: G_bind decomposition (disabled by default) ──
     ThermodynamicEngine.cpp
     # ── Coarse pocket-scan gen-0 seeding ──

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -16,6 +16,7 @@
 #include "DatasetRunner.h"
 #include "AsyncPipeline.h"
 #include "BenchmarkRunner.h"
+#include "ProtocolConfig.h"
 #include "statmech.h"
 #include "receptor_prep.h"
 #include "tENCoM/tencm.h"   // tencm::TorsionalENM — ligand Cartesian ANM for H(ω)
@@ -88,12 +89,9 @@ static std::uint64_t stable_seed_hash(const std::string& label,
     return hash;
 }
 
-static int deterministic_ga_seed(const std::string& target_id, int restart) {
-    std::uint64_t base = 0;
-    if (const char* value = std::getenv("FLEXAIDDS_SEED_BASE")) {
-        try { base = std::stoull(value); } catch (...) { base = 0; }
-    }
-    const std::uint64_t stream = base ^ static_cast<std::uint64_t>(restart);
+static int deterministic_ga_seed(const std::string& target_id, int restart,
+                                 std::uint64_t seed_base = 0) {
+    const std::uint64_t stream = seed_base ^ static_cast<std::uint64_t>(restart);
     return 1 + static_cast<int>(stable_seed_hash(target_id, stream) % 2147483646ULL);
 }
 
@@ -1885,13 +1883,14 @@ DatasetRunner::DatasetRunner(const std::string& cache_dir) {
     }
     ensure_dir(cache_dir_);
 
+    // Typed protocol snapshot: env remains the compatibility adapter only.
+    protocol_cfg_ = flexaids::ProtocolConfig::from_env();
+
     // Fix A: CF-window pose selector gate (default off for safety).
-    if (const char* e = std::getenv("FLEXAIDDS_CF_WINDOW_SELECTOR"))
-        cf_window_selector_ = (std::atoi(e) != 0);
+    cf_window_selector_ = protocol_cfg_.cf_window_selector;
 
     // Fix B: cluster member emission for near-miss BCR recovery (default off).
-    if (const char* e = std::getenv("FLEXAIDDS_CLUSTER_MEMBER_EMIT"))
-        cluster_member_emit_ = (std::atoi(e) != 0);
+    cluster_member_emit_ = protocol_cfg_.cluster_member_emit;
 }
 
 // =============================================================================
@@ -5051,8 +5050,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         // explicit override, immutable data staged beside the binary, then the
         // mutable source-tree WRK directory as a development fallback.
         std::string matrix_path;
-        if (const char* dd = std::getenv("FLEXAIDDS_DATA_DIR")) {
-            std::string cand = std::string(dd) + "/MC_st0r5.2_6.dat";
+        if (!protocol_cfg_.data_dir.empty()) {
+            std::string cand = protocol_cfg_.data_dir + "/MC_st0r5.2_6.dat";
             if (fs::exists(cand)) matrix_path = cand;
         }
         if (matrix_path.empty()) {
@@ -5325,9 +5324,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         // any changes to GA internals.  Restart 0 always uses the canonical out_dir
         // / out_prefix for backward compatibility with cached single-run results.
         // v58 default: consensus-5r (v50b proved +2% vs single-run v55).
-        int n_restarts = 5;
-        if (const char* env_r = std::getenv("FLEXAIDDS_RESTARTS"))
-            n_restarts = std::max(1, std::atoi(env_r));
+        // FLEXAIDDS_RESTARTS via protocol_cfg_ (ProtocolConfig::from_env).
+        const int n_restarts = std::max(1, protocol_cfg_.restarts);
         std::vector<std::string> all_prefixes;  // populated by exec_dock loop below
 
         // ── Grid reuse: check if a prior same-receptor run left a grid file ──
@@ -5593,9 +5591,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             //   n_restarts x T_dock  ->  max(T_dock_r0, T_dock_r1, ...)
             // which is ~3x speedup for the default FLEXAIDDS_RESTARTS=3.
             // Set FLEXAIDDS_PARALLEL_RESTARTS=0 to revert to sequential mode.
-            bool parallel_restarts = (n_restarts > 1);
-            if (const char* e = std::getenv("FLEXAIDDS_PARALLEL_RESTARTS"))
-                parallel_restarts = (std::atoi(e) != 0) && (n_restarts > 1);
+            bool parallel_restarts = protocol_cfg_.parallel_restarts && (n_restarts > 1);
             // Fall back to sequential if proc_guard_ unavailable (no PID tracking).
             if (!proc_guard_) parallel_restarts = false;
 
@@ -5640,15 +5636,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // v70: restored P9 default 4.0 → 7.0.  The v69 r0=4.0 revert was a net
             // regression (79/85 vs v68's 82/85); r0=7.0 was better for the full
             // set, so we keep it (env FLEXAIDDS_VCT_R0 still overrides).
-            double vct_r0 = 7.0;
-            if (const char* r0env = std::getenv("FLEXAIDDS_VCT_R0")) {
-                try { vct_r0 = std::stod(r0env); } catch (...) { vct_r0 = 7.0; }
-            }
-            const bool vct_norm = (std::getenv("FLEXAIDDS_VCT_NORM") != nullptr);
-            double vct_entropy_w = 0.0;
-            if (const char* ewenv = std::getenv("FLEXAIDDS_VCT_ENTROPY_WEIGHT")) {
-                try { vct_entropy_w = std::stod(ewenv); } catch (...) { vct_entropy_w = 0.0; }
-            }
+            const double vct_r0 = protocol_cfg_.vct_r0;
+            const bool vct_norm = protocol_cfg_.vct_normalize_contacts;
+            const double vct_entropy_w = protocol_cfg_.vct_entropy_weight;
             {
                 std::ofstream jf(config_path);
                 jf << "{\n"
@@ -5818,9 +5808,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                    // Reduce alpha so each niche still contains ~pop_base chromosomes:
                    //   alpha_eff = 4.0 * pop_base / pop_scaled
                    // At pop_scaled==pop_base (rigid target) this is 4.0 (original).
-                   << (std::getenv("FLEXAIDDS_SHARING_ALPHA")
-                         ? std::atof(std::getenv("FLEXAIDDS_SHARING_ALPHA"))
-                         : 4.0 * static_cast<double>(pop_base) / static_cast<double>(pop_scaled))
+                   << protocol_cfg_.effective_sharing_alpha(pop_base, pop_scaled)
                    << ",\n"
                    << "    \"boom_inject_interval\": 100,\n"
                    << "    \"boom_inject_fraction\": "
@@ -5837,15 +5825,13 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                         config.mode == BenchmarkMode::DEFINED_CLEFT_REDOCK ||
                         config.mode == BenchmarkMode::ORACLE_CEILING)
                          ? 0.0
-                         : (std::getenv("FLEXAIDDS_BOOM_FRAC")
-                               ? std::atof(std::getenv("FLEXAIDDS_BOOM_FRAC")) : 1.0))
+                         : protocol_cfg_.effective_boom_frac())
                    << ",\n"
                    // v27: true GA elitism — protect n_elite lowest-CF individuals
                    // from boom injection + niche-sharing (engine-side env override
                    // FLEXAIDDS_N_ELITE still wins, but echo it for auditability).
                    << "    \"n_elite\": "
-                   << (std::getenv("FLEXAIDDS_N_ELITE")
-                         ? std::atoi(std::getenv("FLEXAIDDS_N_ELITE")) : 1)
+                   << protocol_cfg_.n_elite
                    << ",\n"
                    // Shannon configurational entropy in the GA fitness is OFF by
                    // default (config_parser ga.use_shannon=false). Setting the
@@ -5854,22 +5840,20 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                    // binary — no source fork. The flag is echoed into the per-case
                    // dock_config.json so the experiment arm is greppable on disk.
                    <<    "    \"fitness_model\": \"SMFREE\"";  // v121: SMFREE e^(-CF/kT) overflows at docking CF~-80,kT=0.596 -> fitness=1000 for all -> GA=random sampler. v50b 81.2% relied on this: crystal-seed+exploration+5r-consensus finds native. PSHARE (ee9db7f9) optimizes correctly but converges to CF false-min -> 41.2%.
-                if (std::getenv("FLEXAIDDS_USE_SHANNON")) {
+                if (protocol_cfg_.use_shannon) {
                     jf << ",\n    \"use_shannon\": true";
                 }
                 // Every restart is deterministic. FLEXAIDDS_SEED_BASE can define
                 // an independent replicate while the emitted config records the
                 // exact target-specific seed used by this run.
                 jf << ",\n    \"seed\": "
-                   << deterministic_ga_seed(entry.pdb_id, ri);
+                   << deterministic_ga_seed(entry.pdb_id, ri, protocol_cfg_.seed_base);
                 jf << "\n  }";
                 // ThermodynamicEngine — disabled by default; enable via FLEXAIDDS_THERMO=1
-                if (std::getenv("FLEXAIDDS_THERMO")) {
-                    const char* t_eff_env = std::getenv("FLEXAIDDS_T_EFF");
-                    float t_eff_val = t_eff_env ? std::stof(t_eff_env) : 0.596f;
-                    const char* ts_env = std::getenv("FLEXAIDDS_TENCOM_SCALE");
-                    float ts_val = ts_env ? std::stof(ts_env) : 1.0f;
-                    jf << ",\n  \"thermo_engine\": {\"enabled\": true, \"T_eff\": " << t_eff_val << ", \"tencom_scale\": " << ts_val << "}";
+                if (protocol_cfg_.thermo_enabled) {
+                    jf << ",\n  \"thermo_engine\": {\"enabled\": true, \"T_eff\": "
+                       << protocol_cfg_.t_eff << ", \"tencom_scale\": "
+                       << protocol_cfg_.tencom_scale << "}";
                 }
                 // If a grid file from a prior same-receptor run exists, tell
                 // FlexAIDdS to reuse it instead of regenerating from scratch.
@@ -5887,8 +5871,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                 // controlled A/B tests. Normal runs prefer data staged beside
                 // the binary so uncommitted WRK edits cannot silently change a
                 // benchmark; WRK remains a development-only fallback.
-                const char* dd_override = std::getenv("FLEXAIDDS_DATA_DIR");
-                if (dd_override && fs::exists(std::string(dd_override) + "/MC_st0r5.2_6.dat")) {
+                const std::string& dd_override = protocol_cfg_.data_dir;
+                if (!dd_override.empty() &&
+                    fs::exists(dd_override + "/MC_st0r5.2_6.dat")) {
                     data_dir_arg = " --data-dir '" +
                                    fs::canonical(dd_override).string() + "' ";
                 } else {

--- a/LIB/DatasetRunner.h
+++ b/LIB/DatasetRunner.h
@@ -38,6 +38,7 @@
 #endif
 
 #include "TargetServer.h"
+#include "ProtocolConfig.h"
 
 namespace dataset {
 
@@ -499,6 +500,13 @@ public:
 
 private:
     std::string cache_dir_;
+
+    /// Typed protocol snapshot (seed/restarts/VCT/GA/thermo/data_dir).
+    /// Loaded once via ProtocolConfig::from_env() in the constructor so
+    /// high-traffic getenv fragments go through one adapter (see
+    /// docs/implementation/protocol-config.md). Residual getenv sites remain
+    /// until later migration chunks.
+    flexaids::ProtocolConfig protocol_cfg_{};
 
     // ── Pose selector tuning ─────────────────────────────────────────
     /// CF-window gate (Fix A): when true the freq>1 gate in

--- a/LIB/ProtocolConfig.cpp
+++ b/LIB/ProtocolConfig.cpp
@@ -1,0 +1,225 @@
+// ProtocolConfig.cpp — env adapter + light JSON for typed protocol knobs
+//
+// Copyright 2026 Le Bonhomme Pharma. Licensed under Apache-2.0.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ProtocolConfig.h"
+#include "json_value.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <sstream>
+#include <stdexcept>
+
+namespace flexaids {
+namespace {
+
+const char* env_raw(const char* name) {
+    return std::getenv(name);
+}
+
+bool env_present(const char* name) {
+    const char* e = env_raw(name);
+    return e != nullptr && e[0] != '\0';
+}
+
+// Truthy presence: non-null and not an explicit "0"/false/off.
+// Used for gates that historically treated any non-null getenv as ON, but
+// also accept FLEXAIDDS_FOO=0 to disable when callers used atoi.
+bool env_truthy_int(const char* name, bool default_value) {
+    const char* e = env_raw(name);
+    if (!e || e[0] == '\0') return default_value;
+    return std::atoi(e) != 0;
+}
+
+std::optional<double> env_opt_double(const char* name) {
+    const char* e = env_raw(name);
+    if (!e || e[0] == '\0') return std::nullopt;
+    try {
+        return std::stod(e);
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::optional<int> env_opt_int(const char* name) {
+    const char* e = env_raw(name);
+    if (!e || e[0] == '\0') return std::nullopt;
+    return std::atoi(e);
+}
+
+std::string json_escape(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 8);
+    for (char c : s) {
+        switch (c) {
+            case '\\': out += "\\\\"; break;
+            case '"':  out += "\\\""; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:   out += c; break;
+        }
+    }
+    return out;
+}
+
+}  // namespace
+
+ProtocolConfig ProtocolConfig::defaults() {
+    return ProtocolConfig{};
+}
+
+ProtocolConfig ProtocolConfig::from_env() {
+    ProtocolConfig cfg = defaults();
+
+    if (const char* e = env_raw("FLEXAIDDS_SEED_BASE")) {
+        try {
+            cfg.seed_base = std::stoull(e);
+        } catch (...) {
+            cfg.seed_base = 0;
+        }
+    }
+
+    if (auto r = env_opt_int("FLEXAIDDS_RESTARTS")) {
+        cfg.restarts = std::max(1, *r);
+    }
+
+    if (const char* e = env_raw("FLEXAIDDS_PARALLEL_RESTARTS")) {
+        cfg.parallel_restarts_explicit = true;
+        cfg.parallel_restarts = (std::atoi(e) != 0) && (cfg.restarts > 1);
+    } else {
+        cfg.parallel_restarts = (cfg.restarts > 1);
+    }
+
+    if (auto v = env_opt_double("FLEXAIDDS_VCT_R0")) {
+        cfg.vct_r0 = *v;
+    }
+    cfg.vct_normalize_contacts = env_present("FLEXAIDDS_VCT_NORM");
+    if (auto v = env_opt_double("FLEXAIDDS_VCT_ENTROPY_WEIGHT")) {
+        cfg.vct_entropy_weight = *v;
+    }
+
+    cfg.sharing_alpha = env_opt_double("FLEXAIDDS_SHARING_ALPHA");
+    cfg.boom_frac = env_opt_double("FLEXAIDDS_BOOM_FRAC");
+    if (auto n = env_opt_int("FLEXAIDDS_N_ELITE")) {
+        cfg.n_elite = *n;
+    }
+    // Historical DatasetRunner: presence of FLEXAIDDS_USE_SHANNON enables.
+    cfg.use_shannon = env_present("FLEXAIDDS_USE_SHANNON");
+
+    cfg.thermo_enabled = env_present("FLEXAIDDS_THERMO");
+    if (auto v = env_opt_double("FLEXAIDDS_T_EFF")) {
+        cfg.t_eff = static_cast<float>(*v);
+    }
+    if (auto v = env_opt_double("FLEXAIDDS_TENCOM_SCALE")) {
+        cfg.tencom_scale = static_cast<float>(*v);
+    }
+
+    if (const char* e = env_raw("FLEXAIDDS_DATA_DIR")) {
+        if (e[0] != '\0') cfg.data_dir = e;
+    }
+
+    cfg.cf_window_selector =
+        env_truthy_int("FLEXAIDDS_CF_WINDOW_SELECTOR", /*default_value=*/false);
+    cfg.cluster_member_emit =
+        env_truthy_int("FLEXAIDDS_CLUSTER_MEMBER_EMIT", /*default_value=*/false);
+
+    if (auto v = env_opt_double("FLEXAIDDS_HBOND_WEIGHT")) {
+        cfg.hbond_weight = *v;
+    }
+
+    return cfg;
+}
+
+double ProtocolConfig::effective_sharing_alpha(int pop_base, int pop_scaled) const {
+    if (sharing_alpha.has_value()) return *sharing_alpha;
+    if (pop_scaled <= 0) return 4.0;
+    return 4.0 * static_cast<double>(pop_base) / static_cast<double>(pop_scaled);
+}
+
+double ProtocolConfig::effective_boom_frac() const {
+    return boom_frac.value_or(1.0);
+}
+
+std::string ProtocolConfig::to_json() const {
+    std::ostringstream o;
+    o.setf(std::ios::fixed);
+    o.precision(6);
+    o << '{';
+    o << "\"seed_base\":" << seed_base << ',';
+    o << "\"restarts\":" << restarts << ',';
+    o << "\"parallel_restarts\":" << (parallel_restarts ? "true" : "false") << ',';
+    o << "\"vct_r0\":" << vct_r0 << ',';
+    o << "\"vct_normalize_contacts\":"
+      << (vct_normalize_contacts ? "true" : "false") << ',';
+    o << "\"vct_entropy_weight\":" << vct_entropy_weight << ',';
+    if (sharing_alpha) {
+        o << "\"sharing_alpha\":" << *sharing_alpha << ',';
+    } else {
+        o << "\"sharing_alpha\":null,";
+    }
+    if (boom_frac) {
+        o << "\"boom_frac\":" << *boom_frac << ',';
+    } else {
+        o << "\"boom_frac\":null,";
+    }
+    o << "\"n_elite\":" << n_elite << ',';
+    o << "\"use_shannon\":" << (use_shannon ? "true" : "false") << ',';
+    o << "\"thermo_enabled\":" << (thermo_enabled ? "true" : "false") << ',';
+    o << "\"t_eff\":" << t_eff << ',';
+    o << "\"tencom_scale\":" << tencom_scale << ',';
+    o << "\"data_dir\":\"" << json_escape(data_dir) << "\",";
+    o << "\"cf_window_selector\":" << (cf_window_selector ? "true" : "false") << ',';
+    o << "\"cluster_member_emit\":" << (cluster_member_emit ? "true" : "false") << ',';
+    o << "\"hbond_weight\":" << hbond_weight;
+    o << '}';
+    return o.str();
+}
+
+ProtocolConfig ProtocolConfig::from_json(const std::string& json_text) {
+    ProtocolConfig cfg = defaults();
+    const json::Value root = json::parse(json_text);
+    if (!root.is_object()) {
+        throw std::runtime_error("ProtocolConfig::from_json: root must be object");
+    }
+
+    if (!root["seed_base"].is_null())
+        cfg.seed_base = static_cast<std::uint64_t>(root["seed_base"].as_int(0));
+    if (!root["restarts"].is_null())
+        cfg.restarts = std::max(1, root["restarts"].as_int(5));
+    if (!root["parallel_restarts"].is_null())
+        cfg.parallel_restarts = root["parallel_restarts"].as_bool(true);
+    if (!root["vct_r0"].is_null())
+        cfg.vct_r0 = root["vct_r0"].as_double(7.0);
+    if (!root["vct_normalize_contacts"].is_null())
+        cfg.vct_normalize_contacts = root["vct_normalize_contacts"].as_bool(false);
+    if (!root["vct_entropy_weight"].is_null())
+        cfg.vct_entropy_weight = root["vct_entropy_weight"].as_double(0.0);
+    if (!root["sharing_alpha"].is_null())
+        cfg.sharing_alpha = root["sharing_alpha"].as_double(4.0);
+    if (!root["boom_frac"].is_null())
+        cfg.boom_frac = root["boom_frac"].as_double(1.0);
+    if (!root["n_elite"].is_null())
+        cfg.n_elite = root["n_elite"].as_int(1);
+    if (!root["use_shannon"].is_null())
+        cfg.use_shannon = root["use_shannon"].as_bool(false);
+    if (!root["thermo_enabled"].is_null())
+        cfg.thermo_enabled = root["thermo_enabled"].as_bool(false);
+    if (!root["t_eff"].is_null())
+        cfg.t_eff = root["t_eff"].as_float(0.596f);
+    if (!root["tencom_scale"].is_null())
+        cfg.tencom_scale = root["tencom_scale"].as_float(1.0f);
+    if (!root["data_dir"].is_null())
+        cfg.data_dir = root["data_dir"].as_string("");
+    if (!root["cf_window_selector"].is_null())
+        cfg.cf_window_selector = root["cf_window_selector"].as_bool(false);
+    if (!root["cluster_member_emit"].is_null())
+        cfg.cluster_member_emit = root["cluster_member_emit"].as_bool(false);
+    if (!root["hbond_weight"].is_null())
+        cfg.hbond_weight = root["hbond_weight"].as_double(-2.5);
+
+    return cfg;
+}
+
+}  // namespace flexaids

--- a/LIB/ProtocolConfig.h
+++ b/LIB/ProtocolConfig.h
@@ -1,0 +1,78 @@
+// ProtocolConfig.h — Typed protocol knobs with env-as-compat adapter
+//
+// Audit path: many FLEXAIDDS_* getenv() fragments currently configure
+// benchmarks and the engine ad hoc. ProtocolConfig is the typed home for
+// common science/benchmark knobs; getenv remains a compatibility adapter via
+// from_env() until call sites are migrated (see docs/implementation/
+// protocol-config.md).
+//
+// Copyright 2026 Le Bonhomme Pharma. Licensed under Apache-2.0.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace flexaids {
+
+/// Typed snapshot of high-traffic protocol / benchmark knobs.
+/// Defaults match historical getenv fallbacks (byte-stable when env is unset).
+struct ProtocolConfig {
+    // ── Seed / restarts (DatasetRunner) ──────────────────────────────────
+    std::uint64_t seed_base{0};       ///< FLEXAIDDS_SEED_BASE
+    int restarts{5};                  ///< FLEXAIDDS_RESTARTS (min 1)
+    /// When true and restarts > 1, launch restart workers in parallel.
+    /// Env FLEXAIDDS_PARALLEL_RESTARTS: if unset, defaults to (restarts > 1).
+    bool parallel_restarts{true};
+    bool parallel_restarts_explicit{false}; ///< true if env overrode default
+
+    // ── VCT / scoring knobs ──────────────────────────────────────────────
+    double vct_r0{7.0};               ///< FLEXAIDDS_VCT_R0
+    bool vct_normalize_contacts{false}; ///< FLEXAIDDS_VCT_NORM (presence)
+    double vct_entropy_weight{0.0};   ///< FLEXAIDDS_VCT_ENTROPY_WEIGHT
+    /// Niche-sharing exponent. nullopt → DatasetRunner uses pop-scaled 4.0.
+    std::optional<double> sharing_alpha; ///< FLEXAIDDS_SHARING_ALPHA
+    /// Boom inject fraction for legacy seed modes. nullopt → 1.0.
+    std::optional<double> boom_frac;  ///< FLEXAIDDS_BOOM_FRAC
+    int n_elite{1};                   ///< FLEXAIDDS_N_ELITE
+    bool use_shannon{false};          ///< FLEXAIDDS_USE_SHANNON (presence)
+
+    // ── Thermo engine (dock_config emission) ─────────────────────────────
+    bool thermo_enabled{false};       ///< FLEXAIDDS_THERMO (presence)
+    float t_eff{0.596f};              ///< FLEXAIDDS_T_EFF
+    float tencom_scale{1.0f};         ///< FLEXAIDDS_TENCOM_SCALE
+
+    // ── Paths ────────────────────────────────────────────────────────────
+    std::string data_dir;             ///< FLEXAIDDS_DATA_DIR (empty = unset)
+
+    // ── DatasetRunner pose-selector gates ────────────────────────────────
+    bool cf_window_selector{false};   ///< FLEXAIDDS_CF_WINDOW_SELECTOR
+    bool cluster_member_emit{false};  ///< FLEXAIDDS_CLUSTER_MEMBER_EMIT
+
+    // ── Engine init (top.cpp) ────────────────────────────────────────────
+    double hbond_weight{-2.5};        ///< FLEXAIDDS_HBOND_WEIGHT
+
+    /// Built-in defaults (no env consultation).
+    static ProtocolConfig defaults();
+
+    /// Compatibility adapter: read FLEXAIDDS_* env vars into typed fields.
+    /// Unset variables keep the same defaults as the pre-migration getenv sites.
+    static ProtocolConfig from_env();
+
+    /// Minimal JSON object of the typed fields (for audit / serialization).
+    [[nodiscard]] std::string to_json() const;
+
+    /// Parse a JSON object previously emitted by to_json() (or a superset).
+    /// Missing keys keep defaults(). Throws std::runtime_error on bad JSON.
+    static ProtocolConfig from_json(const std::string& json_text);
+
+    /// Effective sharing alpha given population scaling (mirrors DatasetRunner).
+    [[nodiscard]] double effective_sharing_alpha(int pop_base, int pop_scaled) const;
+
+    /// Effective boom inject fraction: mode-aware caller still forces 0.0 for
+    /// no-seed benchmark modes; this returns the env/default for seed modes.
+    [[nodiscard]] double effective_boom_frac() const;
+};
+
+}  // namespace flexaids

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -28,6 +28,7 @@
 #include "hbond_potential.h"
 #include "RngSeed.h"
 #include "ensemble_pipeline.h"
+#include "ProtocolConfig.h"
 
 #include <algorithm>
 #include <cmath>
@@ -573,7 +574,8 @@ int main(int argc, char **argv){
 	FA->use_hbond_rank=0;
 	FA->hbond_rank_rescore=0;
 	FA->hbond_weight=-2.5;
-	{ const char* _hbw=std::getenv("FLEXAIDDS_HBOND_WEIGHT"); if(_hbw) FA->hbond_weight=std::atof(_hbw); }  // v116: tuneable via env
+	// v116: tuneable via env — routed through ProtocolConfig (typed adapter).
+	FA->hbond_weight = flexaids::ProtocolConfig::from_env().hbond_weight;
 	FA->hbond_optimal_dist=2.8;
 	FA->hbond_optimal_angle=180.0;
 	FA->hbond_sigma_dist=0.4;
@@ -651,13 +653,13 @@ int main(int argc, char **argv){
 		{
 			char probe[MAX_PATH__];
 			int found = 0;
-			const char* env_dd = getenv("FLEXAIDDS_DATA_DIR");
-			if (env_dd != NULL && env_dd[0] != '\0') {
-				snprintf(probe, MAX_PATH__, "%s/MC_st0r5.2_6.dat", env_dd);
+			const flexaids::ProtocolConfig proto = flexaids::ProtocolConfig::from_env();
+			if (!proto.data_dir.empty()) {
+				snprintf(probe, MAX_PATH__, "%s/MC_st0r5.2_6.dat", proto.data_dir.c_str());
 				FILE* fp = fopen(probe, "r");
 				if (fp) {
 					fclose(fp);
-					strncpy(FA->dependencies_path, env_dd, MAX_PATH__ - 1);
+					strncpy(FA->dependencies_path, proto.data_dir.c_str(), MAX_PATH__ - 1);
 					FA->dependencies_path[MAX_PATH__ - 1] = '\0';
 					printf("data directory from FLEXAIDDS_DATA_DIR: '%s'\n", FA->dependencies_path);
 					found = 1;

--- a/docs/implementation/protocol-config.md
+++ b/docs/implementation/protocol-config.md
@@ -1,0 +1,145 @@
+# ProtocolConfig — typed protocol knobs (getenv consolidation)
+
+**Status:** Chunk 1 (foundation)  
+**Owner path:** `LIB/ProtocolConfig.{h,cpp}`  
+**Related audit:** ~64 `getenv` / `std::getenv` call sites in
+`LIB/DatasetRunner.cpp`, `LIB/gaboom.cpp`, `LIB/top.cpp` (repo-wide getenv
+surface is larger; this doc tracks the audit trio first).
+
+## Goal
+
+Replace ad-hoc `FLEXAIDDS_*` environment reads with **one typed, serializable
+`flexaids::ProtocolConfig`**. Environment variables remain a **compatibility
+adapter only** (`ProtocolConfig::from_env()`). Future chunks can load JSON /
+CLI / skill configs into the same struct without touching call sites again.
+
+## What landed in chunk 1
+
+| Piece | Location |
+|-------|----------|
+| Typed struct + `defaults()` / `from_env()` / `to_json()` / `from_json()` | `LIB/ProtocolConfig.h`, `LIB/ProtocolConfig.cpp` |
+| Unit tests (defaults, env overrides, JSON round-trip) | `tests/test_protocol_config.cpp` |
+| DatasetRunner constructor + dock-config emission path | `LIB/DatasetRunner.cpp` / `.h` |
+| Engine init: `FLEXAIDDS_DATA_DIR`, `FLEXAIDDS_HBOND_WEIGHT` | `LIB/top.cpp` |
+
+### Migrated env vars (go through `ProtocolConfig`)
+
+| Env var | Field | Default | Migrated call sites |
+|---------|-------|---------|---------------------|
+| `FLEXAIDDS_SEED_BASE` | `seed_base` | `0` | DatasetRunner `deterministic_ga_seed` |
+| `FLEXAIDDS_RESTARTS` | `restarts` | `5` | DatasetRunner multi-restart loop |
+| `FLEXAIDDS_PARALLEL_RESTARTS` | `parallel_restarts` | `restarts > 1` | DatasetRunner restart launcher |
+| `FLEXAIDDS_VCT_R0` | `vct_r0` | `7.0` | DatasetRunner dock_config scoring |
+| `FLEXAIDDS_VCT_NORM` | `vct_normalize_contacts` | off (presence) | DatasetRunner dock_config scoring |
+| `FLEXAIDDS_VCT_ENTROPY_WEIGHT` | `vct_entropy_weight` | `0.0` | DatasetRunner dock_config scoring |
+| `FLEXAIDDS_SHARING_ALPHA` | `sharing_alpha` (optional) | pop-scaled `4.0` | DatasetRunner GA section |
+| `FLEXAIDDS_BOOM_FRAC` | `boom_frac` (optional) | `1.0` | DatasetRunner GA section |
+| `FLEXAIDDS_N_ELITE` | `n_elite` | `1` | DatasetRunner GA section |
+| `FLEXAIDDS_USE_SHANNON` | `use_shannon` | off (presence) | DatasetRunner dock_config |
+| `FLEXAIDDS_THERMO` | `thermo_enabled` | off (presence) | DatasetRunner dock_config |
+| `FLEXAIDDS_T_EFF` | `t_eff` | `0.596` | DatasetRunner thermo_engine |
+| `FLEXAIDDS_TENCOM_SCALE` | `tencom_scale` | `1.0` | DatasetRunner thermo_engine |
+| `FLEXAIDDS_DATA_DIR` | `data_dir` | empty | DatasetRunner matrix + `--data-dir`; `top.cpp` auto-detect |
+| `FLEXAIDDS_CF_WINDOW_SELECTOR` | `cf_window_selector` | `false` | DatasetRunner ctor |
+| `FLEXAIDDS_CLUSTER_MEMBER_EMIT` | `cluster_member_emit` | `false` | DatasetRunner ctor |
+| `FLEXAIDDS_HBOND_WEIGHT` | `hbond_weight` | `-2.5` | `top.cpp` FA init |
+
+**Estimate:** ~17 unique vars / ~22 call sites migrated; residual in the audit
+trio is roughly **~42 getenv call sites** (including `HOME` / `OMP_*` and
+double-reads).
+
+## Residual getenv inventory (TODO — later chunks)
+
+### `LIB/DatasetRunner.cpp` (owner: benchmark / DatasetRunner)
+
+| Env var | Purpose | Default / notes | Priority |
+|---------|---------|-----------------|----------|
+| `FLEXAIDDS_SEED_ELITISM` | Crystal seed elitism gate | mode-dependent | P1 |
+| `FLEXAIDDS_FREQSEL` | Frequency-gated pose selector | off | P1 |
+| `FLEXAIDDS_FREQSEL_ALPHA` | Freqsel soft weight | `12.0` | P1 |
+| `FLEXAIDDS_FREQSEL_RMSD` | Freqsel RMSD bin | `1.5` | P1 |
+| `FLEXAIDDS_SEED_ELITISM_DELTA_CF` | Seed elitism CF window | `10.0` | P1 |
+| `FLEXAIDDS_HTTP_RETRIES` | RCSB download retries | `3` | P2 |
+| `FLEXAIDDS_ORACLE_SITE_DIR` | Oracle sphere directory | unset | P1 |
+| `FLEXAIDDS_USE_DP` | Force DensityPeak clustering | off | P2 |
+| `FLEXAIDDS_BINARY` / `_BUILD` / `_REPO` | FlexAIDdS binary resolution | path search | P2 |
+| `FLEXAIDDS_PRIORITY_TARGETS` | Target priority list | unset | P2 |
+| `FLEXAIDDS_IGNORE_CACHE` | Skip completed-cache | off | P2 |
+| `FLEXAIDDS_RING_FLEX` | Ring pucker DoF | off | P1 |
+| `FLEXAIDDS_EVAL_SCALE_DIHEDRAL` | DoF budget scaling mode | `1` | P1 |
+| `FLEXAIDDS_BUDGET_SCALE` | Extra budget scale | on | P1 |
+| `FLEXAIDDS_FINE_GRID` | Finer angle/dihedral steps | off (presence) | P2 |
+| `OMP_NUM_THREADS` | Worker OMP sizing | hardware | leave (OpenMP contract) |
+| `HOME` | `~` expansion | `/tmp` | leave (platform) |
+| `FLEXAIDDS_COGNATE_SITE` | Cognate redock site inject | off | P1 |
+| `FLEXAIDDS_SCORE_NATIVE` | Native CF diagnostic | off | P1 |
+| `FLEXAIDDS_MULTI_CLEFT` | Parallel cleft regions | off | P2 |
+| `FLEXAIDDS_CONSENSUS_SCORER` | Cross-restart consensus | off | P1 |
+| `FLEXAIDDS_HVIB` | tENCoM/H(ω) validator | on unless `=0` | P1 |
+| `FLEXAIDDS_THERMO_CSV` | Extra thermo CSV columns | off | P2 |
+
+### `LIB/gaboom.cpp` (owner: GA engine)
+
+| Env var | Purpose | Default / notes | Priority |
+|---------|---------|-----------------|----------|
+| `FLEXAIDDS_CHAIN_NORM` | Multi-chain receptor norm | off | P2 |
+| `OMP_NUM_THREADS` | Default OMP=2 if unset | platform | leave |
+| `FLEXAIDDS_USE_SHANNON` | Enable Shannon in fitness | off | P1 (already on ProtocolConfig; wire gaboom) |
+| `FLEXAIDDS_INSTREAM_INTERVAL` | In-stream clustering interval | compile default | P2 |
+| `FLEXAIDDS_NO_SEC` | Disable SEC early exits | off | P1 |
+| `FLEXAIDDS_T_HOT` | Hot anneal temperature | `0.0` | P1 |
+| `FLEXAIDDS_BENCHMARK` | Full-gen benchmark mode | off | P1 |
+| `FLEXAIDDS_SMFREE_REQUIRE_T` | Require T for SMFREE | off | P2 |
+
+### `LIB/top.cpp` (owner: engine entry)
+
+| Env var | Purpose | Default / notes | Priority |
+|---------|---------|-----------------|----------|
+| `FLEXAIDDS_GRID_CACHE_DIR` | Grid cache directory | unset | P2 |
+| `FLEXAIDDS_LIGAND_BATCH` | Batch ligand directory | unset | P2 |
+| `FLEXAIDS_VH_DEBUG` | Vector H-bond debug dump | off | P3 |
+| `FLEXAIDDS_CLEFT_SPHERE_FILE` | Explicit cleft spheres | unset | P1 |
+| `FLEXAIDDS_ORACLE_SITE` | Oracle site path | unset | P1 |
+| `FLEXAIDDS_SCORE_NATIVE` / `FLEXAIDDS_NATIVE_ONLY` | Native scoring path | off | P1 |
+
+### Also still env-backed (out of chunk-1 audit trio but related)
+
+`LIB/config_parser.cpp` still applies `FLEXAIDDS_VCT_ENTROPY_WEIGHT`,
+`FLEXAIDDS_N_ELITE`, `FLEXAIDDS_SHARING_ALPHA`, `FLEXAIDDS_BOOM_FRAC`,
+`FLEXAIDDS_ENTROPY_WEIGHT`, `FLEXAIDDS_DIVERSITY_MONITORING`, ranking flags.
+**Chunk 2 recommendation:** have `apply_config()` accept an optional
+`const ProtocolConfig*` so engine-side overrides share the same typed source
+as DatasetRunner (env adapter still works for standalone CLI).
+
+## Migration rules (for later PRs)
+
+1. **Do not rewrite DatasetRunner in one PR.** One cluster of related knobs per chunk.
+2. Add fields to `ProtocolConfig` first, extend `from_env()` / JSON, then flip call sites.
+3. Keep default values byte-identical when env is unset (tests + golden dock_config when practical).
+4. Prefer reading `protocol_cfg_` (or a passed-in snapshot) over re-calling `getenv` in loops.
+5. Leave platform env (`HOME`, `PATH`, `OMP_*`) as raw getenv unless a strong reason exists.
+6. Document each migrated var in the table above and drop it from Residual.
+
+## Usage sketch
+
+```cpp
+#include "ProtocolConfig.h"
+
+// Compatibility (benchmarks / CLI):
+auto cfg = flexaids::ProtocolConfig::from_env();
+
+// Future: skill / JSON protocol file
+// auto cfg = flexaids::ProtocolConfig::from_json(text);
+
+// Engine or runner:
+int n = cfg.restarts;
+double alpha = cfg.effective_sharing_alpha(pop_base, pop_scaled);
+```
+
+## Tests
+
+```bash
+cmake -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build --target test_protocol_config -j
+ctest --test-dir build -R ProtocolConfigTests --output-on-failure
+```

--- a/tests/test_protocol_config.cpp
+++ b/tests/test_protocol_config.cpp
@@ -1,0 +1,178 @@
+// tests/test_protocol_config.cpp — ProtocolConfig from_env + JSON round-trip
+// Apache-2.0 © 2026 Le Bonhomme Pharma
+
+#include <gtest/gtest.h>
+
+#include "ProtocolConfig.h"
+
+#include <cstdlib>
+#include <string>
+
+namespace {
+
+// RAII env override that restores the previous value on scope exit.
+class ScopedEnv {
+public:
+    ScopedEnv(const char* name, const char* value) : name_(name) {
+        const char* prev = std::getenv(name);
+        if (prev) {
+            had_prev_ = true;
+            prev_ = prev;
+        }
+        if (value) {
+#if defined(_WIN32)
+            _putenv_s(name, value);
+#else
+            setenv(name, value, 1);
+#endif
+        } else {
+#if defined(_WIN32)
+            _putenv_s(name, "");
+#else
+            unsetenv(name);
+#endif
+        }
+    }
+
+    ~ScopedEnv() {
+#if defined(_WIN32)
+        if (had_prev_) _putenv_s(name_.c_str(), prev_.c_str());
+        else _putenv_s(name_.c_str(), "");
+#else
+        if (had_prev_) setenv(name_.c_str(), prev_.c_str(), 1);
+        else unsetenv(name_.c_str());
+#endif
+    }
+
+    ScopedEnv(const ScopedEnv&) = delete;
+    ScopedEnv& operator=(const ScopedEnv&) = delete;
+
+private:
+    std::string name_;
+    std::string prev_;
+    bool had_prev_{false};
+};
+
+// Clear the knobs ProtocolConfig::from_env() reads so tests are hermetic.
+struct ClearProtocolEnv {
+    ClearProtocolEnv()
+        : seed_base("FLEXAIDDS_SEED_BASE", nullptr)
+        , restarts("FLEXAIDDS_RESTARTS", nullptr)
+        , parallel("FLEXAIDDS_PARALLEL_RESTARTS", nullptr)
+        , vct_r0("FLEXAIDDS_VCT_R0", nullptr)
+        , vct_norm("FLEXAIDDS_VCT_NORM", nullptr)
+        , vct_ew("FLEXAIDDS_VCT_ENTROPY_WEIGHT", nullptr)
+        , sharing("FLEXAIDDS_SHARING_ALPHA", nullptr)
+        , boom("FLEXAIDDS_BOOM_FRAC", nullptr)
+        , n_elite("FLEXAIDDS_N_ELITE", nullptr)
+        , shannon("FLEXAIDDS_USE_SHANNON", nullptr)
+        , thermo("FLEXAIDDS_THERMO", nullptr)
+        , t_eff("FLEXAIDDS_T_EFF", nullptr)
+        , tencom("FLEXAIDDS_TENCOM_SCALE", nullptr)
+        , data_dir("FLEXAIDDS_DATA_DIR", nullptr)
+        , cf_win("FLEXAIDDS_CF_WINDOW_SELECTOR", nullptr)
+        , cluster("FLEXAIDDS_CLUSTER_MEMBER_EMIT", nullptr)
+        , hbond("FLEXAIDDS_HBOND_WEIGHT", nullptr) {}
+
+    ScopedEnv seed_base, restarts, parallel, vct_r0, vct_norm, vct_ew,
+              sharing, boom, n_elite, shannon, thermo, t_eff, tencom,
+              data_dir, cf_win, cluster, hbond;
+};
+
+}  // namespace
+
+TEST(ProtocolConfig, DefaultsMatchHistoricalFallbacks) {
+    ClearProtocolEnv clear;
+    const auto d = flexaids::ProtocolConfig::defaults();
+    const auto e = flexaids::ProtocolConfig::from_env();
+
+    EXPECT_EQ(e.seed_base, d.seed_base);
+    EXPECT_EQ(e.restarts, 5);
+    EXPECT_TRUE(e.parallel_restarts);  // restarts default 5 > 1
+    EXPECT_DOUBLE_EQ(e.vct_r0, 7.0);
+    EXPECT_FALSE(e.vct_normalize_contacts);
+    EXPECT_DOUBLE_EQ(e.vct_entropy_weight, 0.0);
+    EXPECT_FALSE(e.sharing_alpha.has_value());
+    EXPECT_FALSE(e.boom_frac.has_value());
+    EXPECT_EQ(e.n_elite, 1);
+    EXPECT_FALSE(e.use_shannon);
+    EXPECT_FALSE(e.thermo_enabled);
+    EXPECT_FLOAT_EQ(e.t_eff, 0.596f);
+    EXPECT_FLOAT_EQ(e.tencom_scale, 1.0f);
+    EXPECT_TRUE(e.data_dir.empty());
+    EXPECT_FALSE(e.cf_window_selector);
+    EXPECT_FALSE(e.cluster_member_emit);
+    EXPECT_DOUBLE_EQ(e.hbond_weight, -2.5);
+
+    EXPECT_DOUBLE_EQ(e.effective_sharing_alpha(1000, 1000), 4.0);
+    EXPECT_DOUBLE_EQ(e.effective_sharing_alpha(1000, 2000), 2.0);
+    EXPECT_DOUBLE_EQ(e.effective_boom_frac(), 1.0);
+}
+
+TEST(ProtocolConfig, FromEnvOverridesKeyVars) {
+    ClearProtocolEnv clear;
+    ScopedEnv seed("FLEXAIDDS_SEED_BASE", "42");
+    ScopedEnv restarts("FLEXAIDDS_RESTARTS", "3");
+    ScopedEnv vct("FLEXAIDDS_VCT_R0", "5.5");
+    ScopedEnv alpha("FLEXAIDDS_SHARING_ALPHA", "2.5");
+    ScopedEnv elite("FLEXAIDDS_N_ELITE", "4");
+    ScopedEnv data("FLEXAIDDS_DATA_DIR", "/tmp/flexaidds-data");
+    ScopedEnv hbond("FLEXAIDDS_HBOND_WEIGHT", "-3.1");
+
+    const auto cfg = flexaids::ProtocolConfig::from_env();
+    EXPECT_EQ(cfg.seed_base, 42u);
+    EXPECT_EQ(cfg.restarts, 3);
+    EXPECT_DOUBLE_EQ(cfg.vct_r0, 5.5);
+    ASSERT_TRUE(cfg.sharing_alpha.has_value());
+    EXPECT_DOUBLE_EQ(*cfg.sharing_alpha, 2.5);
+    EXPECT_DOUBLE_EQ(cfg.effective_sharing_alpha(1000, 2000), 2.5);
+    EXPECT_EQ(cfg.n_elite, 4);
+    EXPECT_EQ(cfg.data_dir, "/tmp/flexaidds-data");
+    EXPECT_DOUBLE_EQ(cfg.hbond_weight, -3.1);
+}
+
+TEST(ProtocolConfig, PresenceFlagsAndParallelRestarts) {
+    ClearProtocolEnv clear;
+    ScopedEnv norm("FLEXAIDDS_VCT_NORM", "1");
+    ScopedEnv shannon("FLEXAIDDS_USE_SHANNON", "1");
+    ScopedEnv thermo("FLEXAIDDS_THERMO", "1");
+    ScopedEnv teff("FLEXAIDDS_T_EFF", "0.8");
+    ScopedEnv tscale("FLEXAIDDS_TENCOM_SCALE", "1.5");
+    ScopedEnv cf("FLEXAIDDS_CF_WINDOW_SELECTOR", "1");
+    ScopedEnv cl("FLEXAIDDS_CLUSTER_MEMBER_EMIT", "0");
+    ScopedEnv restarts("FLEXAIDDS_RESTARTS", "1");
+    ScopedEnv par("FLEXAIDDS_PARALLEL_RESTARTS", "1");
+
+    const auto cfg = flexaids::ProtocolConfig::from_env();
+    EXPECT_TRUE(cfg.vct_normalize_contacts);
+    EXPECT_TRUE(cfg.use_shannon);
+    EXPECT_TRUE(cfg.thermo_enabled);
+    EXPECT_FLOAT_EQ(cfg.t_eff, 0.8f);
+    EXPECT_FLOAT_EQ(cfg.tencom_scale, 1.5f);
+    EXPECT_TRUE(cfg.cf_window_selector);
+    EXPECT_FALSE(cfg.cluster_member_emit);
+    EXPECT_EQ(cfg.restarts, 1);
+    // Explicit parallel=1 but restarts==1 → parallel stays false.
+    EXPECT_FALSE(cfg.parallel_restarts);
+    EXPECT_TRUE(cfg.parallel_restarts_explicit);
+}
+
+TEST(ProtocolConfig, JsonRoundTrip) {
+    ClearProtocolEnv clear;
+    ScopedEnv seed("FLEXAIDDS_SEED_BASE", "99");
+    ScopedEnv restarts("FLEXAIDDS_RESTARTS", "7");
+    ScopedEnv alpha("FLEXAIDDS_SHARING_ALPHA", "3.25");
+    ScopedEnv data("FLEXAIDDS_DATA_DIR", "/opt/share/flexaidds");
+
+    const auto a = flexaids::ProtocolConfig::from_env();
+    const std::string json = a.to_json();
+    EXPECT_NE(json.find("\"seed_base\":99"), std::string::npos);
+    EXPECT_NE(json.find("\"restarts\":7"), std::string::npos);
+
+    const auto b = flexaids::ProtocolConfig::from_json(json);
+    EXPECT_EQ(b.seed_base, a.seed_base);
+    EXPECT_EQ(b.restarts, a.restarts);
+    ASSERT_TRUE(b.sharing_alpha.has_value());
+    EXPECT_DOUBLE_EQ(*b.sharing_alpha, 3.25);
+    EXPECT_EQ(b.data_dir, "/opt/share/flexaidds");
+}


### PR DESCRIPTION
## Summary
- Introduce `flexaids::ProtocolConfig` (`LIB/ProtocolConfig.{h,cpp}`) as the typed home for high-traffic benchmark/science knobs, with `defaults()`, `from_env()` (compatibility adapter), and light JSON `to_json()` / `from_json()`.
- Wire **DatasetRunner** constructor + dock-config emission path through `protocol_cfg_` (seed/restarts/parallel restarts, VCT, sharing alpha / boom / n_elite, Shannon, thermo, data_dir, pose-selector gates).
- Wire **top.cpp** init for `FLEXAIDDS_DATA_DIR` and `FLEXAIDDS_HBOND_WEIGHT`.
- Document residual getenv inventory + migration rules in [`docs/implementation/protocol-config.md`](docs/implementation/protocol-config.md).
- Unit tests: `tests/test_protocol_config.cpp` (`ProtocolConfigTests`).

This is **chunk 1 only** — not a full DatasetRunner rewrite; residual getenv (~42 call sites in the audit trio) remains for later PRs.

## Inventory artifact
`docs/implementation/protocol-config.md` (migrated table + residual TODO tables with owners/priorities).

## Migrated (via ProtocolConfig)
`SEED_BASE`, `RESTARTS`, `PARALLEL_RESTARTS`, `VCT_R0`, `VCT_NORM`, `VCT_ENTROPY_WEIGHT`, `SHARING_ALPHA`, `BOOM_FRAC`, `N_ELITE`, `USE_SHANNON`, `THERMO`, `T_EFF`, `TENCOM_SCALE`, `DATA_DIR`, `CF_WINDOW_SELECTOR`, `CLUSTER_MEMBER_EMIT`, `HBOND_WEIGHT`.

## Residual getenv estimate (audit trio after this PR)
- `DatasetRunner.cpp`: **26** call sites
- `top.cpp`: **8**
- `gaboom.cpp`: **8** (untouched this chunk)
- **Total ~42** (down from ~64)

## Test plan
- [x] `cmake -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release`
- [x] `cmake --build build --target test_protocol_config`
- [x] `ctest --test-dir build -R ProtocolConfigTests --output-on-failure` → **100% passed**
- [x] `cmake --build build --target FlexAIDdS benchmark_datasets` → link OK

## Out of scope
- Full DatasetRunner split
- CF naming
- CI / Metal / packaging
- gaboom / config_parser full migration (chunk 2+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added centralized protocol configuration for seeds, restarts, scoring, thermodynamic settings, and data directory options.
  - Configuration can now be loaded from environment variables and saved to or restored from JSON.
  - Dataset and engine workflows consistently use the configured settings, including data directory and hydrogen-bond weighting.

- **Documentation**
  - Added configuration reference documentation, migration guidance, and test instructions.

- **Tests**
  - Added automated coverage for defaults, overrides, flag handling, and JSON round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->