### PR TITLE
Add: Enforceable S1/S2/S3 admission + metrics claim contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
         env:
           FLEXAIDDS_REQUIRE_BUILD: '0'
           PYTHONPATH: ${{ github.workspace }}/python
-        run: python3 -m pytest tests/test_flexaid_skill.py tests/test_flexaidds_skill_figure.py tests/test_resolve_build.py tests/test_skill_edge_cases.py -q --tb=line
+        run: python3 -m pytest tests/test_flexaid_skill.py tests/test_flexaidds_skill_figure.py tests/test_resolve_build.py tests/test_skill_edge_cases.py tests/test_aggregate_claim_metrics.py -q --tb=line
 
   # New job: Validates the flexaidds skill's DatasetRunner features
   # (per-entry checkpointing, --resume + CostHistory, --package reproducibility)

--- a/benchmarks/protocols/admission_metrics_contract.md
+++ b/benchmarks/protocols/admission_metrics_contract.md
@@ -2,7 +2,7 @@
 
 **Status:** Normative for claim-table aggregation and abstract / headline rates.  
 **Aligned with:** `benchmarks/protocols/three_engine_entropy_comparison.md` §1.4–§5, `AGENTS.md` scientific guardrails, `benchmarks/BENCHMARK_STANDARD.md` (no-seed, seed_echo).  
-**Enforcement:** `scripts/aggregate_claim_metrics.py` (fail-closed claim filters; S3 never primary).
+**Enforcement:** `scripts/aggregate_claim_metrics.py` (fail-closed claim filters (missing seed columns fail); S3 never primary).
 
 ---
 
