### PR TITLE
Refactor: DatasetRunner split P1 — provenance.json leaf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -933,6 +933,7 @@ if(ENABLE_BENCHMARK_DATASETS)
         LIB/benchmark_datasets.cpp
         LIB/DatasetRunner.cpp
         LIB/DatasetRunnerStats.cpp
+        LIB/DatasetRunnerProvenance.cpp
         LIB/AsyncPipeline.cpp
         # NativePoseQC diagnostic plus upstream PoseBusters CLI bridge
         ${FLEXAIDDS_POSEBUST_SOURCES}
@@ -2131,6 +2132,7 @@ if(BUILD_TESTING)
         tests/test_dataset_runner.cpp
         LIB/DatasetRunner.cpp
         LIB/DatasetRunnerStats.cpp
+        LIB/DatasetRunnerProvenance.cpp
         LIB/AsyncPipeline.cpp
         ${FLEXAIDDS_POSEBUST_SOURCES}
     )
@@ -2158,6 +2160,7 @@ if(BUILD_TESTING)
         tests/test_cofactor_blacklist.cpp
         LIB/DatasetRunner.cpp
         LIB/DatasetRunnerStats.cpp
+        LIB/DatasetRunnerProvenance.cpp
         LIB/AsyncPipeline.cpp
         ${FLEXAIDDS_POSEBUST_SOURCES}
     )

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -4895,95 +4895,15 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
     // this run so results are reproducible without relying on /tmp staging or
     // file timestamps (which do not survive a reboot). Best-effort: any
     // failure here is non-fatal and must not block docking.
+    // Implementation lives in DatasetRunnerProvenance (P1 split leaf).
     {
-        // First non-empty whitespace token of a shell command's stdout, or "".
-        auto cmd_token = [](const std::string& cmd) -> std::string {
-            std::string out;
-            FILE* p = popen(cmd.c_str(), "r");
-            if (!p) return out;
-            char buf[512];
-            while (fgets(buf, sizeof(buf), p)) out += buf;
-            pclose(p);
-            std::string tok;
-            for (char c : out) {
-                if (std::isspace(static_cast<unsigned char>(c))) { if (!tok.empty()) break; }
-                else tok += c;
-            }
-            return tok;
-        };
-        auto shell_quote = [](const std::string& s) {
-            std::string q = "'";
-            for (char c : s) { if (c == '\'') q += "'\\''"; else q += c; }
-            q += "'";
-            return q;
-        };
-        auto md5_of = [&](const std::string& path) -> std::string {
-            if (path.empty() || !fs::exists(path)) return "";
-            std::string t = cmd_token("md5 -q " + shell_quote(path) + " 2>/dev/null");
-            if (t.empty()) t = cmd_token("md5sum " + shell_quote(path) + " 2>/dev/null");
-            return t;
-        };
-        auto sha256_of = [&](const std::string& path) -> std::string {
-            if (path.empty() || !fs::exists(path)) return "";
-            std::string t = cmd_token("shasum -a 256 " + shell_quote(path) + " 2>/dev/null");
-            if (t.empty()) t = cmd_token("sha256sum " + shell_quote(path) + " 2>/dev/null");
-            return t;
-        };
-
-        // Resolve the scoring matrix with the same precedence as each child:
-        // explicit override, immutable data staged beside the binary, then the
-        // mutable source-tree WRK directory as a development fallback.
-        std::string matrix_path;
-        if (!protocol_cfg_.data_dir.empty()) {
-            std::string cand = protocol_cfg_.data_dir + "/MC_st0r5.2_6.dat";
-            if (fs::exists(cand)) matrix_path = cand;
-        }
-        if (matrix_path.empty()) {
-            std::string bin_dir = flexaidds_bin;
-            auto slash = bin_dir.rfind('/');
-            if (slash != std::string::npos) bin_dir = bin_dir.substr(0, slash);
-            const std::string staged = bin_dir + "/MC_st0r5.2_6.dat";
-            const std::string source = bin_dir + "/../WRK/MC_st0r5.2_6.dat";
-            if (fs::exists(staged)) matrix_path = staged;
-            else if (fs::exists(source)) matrix_path = source;
-        }
-
         const char* oracle_env = std::getenv("FLEXAIDDS_ORACLE_SITE_DIR");
-        std::string git_commit = cmd_token(
-            "git rev-parse HEAD 2>/dev/null");
-
-        auto json_esc = [](const std::string& s) {
-            std::string r;
-            for (char c : s) {
-                if (c == '\\' || c == '"') { r += '\\'; r += c; }
-                else if (c == '\n') r += "\\n";
-                else r += c;
-            }
-            return r;
-        };
-
-        std::error_code mk_ec;
-        fs::create_directories(config.output_dir, mk_ec);
-        std::string prov_path = config.output_dir + "/provenance.json";
-        std::ofstream pj(prov_path);
-        if (pj.is_open()) {
-            pj << "{\n"
-               << "  \"dataset\": \""        << json_esc(report.dataset_name)   << "\",\n"
-               << "  \"matrix_path\": \""    << json_esc(matrix_path)           << "\",\n"
-               << "  \"matrix_md5\": \""     << json_esc(md5_of(matrix_path))   << "\",\n"
-               << "  \"matrix_sha256\": \""  << json_esc(sha256_of(matrix_path)) << "\",\n"
-               << "  \"binary_path\": \""    << json_esc(flexaidds_bin)         << "\",\n"
-               << "  \"binary_sha256\": \""  << json_esc(sha256_of(flexaidds_bin)) << "\",\n"
-               << "  \"git_commit\": \""     << json_esc(git_commit)            << "\",\n"
-               << "  \"oracle_site_dir\": \""<< json_esc(oracle_env ? oracle_env : "") << "\",\n"
-               << "  \"oracle_site_dir_set\": " << (oracle_env && oracle_env[0] ? "true" : "false") << "\n"
-               << "}\n";
-            pj.close();
-            std::cout << "[DatasetRunner] Wrote provenance: " << prov_path << "\n";
-        } else {
-            std::cerr << "[WARN] Could not write provenance.json to "
-                      << prov_path << "\n";
-        }
+        write_dataset_run_provenance(
+            config.output_dir,
+            report.dataset_name,
+            flexaidds_bin,
+            protocol_cfg_.data_dir,
+            oracle_env ? std::string(oracle_env) : std::string());
     }
 
     std::cout << "[DatasetRunner] Docking " << entries.size() << " entries ("

