### PR TITLE
Add production Bonhomme Fleet benchmark orchestration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1021,9 +1021,20 @@ if(ENABLE_CAVITY_DETECT_CLI)
     endif()
     if(FLEXAIDS_USE_METAL)
         target_sources(cavity_detect_cli PRIVATE
+            LIB/metal_eval.mm
+            LIB/MetalRMSDBridge.mm
             LIB/CavityDetect/CavityDetectMetalBridge.mm
+            LIB/ShannonThermoStack/ShannonMetalBridge.mm
+            LIB/gpu_fast_optics_metal.mm
         )
-        target_compile_definitions(cavity_detect_cli PRIVATE FLEXAIDS_USE_METAL)
+        target_compile_definitions(cavity_detect_cli PRIVATE
+            FLEXAIDS_USE_METAL
+            FLEXAIDS_HAS_METAL_SHANNON
+            SHANNON_METALLIB_PATH="${SHANNON_METALLIB}"
+            METALRMSD_METALLIB_PATH="${RMSD_METALLIB_DS}"
+            CAVITY_METALLIB_PATH="${CAVITY_METALLIB_DS}"
+            TURBOQUANT_METALLIB_PATH="${TQ_METALLIB_DS}"
+        )
         target_compile_options(cavity_detect_cli PRIVATE -fno-objc-arc)
         target_link_libraries(cavity_detect_cli PRIVATE
             ${METAL_LIBRARY}
@@ -1031,17 +1042,18 @@ if(ENABLE_CAVITY_DETECT_CLI)
             ${METALKIT_LIBRARY}
         )
         set_source_files_properties(
+            LIB/metal_eval.mm
+            LIB/MetalRMSDBridge.mm
             LIB/CavityDetect/CavityDetectMetalBridge.mm
+            LIB/ShannonThermoStack/ShannonMetalBridge.mm
+            LIB/gpu_fast_optics_metal.mm
             PROPERTIES LANGUAGE OBJCXX COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
         )
-        if(TARGET CavityDetectMetalDS)
-            add_dependencies(cavity_detect_cli CavityDetectMetalDS)
-        endif()
-        if(DEFINED CAVITY_METALLIB_DS)
-            target_compile_definitions(cavity_detect_cli PRIVATE
-                CAVITY_METALLIB_PATH="${CAVITY_METALLIB_DS}"
-            )
-        endif()
+        add_dependencies(cavity_detect_cli
+            CavityDetectMetalDS
+            ShannonEntropyMetal
+            MetalRMSDMetalDS
+        )
     endif()
     message(STATUS "Native CavityDetector CLI enabled -- build target: cavity_detect_cli")
 endif()
@@ -1063,6 +1075,8 @@ if(ENABLE_BENCHMARK_DATASETS)
     add_executable(benchmark_datasets
         LIB/benchmark_datasets.cpp
         LIB/DatasetRunner.cpp
+        LIB/FleetRunner.cpp
+        LIB/FleetRunner.h
         LIB/AsyncPipeline.cpp
         # NativePoseQC diagnostic plus upstream PoseBusters CLI bridge
         ${FLEXAIDDS_POSEBUST_SOURCES}
@@ -2279,6 +2293,14 @@ if(BUILD_TESTING)
     )
 
     # test_dataset_runner — benchmark dataset runner tests
+    flexaids_add_unit_test(test_fleet_runner
+        SOURCES
+            tests/test_fleet_runner.cpp
+            LIB/FleetRunner.cpp
+            LIB/FleetRunner.h
+        TEST_NAME FleetRunnerTests
+    )
+
     add_executable(test_dataset_runner
         tests/test_dataset_runner.cpp
         LIB/DatasetRunner.cpp
@@ -2300,6 +2322,44 @@ if(BUILD_TESTING)
     if(CURL_FOUND)
         target_link_libraries(test_dataset_runner PRIVATE CURL::libcurl)
         target_compile_definitions(test_dataset_runner PRIVATE FLEXAIDS_HAS_LIBCURL)
+    endif()
+    if(FLEXAIDS_USE_METAL)
+        target_sources(test_dataset_runner PRIVATE
+            LIB/metal_eval.mm
+            LIB/MetalRMSDBridge.mm
+            LIB/CavityDetect/CavityDetectMetalBridge.mm
+            LIB/ShannonThermoStack/ShannonMetalBridge.mm
+            LIB/gpu_fast_optics_metal.mm
+        )
+        target_compile_definitions(test_dataset_runner PRIVATE
+            FLEXAIDS_USE_METAL
+            FLEXAIDS_HAS_METAL_SHANNON
+        )
+        target_compile_options(test_dataset_runner PRIVATE -fno-objc-arc)
+        target_link_libraries(test_dataset_runner PRIVATE
+            ${METAL_LIBRARY}
+            ${FOUNDATION_LIBRARY}
+            ${METALKIT_LIBRARY}
+        )
+        set_source_files_properties(
+            LIB/metal_eval.mm
+            LIB/MetalRMSDBridge.mm
+            LIB/CavityDetect/CavityDetectMetalBridge.mm
+            LIB/ShannonThermoStack/ShannonMetalBridge.mm
+            LIB/gpu_fast_optics_metal.mm
+            PROPERTIES LANGUAGE OBJCXX COMPILE_FLAGS "-std=c++26 -fno-objc-arc"
+        )
+        add_dependencies(test_dataset_runner
+            CavityDetectMetalDS
+            ShannonEntropyMetal
+            MetalRMSDMetalDS
+        )
+        target_compile_definitions(test_dataset_runner PRIVATE
+            SHANNON_METALLIB_PATH="${SHANNON_METALLIB}"
+            METALRMSD_METALLIB_PATH="${RMSD_METALLIB_DS}"
+            CAVITY_METALLIB_PATH="${CAVITY_METALLIB_DS}"
+            TURBOQUANT_METALLIB_PATH="${TQ_METALLIB_DS}"
+        )
     endif()
     flexaids_configure_msvc_test(test_dataset_runner)
     add_test(NAME DatasetRunnerTests COMMAND test_dataset_runner)
@@ -2328,6 +2388,34 @@ if(BUILD_TESTING)
     if(CURL_FOUND)
         target_link_libraries(test_cofactor_blacklist PRIVATE CURL::libcurl)
         target_compile_definitions(test_cofactor_blacklist PRIVATE FLEXAIDS_HAS_LIBCURL)
+    endif()
+    if(FLEXAIDS_USE_METAL)
+        target_sources(test_cofactor_blacklist PRIVATE
+            LIB/metal_eval.mm
+            LIB/MetalRMSDBridge.mm
+            LIB/CavityDetect/CavityDetectMetalBridge.mm
+            LIB/ShannonThermoStack/ShannonMetalBridge.mm
+            LIB/gpu_fast_optics_metal.mm
+        )
+        target_compile_definitions(test_cofactor_blacklist PRIVATE
+            FLEXAIDS_USE_METAL
+            FLEXAIDS_HAS_METAL_SHANNON
+            SHANNON_METALLIB_PATH="${SHANNON_METALLIB}"
+            METALRMSD_METALLIB_PATH="${RMSD_METALLIB_DS}"
+            CAVITY_METALLIB_PATH="${CAVITY_METALLIB_DS}"
+            TURBOQUANT_METALLIB_PATH="${TQ_METALLIB_DS}"
+        )
+        target_compile_options(test_cofactor_blacklist PRIVATE -fno-objc-arc)
+        target_link_libraries(test_cofactor_blacklist PRIVATE
+            ${METAL_LIBRARY}
+            ${FOUNDATION_LIBRARY}
+            ${METALKIT_LIBRARY}
+        )
+        add_dependencies(test_cofactor_blacklist
+            CavityDetectMetalDS
+            ShannonEntropyMetal
+            MetalRMSDMetalDS
+        )
     endif()
     flexaids_configure_msvc_test(test_cofactor_blacklist)
     add_test(NAME CofactorBlacklistTests COMMAND test_cofactor_blacklist)

--- a/LIB/FleetRunner.cpp
+++ b/LIB/FleetRunner.cpp
@@ -1,0 +1,285 @@
+// FleetRunner.cpp - immutable Fleet result serialization for DatasetRunner.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "FleetRunner.h"
+
+#include <chrono>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <system_error>
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string json_escape(const std::string& value) {
+    std::ostringstream out;
+    for (const unsigned char c : value) {
+        switch (c) {
+            case '"': out << "\\\""; break;
+            case '\\': out << "\\\\"; break;
+            case '\b': out << "\\b"; break;
+            case '\f': out << "\\f"; break;
+            case '\n': out << "\\n"; break;
+            case '\r': out << "\\r"; break;
+            case '\t': out << "\\t"; break;
+            default:
+                if (c < 0x20) {
+                    out << "\\u" << std::hex << std::setw(4)
+                        << std::setfill('0') << static_cast<int>(c)
+                        << std::dec << std::setfill(' ');
+                } else {
+                    out << static_cast<char>(c);
+                }
+        }
+    }
+    return out.str();
+}
+
+void json_string(std::ostringstream& out, const std::string& value) {
+    out << '"' << json_escape(value) << '"';
+}
+
+template <typename T>
+void json_number(std::ostringstream& out, T value) {
+    if (std::isfinite(static_cast<double>(value))) {
+        out << value;
+    } else {
+        out << "null";
+    }
+}
+
+const char* json_bool(bool value) {
+    return value ? "true" : "false";
+}
+
+const char* mode_name(dataset::BenchmarkMode mode) {
+    switch (mode) {
+        case dataset::BenchmarkMode::ORACLE_CEILING: return "oracle-ceiling";
+        case dataset::BenchmarkMode::DEFINED_CLEFT_REDOCK: return "defined-cleft-redock";
+        case dataset::BenchmarkMode::AUTONOMOUS: return "autonomous";
+        case dataset::BenchmarkMode::UNSET: return "unset";
+    }
+    return "unset";
+}
+
+std::string utc_now() {
+    const auto now = std::chrono::system_clock::now();
+    const auto value = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#ifdef _WIN32
+    gmtime_s(&tm, &value);
+#else
+    gmtime_r(&value, &tm);
+#endif
+    std::ostringstream out;
+    out << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
+    return out.str();
+}
+
+bool execution_completed(const dataset::DockingResult& result) {
+    return result.num_poses > 0 && !result.elected_pose_path.empty();
+}
+
+bool validators_complete(const dataset::DockingResult& result) {
+    if (!result.pb_ran || result.tencom_status != "ok" ||
+        result.eigen_status != "ok" || result.pose_sha256.empty()) {
+        return false;
+    }
+    return result.rmsd_pose_sha256 == result.pose_sha256 &&
+           result.posebusters_pose_sha256 == result.pose_sha256 &&
+           result.tencom_pose_sha256 == result.pose_sha256;
+}
+
+} // namespace
+
+namespace fleet {
+
+std::string FleetRunner::serialize_chunk_result(
+    const ChunkMetadata& metadata,
+    const dataset::BenchmarkReport& report,
+    const dataset::DockingConfig& config,
+    double duration_s) {
+    int completed = 0;
+    int successful_rmsd = 0;
+    int successful_pb = 0;
+    int claim_ready = 0;
+    int validators_done = 0;
+
+    for (const auto& result : report.results) {
+        completed += execution_completed(result) ? 1 : 0;
+        successful_rmsd += result.success_rmsd ? 1 : 0;
+        successful_pb += result.success_pb ? 1 : 0;
+        claim_ready += result.claim_ready ? 1 : 0;
+        validators_done += validators_complete(result) ? 1 : 0;
+    }
+
+    std::ostringstream out;
+    out << std::setprecision(9);
+    out << "{\n  \"schema_version\": 1,\n";
+    out << "  \"type\": \"flexaidds-fleet-chunk-result\",\n";
+    out << "  \"created_at\": "; json_string(out, utc_now()); out << ",\n";
+    out << "  \"campaign_id\": "; json_string(out, metadata.campaign_id); out << ",\n";
+    out << "  \"chunk_id\": "; json_string(out, metadata.chunk_id); out << ",\n";
+    out << "  \"attempt_id\": "; json_string(out, metadata.attempt_id); out << ",\n";
+    out << "  \"worker_id\": "; json_string(out, metadata.worker_id); out << ",\n";
+    out << "  \"dataset\": "; json_string(out, metadata.dataset); out << ",\n";
+    out << "  \"duration_s\": "; json_number(out, duration_s); out << ",\n";
+
+    out << "  \"provenance\": {\n";
+    out << "    \"manifest_sha256\": "; json_string(out, metadata.manifest_sha256); out << ",\n";
+    out << "    \"runner_path\": "; json_string(out, metadata.runner_path); out << ",\n";
+    out << "    \"runner_sha256\": "; json_string(out, metadata.runner_sha256); out << ",\n";
+    out << "    \"engine_path\": "; json_string(out, metadata.engine_path); out << ",\n";
+    out << "    \"engine_sha256\": "; json_string(out, metadata.engine_sha256); out << ",\n";
+    out << "    \"command\": "; json_string(out, metadata.command); out << "\n  },\n";
+
+    out << "  \"protocol\": {\n";
+    out << "    \"mode\": "; json_string(out, mode_name(config.mode)); out << ",\n";
+    out << "    \"ga_population\": " << config.ga_population << ",\n";
+    out << "    \"ga_generations\": " << config.ga_generations << ",\n";
+    out << "    \"temperature_k\": "; json_number(out, config.temperature); out << ",\n";
+    out << "    \"grid_spacing_a\": "; json_number(out, config.grid_spacing); out << ",\n";
+    out << "    \"dataset_workers\": " << config.num_threads << ",\n";
+    out << "    \"omp_threads_per_worker\": " << config.omp_threads_per_worker << ",\n";
+    out << "    \"job_timeout_s\": " << config.per_job_timeout_s << ",\n";
+    out << "    \"clustering\": "; json_string(out, config.clustering_algorithm); out << ",\n";
+    out << "    \"gpu_enabled\": " << json_bool(config.use_gpu) << ",\n";
+    out << "    \"gpu_backend\": "; json_string(out, config.gpu_backend); out << "\n  },\n";
+
+    out << "  \"summary\": {\n";
+    out << "    \"target_count\": " << report.results.size() << ",\n";
+    out << "    \"execution_completed\": " << completed << ",\n";
+    out << "    \"execution_failed\": " << (static_cast<int>(report.results.size()) - completed) << ",\n";
+    out << "    \"success_rmsd\": " << successful_rmsd << ",\n";
+    out << "    \"success_pb\": " << successful_pb << ",\n";
+    out << "    \"validators_complete\": " << validators_done << ",\n";
+    out << "    \"claim_ready\": " << claim_ready << "\n  },\n";
+
+    out << "  \"targets\": [\n";
+    for (std::size_t i = 0; i < report.results.size(); ++i) {
+        const auto& result = report.results[i];
+        out << "    {\n";
+        out << "      \"pdb_id\": "; json_string(out, result.pdb_id); out << ",\n";
+        out << "      \"execution_completed\": " << json_bool(execution_completed(result)) << ",\n";
+        out << "      \"num_poses\": " << result.num_poses << ",\n";
+        out << "      \"wall_time_s\": "; json_number(out, result.wall_time_s); out << ",\n";
+        out << "      \"rmsd_hungarian_a\": "; json_number(out, result.rmsd_hungarian); out << ",\n";
+        out << "      \"rmsd_serial_a\": "; json_number(out, result.rmsd_to_crystal); out << ",\n";
+        out << "      \"success_rmsd\": " << json_bool(result.success_rmsd) << ",\n";
+        out << "      \"posebusters_ran\": " << json_bool(result.pb_ran) << ",\n";
+        out << "      \"posebusters_pass\": " << json_bool(result.pb_pass) << ",\n";
+        out << "      \"posebusters_backend\": "; json_string(out, result.pb_backend); out << ",\n";
+        out << "      \"posebusters_failed_keys\": "; json_string(out, result.pb_failed_keys); out << ",\n";
+        out << "      \"success_pb\": " << json_bool(result.success_pb) << ",\n";
+        out << "      \"tencom_status\": "; json_string(out, result.tencom_status); out << ",\n";
+        out << "      \"eigen_status\": "; json_string(out, result.eigen_status); out << ",\n";
+        out << "      \"eigen_n_modes\": " << result.eigen_n_modes << ",\n";
+        out << "      \"validators_complete\": " << json_bool(validators_complete(result)) << ",\n";
+        out << "      \"protocol_claim_eligible\": " << json_bool(result.protocol_claim_eligible) << ",\n";
+        out << "      \"claim_ready\": " << json_bool(result.claim_ready) << ",\n";
+        out << "      \"native_pose_seeded\": " << json_bool(result.native_pose_seeded) << ",\n";
+        out << "      \"seed_echo\": " << json_bool(result.seed_echo) << ",\n";
+        out << "      \"pose_source\": "; json_string(out, result.pose_source); out << ",\n";
+        out << "      \"elected_pose_path\": "; json_string(out, result.elected_pose_path); out << ",\n";
+        out << "      \"elected_pose_source\": "; json_string(out, result.elected_pose_source); out << ",\n";
+        out << "      \"elected_restart\": " << result.elected_restart << ",\n";
+        out << "      \"elected_cluster\": " << result.elected_cluster << ",\n";
+        out << "      \"elected_cf\": "; json_number(out, result.elected_cf); out << ",\n";
+        out << "      \"best_cluster_rmsd_a\": "; json_number(out, result.best_cluster_rmsd); out << ",\n";
+        out << "      \"pose_sha256\": "; json_string(out, result.pose_sha256); out << ",\n";
+        out << "      \"rmsd_pose_sha256\": "; json_string(out, result.rmsd_pose_sha256); out << ",\n";
+        out << "      \"posebusters_pose_sha256\": "; json_string(out, result.posebusters_pose_sha256); out << ",\n";
+        out << "      \"posebusters_input_sha256\": "; json_string(out, result.posebusters_input_sha256); out << ",\n";
+        out << "      \"tencom_pose_sha256\": "; json_string(out, result.tencom_pose_sha256); out << ",\n";
+        out << "      \"shannon_entropy_nats\": "; json_number(out, result.shannon_entropy); out << ",\n";
+        out << "      \"elected_h_vib_nats\": "; json_number(out, result.elected_H_vib); out << ",\n";
+        out << "      \"thermo_available\": " << json_bool(result.has_thermo) << "\n";
+        out << "    }" << (i + 1 < report.results.size() ? "," : "") << "\n";
+    }
+    out << "  ]\n}\n";
+    return out.str();
+}
+
+bool FleetRunner::write_chunk_result_atomic(
+    const std::string& destination,
+    const std::string& contents,
+    std::string* error) {
+    if (destination.empty() || destination == "-") {
+        if (error) *error = "Fleet result requires a file destination";
+        return false;
+    }
+
+    const fs::path target(destination);
+    std::error_code ec;
+    if (!target.parent_path().empty()) {
+        fs::create_directories(target.parent_path(), ec);
+        if (ec) {
+            if (error) *error = "cannot create result directory: " + ec.message();
+            return false;
+        }
+    }
+    if (fs::exists(target, ec)) {
+        if (error) *error = "refusing to overwrite immutable Fleet result";
+        return false;
+    }
+
+    const fs::path temp = target.string() + ".tmp." +
+        std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    {
+        std::ofstream stream(temp, std::ios::binary | std::ios::trunc);
+        if (!stream) {
+            if (error) *error = "cannot open temporary Fleet result";
+            return false;
+        }
+        stream.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+        stream.flush();
+        if (!stream) {
+            if (error) *error = "cannot write temporary Fleet result";
+            stream.close();
+            fs::remove(temp, ec);
+            return false;
+        }
+    }
+
+#ifndef _WIN32
+    const int fd = ::open(temp.c_str(), O_RDONLY);
+    if (fd >= 0) {
+        (void)::fsync(fd);
+        (void)::close(fd);
+    }
+    if (::link(temp.c_str(), target.c_str()) != 0) {
+        if (error) *error = fs::exists(target) ?
+            "refusing to overwrite immutable Fleet result" :
+            "cannot publish Fleet result";
+        fs::remove(temp, ec);
+        return false;
+    }
+    fs::remove(temp, ec);
+    if (!target.parent_path().empty()) {
+        const int dir_fd = ::open(target.parent_path().c_str(), O_RDONLY);
+        if (dir_fd >= 0) {
+            (void)::fsync(dir_fd);
+            (void)::close(dir_fd);
+        }
+    }
+#else
+    fs::rename(temp, target, ec);
+    if (ec) {
+        if (error) *error = "cannot publish Fleet result: " + ec.message();
+        fs::remove(temp, ec);
+        return false;
+    }
+#endif
+    return true;
+}
+
+} // namespace fleet