@@ -123,3 +123,8 @@ Expect per-target `<PDB>/result.csv`, plus `RUN_RECEIPT.json` / `provenance.json
 | `CLAUDE_BENCHMARK_HANDOFF.md` | Live C0 full85 ops handoff |
 | `scripts/aggregate_claim_metrics.py` | Enforcement implementation |
 | `scripts/aggregate_oracle_ceiling.py` | Seeded ceiling track only |
+
+
+### Fail-closed seed flags
+
+`seed_echo` and `native_pose_seeded` must be **explicitly** `0` (or `0.0`/`false`). Missing/blank columns fail admission.

--- a/benchmarks/protocols/admission_metrics_contract.md
+++ b/benchmarks/protocols/admission_metrics_contract.md
@@ -1,0 +1,125 @@
+# Admission + Metrics Contract (Normative)
+
+**Status:** Normative for claim-table aggregation and abstract / headline rates.  
+**Aligned with:** `benchmarks/protocols/three_engine_entropy_comparison.md` §1.4–§5, `AGENTS.md` scientific guardrails, `benchmarks/BENCHMARK_STANDARD.md` (no-seed, seed_echo).  
+**Enforcement:** `scripts/aggregate_claim_metrics.py` (fail-closed claim filters; S3 never primary).
+
+---
+
+## 1. Success metrics (report all; headline uses S1)
+
+| ID | Definition | Role |
+|----|------------|------|
+| **S1** | Elected (top-1) pose RMSD ≤ 2.0 Å | **Primary / claim KPI** |
+| **S2** | S1 ∧ PoseBusters pass on elected pose | Modern secondary |
+| **S3** | Any emitted cluster pose RMSD ≤ 2.0 Å (BCR / sampling ceiling) | **Diagnostic only** |
+
+### Field mapping (DatasetRunner `result.csv`)
+
+| Metric | Preferred fields (first hit) |
+|--------|------------------------------|
+| Elected RMSD | `rmsd_hungarian` → else `rmsd_to_crystal` |
+| S1 flag (optional) | `success_s1` → else recompute from elected RMSD ≤ 2.0 and `seed_echo==0` → else `success_rmsd` |
+| PoseBusters | `pb_pass` / `success_pb` (`success_pb` should equal S1 ∧ `pb_pass`) |
+| S3 / BCR | `best_cluster_rmsd` ≤ 2.0 Å |
+
+**Hungarian preferred** for S1 when present (symmetry-corrected elected pose vs crystal).  
+`rmsd_to_crystal` is serial-order and is a fallback / diagnostic, not the preferred claim RMSD.
+
+### Hard rules
+
+1. **Never report S3 as abstract / headline success.** Always label S3 “diagnostic (BCR / any-pose ceiling).”
+2. **Always report S1, S2, and S3 separately** when aggregating claim rows.
+3. **Election gap** = targets with S3=1 and S1=0 (sampling found a near-native pose the elector missed). Report counts; do not fold into S1.
+
+---
+
+## 2. Claim admission (row must pass all)
+
+A row is **claim-eligible** only if:
+
+| Check | Required value |
+|-------|----------------|
+| `seed_echo` | **0** |
+| `native_pose_seeded` | **0** |
+| `matrix_md5` | equals campaign **matrix pin** |
+
+Optional column `protocol_claim_eligible` (engine) is treated as an additional gate when present: claim rows require it true **or** missing (missing → recompute from seed flags). Rows with `protocol_claim_eligible=0` are excluded from claim aggregates even if seed flags are clean, to honour runner metadata.
+
+### Default matrix pin
+
+| Field | Value |
+|-------|--------|
+| Canonical matrix | `MC_st0r5.2_6.dat` |
+| **Default MD5 pin** | `72d7c7396702331d96ff12d18f831796` |
+
+Override pin sources (first available):
+
+1. CLI `--matrix-md5`
+2. Campaign `RUN_RECEIPT.json` → `matrix_md5`
+3. Campaign `provenance.json` → `matrix_md5`
+4. Default pin above
+
+Per-row `matrix_md5` (if present) must match the pin. Campaign-level pin is applied when rows omit the column.
+
+**Seeded / oracle-ceiling campaigns** (native inheritance) are a **separate science track**. Do not mix their rates into three-engine or TIER-1 claim tables. Use `scripts/aggregate_oracle_ceiling.py` for that track only.
+
+---
+
+## 3. Aggregator CLI (enforceable)
+
+```bash
+# Default claim aggregation (S1 primary)
+python3 scripts/aggregate_claim_metrics.py <campaign_dir> [--json out.json]
+
+# C0 full85 via env (after source ~/.flexaidds_env)
+python3 scripts/aggregate_claim_metrics.py --c0-full85
+
+# Explicit pin / receipt
+python3 scripts/aggregate_claim_metrics.py <campaign_dir> --matrix-md5 72d7c7396702331d96ff12d18f831796
+
+# FAIL: S3 as headline without diagnostic-only
+python3 scripts/aggregate_claim_metrics.py <dir> --headline s3          # exit 2
+python3 scripts/aggregate_claim_metrics.py <dir> --headline s3 --diagnostic-only  # OK, still labels diagnostic
+```
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| 0 | Claim rows present; aggregation OK |
+| 1 | No claim-eligible rows (or empty campaign) |
+| 2 | Usage / contract violation (`--headline s3` without `--diagnostic-only`, bad path) |
+
+---
+
+## 4. C0 full85 path
+
+After `source ~/.flexaidds_env`:
+
+```text
+$FLEXAIDDS_RESULTS/campaigns/C0_full85_defined_cleft_nativeseed_forbidden
+```
+
+Expect per-target `<PDB>/result.csv`, plus `RUN_RECEIPT.json` / `provenance.json` with `matrix_md5`.
+
+---
+
+## 5. What this contract does **not** change
+
+- Pose ranking, clustering, election, or docking engine code.
+- GA search or CF/contact-function scoring.
+- Seeded oracle-ceiling science (separate aggregator).
+
+---
+
+## 6. Cross-references
+
+| Doc | Role |
+|-----|------|
+| `benchmarks/protocols/three_engine_entropy_comparison.md` | Multi-arm protocol, schema, hypotheses |
+| `benchmarks/BENCHMARK_STANDARD.md` | Tiers, seed_echo, BCR computation notes |
+| `AGENTS.md` | Scientific guardrails (proxy vs thermo; no silent ranking change) |
+| `CLAUDE_BENCHMARK_HANDOFF.md` | Live C0 full85 ops handoff |
+| `scripts/aggregate_claim_metrics.py` | Enforcement implementation |
+| `scripts/aggregate_oracle_ceiling.py` | Seeded ceiling track only |

--- a/benchmarks/protocols/three_engine_entropy_comparison.md
+++ b/benchmarks/protocols/three_engine_entropy_comparison.md
@@ -5,7 +5,8 @@
 
 **Audience:** Queue operators, thesis methods, agents launching array jobs.
 
-**Related:** `benchmarks/BENCHMARK_STANDARD.md` (tiers, no-seed rule), `AGENTS.md` (scientific guardrails).
+**Related:** `benchmarks/BENCHMARK_STANDARD.md` (tiers, no-seed rule), `AGENTS.md` (scientific guardrails),
+**`benchmarks/protocols/admission_metrics_contract.md`** (normative S1/S2/S3 + claim admission; enforced by `scripts/aggregate_claim_metrics.py`).
 
 ---
 
@@ -231,6 +232,18 @@ budget_class
 
 **Admission rule for claim table:**  
 `native_pose_seeded == 0 AND seed_echo == 0 AND matrix_md5 == PIN`.
+
+**Enforced aggregation** (claim filters + separate S1/S2/S3; S3 never primary):
+
+```bash
+python3 scripts/aggregate_claim_metrics.py <results/<ARM>> [--json out.json]
+# C0 full85 after source ~/.flexaidds_env:
+python3 scripts/aggregate_claim_metrics.py --c0-full85
+# FAIL: python3 scripts/aggregate_claim_metrics.py <dir> --headline s3   # needs --diagnostic-only
+```
+
+Default matrix pin: `72d7c7396702331d96ff12d18f831796` (or `RUN_RECEIPT.json` / `provenance.json`).  
+Full contract: `benchmarks/protocols/admission_metrics_contract.md`.
 
 ---
 

--- a/scripts/aggregate_claim_metrics.py
+++ b/scripts/aggregate_claim_metrics.py
@@ -77,14 +77,17 @@ def _truth(row: dict[str, str], key: str) -> bool:
 
 
 def _flag0(row: dict[str, str], key: str) -> bool:
-    """True when the admission flag is explicitly zero / false / missing-as-zero-ok.
+    """True when the admission flag is *explicitly* zero / false.
 
-    Missing key is treated as 0 (claim-pass) so older CSVs without the column
-    can still be filtered by the other gates. Explicit non-zero fails.
+    Fail-closed: missing or blank keys fail admission (return False).
+    Explicit non-zero also fails. Accept common zero spellings including "0.0".
     """
-    if key not in row or row.get(key) is None or str(row.get(key, "")).strip() == "":
-        return True  # missing → treat as 0 for admission
-    return str(row.get(key, "")).strip() in ("0", "False", "false", "NO", "no")
+    if key not in row or row.get(key) is None:
+        return False
+    s = str(row.get(key, "")).strip()
+    if s == "":
+        return False
+    return s in ("0", "0.0", "False", "false", "NO", "no")
 
 
 def _pdb_id(row: dict[str, str]) -> str:
@@ -122,10 +125,17 @@ def resolve_c0_full85_dir() -> Path:
     )
 
 
+def _normalize_matrix_pin(md: str) -> str:
+    s = str(md).strip().lower()
+    if len(s) != 32 or any(c not in "0123456789abcdef" for c in s):
+        raise ValueError(f"matrix_md5 pin must be 32 hex chars, got {md!r}")
+    return s
+
+
 def load_matrix_pin(campaign_dir: Path, cli_pin: str | None) -> tuple[str, str]:
     """Return (md5, source_label)."""
     if cli_pin:
-        return cli_pin.strip().lower(), "cli"
+        return _normalize_matrix_pin(cli_pin), "cli"
     for name in ("RUN_RECEIPT.json", "provenance.json"):
         p = campaign_dir / name
         if not p.is_file():
@@ -136,8 +146,8 @@ def load_matrix_pin(campaign_dir: Path, cli_pin: str | None) -> tuple[str, str]:
             continue
         md = data.get("matrix_md5")
         if md:
-            return str(md).strip().lower(), name
-    return DEFAULT_MATRIX_MD5, "default_pin"
+            return _normalize_matrix_pin(str(md)), name
+    return _normalize_matrix_pin(DEFAULT_MATRIX_MD5), "default_pin"
 
 
 def load_campaign_rows(out_dir: Path) -> list[dict[str, str]]:
@@ -170,22 +180,24 @@ def load_rows_from_csv(path: Path) -> list[dict[str, str]]:
 
 
 def elected_rmsd(row: dict[str, str]) -> float:
-    """Preferred elected RMSD: Hungarian, then crystal."""
-    return _f(row, "rmsd_hungarian", "rmsd_to_crystal")
+    """Preferred elected RMSD: Hungarian → three-engine rmsd_top1 → crystal."""
+    return _f(row, "rmsd_hungarian", "rmsd_top1", "rmsd_to_crystal")
 
 
 def is_s1(row: dict[str, str]) -> bool:
-    """S1: elected pose RMSD ≤ 2.0 Å (not seed echo)."""
+    """S1: elected pose RMSD ≤ 2.0 Å (not seed echo).
+
+    Finite elected RMSD always wins over success_s1 / success_rmsd flags so a
+    stale or wrong flag cannot admit a high-RMSD pose.
+    """
     if _truth(row, "seed_echo"):
         return False
-    if "success_s1" in row and str(row.get("success_s1", "")).strip() != "":
-        return _truth(row, "success_s1")
-    # Prefer recomputation from Hungarian (protocol) over engine success_rmsd,
-    # which historically used min(crystal, hungarian). When success_rmsd is the
-    # only signal and RMSD columns are absent, honour it.
     rh = elected_rmsd(row)
     if math.isfinite(rh):
         return 0.0 <= rh <= RMSD_SUCCESS_A
+    # No finite RMSD: fall back to engine flags only
+    if "success_s1" in row and str(row.get("success_s1", "")).strip() != "":
+        return _truth(row, "success_s1")
     if "success_rmsd" in row and str(row.get("success_rmsd", "")).strip() != "":
         return _truth(row, "success_rmsd")
     if "success" in row and str(row.get("success", "")).strip() != "":
@@ -207,11 +219,13 @@ def is_s2(row: dict[str, str], s1: bool) -> bool:
 
 
 def is_s3(row: dict[str, str]) -> bool:
-    """S3: any-pose / BCR ceiling (diagnostic only)."""
+    """S3: any-pose / BCR ceiling (diagnostic only). Finite BCR always wins over flags."""
+    bc = _f(row, "best_cluster_rmsd", "rmsd_bcr")
+    if math.isfinite(bc):
+        return 0.0 <= bc <= RMSD_SUCCESS_A
     if "success_s3" in row and str(row.get("success_s3", "")).strip() != "":
         return _truth(row, "success_s3")
-    bc = _f(row, "best_cluster_rmsd", "rmsd_bcr")
-    return math.isfinite(bc) and 0.0 <= bc <= RMSD_SUCCESS_A
+    return False
 
 
 def row_matrix_ok(row: dict[str, str], pin: str) -> bool:
@@ -454,6 +468,20 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = ap.parse_args(argv)
 
+    n_sources = sum(
+        [
+            args.csv is not None,
+            bool(args.c0_full85),
+            args.campaign_dir is not None,
+        ]
+    )
+    if n_sources > 1:
+        print(
+            "error: provide exactly one of campaign_dir, --csv, or --c0-full85",
+            file=sys.stderr,
+        )
+        return 2
+
     campaign: Path | None = None
     rows: list[dict[str, str]] = []
 
@@ -492,7 +520,11 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     assert campaign is not None
-    pin, pin_src = load_matrix_pin(campaign, args.matrix_md5)
+    try:
+        pin, pin_src = load_matrix_pin(campaign, args.matrix_md5)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     report = aggregate_rows(
         rows,
         matrix_pin=pin,

--- a/scripts/aggregate_claim_metrics.py
+++ b/scripts/aggregate_claim_metrics.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""Aggregate claim-table metrics under the admission + S1/S2/S3 contract.
+
+Normative contract:
+  benchmarks/protocols/admission_metrics_contract.md
+  benchmarks/protocols/three_engine_entropy_comparison.md §1.4–§5
+
+Claim admission (all required):
+  seed_echo == 0
+  native_pose_seeded == 0
+  matrix_md5 == PIN  (default 72d7c7396702331d96ff12d18f831796,
+                      or RUN_RECEIPT / provenance / --matrix-md5)
+
+Metrics (always reported separately on claim rows):
+  S1  elected RMSD ≤ 2.0 Å          — primary / headline KPI
+  S2  S1 ∧ PoseBusters pass         — modern secondary
+  S3  best_cluster_rmsd ≤ 2.0 Å     — diagnostic only (BCR / any-pose)
+
+Never treat S3 as abstract success. --headline s3 requires --diagnostic-only
+or the process exits nonzero.
+
+Usage:
+  python3 scripts/aggregate_claim_metrics.py <campaign_dir> [--json out.json]
+  python3 scripts/aggregate_claim_metrics.py --c0-full85
+  python3 scripts/aggregate_claim_metrics.py <dir> --headline s1
+  python3 scripts/aggregate_claim_metrics.py <dir> --headline s3 --diagnostic-only
+
+Exit codes:
+  0  OK (N_claim > 0)
+  1  no claim-eligible rows / empty campaign
+  2  usage or contract violation
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+# Production matrix pin used by three-engine / C0 full85 (see RUN_RECEIPT).
+DEFAULT_MATRIX_MD5 = "72d7c7396702331d96ff12d18f831796"
+RMSD_SUCCESS_A = 2.0
+C0_FULL85_REL = "campaigns/C0_full85_defined_cleft_nativeseed_forbidden"
+
+SUMMARY_CSV_NAMES = (
+    "astex_diverse_results.csv",
+    "astex_crossdock_85_results.csv",
+    "results.csv",
+    "summary.csv",
+    "claim_summary.csv",
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _f(row: dict[str, str], *keys: str) -> float:
+    for k in keys:
+        v = row.get(k)
+        if v is None or v == "" or str(v).upper() == "NA":
+            continue
+        try:
+            x = float(v)
+            if math.isfinite(x):
+                return x
+        except (TypeError, ValueError):
+            continue
+    return float("nan")
+
+
+def _truth(row: dict[str, str], key: str) -> bool:
+    return str(row.get(key, "")).strip() in ("1", "True", "true", "YES", "yes")
+
+
+def _flag0(row: dict[str, str], key: str) -> bool:
+    """True when the admission flag is explicitly zero / false / missing-as-zero-ok.
+
+    Missing key is treated as 0 (claim-pass) so older CSVs without the column
+    can still be filtered by the other gates. Explicit non-zero fails.
+    """
+    if key not in row or row.get(key) is None or str(row.get(key, "")).strip() == "":
+        return True  # missing → treat as 0 for admission
+    return str(row.get(key, "")).strip() in ("0", "False", "false", "NO", "no")
+
+
+def _pdb_id(row: dict[str, str]) -> str:
+    return str(row.get("pdb_id") or row.get("pdb") or row.get("target") or "?").strip()
+
+
+def resolve_c0_full85_dir() -> Path:
+    """Resolve C0 full85 campaign dir from FLEXAIDDS_RESULTS (or FLEXAIDDS_ICLOUD)."""
+    results = os.environ.get("FLEXAIDDS_RESULTS", "").strip()
+    if results:
+        return Path(results) / "campaigns" / "C0_full85_defined_cleft_nativeseed_forbidden"
+    icloud = os.environ.get("FLEXAIDDS_ICLOUD", "").strip()
+    if icloud:
+        # FLEXAIDDS_ICLOUD may be the benchmarks root or the nested astex_entropy path
+        base = Path(icloud)
+        candidates = [
+            base / "results" / C0_FULL85_REL,
+            base.parent / "results" / C0_FULL85_REL if base.name else None,
+        ]
+        for c in candidates:
+            if c is not None and c.is_dir():
+                return c
+        return base / "results" / C0_FULL85_REL
+    # Documented default relative to home iCloud Drive (not hardcoded user)
+    home = Path.home()
+    return (
+        home
+        / "Library"
+        / "Mobile Documents"
+        / "com~apple~CloudDocs"
+        / "FlexAIDdS_benchmarks"
+        / "results"
+        / "campaigns"
+        / "C0_full85_defined_cleft_nativeseed_forbidden"
+    )
+
+
+def load_matrix_pin(campaign_dir: Path, cli_pin: str | None) -> tuple[str, str]:
+    """Return (md5, source_label)."""
+    if cli_pin:
+        return cli_pin.strip().lower(), "cli"
+    for name in ("RUN_RECEIPT.json", "provenance.json"):
+        p = campaign_dir / name
+        if not p.is_file():
+            continue
+        try:
+            data = json.loads(p.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        md = data.get("matrix_md5")
+        if md:
+            return str(md).strip().lower(), name
+    return DEFAULT_MATRIX_MD5, "default_pin"
+
+
+def load_campaign_rows(out_dir: Path) -> list[dict[str, str]]:
+    """Load per-target result.csv trees first, then flat summary CSVs."""
+    rows: list[dict[str, str]] = []
+    for rc in sorted(out_dir.glob("*/result.csv")):
+        try:
+            batch = list(csv.DictReader(rc.open(newline="")))
+            if batch:
+                # One authoritative row per target dir (first row)
+                rows.append(dict(batch[0]))
+        except OSError:
+            continue
+    if rows:
+        return rows
+    for name in SUMMARY_CSV_NAMES:
+        p = out_dir / name
+        if p.is_file():
+            try:
+                return [dict(r) for r in csv.DictReader(p.open(newline=""))]
+            except OSError:
+                continue
+    # Also accept a single CSV path masquerading as "dir" (handled by caller)
+    return rows
+
+
+def load_rows_from_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="") as fh:
+        return [dict(r) for r in csv.DictReader(fh)]
+
+
+def elected_rmsd(row: dict[str, str]) -> float:
+    """Preferred elected RMSD: Hungarian, then crystal."""
+    return _f(row, "rmsd_hungarian", "rmsd_to_crystal")
+
+
+def is_s1(row: dict[str, str]) -> bool:
+    """S1: elected pose RMSD ≤ 2.0 Å (not seed echo)."""
+    if _truth(row, "seed_echo"):
+        return False
+    if "success_s1" in row and str(row.get("success_s1", "")).strip() != "":
+        return _truth(row, "success_s1")
+    # Prefer recomputation from Hungarian (protocol) over engine success_rmsd,
+    # which historically used min(crystal, hungarian). When success_rmsd is the
+    # only signal and RMSD columns are absent, honour it.
+    rh = elected_rmsd(row)
+    if math.isfinite(rh):
+        return 0.0 <= rh <= RMSD_SUCCESS_A
+    if "success_rmsd" in row and str(row.get("success_rmsd", "")).strip() != "":
+        return _truth(row, "success_rmsd")
+    if "success" in row and str(row.get("success", "")).strip() != "":
+        return _truth(row, "success")
+    return False
+
+
+def is_s2(row: dict[str, str], s1: bool) -> bool:
+    """S2: S1 ∧ PoseBusters pass."""
+    if not s1:
+        return False
+    if "success_pb" in row and str(row.get("success_pb", "")).strip() != "":
+        # success_pb is defined as success_rmsd && pb_pass in DatasetRunner;
+        # still require s1 so S2 never exceeds S1 under our S1 definition.
+        return _truth(row, "success_pb") and s1
+    if "pb_pass" in row and str(row.get("pb_pass", "")).strip() != "":
+        return _truth(row, "pb_pass")
+    return False
+
+
+def is_s3(row: dict[str, str]) -> bool:
+    """S3: any-pose / BCR ceiling (diagnostic only)."""
+    if "success_s3" in row and str(row.get("success_s3", "")).strip() != "":
+        return _truth(row, "success_s3")
+    bc = _f(row, "best_cluster_rmsd", "rmsd_bcr")
+    return math.isfinite(bc) and 0.0 <= bc <= RMSD_SUCCESS_A
+
+
+def row_matrix_ok(row: dict[str, str], pin: str) -> bool:
+    md = str(row.get("matrix_md5", "")).strip().lower()
+    if not md:
+        return True  # campaign-level pin applies
+    return md == pin
+
+
+def is_claim_eligible(row: dict[str, str], matrix_pin: str) -> tuple[bool, list[str]]:
+    """Apply admission gates. Returns (ok, list of fail reasons)."""
+    reasons: list[str] = []
+    if not _flag0(row, "seed_echo"):
+        reasons.append("seed_echo!=0")
+    if not _flag0(row, "native_pose_seeded"):
+        reasons.append("native_pose_seeded!=0")
+    if not row_matrix_ok(row, matrix_pin):
+        reasons.append(
+            f"matrix_md5_mismatch(got={row.get('matrix_md5')!r}, pin={matrix_pin})"
+        )
+    # Honour engine claim flag when present and false
+    if "protocol_claim_eligible" in row and str(
+        row.get("protocol_claim_eligible", "")
+    ).strip() != "":
+        if not _truth(row, "protocol_claim_eligible"):
+            reasons.append("protocol_claim_eligible=0")
+    return (len(reasons) == 0, reasons)
+
+
+def aggregate_rows(
+    rows: Iterable[dict[str, str]],
+    matrix_pin: str,
+    matrix_pin_source: str,
+    campaign_dir: str | None = None,
+) -> dict[str, Any]:
+    all_rows = list(rows)
+    claim: list[dict[str, str]] = []
+    dropped: list[dict[str, Any]] = []
+
+    for r in all_rows:
+        ok, reasons = is_claim_eligible(r, matrix_pin)
+        if ok:
+            claim.append(r)
+        else:
+            dropped.append({"pdb_id": _pdb_id(r), "reasons": reasons})
+
+    n = len(claim)
+    s1_ids: list[str] = []
+    s2_ids: list[str] = []
+    s3_ids: list[str] = []
+    election_gap_ids: list[str] = []
+    s1_fail_ids: list[str] = []
+
+    for r in claim:
+        pid = _pdb_id(r)
+        s1 = is_s1(r)
+        s2 = is_s2(r, s1)
+        s3 = is_s3(r)
+        if s1:
+            s1_ids.append(pid)
+        else:
+            s1_fail_ids.append(pid)
+        if s2:
+            s2_ids.append(pid)
+        if s3:
+            s3_ids.append(pid)
+        if s3 and not s1:
+            election_gap_ids.append(pid)
+
+    def rate(k: int) -> float:
+        return (k / n) if n else 0.0
+
+    report: dict[str, Any] = {
+        "contract": "admission_metrics_contract",
+        "contract_doc": "benchmarks/protocols/admission_metrics_contract.md",
+        "campaign_dir": campaign_dir,
+        "matrix_md5_pin": matrix_pin,
+        "matrix_md5_pin_source": matrix_pin_source,
+        "N_raw": len(all_rows),
+        "N_claim": n,
+        "N_dropped": len(dropped),
+        "dropped_rows": dropped,
+        "metrics": {
+            "S1": {
+                "definition": "elected RMSD <= 2.0 A (Hungarian preferred)",
+                "role": "primary_headline",
+                "n": len(s1_ids),
+                "rate": rate(len(s1_ids)),
+                "ids": s1_ids,
+            },
+            "S2": {
+                "definition": "S1 AND PoseBusters pass",
+                "role": "secondary",
+                "n": len(s2_ids),
+                "rate": rate(len(s2_ids)),
+                "ids": s2_ids,
+            },
+            "S3": {
+                "definition": "best_cluster_rmsd <= 2.0 A (BCR / any-pose ceiling)",
+                "role": "diagnostic_only",
+                "n": len(s3_ids),
+                "rate": rate(len(s3_ids)),
+                "ids": s3_ids,
+                "warning": "Do not report S3 as abstract / headline success.",
+            },
+        },
+        "election_gap": {
+            "definition": "S3=1 and S1=0 (sampling found near-native; elector missed)",
+            "n": len(election_gap_ids),
+            "rate": rate(len(election_gap_ids)),
+            "ids": election_gap_ids,
+        },
+        "S1_fail_ids": s1_fail_ids,
+        "headline": {
+            "metric": "S1",
+            "n": len(s1_ids),
+            "N": n,
+            "rate": rate(len(s1_ids)),
+            "label": "S1 elected RMSD <= 2.0 A (claim-eligible only)",
+        },
+        "admission": {
+            "seed_echo": 0,
+            "native_pose_seeded": 0,
+            "matrix_md5": matrix_pin,
+        },
+    }
+    return report
+
+
+def format_text_report(report: dict[str, Any]) -> str:
+    m = report["metrics"]
+    n = report["N_claim"]
+    lines = [
+        f"campaign_dir: {report.get('campaign_dir')}",
+        f"matrix_md5_pin: {report['matrix_md5_pin']} (source={report['matrix_md5_pin_source']})",
+        f"N_raw={report['N_raw']}  N_claim={n}  N_dropped={report['N_dropped']}",
+        "",
+        f"S1 (primary):     {m['S1']['n']}/{n} = {100.0 * m['S1']['rate']:.2f}%",
+        f"S2 (S1∧PB):       {m['S2']['n']}/{n} = {100.0 * m['S2']['rate']:.2f}%",
+        f"S3 (diagnostic):  {m['S3']['n']}/{n} = {100.0 * m['S3']['rate']:.2f}%  "
+        f"[NOT abstract success]",
+        f"election_gap (S3∧¬S1): {report['election_gap']['n']}/{n} = "
+        f"{100.0 * report['election_gap']['rate']:.2f}%",
+    ]
+    if report["N_dropped"]:
+        lines.append("")
+        lines.append("dropped (non-claim):")
+        for d in report["dropped_rows"][:20]:
+            lines.append(f"  {_pdb_id_from_drop(d)}: {', '.join(d['reasons'])}")
+        if report["N_dropped"] > 20:
+            lines.append(f"  ... +{report['N_dropped'] - 20} more")
+    return "\n".join(lines) + "\n"
+
+
+def _pdb_id_from_drop(d: dict[str, Any]) -> str:
+    return str(d.get("pdb_id") or "?")
+
+
+def apply_headline(
+    report: dict[str, Any],
+    headline: str,
+    diagnostic_only: bool,
+) -> tuple[dict[str, Any], int | None]:
+    """Mutate report headline; return (report, error_exit_code_or_None)."""
+    h = headline.strip().lower()
+    if h not in ("s1", "s2", "s3"):
+        return report, 2
+    if h == "s3" and not diagnostic_only:
+        print(
+            "CONTRACT VIOLATION: --headline s3 is not allowed as primary without "
+            "--diagnostic-only. S3 is BCR/any-pose diagnostic only; use S1 for "
+            "abstract / claim success.",
+            file=sys.stderr,
+        )
+        return report, 2
+
+    m = report["metrics"][h.upper()]
+    report["headline"] = {
+        "metric": h.upper(),
+        "n": m["n"],
+        "N": report["N_claim"],
+        "rate": m["rate"],
+        "label": m["definition"],
+        "role": m["role"],
+        "diagnostic_only": h == "s3" or diagnostic_only and h != "s1",
+    }
+    if h == "s3":
+        report["headline"]["warning"] = (
+            "S3 is diagnostic only — do not quote as abstract success rate."
+        )
+    return report, None
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "campaign_dir",
+        type=Path,
+        nargs="?",
+        default=None,
+        help="Campaign directory with */result.csv and/or summary CSV",
+    )
+    ap.add_argument(
+        "--c0-full85",
+        action="store_true",
+        help=f"Use $FLEXAIDDS_RESULTS/{C0_FULL85_REL}",
+    )
+    ap.add_argument(
+        "--csv",
+        type=Path,
+        default=None,
+        help="Aggregate a single summary CSV instead of a campaign tree",
+    )
+    ap.add_argument(
+        "--matrix-md5",
+        type=str,
+        default=None,
+        help=f"Matrix pin (default: receipt/provenance or {DEFAULT_MATRIX_MD5})",
+    )
+    ap.add_argument(
+        "--headline",
+        type=str,
+        default="s1",
+        choices=("s1", "s2", "s3", "S1", "S2", "S3"),
+        help="Primary headline metric (default s1). s3 requires --diagnostic-only.",
+    )
+    ap.add_argument(
+        "--diagnostic-only",
+        action="store_true",
+        help="Allow --headline s3 (still labelled diagnostic, never abstract success).",
+    )
+    ap.add_argument("--json", type=Path, default=None, help="Write full JSON report")
+    ap.add_argument(
+        "--quiet",
+        action="store_true",
+        help="JSON only to stdout (no human text block)",
+    )
+    args = ap.parse_args(argv)
+
+    campaign: Path | None = None
+    rows: list[dict[str, str]] = []
+
+    if args.csv is not None:
+        if not args.csv.is_file():
+            print(f"not a file: {args.csv}", file=sys.stderr)
+            return 2
+        rows = load_rows_from_csv(args.csv)
+        campaign = args.csv.parent
+    elif args.c0_full85:
+        campaign = resolve_c0_full85_dir()
+        if not campaign.is_dir():
+            print(
+                f"C0 full85 campaign not found: {campaign}\n"
+                "Source ~/.flexaidds_env or set FLEXAIDDS_RESULTS.",
+                file=sys.stderr,
+            )
+            return 2
+        rows = load_campaign_rows(campaign)
+    elif args.campaign_dir is not None:
+        campaign = args.campaign_dir
+        if campaign.is_file() and campaign.suffix.lower() == ".csv":
+            rows = load_rows_from_csv(campaign)
+            campaign = campaign.parent
+        elif campaign.is_dir():
+            rows = load_campaign_rows(campaign)
+        else:
+            print(f"not a directory or CSV: {campaign}", file=sys.stderr)
+            return 2
+    else:
+        ap.print_help()
+        print(
+            "\nerror: provide campaign_dir, --csv, or --c0-full85",
+            file=sys.stderr,
+        )
+        return 2
+
+    assert campaign is not None
+    pin, pin_src = load_matrix_pin(campaign, args.matrix_md5)
+    report = aggregate_rows(
+        rows,
+        matrix_pin=pin,
+        matrix_pin_source=pin_src,
+        campaign_dir=str(campaign.resolve()),
+    )
+    report, err = apply_headline(report, args.headline, args.diagnostic_only)
+    if err is not None:
+        return err
+
+    if not args.quiet:
+        print(format_text_report(report), end="")
+        print(
+            f"headline: {report['headline']['metric']} "
+            f"{report['headline']['n']}/{report['headline']['N']} "
+            f"= {100.0 * report['headline']['rate']:.2f}%"
+        )
+
+    text = json.dumps(report, indent=2)
+    if args.json:
+        args.json.write_text(text + "\n")
+    if args.quiet:
+        print(text)
+
+    return 0 if report["N_claim"] > 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_aggregate_claim_metrics.py
+++ b/tests/test_aggregate_claim_metrics.py
@@ -271,3 +271,84 @@ def test_cli_csv_flag(tmp_path: Path):
 if __name__ == "__main__":
     # Allow bare `python3 tests/test_aggregate_claim_metrics.py`
     pytest.main([__file__, "-v"])
+
+
+def test_missing_seed_columns_fail_closed(tmp_path: Path):
+    """Fail-closed: omit seed columns → not claim-eligible."""
+    mod = _load()
+    r = _row("1AAA", rmsd_h=1.0, bcr=0.5)
+    del r["seed_echo"]
+    del r["native_pose_seeded"]
+    camp = _write_campaign(tmp_path, [r])
+    # rewrite without seed columns
+    import csv
+    path = camp / "1AAA" / "result.csv"
+    fields = [c for c in CSV_FIELDS if c not in ("seed_echo", "native_pose_seeded")]
+    row = {k: r.get(k, "") for k in fields}
+    with path.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerow(row)
+    rows = mod.load_campaign_rows(camp)
+    pin, _ = mod.load_matrix_pin(camp, None)
+    rep = mod.aggregate_rows(rows, pin, "test", str(camp))
+    assert rep["N_claim"] == 0
+    assert rep["N_dropped"] == 1
+
+
+def test_rmsd_top1_three_engine_schema(tmp_path: Path):
+    mod = _load()
+    camp = tmp_path / "camp"
+    camp.mkdir()
+    d = camp / "1BBB"
+    d.mkdir()
+    fields = ["pdb_id", "rmsd_top1", "rmsd_bcr", "seed_echo", "native_pose_seeded", "matrix_md5"]
+    with (d / "result.csv").open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerow({
+            "pdb_id": "1BBB",
+            "rmsd_top1": "1.2",
+            "rmsd_bcr": "0.8",
+            "seed_echo": "0",
+            "native_pose_seeded": "0",
+            "matrix_md5": "",
+        })
+    (camp / "RUN_RECEIPT.json").write_text('{"matrix_md5": "%s"}' % DEFAULT_PIN)
+    rows = mod.load_campaign_rows(camp)
+    pin, _ = mod.load_matrix_pin(camp, None)
+    rep = mod.aggregate_rows(rows, pin, "test", str(camp))
+    assert rep["N_claim"] == 1
+    assert rep["metrics"]["S1"]["n"] == 1
+    assert rep["metrics"]["S3"]["n"] == 1
+
+
+def test_success_s1_flag_cannot_override_high_rmsd(tmp_path: Path):
+    mod = _load()
+    r = _row("1CCC", rmsd_h=5.0, bcr=5.0)
+    r["success_s1"] = "1"
+    r["success_rmsd"] = "1"
+    camp = _write_campaign(tmp_path, [r])
+    rows = mod.load_campaign_rows(camp)
+    # inject success_s1 into loaded row via rewriting
+    import csv
+    path = camp / "1CCC" / "result.csv"
+    fields = CSV_FIELDS + ["success_s1"]
+    with path.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        full = {k: r.get(k, "") for k in CSV_FIELDS}
+        full["success_s1"] = "1"
+        w.writerow(full)
+    rows = mod.load_campaign_rows(camp)
+    pin, _ = mod.load_matrix_pin(camp, None)
+    rep = mod.aggregate_rows(rows, pin, "test", str(camp))
+    assert rep["N_claim"] == 1
+    assert rep["metrics"]["S1"]["n"] == 0
+
+
+def test_seed_echo_0_0_accepted():
+    mod = _load()
+    row = {"seed_echo": "0.0", "native_pose_seeded": "0.0", "matrix_md5": ""}
+    assert mod._flag0(row, "seed_echo")
+    assert mod._flag0(row, "native_pose_seeded")

--- a/tests/test_aggregate_claim_metrics.py
+++ b/tests/test_aggregate_claim_metrics.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/aggregate_claim_metrics.py admission + S1/S2/S3 contract."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "aggregate_claim_metrics.py"
+DEFAULT_PIN = "72d7c7396702331d96ff12d18f831796"
+
+# Columns used by DatasetRunner-style result.csv claim rows
+CSV_FIELDS = [
+    "pdb_id",
+    "rmsd_to_crystal",
+    "rmsd_hungarian",
+    "best_cluster_rmsd",
+    "success",
+    "success_rmsd",
+    "pb_pass",
+    "success_pb",
+    "seed_echo",
+    "native_pose_seeded",
+    "protocol_claim_eligible",
+    "matrix_md5",
+]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("aggregate_claim_metrics", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_campaign(tmp: Path, rows: list[dict], receipt_md5: str | None = DEFAULT_PIN) -> Path:
+    """Write per-target result.csv tree + optional RUN_RECEIPT.json."""
+    camp = tmp / "campaign"
+    camp.mkdir(parents=True, exist_ok=True)
+    for r in rows:
+        pid = r["pdb_id"]
+        d = camp / pid
+        d.mkdir(exist_ok=True)
+        path = d / "result.csv"
+        with path.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=CSV_FIELDS, extrasaction="ignore")
+            w.writeheader()
+            # fill missing keys
+            full = {k: r.get(k, "") for k in CSV_FIELDS}
+            w.writerow(full)
+    if receipt_md5 is not None:
+        (camp / "RUN_RECEIPT.json").write_text(
+            json.dumps({"matrix_md5": receipt_md5, "run_id": "fixture"})
+        )
+    return camp
+
+
+def _row(
+    pdb_id: str,
+    *,
+    rmsd_h: float,
+    bcr: float,
+    pb: int = 0,
+    seed_echo: int = 0,
+    native_seeded: int = 0,
+    claim: int = 1,
+    matrix_md5: str = "",
+    rmsd_c: float | None = None,
+) -> dict:
+    s1 = 1 if 0.0 <= rmsd_h <= 2.0 and seed_echo == 0 else 0
+    return {
+        "pdb_id": pdb_id,
+        "rmsd_to_crystal": f"{(rmsd_c if rmsd_c is not None else rmsd_h + 0.5):.4f}",
+        "rmsd_hungarian": f"{rmsd_h:.4f}",
+        "best_cluster_rmsd": f"{bcr:.4f}",
+        "success": str(s1),
+        "success_rmsd": str(s1),
+        "pb_pass": str(pb),
+        "success_pb": str(1 if s1 and pb else 0),
+        "seed_echo": str(seed_echo),
+        "native_pose_seeded": str(native_seeded),
+        "protocol_claim_eligible": str(claim),
+        "matrix_md5": matrix_md5,
+    }
+
+
+# ── admission filter ─────────────────────────────────────────────────────────
+
+
+def test_claim_filter_drops_seeded_rows(tmp_path: Path):
+    mod = _load()
+    rows = [
+        _row("GOOD1", rmsd_h=1.2, bcr=0.8, pb=1),
+        _row("SEED1", rmsd_h=0.5, bcr=0.4, pb=1, seed_echo=1, claim=0),
+        _row("NAT1", rmsd_h=0.9, bcr=0.7, pb=1, native_seeded=1, claim=0),
+        _row("GOOD2", rmsd_h=3.5, bcr=1.1, pb=0),  # S1 fail, S3 hit
+    ]
+    camp = _write_campaign(tmp_path, rows)
+    pin, src = mod.load_matrix_pin(camp, None)
+    assert pin == DEFAULT_PIN
+    assert src == "RUN_RECEIPT.json"
+    loaded = mod.load_campaign_rows(camp)
+    report = mod.aggregate_rows(loaded, pin, src, str(camp))
+    assert report["N_raw"] == 4
+    assert report["N_claim"] == 2
+    assert report["N_dropped"] == 2
+    dropped_ids = {d["pdb_id"] for d in report["dropped_rows"]}
+    assert dropped_ids == {"SEED1", "NAT1"}
+    assert set(report["metrics"]["S1"]["ids"]) == {"GOOD1"}
+    assert set(report["metrics"]["S3"]["ids"]) == {"GOOD1", "GOOD2"}
+
+
+def test_matrix_md5_pin_filters_wrong_matrix(tmp_path: Path):
+    mod = _load()
+    rows = [
+        _row("OK", rmsd_h=1.0, bcr=0.9, matrix_md5=DEFAULT_PIN),
+        _row(
+            "BADMAT",
+            rmsd_h=1.0,
+            bcr=0.9,
+            matrix_md5="deadbeefdeadbeefdeadbeefdeadbeef",
+        ),
+    ]
+    camp = _write_campaign(tmp_path, rows)
+    pin, src = mod.load_matrix_pin(camp, None)
+    report = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, src, str(camp))
+    assert report["N_claim"] == 1
+    assert report["dropped_rows"][0]["pdb_id"] == "BADMAT"
+    assert any("matrix_md5_mismatch" in r for r in report["dropped_rows"][0]["reasons"])
+
+
+def test_s1_vs_s3_diverge_election_gap(tmp_path: Path):
+    """S3 can exceed S1 when BCR finds a near-native the elector missed."""
+    mod = _load()
+    rows = [
+        # S1+S2+S3
+        _row("HIT", rmsd_h=1.5, bcr=0.9, pb=1),
+        # election gap: BCR ≤2, elected >2
+        _row("GAP1", rmsd_h=5.7, bcr=1.6, pb=0),
+        _row("GAP2", rmsd_h=4.2, bcr=1.9, pb=0),
+        # both fail
+        _row("MISS", rmsd_h=6.0, bcr=3.5, pb=0),
+        # S1 without PB → S2 fail
+        _row("NOPB", rmsd_h=1.1, bcr=1.0, pb=0),
+    ]
+    camp = _write_campaign(tmp_path, rows)
+    pin, src = mod.load_matrix_pin(camp, None)
+    report = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, src, str(camp))
+    assert report["N_claim"] == 5
+    assert report["metrics"]["S1"]["n"] == 2  # HIT, NOPB
+    assert report["metrics"]["S2"]["n"] == 1  # HIT only
+    assert report["metrics"]["S3"]["n"] == 4  # HIT, GAP1, GAP2, NOPB
+    assert report["election_gap"]["n"] == 2
+    assert set(report["election_gap"]["ids"]) == {"GAP1", "GAP2"}
+    # Rates diverge
+    assert report["metrics"]["S1"]["rate"] == pytest.approx(0.4)
+    assert report["metrics"]["S3"]["rate"] == pytest.approx(0.8)
+    assert report["metrics"]["S3"]["role"] == "diagnostic_only"
+    assert report["headline"]["metric"] == "S1"
+
+
+def test_headline_s3_rejected_without_diagnostic_flag():
+    mod = _load()
+    report = {
+        "N_claim": 1,
+        "metrics": {
+            "S1": {"n": 0, "rate": 0.0, "definition": "s1", "role": "primary_headline"},
+            "S2": {"n": 0, "rate": 0.0, "definition": "s2", "role": "secondary"},
+            "S3": {
+                "n": 1,
+                "rate": 1.0,
+                "definition": "s3",
+                "role": "diagnostic_only",
+            },
+        },
+    }
+    _, err = mod.apply_headline(report, "s3", diagnostic_only=False)
+    assert err == 2
+    out, err2 = mod.apply_headline(report, "s3", diagnostic_only=True)
+    assert err2 is None
+    assert out["headline"]["metric"] == "S3"
+    assert out["headline"].get("warning")
+
+
+def test_cli_headline_s3_exits_nonzero(tmp_path: Path):
+    rows = [_row("A", rmsd_h=5.0, bcr=1.0)]
+    camp = _write_campaign(tmp_path, rows)
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), str(camp), "--headline", "s3"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert "CONTRACT VIOLATION" in proc.stderr
+
+
+def test_cli_happy_path_json(tmp_path: Path):
+    rows = [
+        _row("P1", rmsd_h=1.0, bcr=0.5, pb=1),
+        _row("P2", rmsd_h=4.0, bcr=1.5, pb=0),
+        _row("SEED", rmsd_h=0.1, bcr=0.1, pb=1, seed_echo=1, claim=0),
+    ]
+    camp = _write_campaign(tmp_path, rows)
+    out_json = tmp_path / "out.json"
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), str(camp), "--json", str(out_json), "--quiet"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    report = json.loads(out_json.read_text())
+    assert report["N_claim"] == 2
+    assert report["metrics"]["S1"]["n"] == 1
+    assert report["metrics"]["S3"]["n"] == 2
+    assert report["metrics"]["S3"]["role"] == "diagnostic_only"
+    assert report["matrix_md5_pin"] == DEFAULT_PIN
+
+
+def test_flat_summary_csv(tmp_path: Path):
+    mod = _load()
+    rows = [
+        _row("X", rmsd_h=1.8, bcr=1.2, pb=1),
+        _row("Y", rmsd_h=2.5, bcr=2.1, pb=0),
+    ]
+    csv_path = tmp_path / "summary.csv"
+    with csv_path.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=CSV_FIELDS)
+        w.writeheader()
+        for r in rows:
+            w.writerow({k: r.get(k, "") for k in CSV_FIELDS})
+    # No receipt → default pin; rows omit matrix_md5 → campaign pin applies
+    report = mod.aggregate_rows(
+        mod.load_rows_from_csv(csv_path),
+        DEFAULT_PIN,
+        "default_pin",
+        str(tmp_path),
+    )
+    assert report["N_claim"] == 2
+    assert report["metrics"]["S1"]["n"] == 1
+    assert report["metrics"]["S3"]["n"] == 1
+
+
+def test_cli_csv_flag(tmp_path: Path):
+    rows = [_row("Z", rmsd_h=0.5, bcr=0.4, pb=1)]
+    csv_path = tmp_path / "astex_diverse_results.csv"
+    with csv_path.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=CSV_FIELDS)
+        w.writeheader()
+        w.writerow({k: rows[0].get(k, "") for k in CSV_FIELDS})
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--csv", str(csv_path), "--quiet"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    report = json.loads(proc.stdout)
+    assert report["N_claim"] == 1
+    assert report["metrics"]["S1"]["n"] == 1
+    assert report["metrics"]["S2"]["n"] == 1
+
+
+if __name__ == "__main__":
+    # Allow bare `python3 tests/test_aggregate_claim_metrics.py`
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements the **Science priority #1** admission + metrics contract for claim-table aggregation:

- **S1** = elected RMSD ≤ 2.0 Å (**primary / headline**)
- **S2** = S1 ∧ PoseBusters
- **S3** = BCR / any-pose ≤ 2.0 Å (**diagnostic only** — never abstract success)
- Claim admission: `seed_echo==0`, `native_pose_seeded==0`, `matrix_md5` pin (default `72d7c7396702331d96ff12d18f831796` or `RUN_RECEIPT` / `provenance`)

### Files

| Path | Role |
|------|------|
| `benchmarks/protocols/admission_metrics_contract.md` | Normative contract |
| `benchmarks/protocols/three_engine_entropy_comparison.md` | Cross-link + CLI |
| `scripts/aggregate_claim_metrics.py` | Enforceable aggregator |
| `tests/test_aggregate_claim_metrics.py` | Fixture CSV unit tests |

**No ranking, docking, or election code changes.**

## CLI

```bash
# Campaign tree (*/result.csv) or summary CSV
python3 scripts/aggregate_claim_metrics.py <campaign_dir> [--json out.json]
python3 scripts/aggregate_claim_metrics.py --csv summary.csv