--- a/LIB/DatasetRunner.h
+++ b/LIB/DatasetRunner.h
@@ -40,6 +40,7 @@
 #include "TargetServer.h"
 #include "ProtocolConfig.h"
 #include "DatasetRunnerStats.h"  // pure correlation / RMSD helpers (P0 leaf)
+#include "DatasetRunnerProvenance.h"  // provenance.json writer (P1 leaf)
 
 namespace dataset {
 

--- a/LIB/DatasetRunnerProvenance.cpp
+++ b/LIB/DatasetRunnerProvenance.cpp
@@ -1,0 +1,195 @@
+// =============================================================================
+// DatasetRunnerProvenance.cpp — provenance.json writer for DatasetRunner
+//
+// Extracted from DatasetRunner.cpp (P1 leaf of the split plan). Behaviour is
+// intentionally identical to the pre-split inline run() provenance block.
+//
+// Copyright 2026 Le Bonhomme Pharma. Licensed under Apache-2.0.
+// =============================================================================
+
+#include "DatasetRunnerProvenance.h"
+
+#include <cctype>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace dataset {
+
+namespace {
+
+/// POSIX-shell single-quote escape for paths interpolated into shell commands.
+/// Matches the former run()-local lambda (and DatasetRunner shell_quote).
+std::string shell_quote(const std::string& s) {
+    std::string q = "'";
+    for (char c : s) {
+        if (c == '\'') q += "'\\''";
+        else q += c;
+    }
+    q += "'";
+    return q;
+}
+
+} // namespace
+
+std::string provenance_json_escape(const std::string& s) {
+    std::string r;
+    for (char c : s) {
+        if (c == '\\' || c == '"') {
+            r += '\\';
+            r += c;
+        } else if (c == '\n') {
+            r += "\\n";
+        } else {
+            r += c;
+        }
+    }
+    return r;
+}
+
+std::string provenance_cmd_token(const std::string& cmd) {
+    std::string out;
+    FILE* p = popen(cmd.c_str(), "r");
+    if (!p) return out;
+    char buf[512];
+    while (fgets(buf, sizeof(buf), p)) out += buf;
+    pclose(p);
+    std::string tok;
+    for (char c : out) {
+        if (std::isspace(static_cast<unsigned char>(c))) {
+            if (!tok.empty()) break;
+        } else {
+            tok += c;
+        }
+    }
+    return tok;
+}
+
+std::string provenance_file_md5(const std::string& path) {
+    if (path.empty() || !fs::exists(path)) return "";
+    std::string t = provenance_cmd_token("md5 -q " + shell_quote(path) + " 2>/dev/null");
+    if (t.empty()) t = provenance_cmd_token("md5sum " + shell_quote(path) + " 2>/dev/null");
+    return t;
+}
+
+std::string provenance_file_sha256(const std::string& path) {
+    if (path.empty() || !fs::exists(path)) return "";
+    std::string t =
+        provenance_cmd_token("shasum -a 256 " + shell_quote(path) + " 2>/dev/null");
+    if (t.empty()) t = provenance_cmd_token("sha256sum " + shell_quote(path) + " 2>/dev/null");
+    return t;
+}
+
+std::string resolve_scoring_matrix_path(const std::string& data_dir,
+                                        const std::string& flexaidds_bin) {
+    // Same precedence as each dock child: explicit override, immutable data
+    // staged beside the binary, then the mutable source-tree WRK fallback.
+    if (!data_dir.empty()) {
+        std::string cand = data_dir + "/MC_st0r5.2_6.dat";
+        if (fs::exists(cand)) return cand;
+    }
+    if (!flexaidds_bin.empty()) {
+        std::string bin_dir = flexaidds_bin;
+        auto slash = bin_dir.rfind('/');
+        if (slash != std::string::npos) bin_dir = bin_dir.substr(0, slash);
+        const std::string staged = bin_dir + "/MC_st0r5.2_6.dat";
+        const std::string source = bin_dir + "/../WRK/MC_st0r5.2_6.dat";
+        if (fs::exists(staged)) return staged;
+        if (fs::exists(source)) return source;
+    }
+    return "";
+}
+
+RunProvenanceFields build_run_provenance(const std::string& dataset_name,
+                                         const std::string& matrix_path,
+                                         const std::string& binary_path,
+                                         const std::string& oracle_site_dir) {
+    RunProvenanceFields p;
+    p.dataset = dataset_name;
+    p.matrix_path = matrix_path;
+    p.matrix_md5 = provenance_file_md5(matrix_path);
+    p.matrix_sha256 = provenance_file_sha256(matrix_path);
+    p.binary_path = binary_path;
+    p.binary_sha256 = provenance_file_sha256(binary_path);
+    p.git_commit = provenance_cmd_token("git rev-parse HEAD 2>/dev/null");
+    p.oracle_site_dir = oracle_site_dir;
+    p.oracle_site_dir_set = !oracle_site_dir.empty();
+    return p;
+}
+
+std::string format_run_provenance_json(const RunProvenanceFields& p) {
+    // Exact key order and layout of the former DatasetRunner::run() writer.
+    std::string j;
+    j.reserve(512);
+    j += "{\n";
+    j += "  \"dataset\": \"";
+    j += provenance_json_escape(p.dataset);
+    j += "\",\n";
+    j += "  \"matrix_path\": \"";
+    j += provenance_json_escape(p.matrix_path);
+    j += "\",\n";
+    j += "  \"matrix_md5\": \"";
+    j += provenance_json_escape(p.matrix_md5);
+    j += "\",\n";
+    j += "  \"matrix_sha256\": \"";
+    j += provenance_json_escape(p.matrix_sha256);
+    j += "\",\n";
+    j += "  \"binary_path\": \"";
+    j += provenance_json_escape(p.binary_path);
+    j += "\",\n";
+    j += "  \"binary_sha256\": \"";
+    j += provenance_json_escape(p.binary_sha256);
+    j += "\",\n";
+    j += "  \"git_commit\": \"";
+    j += provenance_json_escape(p.git_commit);
+    j += "\",\n";
+    j += "  \"oracle_site_dir\": \"";
+    j += provenance_json_escape(p.oracle_site_dir);
+    j += "\",\n";
+    j += "  \"oracle_site_dir_set\": ";
+    j += (p.oracle_site_dir_set ? "true" : "false");
+    j += "\n";
+    j += "}\n";
+    return j;
+}
+
+bool write_run_provenance_json(const std::string& output_dir,
+                               const RunProvenanceFields& p,
+                               bool log) {
+    std::error_code mk_ec;
+    fs::create_directories(output_dir, mk_ec);
+    const std::string prov_path = output_dir + "/provenance.json";
+    std::ofstream pj(prov_path);
+    if (!pj.is_open()) {
+        if (log) {
+            std::cerr << "[WARN] Could not write provenance.json to "
+                      << prov_path << "\n";
+        }
+        return false;
+    }
+    pj << format_run_provenance_json(p);
+    pj.close();
+    if (log) {
+        std::cout << "[DatasetRunner] Wrote provenance: " << prov_path << "\n";
+    }
+    return true;
+}
+
+bool write_dataset_run_provenance(const std::string& output_dir,
+                                  const std::string& dataset_name,
+                                  const std::string& flexaidds_bin,
+                                  const std::string& data_dir,
+                                  const std::string& oracle_site_dir) {
+    const std::string matrix_path =
+        resolve_scoring_matrix_path(data_dir, flexaidds_bin);
+    const RunProvenanceFields fields =
+        build_run_provenance(dataset_name, matrix_path, flexaidds_bin,
+                             oracle_site_dir);
+    return write_run_provenance_json(output_dir, fields, /*log=*/true);
+}
+
+} // namespace dataset