--- a/LIB/FleetRunner.h
+++ b/LIB/FleetRunner.h
@@ -1,0 +1,42 @@
+// FleetRunner.h - immutable Fleet result serialization for DatasetRunner.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "DatasetRunner.h"
+
+#include <string>
+
+namespace fleet {
+
+struct ChunkMetadata {
+    std::string campaign_id;
+    std::string chunk_id;
+    std::string attempt_id;
+    std::string worker_id;
+    std::string dataset;
+    std::string command;
+    std::string runner_path;
+    std::string runner_sha256;
+    std::string engine_path;
+    std::string engine_sha256;
+    std::string manifest_sha256;
+};
+
+class FleetRunner {
+public:
+    static std::string serialize_chunk_result(
+        const ChunkMetadata& metadata,
+        const dataset::BenchmarkReport& report,
+        const dataset::DockingConfig& config,
+        double duration_s);
+
+    // Publishes with no-overwrite semantics. Returns false on any error and
+    // leaves an existing destination untouched.
+    static bool write_chunk_result_atomic(
+        const std::string& destination,
+        const std::string& contents,
+        std::string* error = nullptr);
+};
+
+} // namespace fleet

--- a/LIB/benchmark_datasets.cpp
+++ b/LIB/benchmark_datasets.cpp
@@ -17,6 +17,7 @@
 
 #include "DatasetRunner.h"
 #include "BenchmarkRunner.h"
+#include "FleetRunner.h"
 
 #include <algorithm>
 #include <chrono>
@@ -26,11 +27,8 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
-#include <numeric>
 #include <set>
 #include <sstream>
-#include <iomanip>
-#include <ctime>
 #include <string>
 #include <thread>
 #include <vector>