# C0 full85 (after source ~/.flexaidds_env)
python3 scripts/aggregate_claim_metrics.py --c0-full85

# Contract enforcement: S3 as primary fails unless diagnostic-only
python3 scripts/aggregate_claim_metrics.py <dir> --headline s3                 # exit 2
python3 scripts/aggregate_claim_metrics.py <dir> --headline s3 --diagnostic-only  # OK, labelled diagnostic
```

## Test proof

```text
$ python3 -m pytest tests/test_aggregate_claim_metrics.py -q
........                                                                 [100%]
8 passed in 0.17s
```

Coverage includes:
- claim filter drops `seed_echo=1` / `native_pose_seeded=1` rows
- matrix_md5 pin mismatch drops rows
- S1 vs S3 diverge with election_gap (S3∧¬S1)
- `--headline s3` exits 2 without `--diagnostic-only`

### Live C0 partial (N=12 of 85 at aggregation time)

```text
matrix_md5_pin: 72d7c7396702331d96ff12d18f831796 (source=RUN_RECEIPT.json)
N_raw=12  N_claim=12  N_dropped=0
S1 (primary):     2/12 = 16.67%
S2 (S1∧PB):       2/12 = 16.67%
S3 (diagnostic):  4/12 = 33.33%  [NOT abstract success]
election_gap (S3∧¬S1): 2/12 = 16.67%
```

## Aligns with

- `benchmarks/protocols/three_engine_entropy_comparison.md` §1.4–§5
- `AGENTS.md` scientific guardrails
- Default matrix pin matching C0 full85 `RUN_RECEIPT.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to aggregate campaign metrics and generate text or JSON reports.
  * Added eligibility checks for seeded results, matrix versions, and protocol claim status.
  * Added S1, S2, and diagnostic S3 metrics, including rates, counts, exclusions, and election-gap details.
  * Added headline metric selection with safeguards for diagnostic-only reporting.

* **Documentation**
  * Added the normative admission metrics contract and updated the entropy comparison protocol with aggregation guidance.

* **Tests**
  * Added coverage for aggregation, eligibility filtering, CSV inputs, JSON output, and headline validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->