--- a/LIB/DatasetRunnerProvenance.h
+++ b/LIB/DatasetRunnerProvenance.h
@@ -1,0 +1,75 @@
+// =============================================================================
+// DatasetRunnerProvenance.h — provenance.json writer for DatasetRunner
+//
+// Leaf extraction (P1 of the DatasetRunner split plan): hashes, matrix path
+// resolution, and the per-run provenance.json document. No GA, ranking, or
+// docking process control. Safe to unit-test with temp dirs.
+//
+// Copyright 2026 Le Bonhomme Pharma. Licensed under Apache-2.0.
+// =============================================================================
+
+#pragma once
+
+#include <string>
+
+namespace dataset {
+
+/// Fields written to per-run provenance.json (key set is stable for audits).
+struct RunProvenanceFields {
+    std::string dataset;
+    std::string matrix_path;
+    std::string matrix_md5;
+    std::string matrix_sha256;
+    std::string binary_path;
+    std::string binary_sha256;
+    std::string git_commit;
+    std::string oracle_site_dir;
+    bool oracle_site_dir_set = false;
+};
+
+/// Escape a string for embedding inside a JSON string value.
+/// Behaviour matches the former DatasetRunner::run() lambda (backslash, quote, newline).
+std::string provenance_json_escape(const std::string& s);
+
+/// First non-empty whitespace token of a shell command's stdout, or "".
+std::string provenance_cmd_token(const std::string& cmd);
+
+/// File MD5 via `md5 -q` then `md5sum`; empty if path missing or tools fail.
+std::string provenance_file_md5(const std::string& path);
+
+/// File SHA-256 via `shasum -a 256` then `sha256sum`; empty if path missing or tools fail.
+std::string provenance_file_sha256(const std::string& path);
+
+/// Resolve scoring matrix path with the same precedence as dock children:
+/// 1) data_dir/MC_st0r5.2_6.dat when data_dir non-empty and file exists
+/// 2) binary-adjacent MC_st0r5.2_6.dat
+/// 3) binary/../WRK/MC_st0r5.2_6.dat development fallback
+std::string resolve_scoring_matrix_path(const std::string& data_dir,
+                                        const std::string& flexaidds_bin);
+
+/// Build provenance fields (hashes + git commit) from run inputs.
+/// oracle_site_dir_set is true when oracle_site_dir is non-empty.
+RunProvenanceFields build_run_provenance(const std::string& dataset_name,
+                                         const std::string& matrix_path,
+                                         const std::string& binary_path,
+                                         const std::string& oracle_site_dir);
+
+/// Format provenance as the exact JSON document written by DatasetRunner::run.
+std::string format_run_provenance_json(const RunProvenanceFields& p);
+
+/// Write output_dir/provenance.json (creates directories). Best-effort.
+/// Returns true on success. When log is true, emits the same cout/cerr lines
+/// as the former inline block in DatasetRunner::run().
+bool write_run_provenance_json(const std::string& output_dir,
+                               const RunProvenanceFields& p,
+                               bool log = true);
+
+/// Convenience matching the former run() provenance block:
+/// resolve matrix → hash → write provenance.json.
+bool write_dataset_run_provenance(const std::string& output_dir,
+                                  const std::string& dataset_name,
+                                  const std::string& flexaidds_bin,
+                                  const std::string& data_dir,
+                                  const std::string& oracle_site_dir);
+
+} // namespace dataset

