### PR TITLE
Fix: Harden Metal self-hosted gate + release language (science #5)

### DIFF
--- a/.github/workflows/metal-self-hosted.yml
+++ b/.github/workflows/metal-self-hosted.yml
@@ -10,6 +10,10 @@
 #
 # Register a runner with labels: self-hosted, self-hosted-m3
 # Docs: docs/CI_RELEASE_GATES.md
+#
+# Status note: do not claim an M3 self-hosted runner exists unless
+# `gh api repos/.../actions/runners` lists one with label self-hosted-m3.
+# Without a matching runner this workflow stays queued until cancelled.
 
 name: Metal full gate (self-hosted M3)
 
@@ -18,6 +22,14 @@ on:
     inputs:
       run_ctest:
         description: "Run ctest after Metal-enabled build (slower)"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      nm_symbol_smoke:
+        description: "Run nm symbol smoke (metal_eval_get_capabilities / metal_rmsd) on linked binaries"
         required: false
         default: "true"
         type: choice
@@ -82,6 +94,7 @@ jobs:
       - name: Configure (Metal ON, tests ON)
         run: |
           set -euo pipefail
+          # Fail-closed: any cmake configure error exits non-zero (no continue-on-error).
           CMAKE_ARGS=(
             -S . -B build-metal
             -G Ninja
@@ -90,6 +103,7 @@ jobs:
             -DFLEXAIDS_USE_METAL=ON
             -DBUILD_PYTHON_BINDINGS=OFF
             -DBUILD_TESTING=ON
+            -DBUILD_FLEXAIDDS_FAST=ON
             -DFLEXAIDS_STRICT_SOURCE_VALIDATION=ON
           )
           if command -v brew >/dev/null 2>&1; then
@@ -99,12 +113,69 @@ jobs:
             fi
           fi
           cmake "${CMAKE_ARGS[@]}"
+          # Confirm Metal was actually enabled (do not soft-pass a CPU-only configure).
+          if ! grep -E "FLEXAIDS_USE_METAL|Metal" build-metal/CMakeCache.txt >/dev/null 2>&1; then
+            echo "FATAL: expected Metal-related entries in CMakeCache after FLEXAIDS_USE_METAL=ON"
+            exit 1
+          fi
+          if grep -E '^FLEXAIDS_USE_METAL:BOOL=OFF' build-metal/CMakeCache.txt >/dev/null 2>&1; then
+            echo "FATAL: FLEXAIDS_USE_METAL resolved to OFF despite -DFLEXAIDS_USE_METAL=ON"
+            exit 1
+          fi
 
-      - name: Build FlexAID (Metal-linked)
-        run: cmake --build build-metal --parallel --target FlexAID
+      - name: Build FlexAID + FlexAIDdS (Metal-linked)
+        run: |
+          set -euo pipefail
+          # Both production docking binaries must link with Metal ON.
+          cmake --build build-metal --parallel --target FlexAID FlexAIDdS
+          ls -la build-metal/FlexAID build-metal/FlexAIDdS
 
       - name: Metal shader compile smoke
         run: bash scripts/ci/metal_compile_smoke.sh build-metal/metal-smoke
+
+      - name: nm symbol smoke (metal_eval / metal_rmsd)
+        if: inputs.nm_symbol_smoke == 'true'
+        run: |
+          set -euo pipefail
+          # Confirm Metal OBJCXX bridges contributed symbols into both binaries.
+          # C API names appear as substrings even when mangled; metal_rmsd is a
+          # C++ namespace (mangled forms still contain "metal_rmsd").
+          required=(
+            metal_eval_get_capabilities
+            metal_eval_init
+            metal_eval_batch
+            metal_eval_shutdown
+            metal_eval_runtime_available
+            metal_rmsd
+          )
+          for bin in build-metal/FlexAID build-metal/FlexAIDdS; do
+            echo "== nm smoke: ${bin} =="
+            if [[ ! -x "${bin}" ]]; then
+              echo "FATAL: missing binary ${bin}"
+              exit 1
+            fi
+            # Prefer demangled/global table; fall back to full nm.
+            nm_out="$(nm -gU "${bin}" 2>/dev/null || nm "${bin}" 2>/dev/null || true)"
+            if [[ -z "${nm_out}" ]]; then
+              echo "FATAL: nm produced no output for ${bin}"
+              exit 1
+            fi
+            missing=0
+            for sym in "${required[@]}"; do
+              if ! printf '%s\n' "${nm_out}" | grep -E "${sym}" >/dev/null 2>&1; then
+                echo "FATAL: symbol pattern '${sym}' not found in ${bin}"
+                missing=1
+              else
+                echo "OK: ${sym}"
+              fi
+            done
+            if [[ "${missing}" -ne 0 ]]; then
+              echo "---- nm (filtered metal) ----"
+              printf '%s\n' "${nm_out}" | grep -i metal | head -80 || true
+              exit 1
+            fi
+          done
+          echo "nm metal_eval / metal_rmsd symbol smoke PASSED"
 
       - name: Unit tests (optional)
         if: inputs.run_ctest == 'true'
@@ -113,5 +184,7 @@ jobs:
       - name: Summarize gate
         run: |
           echo "Metal full gate PASSED on self-hosted-m3"
-          echo "Binary: build-metal/FlexAID (or FlexAIDdS)"
+          echo "Binaries:"
           ls -la build-metal/FlexAID build-metal/FlexAIDdS 2>/dev/null || true
+          echo "Runner labels required: self-hosted, self-hosted-m3"
+          echo "Dispatch: Actions → 'Metal full gate (self-hosted M3)' → Run workflow"

--- a/docs/CI_RELEASE_GATES.md
+++ b/docs/CI_RELEASE_GATES.md
@@ -43,23 +43,97 @@ gate.
 - Job: `macos_metal_compile_smoke` in `.github/workflows/ci.yml`
 - Script: `scripts/ci/metal_compile_smoke.sh`
 - Compiles tracked `*.metal` sources to `.air` (and `.metallib` when `metallib` exists)
-- Does **not** full-link Metal OBJCXX bridges into `FlexAID` (that path needs a stable Apple Silicon + Xcode Metal toolchain environment)
+- Does **not** full-link Metal OBJCXX bridges into `FlexAID` / `FlexAIDdS`
 - Runtime: seconds to a few minutes — not a docking campaign
 
-If GitHub-hosted `macos-15` lacks the Metal compiler component, the job prints a clear skip notice and exits 0 so Linux/macOS CPU gates stay green. That **does not** authorize Metal release claims.
+If GitHub-hosted `macos-15` lacks the Metal compiler component, the job prints a
+clear skip notice and exits 0 so Linux/macOS CPU gates stay green.
+
+**Soft-skip is not a Metal release claim.** A green or soft-skipped
+`macos_metal_compile_smoke` only means “hosted shader compile was attempted;
+when metalc was missing the job skipped cleanly.” It does **not** validate
+Metal OBJCXX link, `metal_eval_*` / `metal_rmsd` symbols in production
+binaries, GPU runtime, or docking performance.
 
 ### Self-hosted full gate (Metal release claims)
 
 - Workflow: `.github/workflows/metal-self-hosted.yml`
 - Trigger: **`workflow_dispatch` only** (manual or release checklist)
-- Runner labels: **`self-hosted`**, **`self-hosted-m3`**
+  - GitHub UI: **Actions → “Metal full gate (self-hosted M3)” → Run workflow**
+  - Inputs: `run_ctest` (default true), `nm_symbol_smoke` (default true)
+- Runner labels (both required): **`self-hosted`**, **`self-hosted-m3`**
+- Builds: **`FlexAID` and `FlexAIDdS`** with `FLEXAIDS_USE_METAL=ON`
+- Optional **`nm` symbol smoke** for `metal_eval_get_capabilities`, other
+  `metal_eval_*` entry points, and `metal_rmsd` (C++ namespace) on **both**
+  binaries
 - Behavior: **fail-closed**
   - Missing Metal compiler → job fails
-  - CMake `FLEXAIDS_USE_METAL=ON` configure/build/link failure → job fails
+  - CMake configure with `FLEXAIDS_USE_METAL=ON` fails or resolves Metal OFF → job fails
+  - Link of either binary fails → job fails
+  - Missing required Metal symbols → job fails (when `nm_symbol_smoke=true`)
   - Optional `ctest` (default on) failure → job fails
   - No `continue-on-error`
 
-Register an Apple Silicon (M-series) machine as a GitHub Actions self-hosted runner with both labels. Without a matching runner, the workflow stays queued until a runner appears or the run is cancelled — it never soft-passes.
+#### Runner registration
+
+```bash
+# On the Apple Silicon host (after installing the GitHub Actions runner):
+# Labels must include BOTH of:
+#   self-hosted
+#   self-hosted-m3
+#
+# Verify for this repo (empty list ⇒ no M3 runner is registered; do not claim one exists):
+gh api repos/LeBonhommePharma/FlexAIDdS/actions/runners \
+  --jq '.runners[] | {name,status,labels:[.labels[].name]}'
+```
+
+Without a matching runner, a dispatched workflow **stays queued** until a runner
+appears or the run is cancelled — it never soft-passes. **Do not claim an M3
+self-hosted runner is online unless the API above lists one with label
+`self-hosted-m3`.**
+
+## Allowed release language vs forbidden claims
+
+Use this table for GitHub releases, Homebrew caveats, README badges, papers,
+and verbal product claims. “Green” means the named gate passed for the
+**same commit/tag** being shipped.
+
+### Allowed without self-hosted Metal green
+
+| You may say | Only if |
+|:--|:--|
+| “macOS CPU build and unit tests are CI-gated.” | `macos_cpu_tests` green on the release commit |
+| “Hosted CI compiles Metal shaders when the Metal toolchain is present.” | `macos_metal_compile_smoke` status is `ok` (not soft-skip) on that commit |
+| “Metal acceleration is **experimental / best-effort** on Apple Silicon; not a production guarantee.” | Always allowed; preferred default when self-hosted gate is not green |
+| “Metal full link/runtime validation requires a self-hosted M3 runner (`metal-self-hosted.yml`).” | Always allowed (factual process note) |
+| “Linux GCC/Clang `ctest` is green.” | Corresponding `cxx_core_build` matrix cells green |
+
+### Forbidden without green `Metal full gate (self-hosted M3)`
+
+Do **not** use any of the following (or equivalent) unless
+`metal-self-hosted.yml` is green for that commit/tag:
+
+| Forbidden claim | Why |
+|:--|:--|
+| “Metal is release-validated / production-ready.” | Needs full self-hosted link (+ optional ctest) |
+| “Metal-accelerated docking is CI-proven on Apple Silicon.” | Hosted jobs do not link/run Metal docking |
+| “`FlexAID` / `FlexAIDdS` ship with verified Metal GPU kernels.” | Needs OBJCXX link + symbol smoke (and preferably runtime) |
+| “Homebrew `--with-metal` is fully validated by GitHub Actions.” | Hosted GHA is shader-smoke only; full gate is self-hosted |
+| “Soft-skipped Metal smoke means Metal works.” | Soft-skip = metalc missing; **not** a Metal pass |
+| “We have a self-hosted M3 runner online.” | Only if `gh api …/actions/runners` lists `self-hosted-m3` |
+
+### Allowed **with** green self-hosted Metal full gate
+
+| You may say | Scope of the green run |
+|:--|:--|
+| “Metal OBJCXX bridges **link** into `FlexAID` and `FlexAIDdS` on Apple Silicon (self-hosted M3 gate).” | Configure + build both targets with `FLEXAIDS_USE_METAL=ON` |
+| “Linked binaries expose `metal_eval_get_capabilities` / `metal_rmsd` symbols (`nm` smoke).” | `nm_symbol_smoke=true` (default) |
+| “Metal-enabled unit tests passed on the self-hosted M3 runner.” | Only if `run_ctest=true` and ctest green |
+| “Metal full gate green for tag/commit X.” | Cite the Actions run URL for that ref |
+
+Still **not** automatic from the full gate alone (unless you add separate
+evidence): full Astex / campaign docking throughput claims, numerical parity
+vs CPU for every kernel, or third-party hardware beyond the registered runner.
 
 ## What still needs a self-hosted M3
 
@@ -67,18 +141,42 @@ Register an Apple Silicon (M-series) machine as a GitHub Actions self-hosted run
 |:--|:--|:--|
 | macOS CPU build + unit tests | Yes (`macos_cpu_tests`) | PR CI |
 | Metal `.metal` → `.air` compile | Usually yes (when Xcode Metal toolchain present) | PR CI smoke |
-| Metal OBJCXX bridge **link** into `FlexAID` | **No** (treat as self-hosted) | `metal-self-hosted.yml` |
+| Metal OBJCXX bridge **link** into `FlexAID` **and** `FlexAIDdS` | **No** (treat as self-hosted) | `metal-self-hosted.yml` |
+| `metal_eval_*` / `metal_rmsd` symbols in both binaries | **No** | self-hosted + `nm` smoke |
 | Metal **runtime** correctness / GPU kernels | **No** | self-hosted + local validation |
 | Full docking campaign on Apple Silicon | **No** | Local / fleet benchmarks (not this gate) |
 
-## Release checklist (minimum)
+## Release checklist (LP release managers)
 
-1. Green blocking jobs on `ci.yml` for the commit/tag (including **`macos_cpu_tests`**).
-2. Linux `ctest` clean (`linux-gcc` and `linux-clang` at minimum).
-3. If advertising Metal acceleration in release notes:
-   - Green `Metal full gate (self-hosted M3)` for that commit/tag, **or**
-   - Explicitly mark Metal as experimental with no production guarantee (see `docs/SUPPORT_MATRIX.md`).
-4. No secrets / machine-absolute paths: `python3 scripts/check_repo_hygiene.py`.
+Copy this into the release issue or PR checklist.
+
+### Always (every release)
+
+- [ ] Green blocking jobs on `ci.yml` for the commit/tag, including **`macos_cpu_tests`** (blocking; no `continue-on-error`).
+- [ ] Linux `ctest` clean (`linux-gcc` and `linux-clang` at minimum).
+- [ ] `python3 scripts/check_repo_hygiene.py` clean.
+- [ ] Release notes use only **allowed** language from the table above for platforms not fully gated.
+
+### macOS CPU claims
+
+- [ ] Cite green `macos_cpu_tests` for the release SHA.
+- [ ] Do **not** imply Metal from macOS CPU green alone.
+
+### Metal claims
+
+- [ ] Decide claim level:
+  - **Experimental only** → no self-hosted run required; use experimental wording.
+  - **Link / production Metal** → dispatch `Metal full gate (self-hosted M3)` on the release SHA.
+- [ ] Confirm a runner exists: `gh api repos/LeBonhommePharma/FlexAIDdS/actions/runners --jq '.runners[] | {name,status,labels:[.labels[].name]}'` shows `self-hosted-m3`.
+- [ ] Green self-hosted run for that SHA builds **both** `FlexAID` and `FlexAIDdS`.
+- [ ] Prefer leave `nm_symbol_smoke=true` and `run_ctest=true` (defaults).
+- [ ] Paste Actions run URL into the release notes / checklist.
+- [ ] Never treat hosted `macos_metal_compile_smoke` soft-skip as Metal validation.
+
+### Explicit non-claims (unless separate evidence)
+
+- [ ] No RMSD-only “success” without PoseBusters when citing docking benchmarks.
+- [ ] No “true ΔG” language for CF-only scoring (see `AGENTS.md` scientific guardrails).
 
 ## Local reproduction
 
@@ -101,6 +199,9 @@ bash scripts/ci/metal_compile_smoke.sh /tmp/metal-smoke
 cmake -B build-metal -G Ninja \
   -DCMAKE_BUILD_TYPE=Release \
   -DFLEXAIDS_USE_METAL=ON \
-  -DBUILD_TESTING=ON
-cmake --build build-metal --parallel --target FlexAID
+  -DBUILD_TESTING=ON \
+  -DBUILD_FLEXAIDDS_FAST=ON
+cmake --build build-metal --parallel --target FlexAID FlexAIDdS
+# Optional symbol smoke (matches metal-self-hosted.yml nm step)
+nm -gU build-metal/FlexAID build-metal/FlexAIDdS | grep -E 'metal_eval_get_capabilities|metal_rmsd'
 ```


### PR DESCRIPTION
## Summary

Science priority **#5** — blocking macOS CPU + self-hosted Metal for release language.

### Already on `main` (PR #261) — verified
| Item | Status |
|:--|:--|
| `ci.yml` → `macos_cpu_tests` | **Blocking** on `macos-15`, `BUILD_TESTING=ON`, **ctest**, **no** `continue-on-error` |
| `ci.yml` → `macos_metal_compile_smoke` | Present; soft-skip (exit 0 + notice) only if metalc missing |
| Soft-skip ≠ Metal release claim | Reinforced in docs |

### This PR — hardening beyond #261
| Item | Change |
|:--|:--|
| `metal-self-hosted.yml` targets | Build **`FlexAID` and `FlexAIDdS`** (`BUILD_FLEXAIDDS_FAST=ON`) |
| Optional `nm` smoke | Default on: `metal_eval_get_capabilities`, other `metal_eval_*`, **`metal_rmsd`** on both binaries |
| Trigger | **`workflow_dispatch` only** |
| Runner labels | **`self-hosted`**, **`self-hosted-m3`** |
| Fail-closed configure | `set -euo pipefail` + reject `FLEXAIDS_USE_METAL:BOOL=OFF` after configure |
| Docs | Exact **allowed / forbidden** release language + **LP release manager checklist** |

### Verification (this session)
- Structural checks: `macos_cpu_tests` has no `continue-on-error`; metal smoke soft-skip path present
- `metal-self-hosted.yml`: workflow_dispatch only, dual targets, nm symbols, fail-closed
- `python3 scripts/check_repo_hygiene.py` OK
- `gh api …/actions/runners` currently lists **no** `self-hosted-m3` runner — full Metal link gate cannot be green until one is registered

## Test plan
- [ ] PR CI: `macos_cpu_tests` still required/blocking
- [ ] PR CI: `macos_metal_compile_smoke` ok or soft-skip with notice
- [ ] Manual (when runner available): Actions → **Metal full gate (self-hosted M3)** → Run workflow on this branch
- [ ] Confirm both binaries + nm smoke on green self-hosted run before any production Metal claim

## LP release checklist
See `docs/CI_RELEASE_GATES.md` → **Release checklist (LP release managers)**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI and Validation**
  * Strengthened Apple Silicon Metal build verification with fail-closed checks.
  * Added validation that Metal support is enabled and both required binaries link correctly.
  * Added optional symbol-level smoke testing for Metal functionality.

* **Documentation**
  * Clarified hosted versus self-hosted Metal validation and release claims.
  * Expanded release checklists, runner verification guidance, and local reproduction instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->