@@ -72,9 +70,15 @@ static void print_usage(const char* progname) {
     printf("  --ga-population <N>   GA population size (default: 1000)\n");
     printf("  --grid-spacing <F>    Grid spacing in Å (default: 0.375; use 0.5 for coarse pass)\n");
     printf("  --job-timeout-seconds <N>  Per-complex timeout in s (default: 3600)\n");
-    printf("  --fleet               Enable Fleet mode (JSON chunk result output)\n");
-    printf("  --chunk-id <ID>       Unique chunk identifier for Fleet mode\n");
-    printf("  --output-json <path>  Write Fleet JSON result to this file\n");
+    printf("  --fleet               Enable immutable Fleet chunk-result output\n");
+    printf("  --campaign-id <ID>    Fleet campaign identifier (required with --fleet)\n");
+    printf("  --chunk-id <ID>       Fleet chunk identifier (required with --fleet)\n");
+    printf("  --attempt-id <ID>     Fleet attempt identifier (required with --fleet)\n");
+    printf("  --worker-id <ID>      Fleet worker identifier (required with --fleet)\n");
+    printf("  --manifest-sha256 <H> SHA-256 of immutable campaign manifest\n");
+    printf("  --runner-sha256 <H>   SHA-256 of this benchmark runner\n");
+    printf("  --engine-sha256 <H>   SHA-256 of the pinned FlexAIDdS engine\n");
+    printf("  --output-json <path>  Immutable Fleet chunk JSON destination\n");
     printf("  --mode <mode>         Benchmark protocol (Layer 1):\n");
     printf("                        oracle-ceiling  seed_elitism=ON,  blinding=OFF (ceiling)\n");
     printf("                        defined-cleft-redock  seed_elitism=OFF, blinding=ON, known cleft/site\n");
@@ -282,79 +286,6 @@ static void filter_entries_by_code(std::vector<dataset::DatasetEntry>& entries,
     entries = std::move(filtered);
 }
 
-/// Write Fleet-compatible JSON chunk result.
-static void write_fleet_json(const std::string& json_path,
-                              const std::string& chunk_id,
-                              const std::string& dataset,
-                              const dataset::BenchmarkReport& report,
-                              double duration_s) {
-    std::vector<double> dG_vals, rmsd_vals;
-    int n_completed = 0;
-    for (const auto& r : report.results) {
-        if (r.success) {
-            n_completed++;
-            dG_vals.push_back(static_cast<double>(r.predicted_dG));
-            rmsd_vals.push_back(static_cast<double>(r.rmsd_to_crystal));
-        }
-    }
-    int n_failed = static_cast<int>(report.results.size()) - n_completed;
-
-    double dG_mean = 0.0, dG_std = 0.0, rmsd_mean = 0.0;
-    if (!dG_vals.empty()) {
-        dG_mean = std::accumulate(dG_vals.begin(), dG_vals.end(), 0.0) / dG_vals.size();
-        double sq_sum = 0.0;
-        for (double v : dG_vals) sq_sum += (v - dG_mean) * (v - dG_mean);
-        dG_std = dG_vals.size() > 1 ? std::sqrt(sq_sum / (dG_vals.size() - 1)) : 0.0;
-    }
-    if (!rmsd_vals.empty()) {
-        rmsd_mean = std::accumulate(rmsd_vals.begin(), rmsd_vals.end(), 0.0) / rmsd_vals.size();
-    }
-
-    auto now = std::chrono::system_clock::now();
-    auto time_t_now = std::chrono::system_clock::to_time_t(now);
-    char ts_buf[32];
-    std::strftime(ts_buf, sizeof(ts_buf), "%Y-%m-%dT%H:%M:%S", std::localtime(&time_t_now));
-
-    std::ostringstream json;
-    json << "{\n"
-         << "  \"chunk_id\": \"" << chunk_id << "\",\n"
-         << "  \"dataset\": \"" << dataset << "\",\n"
-         << "  \"n_total\": " << report.total_systems << ",\n"
-         << "  \"n_completed\": " << n_completed << ",\n"
-         << "  \"n_failed\": " << n_failed << ",\n"
-         << "  \"success_rate\": " << std::fixed << std::setprecision(4) << report.success_rate << ",\n"
-         << "  \"dG_mean\": " << std::setprecision(3) << dG_mean << ",\n"
-         << "  \"dG_std\": " << dG_std << ",\n"
-         << "  \"rmsd_mean\": " << rmsd_mean << ",\n"
-         << "  \"pearson_r\": " << std::setprecision(4) << report.pearson_r << ",\n"
-         << "  \"duration_s\": " << std::setprecision(1) << duration_s << ",\n"
-         << "  \"timestamp\": \"" << ts_buf << "\",\n"
-         << "  \"cross_ligand\": [\n";
-    for (size_t i = 0; i < report.cross_ligand_results.size(); ++i) {
-        const auto& clr = report.cross_ligand_results[i];
-        json << "    {\"receptor\": \"" << clr.receptor_id << "\","
-             << " \"n_ligands\": " << clr.n_ligands << ","
-             << " \"n_completed\": " << clr.n_completed << "}";
-        if (i + 1 < report.cross_ligand_results.size()) json << ",";
-        json << "\n";
-    }
-    json << "  ]\n}\n";
-
-    if (json_path == "-" || json_path.empty()) {
-        std::cout << json.str();
-    } else {
-        std::ofstream ofs(json_path);
-        if (ofs.is_open()) {
-            ofs << json.str();
-            std::cerr << "  [Fleet] JSON written to " << json_path << "\n";
-        } else {
-            std::cerr << "  [Fleet] WARNING: could not open " << json_path << "\n";
-            std::cout << json.str();
-        }
-    }
-}
-
-
 static dataset::BenchmarkReport run_single_benchmark(const std::string& name,
                                   dataset::DatasetRunner& runner,
                                   const dataset::DockingConfig& config,
@@ -407,6 +338,7 @@ static dataset::BenchmarkReport run_single_benchmark(const std::string& name,
         }
         std::string content((std::istreambuf_iterator<char>(ifs)),
                              std::istreambuf_iterator<char>());
+        const fs::path json_base = fs::absolute(fs::path(json_file)).parent_path();
 
         // Minimal JSON string-field extractor (no external JSON lib needed).
         auto extract_str = [&](const std::string& obj, const std::string& key) -> std::string {
@@ -416,6 +348,14 @@ static dataset::BenchmarkReport run_single_benchmark(const std::string& name,
             pos += needle.size();
             auto end = obj.find('"', pos);
             return (end != std::string::npos) ? obj.substr(pos, end - pos) : "";
+        };
+        auto resolve_input_path = [&](const std::string& value) -> std::string {
+            if (value.empty()) return value;
+            fs::path path(value);
+            if (path.is_relative()) path = json_base / path;
+            std::error_code ec;
+            fs::path normalized = fs::weakly_canonical(path, ec);
+            return ec ? path.lexically_normal().string() : normalized.string();
         };
 
         // Walk JSON locating each pair object by scanning for "receptor_id" keys.
@@ -431,11 +371,11 @@ static dataset::BenchmarkReport run_single_benchmark(const std::string& name,
 
             dataset::DatasetEntry entry;
             entry.pdb_id            = extract_str(obj, "receptor_id");
-            entry.receptor_path     = extract_str(obj, "receptor_pdb");
-            entry.ligand_path       = extract_str(obj, "ligand_sdf");
-            entry.rmsd_reference_path = extract_str(obj, "rmsd_ref_sdf");
-            entry.binding_site_path = extract_str(obj, "oracle_site_pdb");
-            entry.cleft_sphere_path = extract_str(obj, "cleft_sphere_file");
+            entry.receptor_path     = resolve_input_path(extract_str(obj, "receptor_pdb"));
+            entry.ligand_path       = resolve_input_path(extract_str(obj, "ligand_sdf"));
+            entry.rmsd_reference_path = resolve_input_path(extract_str(obj, "rmsd_ref_sdf"));
+            entry.binding_site_path = resolve_input_path(extract_str(obj, "oracle_site_pdb"));
+            entry.cleft_sphere_path = resolve_input_path(extract_str(obj, "cleft_sphere_file"));
             entry.source            = "astex_crossdock_85";
 
             if (!entry.pdb_id.empty() &&
@@ -536,7 +476,13 @@ int main(int argc, char** argv) {
     std::vector<std::string> only_codes;
     // Fleet mode options
     bool fleet_mode = false;
+    std::string campaign_id;
     std::string chunk_id;
+    std::string attempt_id;
+    std::string worker_id;
+    std::string manifest_sha256;
+    std::string runner_sha256;
+    std::string engine_sha256;
     std::string output_json;
     // Layer 1: benchmark protocol mode
     std::string mode_str;
@@ -617,8 +563,32 @@ int main(int argc, char** argv) {
             fleet_mode = true;
             continue;
         }
+        if (arg == "--campaign-id" && i + 1 < argc) {
+            campaign_id = argv[++i];
+            continue;
+        }
         if (arg == "--chunk-id" && i + 1 < argc) {
             chunk_id = argv[++i];
+            continue;
+        }
+        if (arg == "--attempt-id" && i + 1 < argc) {
+            attempt_id = argv[++i];
+            continue;
+        }
+        if (arg == "--worker-id" && i + 1 < argc) {
+            worker_id = argv[++i];
+            continue;
+        }
+        if (arg == "--manifest-sha256" && i + 1 < argc) {
+            manifest_sha256 = argv[++i];
+            continue;
+        }
+        if (arg == "--runner-sha256" && i + 1 < argc) {
+            runner_sha256 = argv[++i];
+            continue;
+        }
+        if (arg == "--engine-sha256" && i + 1 < argc) {
+            engine_sha256 = argv[++i];
             continue;
         }
         if (arg == "--output-json" && i + 1 < argc) {
@@ -640,6 +610,23 @@ int main(int argc, char** argv) {
         fprintf(stderr, "ERROR: No benchmark specified. Use --benchmark <name>\n");
         print_usage(argv[0]);
         return 1;
+    }
+
+    if (fleet_mode) {
+        const bool missing_metadata = campaign_id.empty() || chunk_id.empty() ||
+            attempt_id.empty() || worker_id.empty() || manifest_sha256.empty() ||
+            runner_sha256.empty() || engine_sha256.empty() || output_json.empty();
+        if (missing_metadata) {
+            fprintf(stderr, "ERROR: --fleet requires campaign/chunk/attempt/worker IDs, "
+                    "manifest/runner/engine SHA-256 values, and --output-json\n");
+            return 1;
+        }
+        if (benchmark_name == "all" || prepare_only || list_codes_only ||
+            only_codes.empty() || mode_str.empty() || output_json == "-") {
+            fprintf(stderr, "ERROR: Fleet mode requires one explicit benchmark, --only-codes, "
+                    "an explicit --mode, and a file output; prepare/list/all modes are unsupported\n");
+            return 1;
+        }
     }
 
     // Create runner and config
@@ -736,10 +723,10 @@ int main(int argc, char** argv) {
         std::cout << "  Mode:         " << mode_label << "\n";
     }
     if (fleet_mode) {
-        if (chunk_id.empty()) chunk_id = benchmark_name + "_chunk";
-        std::cout << "  Fleet:   enabled (chunk_id=" << chunk_id << ")\n";
-        if (!output_json.empty())
-            std::cout << "  JSON:    " << output_json << "\n";
+        std::cout << "  Fleet:        enabled\n";
+        std::cout << "  Campaign:     " << campaign_id << "\n";
+        std::cout << "  Chunk/attempt:" << chunk_id << "/" << attempt_id << "\n";
+        std::cout << "  JSON:         " << output_json << "\n";
     }
     std::cout << "\n";
 
@@ -764,13 +751,47 @@ int main(int argc, char** argv) {
         std::cout << "  All benchmarks completed. Results in: " << output_dir << "\n";
         std::cout << "═══════════════════════════════════════════════════════════════\n";
     } else {
+        const auto fleet_started = std::chrono::steady_clock::now();
         auto report = run_single_benchmark(benchmark_name, runner, config, prepare_only, list_codes_only, only_codes);
 
-        // Fleet mode: emit JSON chunk result
-        if (fleet_mode && report.total_systems > 0) {
-            double total_wall = 0.0;
-            for (const auto& r : report.results) total_wall += r.wall_time_s;
-            write_fleet_json(output_json, chunk_id, benchmark_name, report, total_wall);
+        if (fleet_mode) {
+            const double duration_s = std::chrono::duration<double>(
+                std::chrono::steady_clock::now() - fleet_started).count();
+            std::ostringstream command;
+            for (int i = 0; i < argc; ++i) {
+                if (i > 0) command << ' ';
+                command << argv[i];
+            }
+            std::error_code path_error;
+            fs::path runner_path = fs::weakly_canonical(fs::absolute(argv[0]), path_error);
+            if (path_error) runner_path = fs::absolute(argv[0]);
+            const char* engine_env = std::getenv("FLEXAIDDS_BINARY");
+            fleet::ChunkMetadata metadata{
+                campaign_id,
+                chunk_id,
+                attempt_id,
+                worker_id,
+                benchmark_name,
+                command.str(),
+                runner_path.string(),
+                runner_sha256,
+                engine_env ? engine_env : "",
+                engine_sha256,
+                manifest_sha256,
+            };
+            const std::string payload = fleet::FleetRunner::serialize_chunk_result(
+                metadata, report, config, duration_s);
+            std::string write_error;
+            if (!fleet::FleetRunner::write_chunk_result_atomic(
+                    output_json, payload, &write_error)) {
+                std::cerr << "ERROR: Fleet result publication failed: " << write_error << "\n";
+                return 3;
+            }
+            std::cout << "  [Fleet] immutable chunk result: " << output_json << "\n";
+            if (report.total_systems == 0 || report.results.empty()) {
+                std::cerr << "ERROR: Fleet chunk produced no target results\n";
+                return 2;
+            }
         }
     }
 

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -403,7 +403,9 @@ int main(int argc, char **argv){
 	char tmpremark[MAX_REMARK];
 	char dockinp[MAX_PATH__];
 	char gainp[MAX_PATH__];
+	#ifdef _WIN32
 	char *pch;                               // for finding base path
+	#endif
 	char end_strfile[MAX_PATH__];
 	char tmp_end_strfile[MAX_PATH__];
 
@@ -616,11 +618,9 @@ int main(int argc, char **argv){
 			if (n >= MAX_PATH__) n = MAX_PATH__ - 1;
 			memcpy(FA->base_path, src, n);
 			FA->base_path[n] = '\0';
-			pch = FA->base_path; // satisfy any later uses of pch
 		} else {
 			strncpy(FA->base_path, ".", MAX_PATH__ - 1);
 			FA->base_path[MAX_PATH__ - 1] = '\0';
-			pch = NULL;
 		}
 	}
 #else

--- a/benchmarks/datasets/benchmark_astex_native_85.json
+++ b/benchmarks/datasets/benchmark_astex_native_85.json
@@ -1,690 +1,690 @@
 {
   "schema_version": 1,
   "name": "astex_native_85",
-  "description": "85-case Astex Diverse native self-docking benchmark. Each receptor docked with its own ligand. Oracle binding sites used. Ligand paths use project repo SDFs (not cache extraction).",
+  "description": "85-case Astex Diverse cognate redocking benchmark. Each receptor is docked with its own ligand in the ligand-anchored NRGlab Get_Cleft occupied cavity; the crystal coordinates define the site and RMSD reference but are not a GA pose seed. All input paths are manifest-relative.",
   "n_pairs": 85,
   "oracle_mode": true,
-  "astex_diverse_dir": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse",
+  "astex_diverse_dir": "../astex_diverse/astex_diverse",
   "pairs": [
     {
       "index": 0,
       "receptor_id": "1G9V",
       "ligand_id": "1G9V",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1G9V/1G9V_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1G9V/1G9V_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1G9V/1G9V_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1G9V/1G9V_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1G9V/1G9V_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1G9V/1G9V_binding_site.pdb"
     },
     {
       "index": 1,
       "receptor_id": "1GM8",
       "ligand_id": "1GM8",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1GM8/1GM8_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1GM8/1GM8_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1GM8/1GM8_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1GM8/1GM8_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1GM8/1GM8_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1GM8/1GM8_binding_site.pdb"
     },
     {
       "index": 2,
       "receptor_id": "1GPK",
       "ligand_id": "1GPK",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1GPK/1GPK_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1GPK/1GPK_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1GPK/1GPK_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1GPK/1GPK_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1GPK/1GPK_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1GPK/1GPK_binding_site.pdb"
     },
     {
       "index": 3,
       "receptor_id": "1HNN",
       "ligand_id": "1HNN",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1HNN/1HNN_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1HNN/1HNN_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1HNN/1HNN_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1HNN/1HNN_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1HNN/1HNN_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1HNN/1HNN_binding_site.pdb"
     },
     {
       "index": 4,
       "receptor_id": "1HP0",
       "ligand_id": "1HP0",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1HP0/1HP0_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1HP0/1HP0_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1HP0/1HP0_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1HP0/1HP0_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1HP0/1HP0_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1HP0/1HP0_binding_site.pdb"
     },
     {
       "index": 5,
       "receptor_id": "1HQ2",
       "ligand_id": "1HQ2",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1HQ2/1HQ2_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1HQ2/1HQ2_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1HQ2/1HQ2_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1HQ2/1HQ2_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1HQ2/1HQ2_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1HQ2/1HQ2_binding_site.pdb"
     },
     {
       "index": 6,
       "receptor_id": "1IA1",
       "ligand_id": "1IA1",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1IA1/1IA1_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1IA1/1IA1_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1IA1/1IA1_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1IA1/1IA1_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1IA1/1IA1_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1IA1/1IA1_binding_site.pdb"
     },
     {
       "index": 7,
       "receptor_id": "1IGJ",
       "ligand_id": "1IGJ",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1IGJ/1IGJ_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1IGJ/1IGJ_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1IGJ/1IGJ_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1IGJ/1IGJ_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1IGJ/1IGJ_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1IGJ/1IGJ_binding_site.pdb"
     },
     {
       "index": 8,
       "receptor_id": "1J3J",
       "ligand_id": "1J3J",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1J3J/1J3J_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1J3J/1J3J_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1J3J/1J3J_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1J3J/1J3J_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1J3J/1J3J_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1J3J/1J3J_binding_site.pdb"
     },
     {
       "index": 9,
       "receptor_id": "1JD0",
       "ligand_id": "1JD0",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1JD0/1JD0_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1JD0/1JD0_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1JD0/1JD0_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1JD0/1JD0_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1JD0/1JD0_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1JD0/1JD0_binding_site.pdb"
     },
     {
       "index": 10,
       "receptor_id": "1JJE",
       "ligand_id": "1JJE",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1JJE/1JJE_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1JJE/1JJE_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1JJE/1JJE_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1JJE/1JJE_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1JJE/1JJE_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1JJE/1JJE_binding_site.pdb"
     },
     {
       "index": 11,
       "receptor_id": "1K3U",
       "ligand_id": "1K3U",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1K3U/1K3U_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1K3U/1K3U_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1K3U/1K3U_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1K3U/1K3U_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1K3U/1K3U_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1K3U/1K3U_binding_site.pdb"
     },
     {
       "index": 12,
       "receptor_id": "1KE5",
       "ligand_id": "1KE5",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1KE5/1KE5_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1KE5/1KE5_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1KE5/1KE5_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1KE5/1KE5_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1KE5/1KE5_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1KE5/1KE5_binding_site.pdb"
     },
     {
       "index": 13,
       "receptor_id": "1KZK",
       "ligand_id": "1KZK",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1KZK/1KZK_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1KZK/1KZK_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1KZK/1KZK_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1KZK/1KZK_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1KZK/1KZK_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1KZK/1KZK_binding_site.pdb"
     },
     {
       "index": 14,
       "receptor_id": "1L2S",
       "ligand_id": "1L2S",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1L2S/1L2S_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1L2S/1L2S_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1L2S/1L2S_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1L2S/1L2S_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1L2S/1L2S_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1L2S/1L2S_binding_site.pdb"
     },
     {
       "index": 15,
       "receptor_id": "1L7F",
       "ligand_id": "1L7F",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1L7F/1L7F_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1L7F/1L7F_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1L7F/1L7F_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1L7F/1L7F_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1L7F/1L7F_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1L7F/1L7F_binding_site.pdb"
     },
     {
       "index": 16,
       "receptor_id": "1LPZ",
       "ligand_id": "1LPZ",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1LPZ/1LPZ_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1LPZ/1LPZ_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1LPZ/1LPZ_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1LPZ/1LPZ_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1LPZ/1LPZ_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1LPZ/1LPZ_binding_site.pdb"
     },
     {
       "index": 17,
       "receptor_id": "1M2Z",
       "ligand_id": "1M2Z",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1M2Z/1M2Z_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1M2Z/1M2Z_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1M2Z/1M2Z_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1M2Z/1M2Z_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1M2Z/1M2Z_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1M2Z/1M2Z_binding_site.pdb"
     },
     {
       "index": 18,
       "receptor_id": "1MEH",
       "ligand_id": "1MEH",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1MEH/1MEH_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1MEH/1MEH_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1MEH/1MEH_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1MEH/1MEH_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1MEH/1MEH_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1MEH/1MEH_binding_site.pdb"
     },
     {
       "index": 19,
       "receptor_id": "1MQ6",
       "ligand_id": "1MQ6",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1MQ6/1MQ6_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1MQ6/1MQ6_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1MQ6/1MQ6_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1MQ6/1MQ6_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1MQ6/1MQ6_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1MQ6/1MQ6_binding_site.pdb"
     },
     {
       "index": 20,
       "receptor_id": "1N1M",
       "ligand_id": "1N1M",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N1M/1N1M_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N1M/1N1M_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N1M/1N1M_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1N1M/1N1M_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1N1M/1N1M_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1N1M/1N1M_binding_site.pdb"
     },
     {
       "index": 21,
       "receptor_id": "1N2J",
       "ligand_id": "1N2J",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N2J/1N2J_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N2J/1N2J_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N2J/1N2J_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1N2J/1N2J_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1N2J/1N2J_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1N2J/1N2J_binding_site.pdb"
     },
     {
       "index": 22,
       "receptor_id": "1N2V",
       "ligand_id": "1N2V",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N2V/1N2V_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N2V/1N2V_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N2V/1N2V_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1N2V/1N2V_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1N2V/1N2V_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1N2V/1N2V_binding_site.pdb"
     },
     {
       "index": 23,
       "receptor_id": "1N46",
       "ligand_id": "1N46",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N46/1N46_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N46/1N46_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N46/1N46_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1N46/1N46_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1N46/1N46_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1N46/1N46_binding_site.pdb"
     },
     {
       "index": 24,
       "receptor_id": "1NAV",
       "ligand_id": "1NAV",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1NAV/1NAV_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1NAV/1NAV_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1NAV/1NAV_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1NAV/1NAV_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1NAV/1NAV_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1NAV/1NAV_binding_site.pdb"
     },
     {
       "index": 25,
       "receptor_id": "1OF1",
       "ligand_id": "1OF1",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OF1/1OF1_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OF1/1OF1_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OF1/1OF1_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1OF1/1OF1_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1OF1/1OF1_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1OF1/1OF1_binding_site.pdb"
     },
     {
       "index": 26,
       "receptor_id": "1OF6",
       "ligand_id": "1OF6",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OF6/1OF6_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OF6/1OF6_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OF6/1OF6_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1OF6/1OF6_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1OF6/1OF6_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1OF6/1OF6_binding_site.pdb"
     },
     {
       "index": 27,
       "receptor_id": "1OPK",
       "ligand_id": "1OPK",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OPK/1OPK_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OPK/1OPK_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OPK/1OPK_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1OPK/1OPK_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1OPK/1OPK_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1OPK/1OPK_binding_site.pdb"
     },
     {
       "index": 28,
       "receptor_id": "1OQ5",
       "ligand_id": "1OQ5",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OQ5/1OQ5_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OQ5/1OQ5_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OQ5/1OQ5_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1OQ5/1OQ5_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1OQ5/1OQ5_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1OQ5/1OQ5_binding_site.pdb"
     },
     {
       "index": 29,
       "receptor_id": "1OWE",
       "ligand_id": "1OWE",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OWE/1OWE_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OWE/1OWE_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1OWE/1OWE_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1OWE/1OWE_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1OWE/1OWE_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1OWE/1OWE_binding_site.pdb"
     },
     {
       "index": 30,
       "receptor_id": "1P2Y",
       "ligand_id": "1P2Y",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1P2Y/1P2Y_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1P2Y/1P2Y_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1P2Y/1P2Y_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1P2Y/1P2Y_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1P2Y/1P2Y_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1P2Y/1P2Y_binding_site.pdb"
     },
     {
       "index": 31,
       "receptor_id": "1P62",
       "ligand_id": "1P62",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1P62/1P62_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1P62/1P62_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1P62/1P62_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1P62/1P62_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1P62/1P62_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1P62/1P62_binding_site.pdb"
     },
     {
       "index": 32,
       "receptor_id": "1PMN",
       "ligand_id": "1PMN",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1PMN/1PMN_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1PMN/1PMN_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1PMN/1PMN_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1PMN/1PMN_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1PMN/1PMN_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1PMN/1PMN_binding_site.pdb"
     },
     {
       "index": 33,
       "receptor_id": "1Q1G",
       "ligand_id": "1Q1G",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Q1G/1Q1G_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Q1G/1Q1G_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Q1G/1Q1G_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1Q1G/1Q1G_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1Q1G/1Q1G_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1Q1G/1Q1G_binding_site.pdb"
     },
     {
       "index": 34,
       "receptor_id": "1Q41",
       "ligand_id": "1Q41",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Q41/1Q41_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Q41/1Q41_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Q41/1Q41_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1Q41/1Q41_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1Q41/1Q41_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1Q41/1Q41_binding_site.pdb"
     },
     {
       "index": 35,
       "receptor_id": "1Q4G",
       "ligand_id": "1Q4G",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Q4G/1Q4G_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Q4G/1Q4G_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Q4G/1Q4G_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1Q4G/1Q4G_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1Q4G/1Q4G_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1Q4G/1Q4G_binding_site.pdb"
     },
     {
       "index": 36,
       "receptor_id": "1R1H",
       "ligand_id": "1R1H",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1R1H/1R1H_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1R1H/1R1H_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1R1H/1R1H_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1R1H/1R1H_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1R1H/1R1H_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1R1H/1R1H_binding_site.pdb"
     },
     {
       "index": 37,
       "receptor_id": "1R55",
       "ligand_id": "1R55",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1R55/1R55_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1R55/1R55_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1R55/1R55_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1R55/1R55_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1R55/1R55_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1R55/1R55_binding_site.pdb"
     },
     {
       "index": 38,
       "receptor_id": "1R58",
       "ligand_id": "1R58",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1R58/1R58_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1R58/1R58_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1R58/1R58_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1R58/1R58_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1R58/1R58_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1R58/1R58_binding_site.pdb"
     },
     {
       "index": 39,
       "receptor_id": "1R9O",
       "ligand_id": "1R9O",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1R9O/1R9O_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1R9O/1R9O_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1R9O/1R9O_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1R9O/1R9O_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1R9O/1R9O_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1R9O/1R9O_binding_site.pdb"
     },
     {
       "index": 40,
       "receptor_id": "1S19",
       "ligand_id": "1S19",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1S19/1S19_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1S19/1S19_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1S19/1S19_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1S19/1S19_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1S19/1S19_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1S19/1S19_binding_site.pdb"
     },
     {
       "index": 41,
       "receptor_id": "1S3V",
       "ligand_id": "1S3V",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1S3V/1S3V_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1S3V/1S3V_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1S3V/1S3V_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1S3V/1S3V_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1S3V/1S3V_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1S3V/1S3V_binding_site.pdb"
     },
     {
       "index": 42,
       "receptor_id": "1SG0",
       "ligand_id": "1SG0",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1SG0/1SG0_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1SG0/1SG0_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1SG0/1SG0_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1SG0/1SG0_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1SG0/1SG0_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1SG0/1SG0_binding_site.pdb"
     },
     {
       "index": 43,
       "receptor_id": "1SJ0",
       "ligand_id": "1SJ0",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1SJ0/1SJ0_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1SJ0/1SJ0_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1SJ0/1SJ0_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1SJ0/1SJ0_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1SJ0/1SJ0_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1SJ0/1SJ0_binding_site.pdb"
     },
     {
       "index": 44,
       "receptor_id": "1SQ5",
       "ligand_id": "1SQ5",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1SQ5/1SQ5_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1SQ5/1SQ5_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1SQ5/1SQ5_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1SQ5/1SQ5_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1SQ5/1SQ5_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1SQ5/1SQ5_binding_site.pdb"
     },
     {
       "index": 45,
       "receptor_id": "1T40",
       "ligand_id": "1T40",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1T40/1T40_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1T40/1T40_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1T40/1T40_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1T40/1T40_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1T40/1T40_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1T40/1T40_binding_site.pdb"
     },
     {
       "index": 46,
       "receptor_id": "1T46",
       "ligand_id": "1T46",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1T46/1T46_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1T46/1T46_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1T46/1T46_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1T46/1T46_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1T46/1T46_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1T46/1T46_binding_site.pdb"
     },
     {
       "index": 47,
       "receptor_id": "1T9B",
       "ligand_id": "1T9B",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1T9B/1T9B_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1T9B/1T9B_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1T9B/1T9B_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1T9B/1T9B_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1T9B/1T9B_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1T9B/1T9B_binding_site.pdb"
     },
     {
       "index": 48,
       "receptor_id": "1TT1",
       "ligand_id": "1TT1",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1TT1/1TT1_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1TT1/1TT1_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1TT1/1TT1_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1TT1/1TT1_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1TT1/1TT1_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1TT1/1TT1_binding_site.pdb"
     },
     {
       "index": 49,
       "receptor_id": "1TW6",
       "ligand_id": "1TW6",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1TW6/1TW6.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1TW6/1TW6_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1TW6/1TW6_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1TW6/1TW6.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1TW6/1TW6_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1TW6/1TW6_binding_site.pdb"
     },
     {
       "index": 50,
       "receptor_id": "1TZ8",
       "ligand_id": "1TZ8",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1TZ8/1TZ8_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1TZ8/1TZ8_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1TZ8/1TZ8_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1TZ8/1TZ8_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1TZ8/1TZ8_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1TZ8/1TZ8_binding_site.pdb"
     },
     {
       "index": 51,
       "receptor_id": "1U1C",
       "ligand_id": "1U1C",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1U1C/1U1C_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1U1C/1U1C_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1U1C/1U1C_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1U1C/1U1C_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1U1C/1U1C_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1U1C/1U1C_binding_site.pdb"
     },
     {
       "index": 52,
       "receptor_id": "1U4D",
       "ligand_id": "1U4D",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1U4D/1U4D_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1U4D/1U4D_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1U4D/1U4D_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1U4D/1U4D_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1U4D/1U4D_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1U4D/1U4D_binding_site.pdb"
     },
     {
       "index": 53,
       "receptor_id": "1UML",
       "ligand_id": "1UML",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1UML/1UML_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1UML/1UML_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1UML/1UML_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1UML/1UML_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1UML/1UML_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1UML/1UML_binding_site.pdb"
     },
     {
       "index": 54,
       "receptor_id": "1UNL",
       "ligand_id": "1UNL",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1UNL/1UNL_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1UNL/1UNL_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1UNL/1UNL_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1UNL/1UNL_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1UNL/1UNL_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1UNL/1UNL_binding_site.pdb"
     },
     {
       "index": 55,
       "receptor_id": "1UOU",
       "ligand_id": "1UOU",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1UOU/1UOU_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1UOU/1UOU_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1UOU/1UOU_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1UOU/1UOU_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1UOU/1UOU_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1UOU/1UOU_binding_site.pdb"
     },
     {
       "index": 56,
       "receptor_id": "1V0P",
       "ligand_id": "1V0P",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1V0P/1V0P_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1V0P/1V0P_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1V0P/1V0P_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1V0P/1V0P_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1V0P/1V0P_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1V0P/1V0P_binding_site.pdb"
     },
     {
       "index": 57,
       "receptor_id": "1V48",
       "ligand_id": "1V48",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1V48/1V48_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1V48/1V48_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1V48/1V48_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1V48/1V48_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1V48/1V48_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1V48/1V48_binding_site.pdb"
     },
     {
       "index": 58,
       "receptor_id": "1V4S",
       "ligand_id": "1V4S",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1V4S/1V4S_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1V4S/1V4S_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1V4S/1V4S_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1V4S/1V4S_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1V4S/1V4S_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1V4S/1V4S_binding_site.pdb"
     },
     {
       "index": 59,
       "receptor_id": "1VCJ",
       "ligand_id": "1VCJ",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1VCJ/1VCJ_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1VCJ/1VCJ_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1VCJ/1VCJ_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1VCJ/1VCJ_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1VCJ/1VCJ_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1VCJ/1VCJ_binding_site.pdb"
     },
     {
       "index": 60,
       "receptor_id": "1W1P",
       "ligand_id": "1W1P",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1W1P/1W1P_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1W1P/1W1P_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1W1P/1W1P_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1W1P/1W1P_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1W1P/1W1P_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1W1P/1W1P_binding_site.pdb"
     },
     {
       "index": 61,
       "receptor_id": "1W2G",
       "ligand_id": "1W2G",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1W2G/1W2G_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1W2G/1W2G_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1W2G/1W2G_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1W2G/1W2G_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1W2G/1W2G_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1W2G/1W2G_binding_site.pdb"
     },
     {
       "index": 62,
       "receptor_id": "1X8X",
       "ligand_id": "1X8X",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1X8X/1X8X_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1X8X/1X8X_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1X8X/1X8X_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1X8X/1X8X_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1X8X/1X8X_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1X8X/1X8X_binding_site.pdb"
     },
     {
       "index": 63,
       "receptor_id": "1XM6",
       "ligand_id": "1XM6",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1XM6/1XM6_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1XM6/1XM6_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1XM6/1XM6_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1XM6/1XM6_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1XM6/1XM6_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1XM6/1XM6_binding_site.pdb"
     },
     {
       "index": 64,
       "receptor_id": "1XOZ",
       "ligand_id": "1XOZ",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1XOZ/1XOZ_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1XOZ/1XOZ_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1XOZ/1XOZ_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1XOZ/1XOZ_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1XOZ/1XOZ_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1XOZ/1XOZ_binding_site.pdb"
     },
     {
       "index": 65,
       "receptor_id": "1Y6B",
       "ligand_id": "1Y6B",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Y6B/1Y6B_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Y6B/1Y6B_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Y6B/1Y6B_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1Y6B/1Y6B_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1Y6B/1Y6B_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1Y6B/1Y6B_binding_site.pdb"
     },
     {
       "index": 66,
       "receptor_id": "1Y6R",
       "ligand_id": "1Y6R",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Y6R/1Y6R_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Y6R/1Y6R_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Y6R/1Y6R_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1Y6R/1Y6R_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1Y6R/1Y6R_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1Y6R/1Y6R_binding_site.pdb"
     },
     {
       "index": 67,
       "receptor_id": "1YGC",
       "ligand_id": "1YGC",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YGC/1YGC_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YGC/1YGC_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YGC/1YGC_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1YGC/1YGC_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1YGC/1YGC_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1YGC/1YGC_binding_site.pdb"
     },
     {
       "index": 68,
       "receptor_id": "1YQY",
       "ligand_id": "1YQY",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YQY/1YQY_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YQY/1YQY_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YQY/1YQY_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1YQY/1YQY_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1YQY/1YQY_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1YQY/1YQY_binding_site.pdb"
     },
     {
       "index": 69,
       "receptor_id": "1YV3",
       "ligand_id": "1YV3",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YV3/1YV3_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YV3/1YV3_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YV3/1YV3_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1YV3/1YV3_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1YV3/1YV3_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1YV3/1YV3_binding_site.pdb"
     },
     {
       "index": 70,
       "receptor_id": "1YVF",
       "ligand_id": "1YVF",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YVF/1YVF_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YVF/1YVF_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YVF/1YVF_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1YVF/1YVF_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1YVF/1YVF_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1YVF/1YVF_binding_site.pdb"
     },
     {
       "index": 71,
       "receptor_id": "1YWR",
       "ligand_id": "1YWR",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YWR/1YWR_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YWR/1YWR_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1YWR/1YWR_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1YWR/1YWR_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1YWR/1YWR_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1YWR/1YWR_binding_site.pdb"
     },
     {
       "index": 72,
       "receptor_id": "1Z95",
       "ligand_id": "1Z95",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Z95/1Z95_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Z95/1Z95_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1Z95/1Z95_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/1Z95/1Z95_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/1Z95/1Z95_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/1Z95/1Z95_binding_site.pdb"
     },
     {
       "index": 73,
       "receptor_id": "2BM2",
       "ligand_id": "2BM2",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2BM2/2BM2_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2BM2/2BM2_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2BM2/2BM2_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/2BM2/2BM2_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/2BM2/2BM2_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/2BM2/2BM2_binding_site.pdb"
     },
     {
       "index": 74,
       "receptor_id": "2BR1",
       "ligand_id": "2BR1",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2BR1/2BR1_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2BR1/2BR1_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2BR1/2BR1_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/2BR1/2BR1_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/2BR1/2BR1_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/2BR1/2BR1_binding_site.pdb"
     },
     {
       "index": 75,
       "receptor_id": "2BSM",
       "ligand_id": "2BSM",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2BSM/2BSM_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2BSM/2BSM_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2BSM/2BSM_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/2BSM/2BSM_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/2BSM/2BSM_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/2BSM/2BSM_binding_site.pdb"
     },
     {
       "index": 76,
       "receptor_id": "2BYS",
       "ligand_id": "2BYS",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2BYS/2BYS_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2BYS/2BYS_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2BYS/2BYS_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/2BYS/2BYS_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/2BYS/2BYS_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/2BYS/2BYS_binding_site.pdb"
     },
     {
       "index": 77,
       "receptor_id": "2C3I",
       "ligand_id": "2C3I",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2C3I/2C3I_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2C3I/2C3I_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2C3I/2C3I_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/2C3I/2C3I_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/2C3I/2C3I_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/2C3I/2C3I_binding_site.pdb"
     },
     {
       "index": 78,
       "receptor_id": "2CET",
       "ligand_id": "2CET",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2CET/2CET_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2CET/2CET_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2CET/2CET_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/2CET/2CET_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/2CET/2CET_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/2CET/2CET_binding_site.pdb"
     },
     {
       "index": 79,
       "receptor_id": "2CGR",
       "ligand_id": "2CGR",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2CGR/2CGR_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2CGR/2CGR_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2CGR/2CGR_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/2CGR/2CGR_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/2CGR/2CGR_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/2CGR/2CGR_binding_site.pdb"
     },
     {
       "index": 80,
       "receptor_id": "2D3U",
       "ligand_id": "2D3U",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2D3U/2D3U_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2D3U/2D3U_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2D3U/2D3U_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/2D3U/2D3U_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/2D3U/2D3U_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/2D3U/2D3U_binding_site.pdb"
     },
     {
       "index": 81,
       "receptor_id": "2GBP",
       "ligand_id": "2GBP",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2GBP/2GBP_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2GBP/2GBP_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2GBP/2GBP_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/2GBP/2GBP_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/2GBP/2GBP_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/2GBP/2GBP_binding_site.pdb"
     },
     {
       "index": 82,
       "receptor_id": "2HB1",
       "ligand_id": "2HB1",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2HB1/2HB1_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2HB1/2HB1_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2HB1/2HB1_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/2HB1/2HB1_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/2HB1/2HB1_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/2HB1/2HB1_binding_site.pdb"
     },
     {
       "index": 83,
       "receptor_id": "2HR7",
       "ligand_id": "2HR7",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2HR7/2HR7_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2HR7/2HR7_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2HR7/2HR7_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/2HR7/2HR7_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/2HR7/2HR7_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/2HR7/2HR7_binding_site.pdb"
     },
     {
       "index": 84,
       "receptor_id": "2J62",
       "ligand_id": "2J62",
-      "receptor_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2J62/2J62_apo.pdb",
-      "ligand_sdf": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2J62/2J62_ligand.sdf",
-      "oracle_site_pdb": "/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2J62/2J62_binding_site.pdb"
+      "receptor_pdb": "../astex_diverse/astex_diverse/2J62/2J62_apo.pdb",
+      "ligand_sdf": "../astex_diverse/astex_diverse/2J62/2J62_ligand.sdf",
+      "oracle_site_pdb": "../astex_diverse/astex_diverse/2J62/2J62_binding_site.pdb"
     }
   ]
 }

--- a/benchmarks/m3pro/dashboard/fleet_monitor.py
+++ b/benchmarks/m3pro/dashboard/fleet_monitor.py
@@ -237,7 +237,7 @@ def safe_is_file(path: str) -> bool:
 
 
 def discover_fleet_status_files(icloud_dir: str) -> List[str]:
-    """Find all fleet_status*.json files in the iCloud directory.
+    """Find legacy runner files and Bonhomme Fleet campaign status files.
 
     Args:
         icloud_dir: Path to the iCloud FlexAIDdS directory.
@@ -245,9 +245,12 @@ def discover_fleet_status_files(icloud_dir: str) -> List[str]:
     Returns:
         Sorted list of absolute paths to fleet status JSON files.
     """
-    pattern = os.path.join(icloud_dir, "fleet_status*.json")
-    files = glob(pattern)
-    return sorted(files)
+    patterns = (
+        os.path.join(icloud_dir, "fleet_status*.json"),
+        os.path.join(icloud_dir, "campaigns", "*", "status.json"),
+        os.path.join(icloud_dir, "results", "campaigns", "*", "status.json"),
+    )
+    return sorted({path for pattern in patterns for path in glob(pattern)})
 
 
 def count_flexaidds_workers() -> int:
@@ -342,9 +345,9 @@ def scan_target_dir(target_path: str) -> TargetStatus:
     """Determine the status of a single target directory.
 
     A target is:
-      - "done" if it has a result.csv or non-INI .pdb output file
+      - "done" only if it has a non-empty result.csv commit artifact
       - "stuck" if stdout.log contains [STUCK]
-      - "in_progress" if it has dock_config.json but no result yet
+      - "in_progress" if it has config/log/pose artifacts but no result yet
       - "queued" if the directory doesn't exist yet
 
     Args:
@@ -362,7 +365,11 @@ def scan_target_dir(target_path: str) -> TargetStatus:
 
     entries = safe_list_dir(target_path)
 
-    has_result_csv = "result.csv" in entries
+    result_csv = os.path.join(target_path, "result.csv")
+    try:
+        has_result_csv = "result.csv" in entries and os.path.getsize(result_csv) > 0
+    except OSError:
+        has_result_csv = False
     has_dock_config = "dock_config.json" in entries
     has_stdout = "stdout.log" in entries
 
@@ -372,7 +379,7 @@ def scan_target_dir(target_path: str) -> TargetStatus:
             has_output_pdb = True
             break
 
-    status.has_result = has_result_csv or has_output_pdb
+    status.has_result = has_result_csv
 
     if has_stdout:
         stdout_path = os.path.join(target_path, "stdout.log")
@@ -382,9 +389,9 @@ def scan_target_dir(target_path: str) -> TargetStatus:
             status.state = "stuck"
             return status
 
-    if has_result_csv or has_output_pdb:
+    if has_result_csv:
         status.state = "done"
-    elif has_dock_config:
+    elif has_dock_config or has_stdout or has_output_pdb:
         status.state = "in_progress"
     else:
         status.state = "queued"
@@ -528,8 +535,10 @@ def parse_runner(
         return runner
 
     runner.raw_json = data
-    runner.name = data.get("runner", _runner_name_from_file(filepath))
-    runner.active_dataset = data.get("activeDataset", "none")
+    runner.name = data.get(
+        "runner", data.get("campaign_id", _runner_name_from_file(filepath))
+    )
+    runner.active_dataset = data.get("activeDataset", data.get("dataset", "none"))
     runner.timestamp = data.get("timestamp")
 
     metrics = data.get("metrics", {})
@@ -542,6 +551,23 @@ def parse_runner(
             pass
 
     campaign = data.get("campaign", {})
+    if not campaign and data.get("campaign_id") and data.get("dataset"):
+        states = data.get("states", {})
+        if states.get("completed", 0) == data.get("totalChunks", 0):
+            fleet_status = "complete"
+        elif states.get("running", 0) > 0:
+            fleet_status = "running"
+        elif states.get("failed", 0) > 0:
+            fleet_status = "failed"
+        else:
+            fleet_status = "pending"
+        campaign = {
+            data["dataset"]: {
+                "total": data.get("totalChunks", 0),
+                "completed": data.get("completedChunks", 0),
+                "status": fleet_status,
+            }
+        }
     for ds_name, ds_info in campaign.items():
         total = ds_info.get("total", 0)
         completed = ds_info.get("completed", 0)
@@ -605,6 +631,8 @@ def parse_runner(
 def _runner_name_from_file(filepath: str) -> str:
     """Derive a runner name from the fleet status filename."""
     basename = os.path.basename(filepath)
+    if basename == "status.json":
+        return os.path.basename(os.path.dirname(filepath))
     name = basename.replace("fleet_status", "").replace(".json", "").strip("_")
     if not name:
         return "unknown"

--- a/benchmarks/m3pro/dashboard/fleet_status_server.py
+++ b/benchmarks/m3pro/dashboard/fleet_status_server.py
@@ -10,7 +10,8 @@ Endpoints:
   GET /api/progress/<dataset>/<run> — Deep-scan progress for a specific run
   GET /api/fleet/<filename>         — Raw fleet status JSON file
 
-CORS headers (Access-Control-Allow-Origin: *) are added to all responses.
+The server binds to loopback by default. Cross-origin access is disabled unless
+an explicit ``--cors-origin`` is supplied.
 
 Usage:
   # Start on default port 8787
@@ -43,7 +44,7 @@ from glob import glob
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import unquote
+from urllib.parse import unquote, urlsplit
 
 __version__ = "1.0.0"
 
@@ -52,6 +53,25 @@ ICLOUD_DEFAULT = os.path.expanduser(
 )
 FAST_DEFAULT = os.path.expanduser("~/.flexaidds_fast")
 RESULTS_SUBDIR = "results/tier2"
+SAFE_COMPONENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+def _confined_path(root: str, *parts: str) -> str:
+    """Resolve a path below root, including symlinks, or raise ValueError."""
+    base = os.path.realpath(root)
+    candidate = os.path.realpath(os.path.join(base, *parts))
+    try:
+        if os.path.commonpath((base, candidate)) != base:
+            raise ValueError("path traversal denied")
+    except ValueError as exc:
+        raise ValueError("path traversal denied") from exc
+    return candidate
+
+
+def _safe_component(value: str, label: str) -> str:
+    if not SAFE_COMPONENT.fullmatch(value):
+        raise ValueError(f"invalid {label}")
+    return value
 
 
 def safe_read_json(filepath: str) -> Optional[Dict[str, Any]]:
@@ -64,9 +84,13 @@ def safe_read_json(filepath: str) -> Optional[Dict[str, Any]]:
 
 
 def discover_fleet_status_files(icloud_dir: str) -> List[str]:
-    """Find all fleet_status*.json files in the iCloud directory."""
-    pattern = os.path.join(icloud_dir, "fleet_status*.json")
-    return sorted(glob(pattern))
+    """Find legacy runner files and Bonhomme Fleet campaign status files."""
+    patterns = (
+        os.path.join(icloud_dir, "fleet_status*.json"),
+        os.path.join(icloud_dir, "campaigns", "*", "status.json"),
+        os.path.join(icloud_dir, "results", "campaigns", "*", "status.json"),
+    )
+    return sorted({path for pattern in patterns for path in glob(pattern)})
 
 
 def merge_fleet_status(icloud_dir: str) -> Dict[str, Any]:
@@ -84,14 +108,37 @@ def merge_fleet_status(icloud_dir: str) -> Dict[str, Any]:
         "runners": {},
         "total_workers": 0,
         "fleet_files": [os.path.basename(f) for f in files],
+        "devices": [],
+        "activeChunks": [],
     }
 
     for fpath in files:
         data = safe_read_json(fpath)
         if data is None:
             continue
-        runner_name = data.get("runner", os.path.basename(fpath))
+        runner_name = data.get("runner", data.get("campaign_id", os.path.basename(fpath)))
         merged["runners"][runner_name] = data
+        merged["devices"].extend(data.get("devices", []))
+        merged["activeChunks"].extend(data.get("activeChunks", []))
+
+    metrics = [
+        data.get("metrics", {})
+        for data in merged["runners"].values()
+        if isinstance(data.get("metrics"), dict)
+    ]
+    merged["total_workers"] = sum(int(item.get("activeDevices", 0)) for item in metrics)
+    merged["metrics"] = {
+        "jobID": "fleet-merged",
+        "totalChunks": sum(int(item.get("totalChunks", 0)) for item in metrics),
+        "completedChunks": sum(int(item.get("completedChunks", 0)) for item in metrics),
+        "failedChunks": sum(int(item.get("failedChunks", 0)) for item in metrics),
+        "orphanedChunks": sum(int(item.get("orphanedChunks", 0)) for item in metrics),
+        "activeDevices": merged["total_workers"],
+        "totalTFLOPS": sum(float(item.get("totalTFLOPS", 0.0)) for item in metrics),
+        "meanChunkTimeSeconds": None,
+        "estimatedRemainingSeconds": None,
+        "timestamp": merged["timestamp"],
+    }
 
     return merged
 
@@ -114,6 +161,8 @@ def deep_scan_run(
     Returns:
         Dictionary with per-target progress and summary stats.
     """
+    dataset = _safe_component(dataset, "dataset")
+    run_name = _safe_component(run_name, "run name")
     result: Dict[str, Any] = {
         "dataset": dataset,
         "run": run_name,
@@ -130,7 +179,7 @@ def deep_scan_run(
 
     for base in results_dirs:
         tier2 = base if base.endswith(RESULTS_SUBDIR) else os.path.join(base, RESULTS_SUBDIR)
-        run_path = os.path.join(tier2, dataset, run_name)
+        run_path = _confined_path(tier2, dataset, run_name)
 
         if not os.path.isdir(run_path):
             continue
@@ -179,7 +228,11 @@ def _classify_target(target_path: str) -> Dict[str, Any]:
     except OSError:
         return status
 
-    has_result_csv = "result.csv" in entries
+    result_csv = os.path.join(target_path, "result.csv")
+    try:
+        has_result_csv = "result.csv" in entries and os.path.getsize(result_csv) > 0
+    except OSError:
+        has_result_csv = False
     has_dock_config = "dock_config.json" in entries
     has_stdout = "stdout.log" in entries
 
@@ -188,7 +241,7 @@ def _classify_target(target_path: str) -> Dict[str, Any]:
         for e in entries
     )
 
-    status["has_result"] = has_result_csv or has_output_pdb
+    status["has_result"] = has_result_csv
 
     if has_stdout:
         stdout_path = os.path.join(target_path, "stdout.log")
@@ -202,9 +255,9 @@ def _classify_target(target_path: str) -> Dict[str, Any]:
         except OSError:
             pass
 
-    if has_result_csv or has_output_pdb:
+    if has_result_csv:
         status["state"] = "done"
-    elif has_dock_config:
+    elif has_dock_config or has_stdout or has_output_pdb:
         status["state"] = "in_progress"
     else:
         status["state"] = "queued"
@@ -217,6 +270,7 @@ class FleetStatusHandler(BaseHTTPRequestHandler):
 
     icloud_dir: str = ICLOUD_DEFAULT
     results_dirs: List[str] = []
+    cors_origin: Optional[str] = None
 
     def log_message(self, format: str, *args: Any) -> None:
         """Override to use a cleaner log format."""
@@ -225,14 +279,15 @@ class FleetStatusHandler(BaseHTTPRequestHandler):
         )
 
     def _send_json(self, data: Any, status_code: int = 200) -> None:
-        """Send a JSON response with CORS headers."""
+        """Send a JSON response."""
         body = json.dumps(data, indent=2, default=str).encode("utf-8")
         self.send_response(status_code)
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        if self.cors_origin:
+            self.send_header("Access-Control-Allow-Origin", self.cors_origin)
+            self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type")
         self.send_header("Cache-Control", "no-cache")
         self.end_headers()
         self.wfile.write(body)
@@ -243,15 +298,18 @@ class FleetStatusHandler(BaseHTTPRequestHandler):
 
     def do_OPTIONS(self) -> None:
         """Handle CORS preflight requests."""
+        if not self.cors_origin:
+            self._send_error_json("CORS is disabled", 403)
+            return
         self.send_response(204)
-        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Origin", self.cors_origin)
         self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
         self.send_header("Access-Control-Allow-Headers", "Content-Type")
         self.end_headers()
 
     def do_GET(self) -> None:
         """Route GET requests to appropriate handlers."""
-        path = unquote(self.path).rstrip("/")
+        path = unquote(urlsplit(self.path).path).rstrip("/")
 
         if path == "" or path == "/":
             self._handle_index()
@@ -275,8 +333,6 @@ class FleetStatusHandler(BaseHTTPRequestHandler):
                 "GET /api/progress/<dataset>/<run>": "Deep-scan progress for a run",
                 "GET /api/fleet/<filename>": "Raw fleet status JSON file",
             },
-            "icloud_dir": self.icloud_dir,
-            "results_dirs": self.results_dirs,
         })
 
     def _handle_status(self) -> None:
@@ -287,7 +343,7 @@ class FleetStatusHandler(BaseHTTPRequestHandler):
     def _handle_progress(self, path: str) -> None:
         """Handle GET /api/progress/<dataset>/<run> — deep scan."""
         parts = path.replace("/api/progress/", "").split("/")
-        if len(parts) < 2:
+        if len(parts) != 2:
             self._send_error_json(
                 "Usage: /api/progress/<dataset>/<run>", 400
             )
@@ -296,7 +352,11 @@ class FleetStatusHandler(BaseHTTPRequestHandler):
         dataset = parts[0]
         run_name = parts[1]
 
-        progress = deep_scan_run(self.results_dirs, dataset, run_name)
+        try:
+            progress = deep_scan_run(self.results_dirs, dataset, run_name)
+        except ValueError as exc:
+            self._send_error_json(str(exc), 400)
+            return
         self._send_json(progress)
 
     def _handle_fleet_file(self, path: str) -> None:
@@ -306,10 +366,9 @@ class FleetStatusHandler(BaseHTTPRequestHandler):
             self._send_error_json("Invalid filename pattern", 400)
             return
 
-        filepath = os.path.join(self.icloud_dir, filename)
-        filepath = os.path.realpath(filepath)
-
-        if not filepath.startswith(os.path.realpath(self.icloud_dir)):
+        try:
+            filepath = _confined_path(self.icloud_dir, filename)
+        except ValueError:
             self._send_error_json("Path traversal denied", 403)
             return
 
@@ -336,8 +395,13 @@ def build_argparser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--host",
         type=str,
-        default="0.0.0.0",
-        help="Bind address (default: 0.0.0.0)",
+        default="127.0.0.1",
+        help="Bind address (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--cors-origin",
+        default=None,
+        help="Exact allowed browser origin; CORS is disabled by default",
     )
     parser.add_argument(
         "--icloud",
@@ -388,6 +452,7 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     FleetStatusHandler.icloud_dir = icloud_dir
     FleetStatusHandler.results_dirs = results_dirs
+    FleetStatusHandler.cors_origin = args.cors_origin
 
     server = HTTPServer((args.host, args.port), FleetStatusHandler)
 

--- a/docs/FLEET_BENCHMARKS.md
+++ b/docs/FLEET_BENCHMARKS.md
@@ -1,0 +1,157 @@
+# Bonhomme Fleet Benchmarks
+
+Bonhomme Fleet is the resumable control plane for `benchmark_datasets`. It is
+designed so Codex, Grok Build, Claude Code, Claude Science, or a human can
+inspect and resume the same campaign without owning the original terminal.
+
+Fleet does not change docking, ranking, PoseBusters, or tENCoM/Eigen. It pins
+those executables and the protocol, leases deterministic target shards, runs
+on local storage, verifies the archived tree in iCloud, and writes the accepted
+chunk manifest last.
+
+## Scientific Contract
+
+- Production Astex redocking uses `defined-cleft-redock`: the cognate GetCleft
+  site is supplied, but crystal ligand coordinates are not a GA seed.
+- Official PoseBusters (`bust`) and built-in tENCoM/Eigen are mandatory.
+- RMSD, PoseBusters, and tENCoM/Eigen must cite the same elected-pose SHA-256.
+- `success_rmsd`, `success_pb`, and `claim_ready` are separate. The primary
+  strict rate is `success_pb = RMSD <= 2.0 A AND PoseBusters pass`.
+- `claim_ready` additionally requires tENCoM/Eigen, exact-pose provenance,
+  score/pose consistency, and a claim-eligible no-seed protocol.
+- `best_cluster_rmsd_a` is an any-pose sampling ceiling, not top-1 success.
+- A completed process is not necessarily a scientific success. Fleet reports
+  execution and scientific counters separately.
+
+## M3 Pro Setup
+
+From the repository root:
+
+```bash
+ROOT="$(git rev-parse --show-toplevel)"
+BUILD="$ROOT/build_fleet"
+
+xcrun -f metal
+xcrun metal -v
+cmake -S "$ROOT" -B "$BUILD" \
+  -DBUILD_TESTING=ON \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DFLEXAIDS_USE_METAL=ON
+cmake --build "$BUILD" --target FlexAIDdS benchmark_datasets test_fleet_runner -j 6
+ctest --test-dir "$BUILD" -R 'FleetRunnerTests|DatasetRunnerTests' --output-on-failure
+```
+
+Resolve the required validator and iCloud destination:
+
+```bash
+source "$HOME/.flexaidds_env"
+: "${FLEXAIDDS_RESULTS:?set FLEXAIDDS_RESULTS to the iCloud results directory}"
+
+BUST="${FLEXAIDDS_POSEBUSTERS_BIN:-$ROOT/.venv-posebusters/bin/bust}"
+test -x "$BUST"
+test -d "$ROOT/benchmarks/astex_diverse/astex_diverse"
+df -h / "$FLEXAIDDS_RESULTS"
+```
+
+The tracked Astex input manifest uses paths relative to its own location. It
+therefore works in any checkout and contains no username-specific path.
+
+## Plan One Astex Campaign
+
+Create one deterministic shard per Astex target. This makes a failed target
+independently retryable and prevents a partial 85-target process from being
+mistaken for a completed campaign.
+
+```bash
+CODES="/private/tmp/astex-diverse-85.txt"
+sed -n '/^targets:/,/^metrics:/p' "$ROOT/benchmarks/datasets/astex_diverse.yaml" \
+  | awk '/^  - / { print toupper($2) }' > "$CODES"
+test "$(wc -l < "$CODES" | tr -d ' ')" = 85
+
+RUN_ID="astex-defined-cleft-$(date -u +%Y%m%dT%H%M%SZ)"
+CAMPAIGN="$FLEXAIDDS_RESULTS/campaigns/$RUN_ID"
+
+python3 "$ROOT/python/flexaidds/fleet.py" plan "$CAMPAIGN" \
+  --campaign-id "$RUN_ID" \
+  --runner "$BUILD/benchmark_datasets" \
+  --engine "$BUILD/FlexAIDdS" \
+  --posebusters-bin "$BUST" \
+  --benchmark "crossdock_json:$ROOT/benchmarks/datasets/benchmark_astex_native_85.json" \
+  --dataset astex-diverse \
+  --mode defined-cleft-redock \
+  --codes-file "$CODES" \
+  --chunks 85 \
+  --threads 1 \
+  --omp-threads 4 \
+  --ga-population 1000 \
+  --ga-generations 6000 \
+  --temperature 298 \
+  --job-timeout-seconds 10800 \
+  --min-free-gb 5 \
+  --env FLEXAIDDS_RESTARTS=5 \
+  --env FLEXAIDDS_PARALLEL_RESTARTS=0 \
+  --env FLEXAIDDS_VCT_R0=4 \
+  --env SHARING_ALPHA=4 \
+  --env EVAL_SCALE_DIHEDRAL=-1
+```
+
+`manifest.json` and `manifest.sha256` are immutable. Fleet also pins the SHA-256
+of `benchmark_datasets`, `FlexAIDdS`, and `bust`. If any binary changes, resume
+stops instead of silently mixing methods.
+
+## Run, Monitor, and Resume
+
+Use one worker on the 18 GB M3 Pro. The compute tree stays under
+`/private/tmp/flexaidds_fleet`; only a verified archive is committed to iCloud.
+
+```bash
+caffeinate -i -s python3 "$ROOT/python/flexaidds/fleet.py" run "$CAMPAIGN" \
+  --worker-id m3pro-primary
+```
+
+Any agent can monitor without claiming work:
+
+```bash
+python3 "$ROOT/python/flexaidds/fleet.py" status "$CAMPAIGN"
+df -h / "$FLEXAIDDS_RESULTS"
+```
+
+If the worker or machine stops, run the same command with `resume`. Live leases
+are left alone; stale leases are fenced with a higher epoch and the old attempt
+cannot publish an accepted result.
+
+```bash
+caffeinate -i -s python3 "$ROOT/python/flexaidds/fleet.py" resume "$CAMPAIGN" \
+  --worker-id m3pro-primary
+```
+
+Do not use `--force`, delete claims, edit the manifest, or launch another
+campaign into the same directory.
+
+## Aggregate and Report
+
+```bash
+python3 "$ROOT/python/flexaidds/fleet.py" aggregate "$CAMPAIGN"
+cat "$CAMPAIGN/aggregate/summary.json"
+```
+
+Long-term claim artifacts are:
+
+- `manifest.json` plus `manifest.sha256`: protocol and executable pins.
+- `attempts/<chunk>/<attempt>.json`: immutable terminal attempt history.
+- `artifacts/<chunk>/<attempt>/`: verified iCloud copy of logs, poses, validator
+  files, reports, and the C++ Fleet chunk result.
+- `chunks/<chunk>/result.json`: accepted commit manifest, written last.
+- `aggregate/targets.csv`: one row per elected pose.
+- `aggregate/summary.json`: strict `success_pb` and `claim_ready` rates.
+
+The dashboard server is local-only by default:
+
+```bash
+python3 "$ROOT/benchmarks/m3pro/dashboard/fleet_status_server.py" \
+  --host 127.0.0.1 --port 8787
+```
+
+Cross-origin browser access requires an explicit exact `--cors-origin`. Fleet
+does not currently add application-level encryption; confidentiality is the
+responsibility of local disk and iCloud account protection.

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -465,21 +465,27 @@ Requires: `pip install -e ./python`
 
 ## Bonhomme Fleet (Distributed Docking)
 
-Fleet distributes docking workloads across Apple devices via iCloud Drive coordination.
+Fleet provides resumable, target-sharded DatasetRunner execution with verified
+iCloud archival. Its file contract allows different coding agents or terminals
+to monitor and resume the same campaign without duplicate accepted work.
 
 ### Architecture
 
-- **FleetScheduler** (Swift actor) — coordinates work chunks across devices
-- **Device-aware weighting** — adjusts for battery level, thermal state, and TFLOPS
-- **Orphan recovery** — timed-out chunks reclaimed with exponential backoff
-- **Encrypted transit** — ChaChaPoly encryption for secure computation
-- **TypeScript PWA** — real-time Fleet dashboard with Mol* 3D viewer
+- **Immutable manifest** - pins runner, engine, PoseBusters, protocol, and target shards
+- **Lease fencing** - stale attempts cannot publish an accepted result
+- **Local compute** - avoids running active SQLite-like workflows directly in iCloud
+- **Verified archive** - copies results to iCloud, hashes the copied tree, then commits
+- **Strict aggregation** - separates execution, RMSD, PoseBusters, and claim-ready rates
 
 ### Requirements
 
-- macOS 14+ / iOS 17+ (Swift package)
-- iCloud Drive enabled across participating devices
-- FlexAID∆S built with Metal acceleration recommended
+- Python 3.9+, `benchmark_datasets`, `FlexAIDdS`, and official PoseBusters `bust`
+- Built-in tENCoM/Eigen enabled; Fleet refuses a manifest that disables it
+- A local compute directory and an iCloud-backed campaign directory
+
+See [Bonhomme Fleet Benchmarks](FLEET_BENCHMARKS.md) for exact M3 Pro build,
+plan, run, monitor, resume, and aggregate commands. The Swift scheduler and
+TypeScript PWA remain experimental clients of this file contract.
 
 ---
 

--- a/python/flexaidds/fleet.py
+++ b/python/flexaidds/fleet.py
@@ -1,0 +1,972 @@
+"""Bonhomme Fleet: resumable DatasetRunner orchestration with iCloud archival.
+
+The controller uses only the Python standard library. Docking remains in the
+version-pinned ``benchmark_datasets`` and ``FlexAIDdS`` binaries.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+
+SCHEMA_VERSION = 1
+ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+SAFE_ENV_KEYS = {
+    "EVAL_SCALE_DIHEDRAL",
+    "FLEXAIDDS_HVIB",
+    "FLEXAIDDS_NATIVE_SEED_FRAC",
+    "FLEXAIDDS_PARALLEL_RESTARTS",
+    "FLEXAIDDS_POSEBUST_BACKEND",
+    "FLEXAIDDS_POSEBUSTERS_BIN",
+    "FLEXAIDDS_RECEPTOR_ROTAMER_PREP",
+    "FLEXAIDDS_RESTARTS",
+    "FLEXAIDDS_SEED_ELITISM",
+    "FLEXAIDDS_TENCOM_BIN",
+    "FLEXAIDDS_THERMO",
+    "FLEXAIDDS_VCT_R0",
+    "OMP_NUM_THREADS",
+    "SHARING_ALPHA",
+}
+SECRET_KEY_PATTERN = re.compile(r"(?:TOKEN|SECRET|PASSWORD|CREDENTIAL|API_KEY)", re.I)
+
+
+class FleetError(RuntimeError):
+    pass
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_time(value: str) -> float:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+
+
+def _canonical_json(data: Any) -> bytes:
+    return (json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n").encode()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def tree_sha256(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        digest.update(relative)
+        digest.update(b"\0")
+        digest.update(sha256_file(path).encode("ascii"))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        fd = os.open(str(path), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def atomic_write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp-{uuid.uuid4().hex}")
+    payload = _canonical_json(data)
+    with temporary.open("xb") as stream:
+        stream.write(payload)
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, path)
+    _fsync_directory(path.parent)
+
+
+def exclusive_write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(_canonical_json(data))
+            stream.flush()
+            os.fsync(stream.fileno())
+    except BaseException:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise
+    _fsync_directory(path.parent)
+
+
+def read_json(path: Path) -> Dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            data = json.load(stream)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise FleetError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise FleetError(f"expected JSON object in {path}")
+    return data
+
+
+def confined_path(root: Path, *parts: str) -> Path:
+    base = root.resolve()
+    candidate = base.joinpath(*parts).resolve(strict=False)
+    try:
+        common = Path(os.path.commonpath((str(base), str(candidate))))
+    except ValueError as exc:
+        raise FleetError("path is outside campaign root") from exc
+    if common != base:
+        raise FleetError("path is outside campaign root")
+    return candidate
+
+
+def validate_id(value: str, label: str) -> str:
+    if not ID_PATTERN.fullmatch(value):
+        raise FleetError(f"invalid {label}: {value!r}")
+    return value
+
+
+def parse_codes(path: Path) -> List[str]:
+    codes: List[str] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].replace(",", " ")
+        codes.extend(token.upper() for token in line.split())
+    if not codes:
+        raise FleetError(f"no target codes found in {path}")
+    if len(set(codes)) != len(codes):
+        raise FleetError("target code list contains duplicates")
+    for code in codes:
+        validate_id(code, "target code")
+    return codes
+
+
+def parse_environment(items: Sequence[str]) -> Dict[str, str]:
+    environment: Dict[str, str] = {}
+    for item in items:
+        if "=" not in item:
+            raise FleetError(f"environment override must be KEY=VALUE: {item!r}")
+        key, value = item.split("=", 1)
+        if SECRET_KEY_PATTERN.search(key) or key not in SAFE_ENV_KEYS:
+            raise FleetError(f"environment key is not allowed in Fleet manifests: {key}")
+        environment[key] = value
+    return dict(sorted(environment.items()))
+
+
+def _manifest_paths(campaign: Path) -> Tuple[Path, Path]:
+    return campaign / "manifest.json", campaign / "manifest.sha256"
+
+
+def load_manifest(campaign: Path) -> Tuple[Dict[str, Any], str]:
+    manifest_path, hash_path = _manifest_paths(campaign)
+    manifest = read_json(manifest_path)
+    try:
+        expected = hash_path.read_text(encoding="ascii").strip()
+    except OSError as exc:
+        raise FleetError(f"cannot read manifest hash: {exc}") from exc
+    actual = sha256_file(manifest_path)
+    if actual != expected:
+        raise FleetError(f"campaign manifest hash mismatch: expected {expected}, got {actual}")
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise FleetError("unsupported Fleet manifest schema")
+    return manifest, actual
+
+
+def plan_campaign(args: argparse.Namespace) -> Dict[str, Any]:
+    campaign = Path(args.campaign).expanduser().resolve()
+    if campaign.exists() and any(campaign.iterdir()):
+        raise FleetError(f"campaign directory is not empty: {campaign}")
+
+    campaign_id = validate_id(args.campaign_id or campaign.name, "campaign ID")
+    runner = Path(args.runner).expanduser().resolve()
+    engine = Path(args.engine).expanduser().resolve() if args.engine else runner.with_name("FlexAIDdS")
+    for label, binary in (("runner", runner), ("engine", engine)):
+        if not binary.is_file():
+            raise FleetError(f"{label} binary does not exist: {binary}")
+    posebusters = Path(args.posebusters_bin).expanduser().resolve() if args.posebusters_bin else None
+    if posebusters is None:
+        env_bust = os.environ.get("FLEXAIDDS_POSEBUSTERS_BIN")
+        discovered = env_bust or shutil.which("bust")
+        posebusters = Path(discovered).expanduser().resolve() if discovered else None
+    if posebusters is None or not posebusters.is_file() or not os.access(posebusters, os.X_OK):
+        raise FleetError("official PoseBusters 'bust' executable is required; use --posebusters-bin")
+
+    codes = parse_codes(Path(args.codes_file).expanduser().resolve())
+    if args.chunks < 1 or args.chunks > len(codes):
+        raise FleetError("--chunks must be between 1 and the number of target codes")
+    shards = [codes[index::args.chunks] for index in range(args.chunks)]
+    chunks = [
+        {"id": f"chunk-{index:04d}", "index": index, "codes": shard}
+        for index, shard in enumerate(shards)
+    ]
+
+    compute_root = Path(args.compute_root).expanduser().resolve()
+    environment = parse_environment(args.env)
+    required_environment = {
+        "FLEXAIDDS_HVIB": "1",
+        "FLEXAIDDS_NATIVE_SEED_FRAC": "0",
+        "FLEXAIDDS_POSEBUST_BACKEND": "bust_cli",
+        "FLEXAIDDS_POSEBUSTERS_BIN": str(posebusters),
+        "FLEXAIDDS_SEED_ELITISM": "0",
+    }
+    for key, required_value in required_environment.items():
+        if key in environment and environment[key] != required_value:
+            raise FleetError(f"production Fleet requires {key}={required_value}")
+        environment[key] = required_value
+
+    if args.threads < 1 or args.omp_threads < 1:
+        raise FleetError("thread counts must be positive")
+    if args.ga_population < 1 or args.ga_generations < 1:
+        raise FleetError("GA population and generations must be positive")
+    if args.lease_seconds < 30 or args.max_attempts < 1 or args.min_free_gb < 0:
+        raise FleetError("lease must be >=30 s, attempts >=1, and free-space guard non-negative")
+
+    manifest: Dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "type": "flexaidds-fleet-campaign",
+        "campaign_id": campaign_id,
+        "created_at": utc_now(),
+        "dataset": args.dataset or args.benchmark,
+        "benchmark": args.benchmark,
+        "runner": {"path": str(runner), "sha256": sha256_file(runner)},
+        "engine": {"path": str(engine), "sha256": sha256_file(engine)},
+        "validators": {
+            "posebusters": {
+                "backend": "bust_cli",
+                "path": str(posebusters),
+                "sha256": sha256_file(posebusters),
+            },
+            "tencom_eigen": {"backend": "dataset_runner_builtin", "required": True},
+        },
+        "protocol": {
+            "mode": args.mode,
+            "threads": args.threads,
+            "omp_threads": args.omp_threads,
+            "ga_population": args.ga_population,
+            "ga_generations": args.ga_generations,
+            "temperature_k": args.temperature,
+            "grid_spacing_a": args.grid_spacing,
+            "job_timeout_s": args.job_timeout_seconds,
+            "clustering": args.clustering,
+            "gpu_backend": args.gpu,
+            "cache": str(Path(args.cache).expanduser().resolve()) if args.cache else None,
+        },
+        "environment": dict(sorted(environment.items())),
+        "compute_root": str(compute_root),
+        "lease_seconds": args.lease_seconds,
+        "max_attempts": args.max_attempts,
+        "min_free_bytes": int(args.min_free_gb * 1024**3),
+        "chunks": chunks,
+    }
+    if manifest["protocol"]["mode"] == "oracle-ceiling":
+        raise FleetError("oracle-ceiling is diagnostic-only and is not accepted by Fleet production planning")
+
+    campaign.mkdir(parents=True, exist_ok=True)
+    for directory in ("chunks", "attempts", "heartbeats", "artifacts", "quarantine", "aggregate"):
+        (campaign / directory).mkdir()
+    manifest_path, hash_path = _manifest_paths(campaign)
+    exclusive_write_json(manifest_path, manifest)
+    manifest_hash = sha256_file(manifest_path)
+    with hash_path.open("x", encoding="ascii") as stream:
+        stream.write(manifest_hash + "\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    _fsync_directory(campaign)
+    return {"campaign": str(campaign), "manifest_sha256": manifest_hash, "chunks": len(chunks)}
+
+
+def _chunk_dir(campaign: Path, chunk_id: str) -> Path:
+    validate_id(chunk_id, "chunk ID")
+    path = confined_path(campaign, "chunks", chunk_id)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _attempt_files(campaign: Path, chunk_id: str) -> List[Path]:
+    directory = confined_path(campaign, "attempts", chunk_id)
+    return sorted(directory.glob("*.json")) if directory.is_dir() else []
+
+
+def _heartbeat_path(campaign: Path, claim: Mapping[str, Any]) -> Path:
+    return confined_path(
+        campaign, "heartbeats", str(claim["chunk_id"]), f"{claim['lease_token']}.json"
+    )
+
+
+def lease_owned(campaign: Path, claim: Mapping[str, Any]) -> bool:
+    claim_path = _chunk_dir(campaign, str(claim["chunk_id"])) / "claim.json"
+    try:
+        current = read_json(claim_path)
+    except FleetError:
+        return False
+    return current.get("lease_token") == claim.get("lease_token") and current.get("lease_epoch") == claim.get("lease_epoch")
+
+
+def write_heartbeat(campaign: Path, claim: Mapping[str, Any]) -> bool:
+    if not lease_owned(campaign, claim):
+        return False
+    atomic_write_json(_heartbeat_path(campaign, claim), {
+        "campaign_id": claim["campaign_id"],
+        "chunk_id": claim["chunk_id"],
+        "attempt_id": claim["attempt_id"],
+        "lease_token": claim["lease_token"],
+        "lease_epoch": claim["lease_epoch"],
+        "worker_id": claim["worker_id"],
+        "timestamp": utc_now(),
+    })
+    return lease_owned(campaign, claim)
+
+
+def claim_is_stale(campaign: Path, claim: Mapping[str, Any], lease_seconds: int) -> bool:
+    heartbeat = _heartbeat_path(campaign, claim)
+    timestamp = str(claim.get("claimed_at", "1970-01-01T00:00:00Z"))
+    if heartbeat.is_file():
+        try:
+            timestamp = str(read_json(heartbeat).get("timestamp", timestamp))
+        except FleetError:
+            pass
+    try:
+        age = time.time() - _parse_time(timestamp)
+    except (TypeError, ValueError):
+        return True
+    return age > lease_seconds
+
+
+def _new_claim(manifest: Mapping[str, Any], chunk_id: str, worker_id: str, epoch: int) -> Dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "campaign_id": manifest["campaign_id"],
+        "chunk_id": chunk_id,
+        "attempt_id": f"attempt-{uuid.uuid4().hex}",
+        "lease_token": uuid.uuid4().hex,
+        "lease_epoch": epoch,
+        "worker_id": worker_id,
+        "pid": os.getpid(),
+        "claimed_at": utc_now(),
+    }
+
+
+def _acquire_chunk_lock(
+    campaign: Path, manifest: Mapping[str, Any], chunk_id: str, worker_id: str
+) -> Optional[Dict[str, Any]]:
+    lock_path = _chunk_dir(campaign, chunk_id) / "lease.lock"
+    lock = {"token": uuid.uuid4().hex, "worker_id": worker_id, "timestamp": utc_now()}
+    try:
+        exclusive_write_json(lock_path, lock)
+        return lock
+    except FileExistsError:
+        try:
+            existing = read_json(lock_path)
+            age = time.time() - _parse_time(str(existing.get("timestamp", "")))
+            if age <= int(manifest["lease_seconds"]):
+                return None
+            lock_path.unlink()
+            exclusive_write_json(lock_path, lock)
+            return lock
+        except (FleetError, FileExistsError, OSError, TypeError, ValueError):
+            return None
+
+
+def _release_chunk_lock(campaign: Path, chunk_id: str, lock: Mapping[str, Any]) -> None:
+    lock_path = _chunk_dir(campaign, chunk_id) / "lease.lock"
+    try:
+        if read_json(lock_path).get("token") == lock.get("token"):
+            lock_path.unlink()
+    except (FleetError, OSError):
+        pass
+
+
+def _reclaim_stale(campaign: Path, manifest: Mapping[str, Any], chunk_id: str, worker_id: str) -> Optional[Dict[str, Any]]:
+    chunk_dir = _chunk_dir(campaign, chunk_id)
+    claim_path = chunk_dir / "claim.json"
+    lock = _acquire_chunk_lock(campaign, manifest, chunk_id, worker_id)
+    if lock is None:
+        return None
+
+    try:
+        try:
+            old_claim = read_json(claim_path)
+        except FleetError:
+            return None
+        if not claim_is_stale(campaign, old_claim, int(manifest["lease_seconds"])):
+            return None
+        claim = _new_claim(manifest, chunk_id, worker_id, int(old_claim.get("lease_epoch", 0)) + 1)
+        atomic_write_json(claim_path, claim)
+        write_heartbeat(campaign, claim)
+        return claim
+    finally:
+        _release_chunk_lock(campaign, chunk_id, lock)
+
+
+def claim_next(campaign: Path, manifest: Mapping[str, Any], worker_id: str) -> Optional[Tuple[Dict[str, Any], Dict[str, Any]]]:
+    validate_id(worker_id, "worker ID")
+    for chunk in manifest["chunks"]:
+        chunk_id = str(chunk["id"])
+        chunk_dir = _chunk_dir(campaign, chunk_id)
+        if (chunk_dir / "result.json").is_file():
+            continue
+        if len(_attempt_files(campaign, chunk_id)) >= int(manifest["max_attempts"]):
+            continue
+        claim = _new_claim(manifest, chunk_id, worker_id, 1)
+        try:
+            exclusive_write_json(chunk_dir / "claim.json", claim)
+            write_heartbeat(campaign, claim)
+            return dict(chunk), claim
+        except FileExistsError:
+            try:
+                old_claim = read_json(chunk_dir / "claim.json")
+            except FleetError:
+                continue
+            if claim_is_stale(campaign, old_claim, int(manifest["lease_seconds"])):
+                reclaimed = _reclaim_stale(campaign, manifest, chunk_id, worker_id)
+                if reclaimed is not None:
+                    return dict(chunk), reclaimed
+    return None
+
+
+def release_claim(
+    campaign: Path, manifest: Mapping[str, Any], claim: Mapping[str, Any]
+) -> None:
+    lock = _acquire_chunk_lock(
+        campaign, manifest, str(claim["chunk_id"]), str(claim["worker_id"])
+    )
+    if lock is None:
+        return
+    claim_path = _chunk_dir(campaign, str(claim["chunk_id"])) / "claim.json"
+    try:
+        if lease_owned(campaign, claim):
+            claim_path.unlink()
+    finally:
+        _release_chunk_lock(campaign, str(claim["chunk_id"]), lock)
+
+
+def verify_binary_pins(manifest: Mapping[str, Any]) -> None:
+    for label in ("runner", "engine"):
+        path = Path(str(manifest[label]["path"]))
+        if not path.is_file():
+            raise FleetError(f"pinned {label} binary is missing: {path}")
+        actual = sha256_file(path)
+        if actual != manifest[label]["sha256"]:
+            raise FleetError(f"pinned {label} binary changed: expected {manifest[label]['sha256']}, got {actual}")
+    posebusters = manifest["validators"]["posebusters"]
+    pb_path = Path(str(posebusters["path"]))
+    if not pb_path.is_file() or not os.access(pb_path, os.X_OK):
+        raise FleetError(f"pinned PoseBusters executable is missing: {pb_path}")
+    actual_pb = sha256_file(pb_path)
+    if actual_pb != posebusters["sha256"]:
+        raise FleetError(
+            f"pinned PoseBusters executable changed: expected {posebusters['sha256']}, got {actual_pb}"
+        )
+
+
+def summary_matches_chunk(
+    summary: Mapping[str, Any], manifest: Mapping[str, Any], manifest_hash: str,
+    chunk: Mapping[str, Any], claim: Mapping[str, Any],
+) -> bool:
+    targets = summary.get("targets")
+    if not isinstance(targets, list) or not all(isinstance(target, dict) for target in targets):
+        return False
+    expected_codes = [str(code).upper() for code in chunk["codes"]]
+    actual_codes = [str(target.get("pdb_id", "")).upper() for target in targets]
+    target_summary = summary.get("summary")
+    target_count_matches = (
+        isinstance(target_summary, dict)
+        and target_summary.get("target_count") == len(expected_codes)
+    )
+    return all((
+        summary.get("schema_version") == SCHEMA_VERSION,
+        summary.get("type") == "flexaidds-fleet-chunk-result",
+        summary.get("campaign_id") == manifest["campaign_id"],
+        summary.get("chunk_id") == chunk["id"],
+        summary.get("attempt_id") == claim["attempt_id"],
+        summary.get("worker_id") == claim["worker_id"],
+        summary.get("dataset") == manifest["benchmark"],
+        target_count_matches,
+        len(actual_codes) == len(expected_codes),
+        len(set(actual_codes)) == len(actual_codes),
+        set(actual_codes) == set(expected_codes),
+        summary.get("provenance", {}).get("manifest_sha256") == manifest_hash,
+        summary.get("provenance", {}).get("runner_sha256") == manifest["runner"]["sha256"],
+        summary.get("provenance", {}).get("engine_sha256") == manifest["engine"]["sha256"],
+    ))
+
+
+def build_runner_command(
+    manifest: Mapping[str, Any], manifest_hash: str, chunk: Mapping[str, Any],
+    claim: Mapping[str, Any], local_root: Path,
+) -> List[str]:
+    protocol = manifest["protocol"]
+    command = [
+        str(manifest["runner"]["path"]),
+        "--fleet",
+        "--campaign-id", str(manifest["campaign_id"]),
+        "--chunk-id", str(chunk["id"]),
+        "--attempt-id", str(claim["attempt_id"]),
+        "--worker-id", str(claim["worker_id"]),
+        "--manifest-sha256", manifest_hash,
+        "--runner-sha256", str(manifest["runner"]["sha256"]),
+        "--engine-sha256", str(manifest["engine"]["sha256"]),
+        "--output-json", str(local_root / "fleet_chunk_result.json"),
+        "--benchmark", str(manifest["benchmark"]),
+        "--output", str(local_root / "outputs"),
+        "--only-codes", ",".join(chunk["codes"]),
+        "--mode", str(protocol["mode"]),
+        "--threads", str(protocol["threads"]),
+        "--omp-threads", str(protocol["omp_threads"]),
+        "--ga-population", str(protocol["ga_population"]),
+        "--ga-generations", str(protocol["ga_generations"]),
+        "--temperature", str(protocol["temperature_k"]),
+        "--grid-spacing", str(protocol["grid_spacing_a"]),
+        "--job-timeout-seconds", str(protocol["job_timeout_s"]),
+        "--clustering", str(protocol["clustering"]),
+    ]
+    if protocol.get("cache"):
+        command.extend(("--cache", str(protocol["cache"])))
+    if protocol.get("gpu_backend"):
+        command.extend(("--gpu", str(protocol["gpu_backend"])))
+    return command
+
+
+def copy_tree_verified(source: Path, destination: Path) -> str:
+    if destination.exists():
+        raise FleetError(f"immutable archive already exists: {destination}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.tmp-{uuid.uuid4().hex}")
+    source_hash = tree_sha256(source)
+    shutil.copytree(source, temporary, copy_function=shutil.copy2)
+    copied_hash = tree_sha256(temporary)
+    if copied_hash != source_hash:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise FleetError(f"archive verification failed: source {source_hash}, copy {copied_hash}")
+    os.replace(temporary, destination)
+    _fsync_directory(destination.parent)
+    final_hash = tree_sha256(destination)
+    if final_hash != source_hash:
+        raise FleetError(f"archive changed after publication: expected {source_hash}, got {final_hash}")
+    return source_hash
+
+
+def _attempt_record_path(campaign: Path, claim: Mapping[str, Any]) -> Path:
+    return confined_path(campaign, "attempts", str(claim["chunk_id"]), f"{claim['attempt_id']}.json")
+
+
+def _quarantine(campaign: Path, claim: Mapping[str, Any], record: Mapping[str, Any]) -> None:
+    path = confined_path(campaign, "quarantine", str(claim["chunk_id"]), f"{claim['attempt_id']}.json")
+    exclusive_write_json(path, dict(record))
+
+
+def run_claim(
+    campaign: Path, manifest: Mapping[str, Any], manifest_hash: str,
+    chunk: Mapping[str, Any], claim: Mapping[str, Any], keep_local: bool,
+) -> bool:
+    verify_binary_pins(manifest)
+    compute_root = Path(str(manifest["compute_root"]))
+    compute_root.mkdir(parents=True, exist_ok=True)
+    free_bytes = shutil.disk_usage(compute_root).free
+    if free_bytes < int(manifest["min_free_bytes"]):
+        raise FleetError(f"local free-space guard failed: {free_bytes} bytes available")
+
+    local_root = compute_root / str(manifest["campaign_id"]) / str(chunk["id"]) / str(claim["attempt_id"])
+    local_root.mkdir(parents=True, exist_ok=False)
+    (local_root / "outputs").mkdir()
+    command = build_runner_command(manifest, manifest_hash, chunk, claim, local_root)
+    environment = os.environ.copy()
+    environment.update({str(key): str(value) for key, value in manifest["environment"].items()})
+    environment["FLEXAIDDS_BINARY"] = str(manifest["engine"]["path"])
+
+    started = utc_now()
+    return_code: Optional[int] = None
+    lease_lost = False
+    launch_error: Optional[str] = None
+    process = None
+    stdout_path = local_root / "runner.stdout.log"
+    stderr_path = local_root / "runner.stderr.log"
+    try:
+        with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+            try:
+                process = subprocess.Popen(command, stdout=stdout, stderr=stderr, env=environment)
+            except OSError as exc:
+                launch_error = str(exc)
+            else:
+                heartbeat_interval = max(1.0, min(10.0, int(manifest["lease_seconds"]) / 3.0))
+                while True:
+                    if not write_heartbeat(campaign, claim):
+                        lease_lost = True
+                        process.terminate()
+                        try:
+                            process.wait(timeout=10)
+                        except subprocess.TimeoutExpired:
+                            process.kill()
+                        break
+                    try:
+                        return_code = process.wait(timeout=heartbeat_interval)
+                        break
+                    except subprocess.TimeoutExpired:
+                        continue
+                if return_code is None:
+                    return_code = process.wait()
+    except KeyboardInterrupt:
+        if process is not None and process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+        raise
+
+    summary_path = local_root / "fleet_chunk_result.json"
+    summary: Optional[Dict[str, Any]] = None
+    if summary_path.is_file():
+        try:
+            summary = read_json(summary_path)
+        except FleetError:
+            summary = None
+
+    record: Dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "campaign_id": manifest["campaign_id"],
+        "chunk_id": chunk["id"],
+        "attempt_id": claim["attempt_id"],
+        "worker_id": claim["worker_id"],
+        "lease_epoch": claim["lease_epoch"],
+        "manifest_sha256": manifest_hash,
+        "started_at": started,
+        "finished_at": utc_now(),
+        "return_code": return_code,
+        "command": command,
+        "local_root": str(local_root),
+        "launch_error": launch_error,
+    }
+
+    if lease_lost or not lease_owned(campaign, claim):
+        record["status"] = "quarantined_lease_lost"
+        _quarantine(campaign, claim, record)
+        return False
+
+    valid_summary = summary is not None and summary_matches_chunk(
+        summary, manifest, manifest_hash, chunk, claim
+    )
+    if return_code != 0 or not valid_summary:
+        record["status"] = "failed"
+        record["error"] = launch_error or "runner failed or emitted an invalid Fleet summary"
+        record["stderr_path"] = str(stderr_path)
+        exclusive_write_json(_attempt_record_path(campaign, claim), record)
+        release_claim(campaign, manifest, claim)
+        return False
+
+    write_heartbeat(campaign, claim)
+    archive = confined_path(campaign, "artifacts", str(chunk["id"]), str(claim["attempt_id"]))
+    archive_hash = copy_tree_verified(local_root, archive)
+    write_heartbeat(campaign, claim)
+    record.update({
+        "status": "completed",
+        "archive": str(archive.relative_to(campaign)),
+        "archive_tree_sha256": archive_hash,
+        "summary": summary,
+    })
+    exclusive_write_json(_attempt_record_path(campaign, claim), record)
+
+    lock = _acquire_chunk_lock(
+        campaign, manifest, str(chunk["id"]), str(claim["worker_id"])
+    )
+    if lock is None:
+        record["status"] = "quarantined_publish_lock"
+        _quarantine(campaign, claim, record)
+        return False
+    try:
+        if not lease_owned(campaign, claim):
+            record["status"] = "quarantined_after_archive"
+            _quarantine(campaign, claim, record)
+            return False
+        accepted = {
+            "schema_version": SCHEMA_VERSION,
+            "status": "completed",
+            "campaign_id": manifest["campaign_id"],
+            "chunk_id": chunk["id"],
+            "attempt_id": claim["attempt_id"],
+            "worker_id": claim["worker_id"],
+            "lease_epoch": claim["lease_epoch"],
+            "manifest_sha256": manifest_hash,
+            "accepted_at": utc_now(),
+            "archive": str(archive.relative_to(campaign)),
+            "archive_tree_sha256": archive_hash,
+            "summary": summary,
+        }
+        exclusive_write_json(_chunk_dir(campaign, str(chunk["id"])) / "result.json", accepted)
+        claim_path = _chunk_dir(campaign, str(chunk["id"])) / "claim.json"
+        if lease_owned(campaign, claim):
+            claim_path.unlink()
+    finally:
+        _release_chunk_lock(campaign, str(chunk["id"]), lock)
+    if not keep_local:
+        shutil.rmtree(local_root, ignore_errors=True)
+    return True
+
+
+def campaign_snapshot(campaign: Path, manifest: Mapping[str, Any], write: bool = True) -> Dict[str, Any]:
+    states = {"completed": 0, "running": 0, "stale": 0, "failed": 0, "pending": 0}
+    active_chunks: List[Dict[str, Any]] = []
+    devices: Dict[str, Dict[str, Any]] = {}
+    for chunk in manifest["chunks"]:
+        chunk_id = str(chunk["id"])
+        chunk_dir = _chunk_dir(campaign, chunk_id)
+        if (chunk_dir / "result.json").is_file():
+            states["completed"] += 1
+            continue
+        attempts = len(_attempt_files(campaign, chunk_id))
+        claim_path = chunk_dir / "claim.json"
+        if claim_path.is_file():
+            try:
+                claim = read_json(claim_path)
+                stale = claim_is_stale(campaign, claim, int(manifest["lease_seconds"]))
+                state = "stale" if stale else "running"
+                states[state] += 1
+                active_chunks.append({
+                    "id": chunk_id,
+                    "status": state,
+                    "claimedBy": claim.get("worker_id"),
+                    "attemptID": claim.get("attempt_id"),
+                    "leaseEpoch": claim.get("lease_epoch"),
+                })
+                if not stale:
+                    worker = str(claim.get("worker_id", "unknown"))
+                    devices[worker] = {"deviceID": worker, "model": worker, "thermalState": "unknown"}
+                continue
+            except FleetError:
+                states["stale"] += 1
+                continue
+        if attempts >= int(manifest["max_attempts"]):
+            states["failed"] += 1
+        else:
+            states["pending"] += 1
+
+    old_revision = 0
+    status_path = campaign / "status.json"
+    if status_path.is_file():
+        try:
+            old_revision = int(read_json(status_path).get("revision", 0))
+        except FleetError:
+            pass
+    total = len(manifest["chunks"])
+    snapshot: Dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "campaign_id": manifest["campaign_id"],
+        "dataset": manifest["dataset"],
+        "timestamp": utc_now(),
+        "revision": old_revision + 1,
+        "states": states,
+        "devices": list(devices.values()),
+        "activeChunks": active_chunks,
+        "completedChunks": states["completed"],
+        "totalChunks": total,
+        "failedChunks": states["failed"],
+        "orphanedChunks": states["stale"],
+        "metrics": {
+            "jobID": manifest["campaign_id"],
+            "totalChunks": total,
+            "completedChunks": states["completed"],
+            "failedChunks": states["failed"],
+            "orphanedChunks": states["stale"],
+            "activeDevices": len(devices),
+            "totalTFLOPS": 0.0,
+            "meanChunkTimeSeconds": None,
+            "estimatedRemainingSeconds": None,
+            "timestamp": utc_now(),
+        },
+    }
+    if write:
+        atomic_write_json(status_path, snapshot)
+    return snapshot
+
+
+def run_worker(args: argparse.Namespace) -> int:
+    campaign = Path(args.campaign).expanduser().resolve()
+    manifest, manifest_hash = load_manifest(campaign)
+    worker_id = validate_id(args.worker_id or f"{socket.gethostname()}-{os.getpid()}", "worker ID")
+    attempted = 0
+    while True:
+        claimed = claim_next(campaign, manifest, worker_id)
+        if claimed is None:
+            campaign_snapshot(campaign, manifest)
+            return 0
+        chunk, claim = claimed
+        attempted += 1
+        try:
+            run_claim(campaign, manifest, manifest_hash, chunk, claim, args.keep_local)
+        except BaseException:
+            if lease_owned(campaign, claim):
+                release_claim(campaign, manifest, claim)
+            raise
+        finally:
+            campaign_snapshot(campaign, manifest)
+        if args.once or attempted >= args.max_chunks:
+            return 0
+
+
+AGGREGATE_FIELDS = [
+    "campaign_id", "chunk_id", "attempt_id", "pdb_id", "execution_completed",
+    "rmsd_hungarian_a", "success_rmsd", "posebusters_ran", "posebusters_pass",
+    "success_pb", "tencom_status", "eigen_status", "validators_complete",
+    "protocol_claim_eligible", "claim_ready", "seed_echo", "pose_source",
+    "pose_sha256", "rmsd_pose_sha256", "posebusters_pose_sha256",
+    "tencom_pose_sha256", "elected_pose_path", "elected_pose_source",
+    "elected_restart", "elected_cluster", "elected_cf", "best_cluster_rmsd_a",
+]
+
+
+def aggregate_campaign(campaign: Path, manifest: Mapping[str, Any], manifest_hash: str) -> Dict[str, Any]:
+    rows: List[Dict[str, Any]] = []
+    completed_chunks = 0
+    for chunk in manifest["chunks"]:
+        result_path = _chunk_dir(campaign, str(chunk["id"])) / "result.json"
+        if not result_path.is_file():
+            continue
+        result = read_json(result_path)
+        if result.get("manifest_sha256") != manifest_hash:
+            raise FleetError(f"chunk result has wrong manifest hash: {result_path}")
+        completed_chunks += 1
+        summary = result.get("summary", {})
+        for target in summary.get("targets", []):
+            row = {field: target.get(field) for field in AGGREGATE_FIELDS}
+            row.update({
+                "campaign_id": manifest["campaign_id"],
+                "chunk_id": chunk["id"],
+                "attempt_id": result["attempt_id"],
+            })
+            rows.append(row)
+
+    aggregate_dir = campaign / "aggregate"
+    aggregate_dir.mkdir(exist_ok=True)
+    csv_path = aggregate_dir / "targets.csv"
+    temporary = csv_path.with_name(f".{csv_path.name}.tmp-{uuid.uuid4().hex}")
+    with temporary.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=AGGREGATE_FIELDS, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, csv_path)
+
+    def count(field: str) -> int:
+        return sum(value.get(field) is True for value in rows)
+
+    total = len(rows)
+    summary = {
+        "schema_version": SCHEMA_VERSION,
+        "campaign_id": manifest["campaign_id"],
+        "manifest_sha256": manifest_hash,
+        "created_at": utc_now(),
+        "complete": completed_chunks == len(manifest["chunks"]),
+        "chunks_completed": completed_chunks,
+        "chunks_total": len(manifest["chunks"]),
+        "target_count": total,
+        "execution_completed": count("execution_completed"),
+        "success_rmsd": count("success_rmsd"),
+        "success_pb": count("success_pb"),
+        "validators_complete": count("validators_complete"),
+        "claim_ready": count("claim_ready"),
+        "success_pb_rate": count("success_pb") / total if total else 0.0,
+        "claim_ready_rate": count("claim_ready") / total if total else 0.0,
+        "targets_csv": str(csv_path),
+    }
+    atomic_write_json(aggregate_dir / "summary.json", summary)
+    return summary
+
+
+def _print_json(data: Any) -> None:
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="flexaidds-fleet", description="Bonhomme Fleet benchmark orchestrator")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plan = subparsers.add_parser("plan", help="create an immutable campaign manifest")
+    plan.add_argument("campaign")
+    plan.add_argument("--campaign-id")
+    plan.add_argument("--runner", required=True)
+    plan.add_argument("--engine")
+    plan.add_argument("--posebusters-bin")
+    plan.add_argument("--benchmark", required=True)
+    plan.add_argument("--dataset")
+    plan.add_argument("--mode", required=True, choices=("defined-cleft-redock", "autonomous"))
+    plan.add_argument("--codes-file", required=True)
+    plan.add_argument("--chunks", type=int, default=1)
+    plan.add_argument("--compute-root", default=os.environ.get("FLEXAIDDS_FLEET_COMPUTE_ROOT", "/private/tmp/flexaidds_fleet"))
+    plan.add_argument("--cache")
+    plan.add_argument("--threads", type=int, default=1)
+    plan.add_argument("--omp-threads", type=int, default=4)
+    plan.add_argument("--ga-population", type=int, default=1000)
+    plan.add_argument("--ga-generations", type=int, default=6000)
+    plan.add_argument("--temperature", type=float, default=298.0)
+    plan.add_argument("--grid-spacing", type=float, default=0.375)
+    plan.add_argument("--job-timeout-seconds", type=int, default=10800)
+    plan.add_argument("--clustering", default="CF")
+    plan.add_argument("--gpu", choices=("metal", "cuda"))
+    plan.add_argument("--lease-seconds", type=int, default=300)
+    plan.add_argument("--max-attempts", type=int, default=3)
+    plan.add_argument("--min-free-gb", type=float, default=5.0)
+    plan.add_argument("--env", action="append", default=[])
+
+    for name in ("worker", "run", "resume"):
+        worker = subparsers.add_parser(name, help="claim and execute campaign chunks")
+        worker.add_argument("campaign")
+        worker.add_argument("--worker-id")
+        worker.add_argument("--once", action="store_true")
+        worker.add_argument("--max-chunks", type=int, default=sys.maxsize)
+        worker.add_argument("--keep-local", action="store_true")
+
+    status = subparsers.add_parser("status", help="show current campaign state")
+    status.add_argument("campaign")
+
+    aggregate = subparsers.add_parser("aggregate", help="build strict target-level CSV and summary")
+    aggregate.add_argument("campaign")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "plan":
+            _print_json(plan_campaign(args))
+        elif args.command in ("worker", "run", "resume"):
+            return run_worker(args)
+        elif args.command == "status":
+            campaign = Path(args.campaign).expanduser().resolve()
+            manifest, _ = load_manifest(campaign)
+            _print_json(campaign_snapshot(campaign, manifest))
+        elif args.command == "aggregate":
+            campaign = Path(args.campaign).expanduser().resolve()
+            manifest, manifest_hash = load_manifest(campaign)
+            _print_json(aggregate_campaign(campaign, manifest, manifest_hash))
+    except (FleetError, FileExistsError, OSError, ValueError) as exc:
+        print(f"fleet error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,6 +45,7 @@ yaml = ["pyyaml>=6.0.3"]
 [project.scripts]
 flexaidds = "flexaidds.__main__:main"
 flexaidds-benchmark = "flexaidds.dataset_runner.cli:main"
+flexaidds-fleet = "flexaidds.fleet:main"
 
 [project.urls]
 Homepage = "https://github.com/LeBonhommePharma/FlexAIDdS"
@@ -86,4 +87,3 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "12.0" }
 
 [tool.cibuildwheel.windows]
 # MSVC via cibuildwheel; extension optional.
-

--- a/tests/test_fleet_benchmark.py
+++ b/tests/test_fleet_benchmark.py
@@ -1,0 +1,335 @@
+"""Bonhomme Fleet control-plane tests."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "flexaidds_fleet_module", ROOT / "python" / "flexaidds" / "fleet.py"
+)
+assert SPEC and SPEC.loader
+fleet = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(fleet)
+
+
+def _binary(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _plan_args(tmp_path: Path, **overrides: object) -> argparse.Namespace:
+    runner = _binary(tmp_path / "benchmark_datasets", "runner-v1\n")
+    engine = _binary(tmp_path / "FlexAIDdS", "engine-v1\n")
+    posebusters = _binary(tmp_path / "bust", "posebusters-v1\n")
+    codes = tmp_path / "codes.txt"
+    codes.write_text("1GPK\n1HNN\n1P62\n1Q4G\n", encoding="utf-8")
+    values = {
+        "campaign": str(tmp_path / "campaign"),
+        "campaign_id": "fleet-test",
+        "runner": str(runner),
+        "engine": str(engine),
+        "posebusters_bin": str(posebusters),
+        "benchmark": "astex",
+        "dataset": "astex-diverse",
+        "mode": "defined-cleft-redock",
+        "codes_file": str(codes),
+        "chunks": 2,
+        "compute_root": str(tmp_path / "compute"),
+        "cache": None,
+        "threads": 1,
+        "omp_threads": 4,
+        "ga_population": 1000,
+        "ga_generations": 6000,
+        "temperature": 298.0,
+        "grid_spacing": 0.375,
+        "job_timeout_seconds": 10800,
+        "clustering": "CF",
+        "gpu": None,
+        "lease_seconds": 300,
+        "max_attempts": 3,
+        "min_free_gb": 0.0,
+        "env": ["FLEXAIDDS_RESTARTS=5", "FLEXAIDDS_SEED_ELITISM=0"],
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_plan_is_deterministic_and_pins_binary_hashes(tmp_path: Path) -> None:
+    args = _plan_args(tmp_path)
+    result = fleet.plan_campaign(args)
+    campaign = Path(args.campaign)
+    manifest, manifest_hash = fleet.load_manifest(campaign)
+
+    assert result["manifest_sha256"] == manifest_hash
+    assert manifest["chunks"][0]["codes"] == ["1GPK", "1P62"]
+    assert manifest["chunks"][1]["codes"] == ["1HNN", "1Q4G"]
+    assert manifest["runner"]["sha256"] == fleet.sha256_file(Path(args.runner))
+    assert manifest["engine"]["sha256"] == fleet.sha256_file(Path(args.engine))
+    assert manifest["validators"]["posebusters"]["sha256"] == fleet.sha256_file(Path(args.posebusters_bin))
+    assert manifest["environment"]["FLEXAIDDS_HVIB"] == "1"
+    assert manifest["environment"]["FLEXAIDDS_POSEBUST_BACKEND"] == "bust_cli"
+    assert manifest["environment"]["FLEXAIDDS_POSEBUSTERS_BIN"] == str(
+        Path(args.posebusters_bin).resolve()
+    )
+    assert manifest["environment"]["FLEXAIDDS_SEED_ELITISM"] == "0"
+
+
+def test_astex_defined_cleft_manifest_is_portable_and_complete() -> None:
+    manifest_path = ROOT / "benchmarks/datasets/benchmark_astex_native_85.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    pairs = manifest["pairs"]
+
+    assert manifest["n_pairs"] == len(pairs) == 85
+    assert len({pair["receptor_id"] for pair in pairs}) == 85
+    for pair in pairs:
+        assert pair["receptor_id"] == pair["ligand_id"]
+        for field in ("receptor_pdb", "ligand_sdf", "oracle_site_pdb"):
+            value = Path(pair[field])
+            assert not value.is_absolute(), (pair["receptor_id"], field, value)
+            assert (manifest_path.parent / value).resolve().is_file(), (
+                pair["receptor_id"], field, value
+            )
+
+
+def test_claims_are_exclusive_and_stale_leases_are_fenced(tmp_path: Path) -> None:
+    args = _plan_args(tmp_path, chunks=1, lease_seconds=30)
+    fleet.plan_campaign(args)
+    campaign = Path(args.campaign)
+    manifest, _ = fleet.load_manifest(campaign)
+
+    chunk1, claim1 = fleet.claim_next(campaign, manifest, "worker-one")
+    assert chunk1["id"] == "chunk-0000"
+    assert fleet.claim_next(campaign, manifest, "worker-two") is None
+
+    heartbeat = fleet._heartbeat_path(campaign, claim1)
+    data = fleet.read_json(heartbeat)
+    data["timestamp"] = "2000-01-01T00:00:00Z"
+    fleet.atomic_write_json(heartbeat, data)
+    chunk2, claim2 = fleet.claim_next(campaign, manifest, "worker-two")
+
+    assert chunk2["id"] == chunk1["id"]
+    assert claim2["lease_epoch"] == claim1["lease_epoch"] + 1
+    assert claim2["lease_token"] != claim1["lease_token"]
+    assert not fleet.lease_owned(campaign, claim1)
+    assert fleet.lease_owned(campaign, claim2)
+
+
+def test_runner_command_contains_attempt_and_provenance_pins(tmp_path: Path) -> None:
+    args = _plan_args(tmp_path, chunks=1)
+    fleet.plan_campaign(args)
+    campaign = Path(args.campaign)
+    manifest, manifest_hash = fleet.load_manifest(campaign)
+    chunk, claim = fleet.claim_next(campaign, manifest, "worker-one")
+    command = fleet.build_runner_command(
+        manifest, manifest_hash, chunk, claim, tmp_path / "local"
+    )
+
+    assert command[command.index("--manifest-sha256") + 1] == manifest_hash
+    assert command[command.index("--runner-sha256") + 1] == manifest["runner"]["sha256"]
+    assert command[command.index("--engine-sha256") + 1] == manifest["engine"]["sha256"]
+    assert command[command.index("--attempt-id") + 1] == claim["attempt_id"]
+    assert command[command.index("--mode") + 1] == "defined-cleft-redock"
+
+
+def test_chunk_summary_requires_exact_assigned_target_set(tmp_path: Path) -> None:
+    args = _plan_args(tmp_path, chunks=1)
+    fleet.plan_campaign(args)
+    campaign = Path(args.campaign)
+    manifest, manifest_hash = fleet.load_manifest(campaign)
+    chunk, claim = fleet.claim_next(campaign, manifest, "worker-one")
+    summary = {
+        "schema_version": 1,
+        "type": "flexaidds-fleet-chunk-result",
+        "campaign_id": manifest["campaign_id"],
+        "chunk_id": chunk["id"],
+        "attempt_id": claim["attempt_id"],
+        "worker_id": claim["worker_id"],
+        "dataset": manifest["benchmark"],
+        "provenance": {
+            "manifest_sha256": manifest_hash,
+            "runner_sha256": manifest["runner"]["sha256"],
+            "engine_sha256": manifest["engine"]["sha256"],
+        },
+        "summary": {"target_count": len(chunk["codes"])},
+        "targets": [{"pdb_id": code} for code in chunk["codes"]],
+    }
+
+    assert fleet.summary_matches_chunk(summary, manifest, manifest_hash, chunk, claim)
+    summary["targets"][-1]["pdb_id"] = summary["targets"][0]["pdb_id"]
+    assert not fleet.summary_matches_chunk(summary, manifest, manifest_hash, chunk, claim)
+
+
+def test_verified_archive_is_immutable(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "result.csv").write_text("ok\n", encoding="utf-8")
+    destination = tmp_path / "archive" / "attempt-1"
+
+    expected = fleet.tree_sha256(source)
+    assert fleet.copy_tree_verified(source, destination) == expected
+    assert fleet.tree_sha256(destination) == expected
+    with pytest.raises(fleet.FleetError, match="already exists"):
+        fleet.copy_tree_verified(source, destination)
+
+
+def test_aggregate_reports_only_strict_scientific_counters(tmp_path: Path) -> None:
+    args = _plan_args(tmp_path, chunks=1)
+    fleet.plan_campaign(args)
+    campaign = Path(args.campaign)
+    manifest, manifest_hash = fleet.load_manifest(campaign)
+    chunk = manifest["chunks"][0]
+    accepted = {
+        "schema_version": 1,
+        "status": "completed",
+        "campaign_id": manifest["campaign_id"],
+        "chunk_id": chunk["id"],
+        "attempt_id": "attempt-fixed",
+        "worker_id": "worker-one",
+        "lease_epoch": 1,
+        "manifest_sha256": manifest_hash,
+        "accepted_at": fleet.utc_now(),
+        "archive": "artifacts/chunk-0000/attempt-fixed",
+        "archive_tree_sha256": "a" * 64,
+        "summary": {
+            "targets": [
+                {
+                    "pdb_id": "1GPK",
+                    "execution_completed": True,
+                    "success_rmsd": True,
+                    "posebusters_ran": True,
+                    "posebusters_pass": False,
+                    "success_pb": False,
+                    "tencom_status": "ok",
+                    "eigen_status": "ok",
+                    "validators_complete": True,
+                    "protocol_claim_eligible": True,
+                    "claim_ready": False,
+                },
+                {
+                    "pdb_id": "1HNN",
+                    "execution_completed": True,
+                    "success_rmsd": True,
+                    "posebusters_ran": True,
+                    "posebusters_pass": True,
+                    "success_pb": True,
+                    "tencom_status": "ok",
+                    "eigen_status": "ok",
+                    "validators_complete": True,
+                    "protocol_claim_eligible": True,
+                    "claim_ready": True,
+                },
+            ]
+        },
+    }
+    fleet.exclusive_write_json(
+        fleet._chunk_dir(campaign, chunk["id"]) / "result.json", accepted
+    )
+
+    summary = fleet.aggregate_campaign(campaign, manifest, manifest_hash)
+    assert summary["execution_completed"] == 2
+    assert summary["success_rmsd"] == 2
+    assert summary["success_pb"] == 1
+    assert summary["claim_ready"] == 1
+    assert summary["success_pb_rate"] == 0.5
+
+
+def test_secret_or_unknown_environment_keys_are_rejected() -> None:
+    with pytest.raises(fleet.FleetError, match="not allowed"):
+        fleet.parse_environment(["OPENAI_API_KEY=secret"])
+    with pytest.raises(fleet.FleetError, match="not allowed"):
+        fleet.parse_environment(["UNREVIEWED_KNOB=1"])
+
+
+def test_campaign_paths_reject_traversal(tmp_path: Path) -> None:
+    with pytest.raises(fleet.FleetError, match="outside campaign"):
+        fleet.confined_path(tmp_path / "campaign", "chunks", "..", "..", "escape")
+
+
+def test_oracle_campaign_is_rejected_as_production_fleet(tmp_path: Path) -> None:
+    args = _plan_args(tmp_path, mode="oracle-ceiling")
+    with pytest.raises(fleet.FleetError, match="diagnostic-only"):
+        fleet.plan_campaign(args)
+
+
+def test_end_to_end_worker_archives_then_commits_and_aggregates(tmp_path: Path) -> None:
+    args = _plan_args(tmp_path, chunks=1)
+    runner = Path(args.runner)
+    runner.write_text(
+        f"""#!{sys.executable}
+import json, os, sys
+
+def value(flag):
+    return sys.argv[sys.argv.index(flag) + 1]
+
+codes = value('--only-codes').split(',')
+output_dir = value('--output')
+for code in codes:
+    target_dir = os.path.join(output_dir, code)
+    os.makedirs(target_dir, exist_ok=True)
+    with open(os.path.join(target_dir, 'result.csv'), 'x', encoding='utf-8') as stream:
+        stream.write('pdb_id,success_pb\\n' + code + ',1\\n')
+payload = {{
+    'schema_version': 1,
+    'type': 'flexaidds-fleet-chunk-result',
+    'campaign_id': value('--campaign-id'),
+    'chunk_id': value('--chunk-id'),
+    'attempt_id': value('--attempt-id'),
+    'worker_id': value('--worker-id'),
+    'dataset': value('--benchmark'),
+    'provenance': {{
+        'manifest_sha256': value('--manifest-sha256'),
+        'runner_sha256': value('--runner-sha256'),
+        'engine_sha256': value('--engine-sha256'),
+    }},
+    'summary': {{'target_count': len(codes)}},
+    'targets': [{{
+        'pdb_id': target_code,
+        'execution_completed': True,
+        'success_rmsd': True,
+        'posebusters_ran': True,
+        'posebusters_pass': True,
+        'success_pb': True,
+        'tencom_status': 'ok',
+        'eigen_status': 'ok',
+        'validators_complete': True,
+        'protocol_claim_eligible': True,
+        'claim_ready': True,
+    }} for target_code in codes],
+}}
+with open(value('--output-json'), 'x', encoding='utf-8') as stream:
+    json.dump(payload, stream)
+""",
+        encoding="utf-8",
+    )
+    runner.chmod(0o755)
+    fleet.plan_campaign(args)
+    campaign = Path(args.campaign)
+
+    worker_args = argparse.Namespace(
+        campaign=str(campaign), worker_id="worker-one", once=True,
+        max_chunks=1, keep_local=False,
+    )
+    assert fleet.run_worker(worker_args) == 0
+
+    manifest, manifest_hash = fleet.load_manifest(campaign)
+    accepted = fleet.read_json(campaign / "chunks" / "chunk-0000" / "result.json")
+    archive = campaign / accepted["archive"]
+    assert archive.is_dir()
+    assert fleet.tree_sha256(archive) == accepted["archive_tree_sha256"]
+    assert not Path(manifest["compute_root"]).joinpath(
+        manifest["campaign_id"], "chunk-0000", accepted["attempt_id"]
+    ).exists()
+
+    summary = fleet.aggregate_campaign(campaign, manifest, manifest_hash)
+    assert summary["complete"] is True
+    assert summary["success_pb"] == len(manifest["chunks"][0]["codes"])
+    assert summary["claim_ready"] == len(manifest["chunks"][0]["codes"])

--- a/tests/test_fleet_dashboard.py
+++ b/tests/test_fleet_dashboard.py
@@ -1,0 +1,117 @@
+"""Security and completion tests for the Bonhomme Fleet dashboard."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str, relative: str):
+    spec = importlib.util.spec_from_file_location(name, ROOT / relative)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+server = _load("fleet_status_server_test", "benchmarks/m3pro/dashboard/fleet_status_server.py")
+monitor = _load("fleet_monitor_test", "benchmarks/m3pro/dashboard/fleet_monitor.py")
+
+
+def test_pose_file_does_not_commit_target(tmp_path: Path) -> None:
+    target = tmp_path / "1GPK"
+    target.mkdir()
+    (target / "1GPK_0.pdb").write_text("ATOM\n", encoding="utf-8")
+
+    assert server._classify_target(str(target))["state"] == "in_progress"
+    assert not server._classify_target(str(target))["has_result"]
+    assert monitor.scan_target_dir(str(target)).state == "in_progress"
+    assert not monitor.scan_target_dir(str(target)).has_result
+
+
+def test_only_nonempty_result_csv_commits_target(tmp_path: Path) -> None:
+    target = tmp_path / "1GPK"
+    target.mkdir()
+    (target / "result.csv").touch()
+    assert server._classify_target(str(target))["state"] != "done"
+    assert monitor.scan_target_dir(str(target)).state != "done"
+
+    (target / "result.csv").write_text("pdb_id,success_pb\n1GPK,1\n", encoding="utf-8")
+    assert server._classify_target(str(target))["state"] == "done"
+    assert monitor.scan_target_dir(str(target)).state == "done"
+
+
+def test_progress_components_and_symlinks_cannot_escape_roots(tmp_path: Path) -> None:
+    results = tmp_path / "results" / "tier2"
+    results.mkdir(parents=True)
+    with pytest.raises(ValueError, match="invalid dataset"):
+        server.deep_scan_run([str(results)], "..", "run1")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = results / "astex"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are unavailable")
+    with pytest.raises(ValueError, match="traversal"):
+        server.deep_scan_run([str(results)], "astex", "run1")
+
+
+def test_server_is_loopback_and_cors_off_by_default() -> None:
+    args = server.build_argparser().parse_args([])
+    assert args.host == "127.0.0.1"
+    assert args.cors_origin is None
+
+
+def test_merged_status_matches_pwa_root_contract(tmp_path: Path) -> None:
+    payload = {
+        "runner": "worker-one",
+        "devices": [{"deviceID": "worker-one", "model": "Mac"}],
+        "activeChunks": [{"id": "chunk-0000"}],
+        "metrics": {
+            "totalChunks": 2,
+            "completedChunks": 1,
+            "failedChunks": 0,
+            "orphanedChunks": 0,
+            "activeDevices": 1,
+            "totalTFLOPS": 0.0,
+        },
+    }
+    (tmp_path / "fleet_status_worker.json").write_text(json.dumps(payload), encoding="utf-8")
+    merged = server.merge_fleet_status(str(tmp_path))
+
+    assert merged["devices"] == payload["devices"]
+    assert merged["activeChunks"] == payload["activeChunks"]
+    assert merged["metrics"]["completedChunks"] == 1
+    assert merged["metrics"]["totalChunks"] == 2
+
+
+def test_campaign_status_files_are_discovered_and_parsed(tmp_path: Path) -> None:
+    campaign = tmp_path / "results" / "campaigns" / "astex-fleet"
+    campaign.mkdir(parents=True)
+    payload = {
+        "campaign_id": "astex-fleet",
+        "dataset": "astex-diverse",
+        "totalChunks": 85,
+        "completedChunks": 4,
+        "states": {"completed": 4, "running": 1, "failed": 0},
+        "metrics": {"failedChunks": 0, "estimatedRemainingSeconds": None},
+    }
+    status = campaign / "status.json"
+    status.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert str(status) in server.discover_fleet_status_files(str(tmp_path))
+    assert str(status) in monitor.discover_fleet_status_files(str(tmp_path))
+    parsed = monitor.parse_runner(str(status), [])
+    assert parsed.name == "astex-fleet"
+    assert parsed.active_dataset == "astex-diverse"
+    assert parsed.datasets["astex-diverse"].status == "running"

--- a/tests/test_fleet_runner.cpp
+++ b/tests/test_fleet_runner.cpp
@@ -1,0 +1,124 @@
+// test_fleet_runner.cpp - Fleet chunk contract tests.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "FleetRunner.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+fleet::ChunkMetadata metadata() {
+    return {
+        "campaign-1",
+        "chunk-0001",
+        "attempt-1",
+        "worker\"one",
+        "astex",
+        "benchmark_datasets --fleet",
+        "/build/benchmark_datasets",
+        std::string(64, 'a'),
+        "/build/FlexAIDdS",
+        std::string(64, 'b'),
+        std::string(64, 'c'),
+    };
+}
+
+dataset::DockingResult successful_result() {
+    dataset::DockingResult result;
+    result.pdb_id = "1GPK";
+    result.num_poses = 20;
+    result.elected_pose_path = "1GPK/elected_pose.pdb";
+    result.elected_pose_source = "r2/1GPK_0.pdb";
+    result.rmsd_hungarian = 1.25f;
+    result.success_rmsd = true;
+    result.pb_ran = true;
+    result.pb_pass = true;
+    result.success_pb = true;
+    result.protocol_claim_eligible = true;
+    result.claim_ready = true;
+    result.tencom_status = "ok";
+    result.eigen_status = "ok";
+    result.eigen_n_modes = 12;
+    result.pose_sha256 = std::string(64, 'd');
+    result.rmsd_pose_sha256 = result.pose_sha256;
+    result.posebusters_pose_sha256 = result.pose_sha256;
+    result.tencom_pose_sha256 = result.pose_sha256;
+    return result;
+}
+
+} // namespace
+
+TEST(FleetRunner, SeparatesExecutionFromScientificSuccess) {
+    dataset::BenchmarkReport report;
+    report.dataset_name = "Astex Diverse";
+    report.total_systems = 2;
+    report.results.push_back(successful_result());
+
+    dataset::DockingResult miss;
+    miss.pdb_id = "1HNN";
+    miss.num_poses = 20;
+    miss.elected_pose_path = "1HNN/elected_pose.pdb";
+    miss.rmsd_hungarian = 8.0f;
+    miss.pb_ran = true;
+    miss.pb_pass = true;
+    miss.tencom_status = "ok";
+    miss.eigen_status = "ok";
+    miss.pose_sha256 = std::string(64, 'e');
+    miss.rmsd_pose_sha256 = miss.pose_sha256;
+    miss.posebusters_pose_sha256 = miss.pose_sha256;
+    miss.tencom_pose_sha256 = miss.pose_sha256;
+    report.results.push_back(miss);
+
+    dataset::DockingConfig config;
+    config.mode = dataset::BenchmarkMode::DEFINED_CLEFT_REDOCK;
+    const std::string json = fleet::FleetRunner::serialize_chunk_result(
+        metadata(), report, config, 12.5);
+
+    EXPECT_NE(json.find("\"execution_completed\": 2"), std::string::npos);
+    EXPECT_NE(json.find("\"execution_failed\": 0"), std::string::npos);
+    EXPECT_NE(json.find("\"success_rmsd\": 1"), std::string::npos);
+    EXPECT_NE(json.find("\"success_pb\": 1"), std::string::npos);
+    EXPECT_NE(json.find("\"claim_ready\": 1"), std::string::npos);
+    EXPECT_EQ(json.find("\"dG_mean\""), std::string::npos);
+}
+
+TEST(FleetRunner, EscapesMetadataAndEmitsBinaryHashes) {
+    dataset::BenchmarkReport report;
+    report.total_systems = 1;
+    report.results.push_back(successful_result());
+    dataset::DockingConfig config;
+
+    const std::string json = fleet::FleetRunner::serialize_chunk_result(
+        metadata(), report, config, 0.5);
+
+    EXPECT_NE(json.find("worker\\\"one"), std::string::npos);
+    EXPECT_NE(json.find(std::string(64, 'a')), std::string::npos);
+    EXPECT_NE(json.find(std::string(64, 'b')), std::string::npos);
+    EXPECT_NE(json.find(std::string(64, 'c')), std::string::npos);
+}
+
+TEST(FleetRunner, RefusesToOverwritePublishedResult) {
+    const fs::path root = fs::temp_directory_path() /
+        ("fleet_runner_test_" + std::to_string(
+            std::chrono::steady_clock::now().time_since_epoch().count()));
+    const fs::path result = root / "result.json";
+    std::string error;
+
+    ASSERT_TRUE(fleet::FleetRunner::write_chunk_result_atomic(
+        result.string(), "{\"attempt\":1}\n", &error)) << error;
+    EXPECT_FALSE(fleet::FleetRunner::write_chunk_result_atomic(
+        result.string(), "{\"attempt\":2}\n", &error));
+
+    std::ifstream input(result);
+    std::string contents((std::istreambuf_iterator<char>(input)),
+                         std::istreambuf_iterator<char>());
+    EXPECT_EQ(contents, "{\"attempt\":1}\n");
+    fs::remove_all(root);
+}

--- a/tests/test_posebust.cpp
+++ b/tests/test_posebust.cpp
@@ -424,9 +424,6 @@ TEST(PoseBustParity, CrystalSelfDockAgreesWithUpstreamBust) {
 
 // DatasetRunner contract: Backend::Native maps pb_pass from full native suite.
 TEST(PoseBustDatasetRunnerContract, NativeBackendMapsPbPassFromFullSuite) {
-    EXPECT_EQ(resolve_backend_from_env(), Backend::Native)
-        << "default backend must be NativePoseQC (unset FLEXAIDDS_POSEBUST*)";
-
     const fs::path crystal = astex_dir("1G9V") / "1G9V_ligand.sdf";
     const fs::path protein = astex_dir("1G9V") / "1G9V_apo.pdb";
     if (!fs::is_regular_file(crystal) || !fs::is_regular_file(protein)) {
@@ -461,12 +458,12 @@ TEST(PoseBustBustCli, ResolveBinary) {
     EXPECT_TRUE(fs::is_regular_file(b));
 }
 
-TEST(PoseBustEngine, DefaultBackendIsNativePoseQC) {
+TEST(PoseBustEngine, DefaultBackendIsOfficialBustCli) {
     // Clear any accidental env from the parent process for this assertion.
     // (gtest process may inherit; document expectation).
     if (std::getenv("FLEXAIDDS_POSEBUST_BACKEND") ||
         std::getenv("FLEXAIDDS_POSEBUST")) {
         GTEST_SKIP() << "POSEBUST env set; cannot assert default";
     }
-    EXPECT_EQ(resolve_backend_from_env(), Backend::Native);
+    EXPECT_EQ(resolve_backend_from_env(), Backend::BustCli);
 }

--- a/tests/test_posebust_upstream_parity.py
+++ b/tests/test_posebust_upstream_parity.py
@@ -24,6 +24,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 BUST = Path(
     os.environ.get(
@@ -169,6 +171,31 @@ int main(int c,char**v){
   return 0;
 }
 """
+
+
+@pytest.fixture(scope="module")
+def posebust_tools(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
+    directory = tmp_path_factory.mktemp("posebust-tools")
+    return {
+        "extract": compile_tool(EXTRACT_MAIN, "extract", directory),
+        "mismatch": compile_tool(MISMATCH_MAIN, "mismatch", directory),
+        "crystal_self": compile_tool(CRYSTAL_SELF_MAIN, "crystal_self", directory),
+    }
+
+
+@pytest.fixture(scope="module")
+def bin_extract(posebust_tools: dict[str, Path]) -> Path:
+    return posebust_tools["extract"]
+
+
+@pytest.fixture(scope="module")
+def bin_mismatch(posebust_tools: dict[str, Path]) -> Path:
+    return posebust_tools["mismatch"]
+
+
+@pytest.fixture(scope="module")
+def bin_self(posebust_tools: dict[str, Path]) -> Path:
+    return posebust_tools["crystal_self"]
 
 
 def extract_ligand(pose: Path, crystal: Path, out_sdf: Path, bin_extract: Path) -> int:

--- a/tests/test_resolve_build.py
+++ b/tests/test_resolve_build.py
@@ -69,12 +69,16 @@ def test_pin_requires_exact_sha(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     reason="production build not present on this machine",
 )
 def test_resolves_main_checkout_build():
+    build = Path.home() / "Projects/FlexAIDdS/build_lto"
+    environment = os.environ.copy()
+    environment["FLEXAIDDS_ENGINE_SHA256"] = rb._sha256(build / rb.ENGINE_NAME)
     proc = subprocess.run(
         [sys.executable, str(RESOLVE), "--check", "--repo-root", str(REPO_ROOT)],
         capture_output=True,
         text=True,
         timeout=30,
         cwd=REPO_ROOT,
+        env=environment,
     )
     assert proc.returncode == 0, proc.stderr or proc.stdout
 
@@ -88,7 +92,9 @@ def test_export_shell_is_safe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         (build / name).write_text("data")
     monkeypatch.setenv("FLEXAIDDS_BUILD", str(build))
 
-    resolution = rb.resolve_build(repo_root=tmp_path)
+    resolution = rb.resolve_build(
+        repo_root=tmp_path, pin_sha=rb._sha256(build / rb.ENGINE_NAME)
+    )
     shell = rb.export_shell(resolution)
     assert "export FLEXAIDDS_ENGINE_SHA256=" in shell
     assert "';" not in shell


### PR DESCRIPTION
## Summary
- add resumable Fleet planning, workers, leases, immutable attempt records, verified iCloud archival, and strict aggregation
- add immutable C++ DatasetRunner chunk results with exact-pose RMSD, official PoseBusters, and tENCoM/Eigen provenance
- make the Astex 85 fixed Get_Cleft manifest portable and harden Metal-enabled targets and dashboard status handling
- repair stale PoseBust and build-resolution tests exposed by the full verification pass

## Scientific contract
- defined cognate Get_Cleft occupied cavity, no GA crystal-pose seed
- success_pb = elected-pose RMSD <= 2 A and official PoseBusters pass
- claim_ready additionally requires exact-pose tENCoM/Eigen, score/pose consistency, and claim-eligible protocol
- any-pose sampling ceiling remains separate from top-1 success

## Verification
- Metal-enabled CMake build: 100%
- CTest: 67/67 passed
- Python: 57 passed, 2 skipped
- repository hygiene and source validation: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resumable Fleet campaign planning, workers, leasing, archiving, status monitoring, and aggregation via the `flexaidds-fleet` command.
  * Added immutable, atomic chunk-result publishing with provenance and integrity metadata.
  * Added Fleet dashboard support for campaign status, active chunks, and aggregated device metrics.
* **Bug Fixes**
  * Improved dataset path portability and prevented unsafe path traversal.
  * Targets are marked complete only when a non-empty `result.csv` is available.
  * Dashboard networking now defaults to local access with CORS disabled.
* **Documentation**
  * Added Fleet benchmark setup, monitoring, resumption, and aggregation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->