--- a/build_sources.ignore
+++ b/build_sources.ignore
@@ -26,6 +26,7 @@ LIB/CleftDetector.h
 LIB/CoarseScreen.h
 LIB/DatasetRunner.h
 LIB/DatasetRunnerStats.h
+LIB/DatasetRunnerProvenance.h
 LIB/DiFT/DiFT.h
 LIB/DiFT/DiFTGAAdapter.h
 LIB/DistributedBackend.h

--- a/docs/implementation/datasetrunner-split-plan.md
+++ b/docs/implementation/datasetrunner-split-plan.md
@@ -1,8 +1,8 @@
 # DatasetRunner.cpp Split Plan
 
-**Status:** P0 landed (stats leaf). Full split is multi-PR; do not attempt monolithically.
+**Status:** P0 + P1 landed (stats + provenance leaves). Full split is multi-PR; do not attempt monolithically.
 **Source of truth for workflow:** `AGENTS.md`.
-**Audit trigger:** `LIB/DatasetRunner.cpp` ≈ 8010 lines (monolithic prep + execute + validate + report).
+**Audit trigger:** `LIB/DatasetRunner.cpp` ≈ 7816 lines after P1 (was ~8010 at audit; P0 stats + P1 provenance extracted).
 
 ## Goals
 
@@ -44,7 +44,7 @@ extractions. After each extract, ranges for remaining regions shift — re-map f
 LIB/
   DatasetRunner.h / .cpp          # facade: prepare(), run(), class state
   DatasetRunnerStats.h / .cpp     # P0 — pure metrics (done)
-  DatasetRunnerProvenance.*       # P1 candidate — provenance.json + hash helpers
+  DatasetRunnerProvenance.h / .cpp # P1 — provenance.json + hash helpers (done)
   DatasetRunnerRmsd.*             # Hungarian / pose RMSD (not ranking selector)
   DatasetRunnerPrep.*             # download, extract_ligand, residue sets
   DatasetRunnerFetch.*            # fetch_astex, fetch_casf, code lists
@@ -56,7 +56,7 @@ LIB/
 
 ## PR chunks and test gates
 
-### P0 — Pure stats leaf (this PR)
+### P0 — Pure stats leaf ✅ DONE
 
 **Extract:** `compute_pearson_r`, `compute_spearman_rho`, `compute_kendall_tau`, `compute_rmsd` (+ internal `compute_ranks`).
 
@@ -74,11 +74,25 @@ cmake --build build -j$(sysctl -n hw.ncpu) --target test_dataset_runner
 ./build/test_dataset_runner --gtest_filter='StatisticalMetrics.*:RMSDComputation.*'
 ```
 
-### P1 — Provenance JSON writer (leaf)
+### P1 — Provenance JSON writer (leaf) ✅ DONE
 
-**Extract:** `run()` block ~5010–5104 (`cmd_token`, hashes, matrix path, `provenance.json`).
+**Extract:** `run()` block (`cmd_token`, hashes, matrix path, `provenance.json`).
 
-**Test gate:** Temp-dir unit test for JSON keys; no network/docking; DatasetRunnerTests still green.
+**Files:**
+- `LIB/DatasetRunnerProvenance.h` / `.cpp`
+- Wired into `benchmark_datasets`, `test_dataset_runner`, `test_cofactor_blacklist`
+- `DatasetRunner.h` includes `DatasetRunnerProvenance.h`
+- Call site in `DatasetRunner::run()` delegates to `write_dataset_run_provenance(...)`
+
+**Why next:** Self-contained I/O + hash helpers; no ranking, no claim_ready, no GA.
+
+**Test gate:**
+```bash
+cmake -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j$(sysctl -n hw.ncpu) --target test_dataset_runner
+./build/test_dataset_runner --gtest_filter='ProvenanceJson.*:StatisticalMetrics.*:RMSDComputation.*'
+ctest --test-dir build -R DatasetRunnerTests --output-on-failure
+```
 
 ### P2 — Residue sets + path utilities
 
@@ -134,6 +148,6 @@ Do not extract until P0–P6 are green. Includes config/restart loop, Fix B/BCR 
 ```bash
 cmake -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j$(sysctl -n hw.ncpu) --target test_dataset_runner
-./build/test_dataset_runner --gtest_filter='StatisticalMetrics.*:RMSDComputation.*'
+./build/test_dataset_runner --gtest_filter='StatisticalMetrics.*:RMSDComputation.*:ProvenanceJson.*'
 ctest --test-dir build -R DatasetRunnerTests --output-on-failure
 ```

--- a/tests/test_dataset_runner.cpp
+++ b/tests/test_dataset_runner.cpp
@@ -19,7 +19,9 @@
 #define private public
 #include "DatasetRunner.h"
 #include "DatasetRunnerStats.h"  // P0 leaf: pure stats must compile standalone
+#include "DatasetRunnerProvenance.h"  // P1 leaf: provenance.json writer
 #undef private
+#include <cctype>
 #include <cmath>
 #include <chrono>
 #include <cstring>
@@ -274,6 +276,155 @@ TEST(RMSDComputation, MismatchedSize) {
     std::vector<float> b = {0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f};
     double rmsd = compute_rmsd(a, b);
     EXPECT_EQ(rmsd, -1.0); // Invalid/not-computed sentinel
+}
+
+// =============================================================================
+// Provenance JSON writer tests (P1 leaf — DatasetRunnerProvenance)
+// No network, no docking; temp-dir only.
+// =============================================================================
+
+TEST(ProvenanceJson, EscapeQuotesAndBackslash) {
+    EXPECT_EQ(provenance_json_escape("a\"b\\c"), "a\\\"b\\\\c");
+    EXPECT_EQ(provenance_json_escape("line\nbreak"), "line\\nbreak");
+    EXPECT_EQ(provenance_json_escape("plain"), "plain");
+}
+
+TEST(ProvenanceJson, FormatContainsRequiredKeys) {
+    RunProvenanceFields p;
+    p.dataset = "Astex Diverse";
+    p.matrix_path = "/tmp/MC_st0r5.2_6.dat";
+    p.matrix_md5 = "deadbeef";
+    p.matrix_sha256 = "cafebabe";
+    p.binary_path = "/opt/FlexAID";
+    p.binary_sha256 = "012345";
+    p.git_commit = "abc123";
+    p.oracle_site_dir = "/sites";
+    p.oracle_site_dir_set = true;
+
+    const std::string j = format_run_provenance_json(p);
+    for (const char* key : {
+             "\"dataset\"", "\"matrix_path\"", "\"matrix_md5\"", "\"matrix_sha256\"",
+             "\"binary_path\"", "\"binary_sha256\"", "\"git_commit\"",
+             "\"oracle_site_dir\"", "\"oracle_site_dir_set\""}) {
+        EXPECT_NE(j.find(key), std::string::npos) << "missing key " << key;
+    }
+    EXPECT_NE(j.find("\"Astex Diverse\""), std::string::npos);
+    EXPECT_NE(j.find("\"oracle_site_dir_set\": true"), std::string::npos);
+    // Trailing newline, no trailing comma after last field
+    EXPECT_NE(j.find("true\n}\n"), std::string::npos);
+}
+
+TEST(ProvenanceJson, FormatOracleUnset) {
+    RunProvenanceFields p;
+    p.dataset = "test";
+    p.oracle_site_dir_set = false;
+    const std::string j = format_run_provenance_json(p);
+    EXPECT_NE(j.find("\"oracle_site_dir\": \"\""), std::string::npos);
+    EXPECT_NE(j.find("\"oracle_site_dir_set\": false"), std::string::npos);
+}
+
+TEST(ProvenanceJson, WriteToTempDir) {
+    const auto tmp = fs::temp_directory_path() /
+                     ("flexaidds_prov_test_" +
+                      std::to_string(
+                          std::chrono::steady_clock::now().time_since_epoch().count()));
+    fs::create_directories(tmp);
+
+    RunProvenanceFields p;
+    p.dataset = "unit-test-set";
+    p.matrix_path = (tmp / "MC_st0r5.2_6.dat").string();
+    p.matrix_md5 = "md5hash";
+    p.matrix_sha256 = "sha256hash";
+    p.binary_path = (tmp / "FlexAID").string();
+    p.binary_sha256 = "binhash";
+    p.git_commit = "deadbeef";
+    p.oracle_site_dir = "";
+    p.oracle_site_dir_set = false;
+
+    ASSERT_TRUE(write_run_provenance_json(tmp.string(), p, /*log=*/false));
+
+    const fs::path prov = tmp / "provenance.json";
+    ASSERT_TRUE(fs::exists(prov));
+    std::ifstream in(prov);
+    std::stringstream buf;
+    buf << in.rdbuf();
+    const std::string body = buf.str();
+    EXPECT_EQ(body, format_run_provenance_json(p));
+    EXPECT_NE(body.find("\"dataset\": \"unit-test-set\""), std::string::npos);
+    EXPECT_NE(body.find("\"matrix_md5\": \"md5hash\""), std::string::npos);
+    EXPECT_NE(body.find("\"binary_sha256\": \"binhash\""), std::string::npos);
+    EXPECT_NE(body.find("\"git_commit\": \"deadbeef\""), std::string::npos);
+    EXPECT_NE(body.find("\"oracle_site_dir_set\": false"), std::string::npos);
+
+    fs::remove_all(tmp);
+}
+
+TEST(ProvenanceJson, ResolveMatrixPrefersDataDir) {
+    const auto tmp = fs::temp_directory_path() /
+                     ("flexaidds_matrix_test_" +
+                      std::to_string(
+                          std::chrono::steady_clock::now().time_since_epoch().count()));
+    const fs::path data_dir = tmp / "data";
+    const fs::path bin_dir = tmp / "bin";
+    const fs::path wrk = tmp / "WRK";
+    fs::create_directories(data_dir);
+    fs::create_directories(bin_dir);
+    fs::create_directories(wrk);
+
+    {
+        std::ofstream(data_dir / "MC_st0r5.2_6.dat") << "data\n";
+        std::ofstream(bin_dir / "MC_st0r5.2_6.dat") << "staged\n";
+        std::ofstream(wrk / "MC_st0r5.2_6.dat") << "wrk\n";
+        std::ofstream(bin_dir / "FlexAID") << "bin\n";
+    }
+
+    const std::string bin = (bin_dir / "FlexAID").string();
+    const std::string resolved =
+        resolve_scoring_matrix_path(data_dir.string(), bin);
+    EXPECT_EQ(resolved, (data_dir / "MC_st0r5.2_6.dat").string());
+
+    // Without data_dir, prefer binary-adjacent staged matrix over WRK.
+    const std::string staged_only = resolve_scoring_matrix_path("", bin);
+    EXPECT_EQ(staged_only, (bin_dir / "MC_st0r5.2_6.dat").string());
+
+    fs::remove(bin_dir / "MC_st0r5.2_6.dat");
+    const std::string wrk_fallback = resolve_scoring_matrix_path("", bin);
+    // path is bin_dir + "/../WRK/MC_st0r5.2_6.dat" (not necessarily lexically unique)
+    EXPECT_TRUE(fs::exists(wrk_fallback));
+    EXPECT_NE(wrk_fallback.find("WRK/MC_st0r5.2_6.dat"), std::string::npos);
+
+    fs::remove_all(tmp);
+}
+
+TEST(ProvenanceJson, FileHashesEmptyWhenMissing) {
+    EXPECT_EQ(provenance_file_md5(""), "");
+    EXPECT_EQ(provenance_file_sha256(""), "");
+    EXPECT_EQ(provenance_file_md5("/no/such/file/for/provenance_test"), "");
+    EXPECT_EQ(provenance_file_sha256("/no/such/file/for/provenance_test"), "");
+}
+
+TEST(ProvenanceJson, FileHashesMatchOnTempFile) {
+    const auto tmp = fs::temp_directory_path() /
+                     ("flexaidds_hash_test_" +
+                      std::to_string(
+                          std::chrono::steady_clock::now().time_since_epoch().count()));
+    {
+        std::ofstream out(tmp);
+        out << "hello provenance\n";
+    }
+    const std::string md5 = provenance_file_md5(tmp.string());
+    const std::string sha = provenance_file_sha256(tmp.string());
+    EXPECT_FALSE(md5.empty());
+    EXPECT_FALSE(sha.empty());
+    // Hex digests only
+    for (char c : md5) {
+        EXPECT_TRUE(std::isxdigit(static_cast<unsigned char>(c))) << md5;
+    }
+    for (char c : sha) {
+        EXPECT_TRUE(std::isxdigit(static_cast<unsigned char>(c))) << sha;
+    }
+    EXPECT_EQ(sha.size(), 64u);
+    fs::remove(tmp);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Continues the DatasetRunner split plan (**P1 only**): extract the per-run `provenance.json` writer and its pure helpers out of the `DatasetRunner.cpp` monolith.

### Extracted
| API | Role |
|-----|------|
| `provenance_json_escape` | JSON string escaping |
| `provenance_cmd_token` | first shell stdout token |
| `provenance_file_md5` / `provenance_file_sha256` | content hashes |
| `resolve_scoring_matrix_path` | data_dir → staged → WRK precedence |
| `build_run_provenance` / `format_run_provenance_json` | field assembly + exact JSON layout |
| `write_run_provenance_json` / `write_dataset_run_provenance` | best-effort write + cout/cerr logging |

### Files
- **New:** `LIB/DatasetRunnerProvenance.h` / `.cpp`
- **Wired:** `benchmark_datasets`, `test_dataset_runner`, `test_cofactor_blacklist` (CMake)
- **Call site:** `DatasetRunner::run()` → `write_dataset_run_provenance(...)`
- **Plan:** `docs/implementation/datasetrunner-split-plan.md` marked P1 ✅

### Not touched (forbidden)
- Election / Z+H / Fix B / HVIB ranking
- `claim_ready` / PoseBusters / tENCoM success gates
- Cluster ranking order

### Line count
- `DatasetRunner.cpp`: **7816** lines after P1 (was **7896** on main / ~8010 at original audit)
- Provenance leaf: **~270** lines (`.h` + `.cpp`)

## Test plan
- [x] `cmake -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release`
- [x] `cmake --build build --target test_dataset_runner`
- [x] `./build/test_dataset_runner --gtest_filter='ProvenanceJson.*:StatisticalMetrics.*:RMSDComputation.*'` → **31/31 passed**
- [x] `ctest --test-dir build -R DatasetRunnerTests --output-on-failure` → **Passed**
- [x] `python3 scripts/check_repo_hygiene.py` → OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dataset benchmark runs now generate detailed `provenance.json` records.
  * Provenance includes dataset and file paths, file checksums, source revision, and optional oracle configuration.
  * Scoring matrix files are resolved automatically from supported locations.

* **Bug Fixes**
  * Provenance output now creates missing output directories and handles unavailable metadata tools gracefully.

* **Tests**
  * Added coverage for provenance formatting, escaping, file resolution, writing, and checksum generation.

* **Documentation**
  * Updated dataset runner implementation and verification documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->