### PR TITLE
Fix: Shell/exec path hardening for provenance safety

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2378,6 +2378,12 @@ if(BUILD_TESTING)
         TEST_NAME BufferSafetyTests
     )
 
+    # test_shell_exec — path-safe shell quoting / argv exec helpers
+    flexaids_add_unit_test(test_shell_exec
+        SOURCES tests/test_shell_exec.cpp
+        TEST_NAME ShellExecTests
+    )
+
     message(STATUS "Unit tests enabled — build targets: test_statmech, test_hardware_dispatch, test_tencom_diff, test_target_validation, test_grand_partition, test_target_server, test_multi_site_gpf")
     # test_hbond_potential — Angular-dependent H-bond potential unit tests
     flexaids_add_unit_test(test_hbond_potential

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -17,6 +17,7 @@
 #include "AsyncPipeline.h"
 #include "BenchmarkRunner.h"
 #include "ProtocolConfig.h"
+#include "shell_exec.h"
 #include "statmech.h"
 #include "receptor_prep.h"
 #include "tENCoM/tencm.h"   // tencm::TorsionalENM — ligand Cartesian ANM for H(ω)
@@ -96,17 +97,13 @@ static int deterministic_ga_seed(const std::string& target_id, int restart,
 }
 
 /// POSIX-shell single-quote escape for paths interpolated into `sh -c` strings.
-/// Turns `foo'bar` into `'foo'\''bar'`. Prefer argv/exec when no shell is needed.
-static std::string shell_quote(const std::string& s) {
-    std::string o = "'";
-    o.reserve(s.size() + 8);
-    for (char c : s) {
-        if (c == '\'') o += "'\\''";
-        else o += c;
-    }
-    o += "'";
-    return o;
-}
+/// Turns `foo'bar` into `'foo'\''bar'`. Refuses NUL/newlines/control chars.
+/// Prefer argv/exec (fork_exec_argv / shell_exec::run_argv) when no shell is needed.
+using flexaids::shell_exec::shell_quote;
+using flexaids::shell_exec::is_safe_exec_path;
+using flexaids::shell_exec::run_argv;
+using flexaids::shell_exec::run_argv_capture;
+using flexaids::shell_exec::run_argv_first_token;
 
 // =============================================================================
 // Static pointers for async-signal-safe handler access.
@@ -1918,12 +1915,20 @@ bool DatasetRunner::http_download(const std::string& url, const std::string& out
         return retries < 0 ? 0 : retries;
     };
 
-    // Use system curl with retry logic
-    std::ostringstream cmd;
-    cmd << "curl -sS -L --retry " << download_retry_count() << " --retry-delay 2 -o \""
-        << out_path << "\" \"" << url << "\" 2>&1";
+    // Argv exec — no shell. Paths/URLs never pass through sh -c interpolation.
+    if (!is_safe_exec_path(out_path) || !is_safe_exec_path(url)) {
+        std::cerr << "  [ERROR] Unsafe path/URL for download (NUL/newline/control)\n";
+        return false;
+    }
 
-    int ret = exec_cmd(cmd.str());
+    const std::vector<std::string> argv = {
+        "curl", "-sS", "-L",
+        "--retry", std::to_string(download_retry_count()),
+        "--retry-delay", "2",
+        "-o", out_path,
+        url,
+    };
+    int ret = run_argv(argv);
     if (ret != 0) {
         std::cerr << "  [ERROR] Download failed: " << url << "\n";
         return false;
@@ -4950,32 +4955,17 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
     // file timestamps (which do not survive a reboot). Best-effort: any
     // failure here is non-fatal and must not block docking.
     {
-        // First non-empty whitespace token of a shell command's stdout, or "".
-        auto cmd_token = [](const std::string& cmd) -> std::string {
-            std::string out;
-            FILE* p = popen(cmd.c_str(), "r");
-            if (!p) return out;
-            char buf[512];
-            while (fgets(buf, sizeof(buf), p)) out += buf;
-            pclose(p);
-            std::string tok;
-            for (char c : out) {
-                if (std::isspace(static_cast<unsigned char>(c))) { if (!tok.empty()) break; }
-                else tok += c;
-            }
-            return tok;
-        };
-        // shell_quote is file-scope (shell path hardening); reused for md5/sha.
-        auto md5_of = [&](const std::string& path) -> std::string {
-            if (path.empty() || !fs::exists(path)) return "";
-            std::string t = cmd_token("md5 -q " + shell_quote(path) + " 2>/dev/null");
-            if (t.empty()) t = cmd_token("md5sum " + shell_quote(path) + " 2>/dev/null");
+        // Argv-only hash helpers — no shell, so provenance paths cannot inject.
+        auto md5_of = [](const std::string& path) -> std::string {
+            if (path.empty() || !fs::exists(path) || !is_safe_exec_path(path)) return "";
+            std::string t = run_argv_first_token({"md5", "-q", path});
+            if (t.empty()) t = run_argv_first_token({"md5sum", path});
             return t;
         };
-        auto sha256_of = [&](const std::string& path) -> std::string {
-            if (path.empty() || !fs::exists(path)) return "";
-            std::string t = cmd_token("shasum -a 256 " + shell_quote(path) + " 2>/dev/null");
-            if (t.empty()) t = cmd_token("sha256sum " + shell_quote(path) + " 2>/dev/null");
+        auto sha256_of = [](const std::string& path) -> std::string {
+            if (path.empty() || !fs::exists(path) || !is_safe_exec_path(path)) return "";
+            std::string t = run_argv_first_token({"shasum", "-a", "256", path});
+            if (t.empty()) t = run_argv_first_token({"sha256sum", path});
             return t;
         };
 
@@ -5000,8 +4990,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         const char* oracle_env =
             protocol_cfg_.oracle_site_dir.empty() ? nullptr
                                                  : protocol_cfg_.oracle_site_dir.c_str();
-        std::string git_commit = cmd_token(
-            "git rev-parse HEAD 2>/dev/null");
+        std::string git_commit = run_argv_first_token({"git", "rev-parse", "HEAD"});
 
         auto json_esc = [](const std::string& s) {
             std::string r;
@@ -5796,8 +5785,12 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                 const std::string& dd_override = protocol_cfg_.data_dir;
                 if (!dd_override.empty() &&
                     fs::exists(dd_override + "/MC_st0r5.2_6.dat")) {
-                    data_dir_arg = " --data-dir " +
-                                   shell_quote(fs::canonical(dd_override).string()) + " ";
+                    const std::string canon = fs::canonical(dd_override).string();
+                    if (!is_safe_exec_path(canon)) {
+                        throw std::runtime_error(
+                            "FLEXAIDDS_DATA_DIR/path is unsafe for shell (NUL/newline/control)");
+                    }
+                    data_dir_arg = " --data-dir " + shell_quote(canon) + " ";
                 } else {
                     std::string bin_dir = flexaidds_bin;
                     auto slash = bin_dir.rfind('/');

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -95,6 +95,19 @@ static int deterministic_ga_seed(const std::string& target_id, int restart,
     return 1 + static_cast<int>(stable_seed_hash(target_id, stream) % 2147483646ULL);
 }
 
+/// POSIX-shell single-quote escape for paths interpolated into `sh -c` strings.
+/// Turns `foo'bar` into `'foo'\''bar'`. Prefer argv/exec when no shell is needed.
+static std::string shell_quote(const std::string& s) {
+    std::string o = "'";
+    o.reserve(s.size() + 8);
+    for (char c : s) {
+        if (c == '\'') o += "'\\''";
+        else o += c;
+    }
+    o += "'";
+    return o;
+}
+
 // =============================================================================
 // Static pointers for async-signal-safe handler access.
 // Set just before sigaction(), cleared after signal restore on normal exit.
@@ -132,6 +145,8 @@ pid_t SubprocessGuard::fork_exec(const std::string& cmd) {
         ::signal(SIGTERM, SIG_DFL);
         ::signal(SIGINT, SIG_DFL);
 
+        // Shell remains for dock cmds that need env prefixes + redirection.
+        // All interpolated paths must pass through shell_quote().
         ::execl("/bin/sh", "sh", "-c", cmd.c_str(), nullptr);
         ::_exit(127);  // exec failed
     }
@@ -149,6 +164,42 @@ pid_t SubprocessGuard::fork_exec(const std::string& cmd) {
     // Real PID tracking not available on Windows.
     int ret = std::system(cmd.c_str());
     return ret;
+#endif
+}
+
+pid_t SubprocessGuard::fork_exec_argv(const std::vector<std::string>& argv) {
+#ifndef _MSC_VER
+    if (argv.empty() || argv[0].empty()) return -1;
+
+    pid_t pid = fork();
+    if (pid < 0) return -1;
+
+    if (pid == 0) {
+        ::setpgid(0, 0);
+        ::close(0);
+        ::open("/dev/null", O_RDONLY);
+        ::signal(SIGTERM, SIG_DFL);
+        ::signal(SIGINT, SIG_DFL);
+
+        std::vector<char*> c_argv;
+        c_argv.reserve(argv.size() + 1);
+        for (const auto& s : argv) {
+            c_argv.push_back(const_cast<char*>(s.c_str()));
+        }
+        c_argv.push_back(nullptr);
+        ::execvp(c_argv[0], c_argv.data());
+        ::_exit(127);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        pids_.insert(pid);
+    }
+    ::setpgid(pid, pid);
+    return pid;
+#else
+    (void)argv;
+    return -1;
 #endif
 }
 
@@ -4914,12 +4965,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             }
             return tok;
         };
-        auto shell_quote = [](const std::string& s) {
-            std::string q = "'";
-            for (char c : s) { if (c == '\'') q += "'\\''"; else q += c; }
-            q += "'";
-            return q;
-        };
+        // shell_quote is file-scope (shell path hardening); reused for md5/sha.
         auto md5_of = [&](const std::string& path) -> std::string {
             if (path.empty() || !fs::exists(path)) return "";
             std::string t = cmd_token("md5 -q " + shell_quote(path) + " 2>/dev/null");
@@ -5739,6 +5785,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
 
             // Build FlexAIDdS command with --config
             // Resolve the runtime data directory with reproducible precedence.
+            // Paths are shell_quote'd: dock still uses /bin/sh -c for env
+            // prefixes + stdout/stderr redirection (fork_exec_argv cannot).
             std::string data_dir_arg;
             {
                 // FLEXAIDDS_DATA_DIR remains the explicit matrix-swap hook for
@@ -5748,8 +5796,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                 const std::string& dd_override = protocol_cfg_.data_dir;
                 if (!dd_override.empty() &&
                     fs::exists(dd_override + "/MC_st0r5.2_6.dat")) {
-                    data_dir_arg = " --data-dir '" +
-                                   fs::canonical(dd_override).string() + "' ";
+                    data_dir_arg = " --data-dir " +
+                                   shell_quote(fs::canonical(dd_override).string()) + " ";
                 } else {
                     std::string bin_dir = flexaidds_bin;
                     auto slash = bin_dir.rfind('/');
@@ -5757,11 +5805,11 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                     const std::string staged_candidate = bin_dir;
                     const std::string wrk_candidate = bin_dir + "/../WRK";
                     if (fs::exists(staged_candidate + "/MC_st0r5.2_6.dat")) {
-                        data_dir_arg = " --data-dir '" +
-                                       fs::canonical(staged_candidate).string() + "' ";
+                        data_dir_arg = " --data-dir " +
+                                       shell_quote(fs::canonical(staged_candidate).string()) + " ";
                     } else if (fs::exists(wrk_candidate + "/MC_st0r5.2_6.dat")) {
-                        data_dir_arg = " --data-dir '" +
-                                       fs::canonical(wrk_candidate).string() + "' ";
+                        data_dir_arg = " --data-dir " +
+                                       shell_quote(fs::canonical(wrk_candidate).string()) + " ";
                     }
                 }
             }
@@ -5927,7 +5975,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
 
             std::ostringstream cmd;
             if (!entry.cleft_sphere_path.empty() && fs::exists(entry.cleft_sphere_path)) {
-                cmd << "FLEXAIDDS_CLEFT_SPHERE_FILE='" << entry.cleft_sphere_path << "' ";
+                cmd << "FLEXAIDDS_CLEFT_SPHERE_FILE="
+                    << shell_quote(entry.cleft_sphere_path) << " ";
                 std::cerr << "  [MULTI-CLEFT] " << entry.pdb_id
                           << " using cleft sphere file: "
                           << entry.cleft_sphere_path << "\n";
@@ -5952,7 +6001,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             if (entry.cleft_sphere_path.empty() &&
                 inject_oracle_site &&
                 !entry.binding_site_path.empty() && fs::exists(entry.binding_site_path)) {
-                cmd << "FLEXAIDDS_ORACLE_SITE='" << entry.binding_site_path << "' ";
+                cmd << "FLEXAIDDS_ORACLE_SITE="
+                    << shell_quote(entry.binding_site_path) << " ";
                 std::cerr << "  ["
                           << (config.mode == BenchmarkMode::AUTONOMOUS
                                   ? "COGNATE-REDOCK"
@@ -5973,17 +6023,17 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                  native_diag_requested) &&
                 !rmsd_reference_path.empty() && fs::exists(rmsd_reference_path)) {
                 cmd << "FLEXAIDDS_SCORE_NATIVE=1 "
-                    << "FLEXAIDDS_RMSDST='" << rmsd_reference_path << "' ";
+                    << "FLEXAIDDS_RMSDST=" << shell_quote(rmsd_reference_path) << " ";
             }
             cmd << "OMP_NUM_THREADS=" << omp_per_worker << " "
                 << "OMP_PLACES=cores "
                 << "OMP_PROC_BIND=spread "
                 << "OMP_WAIT_POLICY=passive "
-                << "'" << flexaidds_bin << "' "
+                << shell_quote(flexaidds_bin) << " "
                 << data_dir_arg
-                << "'" << effective_receptor << "' "
-                << "'" << dock_ligand_path << "' "
-                << "--config '" << config_path << "' ";
+                << shell_quote(effective_receptor) << " "
+                << shell_quote(dock_ligand_path) << " "
+                << "--config " << shell_quote(config_path) << " ";
 
             // ── Multi-cleft parallel docking (FLEXAIDDS_MULTI_CLEFT=N) ────────
             // When set, each FlexAIDdS invocation runs N independent GA instances
@@ -5998,9 +6048,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                 }
             }
 
-            cmd << "-o '" << ri_prefix << "' "
-                << "2>'" << ri_dir << "/stderr.log' "
-                << ">'" << ri_dir << "/stdout.log'";
+            cmd << "-o " << shell_quote(ri_prefix) << " "
+                << "2>" << shell_quote(ri_dir + "/stderr.log") << " "
+                << ">" << shell_quote(ri_dir + "/stdout.log");
 
             if (parallel_restarts) {
                 // ── Parallel mode: fork now, wait after all restarts launched ──

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -835,9 +835,17 @@ static std::pair<std::string,float> select_pose_freq_gated(const std::string& ou
 // larger, more diverse set for Fix B to select from (v25 multi-restart pooling).
 static std::pair<std::string,float> select_pose_freq_gated_pooled(
         const std::vector<std::string>& prefixes,
-        int seed_elitism_override = -1,  // -1=read env var, 0=force off, 1=force on
-        bool cf_window_selector = false) // Fix A: CF-window gate (see header member)
+        int seed_elitism_override = -1,  // -1=ProtocolConfig default, 0=force off, 1=force on
+        bool cf_window_selector = false, // Fix A: CF-window gate (see header member)
+        const flexaids::ProtocolConfig* protocol = nullptr)
 {
+    // Pose-selector knobs come from ProtocolConfig (env adapter). Prefer a
+    // caller-supplied snapshot (DatasetRunner::protocol_cfg_); fall back to a
+    // fresh from_env() for standalone / legacy call sites.
+    const flexaids::ProtocolConfig local_proto =
+        protocol ? flexaids::ProtocolConfig{} : flexaids::ProtocolConfig::from_env();
+    const flexaids::ProtocolConfig& proto = protocol ? *protocol : local_proto;
+
     // ── Boltzmann Z+H composite cluster selection (Options B+C) ─────────────
     // Instead of pure CF-rank-0, score each cluster by:
     //   Z_cluster  = sum_{i in members} exp(-CF_i / kT)        [partition fn]
@@ -967,9 +975,7 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
     if (seed_elitism_override >= 0) {
         seed_elitism = (seed_elitism_override != 0);
     } else {
-        seed_elitism = true;
-        if (const char* e = std::getenv("FLEXAIDDS_SEED_ELITISM"))
-            seed_elitism = (std::atoi(e) != 0);
+        seed_elitism = proto.seed_elitism;
     }
     std::vector<PoseInfo> seeds;
     if (seed_elitism) {
@@ -1052,15 +1058,9 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
         // pose — it broke 1J3J/1SG0 and never flipped 1Q4G/1MEH. The real lever
         // is the CF scoring false minimum, not pose selection. Kept env-gated
         // (FLEXAIDDS_FREQSEL=1) for experimentation only.
-        bool freqsel = false;
-        if (const char* e = std::getenv("FLEXAIDDS_FREQSEL"))
-            freqsel = (std::atoi(e) != 0);
-        double freqsel_alpha = 12.0;
-        if (const char* e = std::getenv("FLEXAIDDS_FREQSEL_ALPHA"))
-            try { freqsel_alpha = std::stod(e); } catch (...) {}
-        float freqsel_rmsd = 1.5f;
-        if (const char* e = std::getenv("FLEXAIDDS_FREQSEL_RMSD"))
-            try { freqsel_rmsd = std::stof(e); } catch (...) {}
+        const bool freqsel = proto.freqsel;
+        const double freqsel_alpha = proto.freqsel_alpha;
+        const float freqsel_rmsd = proto.freqsel_rmsd;
 
         if (freqsel && chosen.size() > 1) {
             const int n = static_cast<int>(chosen.size());
@@ -1128,12 +1128,8 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
     // no GA pose qualified at all.  The threshold prevents IC-round-trip error
     // from overriding geometrically superior GA poses when the CF gap is small
     // (e.g. 1XM6: crystal IC 2.60 Å vs GA 0.96 Å with ΔCF ≈ 5).
-    // Env: FLEXAIDDS_SEED_ELITISM_DELTA_CF (float, default 10.0).
-    static const double DELTA_CF = [](){
-        if (const char* e = std::getenv("FLEXAIDDS_SEED_ELITISM_DELTA_CF"))
-            try { return std::stod(e); } catch (...) {}
-        return 10.0;
-    }();
+    // Env: FLEXAIDDS_SEED_ELITISM_DELTA_CF via ProtocolConfig (default 10.0).
+    const double DELTA_CF = proto.seed_elitism_delta_cf;
     const PoseInfo* best = freq_best;
     for (const auto& s : seeds)
         if (best == nullptr || s.cf < best->cf - DELTA_CF) best = &s;
@@ -3714,8 +3710,10 @@ std::vector<DatasetEntry> DatasetRunner::fetch_astex() {
     std::vector<DatasetEntry> entries;
     entries.reserve(codes.size());
 
-    // Fallback oracle site directory from env var (used when cache != source tree)
-    const char* oracle_site_dir_env = std::getenv("FLEXAIDDS_ORACLE_SITE_DIR");
+    // Fallback oracle site directory (ProtocolConfig / FLEXAIDDS_ORACLE_SITE_DIR)
+    const char* oracle_site_dir_env =
+        protocol_cfg_.oracle_site_dir.empty() ? nullptr
+                                             : protocol_cfg_.oracle_site_dir.c_str();
 
     int oracle_count = 0;
     for (const auto& pdb : codes) {
@@ -4819,14 +4817,19 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
     report.dataset_name = entries.front().source;
     report.total_systems = static_cast<int>(entries.size());
 
+    // Re-snapshot protocol knobs at run() entry so long-lived runners pick up
+    // env changes after construction (chunk 1 only snapshotted the ctor).
+    protocol_cfg_ = flexaids::ProtocolConfig::from_env();
+    cf_window_selector_ = protocol_cfg_.cf_window_selector;
+    cluster_member_emit_ = protocol_cfg_.cluster_member_emit;
+
     // ── Clustering algorithm override ─────────────────────────────────────
     // FLEXAIDDS_USE_DP=1  → use Density Peak (DP) clustering instead of the
     // default CF.  DP elects the highest-density region as cluster head
     // (OUTPUT_CLUSTER_CENTER=true in DensityPeak_Cluster.cpp) which is more
     // representative of the fitness landscape than the lowest-CF outlier.
-    const char* use_dp_env = std::getenv("FLEXAIDDS_USE_DP");
     const std::string effective_clustering_algo =
-        (use_dp_env && std::strcmp(use_dp_env, "1") == 0) ? "DP" : config.clustering_algorithm;
+        protocol_cfg_.use_dp ? "DP" : config.clustering_algorithm;
     if (effective_clustering_algo != config.clustering_algorithm) {
         std::cout << "[DatasetRunner] FLEXAIDDS_USE_DP=1 → clustering_algorithm overridden to DP\n";
     }
@@ -4948,7 +4951,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             else if (fs::exists(source)) matrix_path = source;
         }
 
-        const char* oracle_env = std::getenv("FLEXAIDDS_ORACLE_SITE_DIR");
+        const char* oracle_env =
+            protocol_cfg_.oracle_site_dir.empty() ? nullptr
+                                                 : protocol_cfg_.oracle_site_dir.c_str();
         std::string git_commit = cmd_token(
             "git rev-parse HEAD 2>/dev/null");
 
@@ -5249,10 +5254,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         // FLEXAIDDS_IGNORE_CACHE=1 forces re-run regardless of cached result.csv.
         // Use when the binary or scoring parameters changed between runs so stale
         // cached results from a different binary are not silently reused.
-        const bool ignore_cache = []() -> bool {
-            const char* e = std::getenv("FLEXAIDDS_IGNORE_CACHE");
-            return e && std::atoi(e) != 0;
-        }();
+        const bool ignore_cache = protocol_cfg_.ignore_cache;
         bool skip = false;
         bool cached_csv_success = false;
         float cached_csv_best_score = 0.0f;
@@ -5380,9 +5382,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // Ring pucker (LigandRingFlex Phase 2) adds DoF via a side-channel
             // gene that does NOT pass through FA->npar — so fold its DoF into the
             // budget scaling input here, but only when ring flex is enabled.
-            const char* ring_flex_env = std::getenv("FLEXAIDDS_RING_FLEX");
             const int   ring_dof_est =
-                (ring_flex_env && std::atoi(ring_flex_env) != 0)
+                protocol_cfg_.ring_flex
                 ? count_ring_pucker_dof_sdf(entry.ligand_path) : 0;
             const int n_genes  = 4 + fdih_est + ring_dof_est;
 
@@ -5394,21 +5395,11 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // one (which caused stochastic search failure for flexible ligands).
             //   n_flex_bonds   = perceived rotatable bonds = dihedral genes (fdih)
             //   n_gen_effective = n_gen_base × max(1.0, n_flex_bonds / 4.0)
-            // Gated by FLEXAIDDS_EVAL_SCALE_DIHEDRAL:
+            // Gated by FLEXAIDDS_EVAL_SCALE_DIHEDRAL (ProtocolConfig):
             //   1 (default) = pop-scale by DoF (iso-budget chromosome swap)
             //   0           = legacy gen-scale ceil(n_genes/4)
             //   -1 / "off"  = fixed pop+gen (no DoF scaling) — v43 oracle-ceiling restore
-            const char* eval_scale_env = std::getenv("FLEXAIDDS_EVAL_SCALE_DIHEDRAL");
-            int eval_scale_mode = 1;
-            if (eval_scale_env) {
-                if (std::strcmp(eval_scale_env, "off") == 0 ||
-                    std::strcmp(eval_scale_env, "none") == 0 ||
-                    std::strcmp(eval_scale_env, "fixed") == 0) {
-                    eval_scale_mode = -1;
-                } else {
-                    eval_scale_mode = std::atoi(eval_scale_env);
-                }
-            }
+            const int eval_scale_mode = protocol_cfg_.eval_scale_dihedral;
             const int   n_flex_bonds   = fdih_est;
             const int   n_gen_base     = config.ga_generations;
             const int   pop_base       = config.ga_population;
@@ -5446,11 +5437,10 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                         entry.pdb_id.c_str(), pop_scaled, n_gen_scaled);
             }
 
-            // ── v27 high-DoF budget scaling (FLEXAIDDS_BUDGET_SCALE) ──
+            // ── v27 high-DoF budget scaling (FLEXAIDDS_BUDGET_SCALE via ProtocolConfig) ──
             // High-DoF ligands (n_genes >= 14, i.e. >=10 rotatable bonds): same
             // population-scaling logic absorbs the extra budget multiplier.
-            const char* bscale_env = std::getenv("FLEXAIDDS_BUDGET_SCALE");
-            const int   budget_scale_on = bscale_env ? std::atoi(bscale_env) : 1;
+            const bool budget_scale_on = protocol_cfg_.budget_scale;
             double budget_scale_factor = 1.0;
             if (budget_scale_on && n_genes >= 14) {
                 budget_scale_factor = std::max(1.0,
@@ -5500,7 +5490,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // rotation step (5->2.5 deg) and tighten torsion/side-chain steps.
             // Emitted into the optimization block below so the arm is greppable.
             std::string opt_extra;
-            if (std::getenv("FLEXAIDDS_FINE_GRID")) {
+            if (protocol_cfg_.fine_grid) {
                 opt_extra = ",\n    \"angle_step\": 2.5,"
                             "\n    \"dihedral_step\": 5.0,"
                             "\n    \"flexible_step\": 5.0";
@@ -5956,8 +5946,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // no FLEXAIDDS_SCORE_NATIVE channel.  This is the protocol directly
             // comparable to rDock/GOLD/Vina Astex redocking numbers (known site,
             // ligand pose searched from scratch — NOT a crystal-pose ceiling).
-            const bool cognate_site_opt_in =
-                std::getenv("FLEXAIDDS_COGNATE_SITE") != nullptr;
+            const bool cognate_site_opt_in = protocol_cfg_.cognate_site;
             const bool inject_oracle_site =
                 (config.mode != BenchmarkMode::AUTONOMOUS) || cognate_site_opt_in;
             if (entry.cleft_sphere_path.empty() &&
@@ -5978,10 +5967,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // scorer sees the correct reference pose, not the blinded input.
             // Skip in AUTONOMOUS mode so blind runs have no native/reference
             // scoring channel in the child process environment.
-            const char* native_diag_env = std::getenv("FLEXAIDDS_SCORE_NATIVE");
-            const bool native_diag_requested =
-                native_diag_env && native_diag_env[0] != '\0' &&
-                std::strcmp(native_diag_env, "0") != 0;
+            const bool native_diag_requested = protocol_cfg_.score_native;
             if (config.mode != BenchmarkMode::AUTONOMOUS &&
                 (config.mode != BenchmarkMode::DEFINED_CLEFT_REDOCK ||
                  native_diag_requested) &&
@@ -6006,10 +5992,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // the fixed ParallelDockManager::get_best_chromosome() path.
             // N=8 is recommended for M3 Pro (leaves headroom for DatasetRunner).
             {
-                const char* mc_env = std::getenv("FLEXAIDDS_MULTI_CLEFT");
-                if (mc_env && std::atoi(mc_env) > 1) {
-                    int n_regions = std::atoi(mc_env);
-                    cmd << "--parallel-dock --parallel-dock-regions " << n_regions << " ";
+                if (protocol_cfg_.multi_cleft > 1) {
+                    cmd << "--parallel-dock --parallel-dock-regions "
+                        << protocol_cfg_.multi_cleft << " ";
                 }
             }
 
@@ -6364,7 +6349,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         // min only if no emitted pose with a REMARK CF is found.
         {
             auto sel = select_pose_freq_gated_pooled(all_prefixes, sel_elitism_ovr,
-                                                     cf_window_selector_);
+                                                     cf_window_selector_,
+                                                     &protocol_cfg_);
             if (!sel.first.empty() && std::isfinite(sel.second))
                 best_cf = sel.second;
         }
@@ -6461,7 +6447,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // clusters with Frequency>1, and returns the min-CF pose within that
             // pool (see helper definition near compute_pose_ligand_rmsd).
             // elected_pose_for_pb lives outside this block for PoseBust post-pass.
-            std::string best_pose_pdb = select_pose_freq_gated_pooled(all_prefixes, sel_elitism_ovr, cf_window_selector_).first;
+            std::string best_pose_pdb = select_pose_freq_gated_pooled(
+                all_prefixes, sel_elitism_ovr, cf_window_selector_, &protocol_cfg_).first;
             // Fallback: no scored pose found — take first available pose file from any restart.
             if (best_pose_pdb.empty()) {
                 for (const auto& pfx : all_prefixes) {
@@ -6488,8 +6475,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // benchmark endpoint. It needs at least two restart
             // prefixes to carry any cross-restart signal.
             {
-                const char* consensus_env = std::getenv("FLEXAIDDS_CONSENSUS_SCORER");
-                const int   consensus_on  = consensus_env ? std::atoi(consensus_env) : 0;
+                const bool consensus_on = protocol_cfg_.consensus_scorer;
                 if (consensus_on && all_prefixes.size() >= 2 && !best_pose_pdb.empty()) {
                     constexpr float kConsensusDelta = 1.5f;
                     struct Cand {
@@ -6948,7 +6934,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // Still try to elect a pose for PoseBust even without crystal RMSD ref.
             if (docking_completed) {
                 elected_pose_pdb = select_pose_freq_gated_pooled(
-                    all_prefixes, sel_elitism_ovr, cf_window_selector_).first;
+                    all_prefixes, sel_elitism_ovr, cf_window_selector_,
+                    &protocol_cfg_).first;
             }
         }
 
@@ -7263,8 +7250,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         // not alter pose election; exact-pose status is hash-joined to the same
         // elected_pose.pdb used by RMSD and PoseBusters.
         {
-            const char* hvib_env = std::getenv("FLEXAIDDS_HVIB");
-            const bool hvib_enabled = !(hvib_env && std::strcmp(hvib_env, "0") == 0);
+            const bool hvib_enabled = protocol_cfg_.hvib_enabled;
             if (hvib_enabled) {
                 HvibColumns hv = compute_target_hvib(all_prefixes);
                 result.H_rep_rank0 = hv.H_rep_rank0;
@@ -7796,7 +7782,7 @@ void DatasetRunner::write_report(const BenchmarkReport& report,
         // thermodynamic decomposition columns (H_vct/TdS_vib/TdS_shannon/G_bind)
         // to the aggregate results CSV so benchmarks/calibrate_itc.py can fit the
         // α (enthalpy) and β (entropy) scaling factors directly from one file.
-        const bool thermo_csv = (std::getenv("FLEXAIDDS_THERMO_CSV") != nullptr);
+        const bool thermo_csv = protocol_cfg_.thermo_csv;
 
         ofs << "pdb_id,best_score,rmsd_to_crystal,rmsd_hungarian,predicted_dG,"
                "predicted_dH,predicted_TdS,shannon_entropy,search_entropy_proxy,num_poses,wall_time_s,success,"

--- a/LIB/DatasetRunner.h
+++ b/LIB/DatasetRunner.h
@@ -370,9 +370,16 @@ public:
     SubprocessGuard();
     ~SubprocessGuard();
 
-    /// Fork, set process group, exec.  Returns child PID (or -1 on failure).
-    /// The child PID is registered for automatic cleanup.
+    /// Fork, set process group, exec via `/bin/sh -c`.  Returns child PID
+    /// (or -1 on failure). The child PID is registered for automatic cleanup.
+    /// Prefer fork_exec_argv when no shell metacharacters/redirection are needed.
     pid_t fork_exec(const std::string& cmd);
+
+    /// Fork + execvp(argv) without a shell. argv[0] is the program path;
+    /// remaining entries are arguments (no env KEY=VAL prefixes). Use this for
+    /// pure binary invocations; use fork_exec(shell string) when the command
+    /// must set env vars or redirect stdout/stderr.
+    pid_t fork_exec_argv(const std::vector<std::string>& argv);
 
     /// Wait for a specific child with a timeout.
     /// Returns exit code (0-255) on normal exit, -1 on signal/timeout/error.

--- a/LIB/DatasetRunner.h
+++ b/LIB/DatasetRunner.h
@@ -488,11 +488,10 @@ public:
 private:
     std::string cache_dir_;
 
-    /// Typed protocol snapshot (seed/restarts/VCT/GA/thermo/data_dir).
-    /// Loaded once via ProtocolConfig::from_env() in the constructor so
-    /// high-traffic getenv fragments go through one adapter (see
-    /// docs/implementation/protocol-config.md). Residual getenv sites remain
-    /// until later migration chunks.
+    /// Typed protocol snapshot (seed/restarts/VCT/GA/thermo/data_dir + chunk-2
+    /// pose/budget/site knobs). Loaded via ProtocolConfig::from_env() in the
+    /// constructor and re-snapshotted at run() entry so long-lived runners pick
+    /// up env changes (see docs/implementation/protocol-config.md).
     flexaids::ProtocolConfig protocol_cfg_{};
 
     // ── Pose selector tuning ─────────────────────────────────────────

--- a/LIB/PoseBust/BustCli.cpp
+++ b/LIB/PoseBust/BustCli.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "BustCli.h"
+#include "shell_exec.h"
 
 #include <cctype>
 #include <cstdio>
@@ -20,6 +21,10 @@ namespace {
 
 namespace fs = std::filesystem;
 
+using flexaids::shell_exec::is_safe_exec_path;
+using flexaids::shell_exec::run_argv_capture;
+using flexaids::shell_exec::run_argv_first_token;
+
 [[nodiscard]] bool file_executable(const fs::path& p) {
     std::error_code ec;
     return fs::is_regular_file(p, ec) &&
@@ -27,32 +32,12 @@ namespace fs = std::filesystem;
                fs::perms::none;
 }
 
-std::string shell_quote(const std::string& s) {
-    std::string o = "'";
-    for (char c : s) {
-        if (c == '\'') o += "'\\''";
-        else o += c;
-    }
-    o += "'";
-    return o;
-}
-
-std::string shell_quote(const std::string& s);
-
 // Portable file SHA-256 via openssl (always present on macOS/Linux CI).
+// Argv exec — path never reaches a shell.
 std::string sha256_via_openssl(const std::string& path) {
-    const std::string cmd =
-        "openssl dgst -sha256 -r " + shell_quote(path) + " 2>/dev/null";
-    FILE* pipe = popen(cmd.c_str(), "r");
-    if (!pipe) return {};
-    char buf[128];
-    std::string out;
-    while (fgets(buf, sizeof(buf), pipe)) out += buf;
-    pclose(pipe);
-    // format: "<hex> *path" or "<hex> path"
-    std::istringstream iss(out);
-    std::string hex;
-    iss >> hex;
+    if (!is_safe_exec_path(path)) return {};
+    std::string hex = run_argv_first_token(
+        {"openssl", "dgst", "-sha256", "-r", path});
     if (hex.size() != 64) return {};
     for (char& c : hex) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
     return hex;
@@ -171,30 +156,36 @@ BustCliResult run_upstream_bust(const std::string& pred_sdf,
         return r;
     }
 
-    std::ostringstream cmd;
-    cmd << shell_quote(bust) << " " << shell_quote(pred_sdf)
-        << " -p " << shell_quote(protein_pdb);
-    if (!crystal_sdf.empty() && fs::is_regular_file(crystal_sdf)) {
-        cmd << " -l " << shell_quote(crystal_sdf);
-    }
-    cmd << " --outfmt csv 2>/dev/null";
-
-    FILE* pipe = popen(cmd.str().c_str(), "r");
-    if (!pipe) {
-        r.error = "popen(bust) failed";
+    if (!is_safe_exec_path(bust) || !is_safe_exec_path(pred_sdf) ||
+        !is_safe_exec_path(protein_pdb) ||
+        (!crystal_sdf.empty() && !is_safe_exec_path(crystal_sdf))) {
+        r.error = "unsafe path for bust argv (NUL/newline/control)";
         r.backend = "error";
         return r;
     }
-    char buf[4096];
-    std::string out;
-    while (fgets(buf, sizeof(buf), pipe)) out += buf;
-    const int rc = pclose(pipe);
+
+    std::vector<std::string> argv = {bust, pred_sdf, "-p", protein_pdb};
+    if (!crystal_sdf.empty() && fs::is_regular_file(crystal_sdf)) {
+        argv.push_back("-l");
+        argv.push_back(crystal_sdf);
+    }
+    argv.push_back("--outfmt");
+    argv.push_back("csv");
+
+    auto cap = run_argv_capture(argv, /*discard_stderr=*/true);
+    if (!cap.ok) {
+        r.error = "exec(bust) failed";
+        r.backend = "error";
+        return r;
+    }
+    const int rc = cap.exit_code;
+    const std::string& out = cap.stdout_text;
     r.raw_csv = out;
     r.ran = true;
     r.backend = "bust_cli";
 
     if (out.empty()) {
-        r.error = "bust produced empty CSV (pclose_status=" + std::to_string(rc) + ")";
+        r.error = "bust produced empty CSV (exit_status=" + std::to_string(rc) + ")";
         r.pb_pass = false;
         return r;
     }

--- a/LIB/PoseBust/ChecksChemistry.cpp
+++ b/LIB/PoseBust/ChecksChemistry.cpp
@@ -7,6 +7,7 @@
 // No RDKit / posebusters source. Optional system `inchi-1` for inchi_convertible.
 
 #include "ChecksChemistry.h"
+#include "shell_exec.h"
 #include "Loaders.h"  // write_sdf for real inchi-1 convertible check
 
 #include <algorithm>
@@ -489,11 +490,15 @@ void check_chemistry_sanity(const Molecule& pred, std::vector<CheckItem>& out) {
                     ok = false;
                     detail = "write_sdf_failed: " + werr;
                 } else {
-                    const std::string cmd =
-                        "'" + inchi_bin + "' '" + tmp.string() + "' '" +
-                        outp.string() + "' -AuxNone -NoLabels -DoNotAddH "
-                        "2>/dev/null";
-                    const int rc = std::system(cmd.c_str());
+                    // Argv exec — no shell. Paths never interpolated into sh -c.
+                    const int rc = flexaids::shell_exec::run_argv({
+                        inchi_bin,
+                        tmp.string(),
+                        outp.string(),
+                        "-AuxNone",
+                        "-NoLabels",
+                        "-DoNotAddH",
+                    });
                     std::string inchi;
                     {
                         std::ifstream ifs(outp);

--- a/LIB/ProtocolConfig.cpp
+++ b/LIB/ProtocolConfig.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <cstring>
 #include <sstream>
 #include <stdexcept>
 
@@ -30,6 +31,11 @@ bool env_truthy_int(const char* name, bool default_value) {
     const char* e = env_raw(name);
     if (!e || e[0] == '\0') return default_value;
     return std::atoi(e) != 0;
+}
+
+// Presence-only historical gates: any non-null getenv is ON (even "0").
+bool env_present_any(const char* name) {
+    return env_raw(name) != nullptr;
 }
 
 std::optional<double> env_opt_double(const char* name) {
@@ -62,6 +68,11 @@ std::string json_escape(const std::string& s) {
         }
     }
     return out;
+}
+
+void json_bool(std::ostringstream& o, const char* key, bool v, bool trailing_comma = true) {
+    o << '"' << key << "\":" << (v ? "true" : "false");
+    if (trailing_comma) o << ',';
 }
 
 }  // namespace
@@ -119,15 +130,93 @@ ProtocolConfig ProtocolConfig::from_env() {
     if (const char* e = env_raw("FLEXAIDDS_DATA_DIR")) {
         if (e[0] != '\0') cfg.data_dir = e;
     }
+    if (const char* e = env_raw("FLEXAIDDS_ORACLE_SITE_DIR")) {
+        if (e[0] != '\0') cfg.oracle_site_dir = e;
+    }
+    if (const char* e = env_raw("FLEXAIDDS_ORACLE_SITE")) {
+        if (e[0] != '\0') cfg.oracle_site = e;
+    }
+    if (const char* e = env_raw("FLEXAIDDS_CLEFT_SPHERE_FILE")) {
+        if (e[0] != '\0') cfg.cleft_sphere_file = e;
+    }
 
     cfg.cf_window_selector =
         env_truthy_int("FLEXAIDDS_CF_WINDOW_SELECTOR", /*default_value=*/false);
     cfg.cluster_member_emit =
         env_truthy_int("FLEXAIDDS_CLUSTER_MEMBER_EMIT", /*default_value=*/false);
 
+    cfg.seed_elitism = env_truthy_int("FLEXAIDDS_SEED_ELITISM", /*default_value=*/true);
+    if (auto v = env_opt_double("FLEXAIDDS_SEED_ELITISM_DELTA_CF")) {
+        cfg.seed_elitism_delta_cf = *v;
+    }
+    cfg.freqsel = env_truthy_int("FLEXAIDDS_FREQSEL", /*default_value=*/false);
+    if (auto v = env_opt_double("FLEXAIDDS_FREQSEL_ALPHA")) {
+        cfg.freqsel_alpha = *v;
+    }
+    if (auto v = env_opt_double("FLEXAIDDS_FREQSEL_RMSD")) {
+        cfg.freqsel_rmsd = static_cast<float>(*v);
+    }
+    cfg.consensus_scorer =
+        env_truthy_int("FLEXAIDDS_CONSENSUS_SCORER", /*default_value=*/false);
+    // HVIB default ON; only FLEXAIDDS_HVIB=0 disables (historical strcmp).
+    {
+        const char* e = env_raw("FLEXAIDDS_HVIB");
+        cfg.hvib_enabled = !(e && std::strcmp(e, "0") == 0);
+    }
+
+    cfg.ring_flex = env_truthy_int("FLEXAIDDS_RING_FLEX", /*default_value=*/false);
+    {
+        const char* e = env_raw("FLEXAIDDS_EVAL_SCALE_DIHEDRAL");
+        if (!e || e[0] == '\0') {
+            cfg.eval_scale_dihedral = 1;
+        } else if (std::strcmp(e, "off") == 0 ||
+                   std::strcmp(e, "none") == 0 ||
+                   std::strcmp(e, "fixed") == 0) {
+            cfg.eval_scale_dihedral = -1;
+        } else {
+            cfg.eval_scale_dihedral = std::atoi(e);
+        }
+    }
+    cfg.budget_scale = env_truthy_int("FLEXAIDDS_BUDGET_SCALE", /*default_value=*/true);
+    cfg.fine_grid = env_present_any("FLEXAIDDS_FINE_GRID");
+    if (auto n = env_opt_int("FLEXAIDDS_MULTI_CLEFT")) {
+        cfg.multi_cleft = *n;
+    }
+    // COGNATE_SITE: historical presence gate (any non-null).
+    cfg.cognate_site = env_present_any("FLEXAIDDS_COGNATE_SITE");
+    {
+        const char* e = env_raw("FLEXAIDDS_SCORE_NATIVE");
+        cfg.score_native = e && e[0] != '\0' && std::strcmp(e, "0") != 0;
+    }
+    {
+        const char* e = env_raw("FLEXAIDDS_NATIVE_ONLY");
+        cfg.native_only = e && e[0] != '\0' && std::strcmp(e, "0") != 0;
+    }
+    {
+        const char* e = env_raw("FLEXAIDDS_USE_DP");
+        cfg.use_dp = e && std::strcmp(e, "1") == 0;
+    }
+    cfg.ignore_cache = env_truthy_int("FLEXAIDDS_IGNORE_CACHE", /*default_value=*/false);
+    cfg.thermo_csv = env_present_any("FLEXAIDDS_THERMO_CSV");
+
     if (auto v = env_opt_double("FLEXAIDDS_HBOND_WEIGHT")) {
         cfg.hbond_weight = *v;
     }
+
+    // gaboom / GA
+    cfg.no_sec = env_present_any("FLEXAIDDS_NO_SEC");
+    cfg.benchmark_mode = env_present_any("FLEXAIDDS_BENCHMARK");
+    if (auto v = env_opt_double("FLEXAIDDS_T_HOT")) {
+        cfg.t_hot = *v;
+    }
+    if (auto n = env_opt_int("FLEXAIDDS_INSTREAM_INTERVAL")) {
+        if (*n >= 1) cfg.instream_interval = *n;
+    }
+    {
+        const char* e = env_raw("FLEXAIDDS_CHAIN_NORM");
+        cfg.chain_norm = e && e[0] != '\0' && e[0] != '0';
+    }
+    cfg.smfree_require_t = env_present("FLEXAIDDS_SMFREE_REQUIRE_T");
 
     return cfg;
 }
@@ -149,10 +238,9 @@ std::string ProtocolConfig::to_json() const {
     o << '{';
     o << "\"seed_base\":" << seed_base << ',';
     o << "\"restarts\":" << restarts << ',';
-    o << "\"parallel_restarts\":" << (parallel_restarts ? "true" : "false") << ',';
+    json_bool(o, "parallel_restarts", parallel_restarts);
     o << "\"vct_r0\":" << vct_r0 << ',';
-    o << "\"vct_normalize_contacts\":"
-      << (vct_normalize_contacts ? "true" : "false") << ',';
+    json_bool(o, "vct_normalize_contacts", vct_normalize_contacts);
     o << "\"vct_entropy_weight\":" << vct_entropy_weight << ',';
     if (sharing_alpha) {
         o << "\"sharing_alpha\":" << *sharing_alpha << ',';
@@ -165,14 +253,41 @@ std::string ProtocolConfig::to_json() const {
         o << "\"boom_frac\":null,";
     }
     o << "\"n_elite\":" << n_elite << ',';
-    o << "\"use_shannon\":" << (use_shannon ? "true" : "false") << ',';
-    o << "\"thermo_enabled\":" << (thermo_enabled ? "true" : "false") << ',';
+    json_bool(o, "use_shannon", use_shannon);
+    json_bool(o, "thermo_enabled", thermo_enabled);
     o << "\"t_eff\":" << t_eff << ',';
     o << "\"tencom_scale\":" << tencom_scale << ',';
     o << "\"data_dir\":\"" << json_escape(data_dir) << "\",";
-    o << "\"cf_window_selector\":" << (cf_window_selector ? "true" : "false") << ',';
-    o << "\"cluster_member_emit\":" << (cluster_member_emit ? "true" : "false") << ',';
-    o << "\"hbond_weight\":" << hbond_weight;
+    o << "\"oracle_site_dir\":\"" << json_escape(oracle_site_dir) << "\",";
+    o << "\"oracle_site\":\"" << json_escape(oracle_site) << "\",";
+    o << "\"cleft_sphere_file\":\"" << json_escape(cleft_sphere_file) << "\",";
+    json_bool(o, "cf_window_selector", cf_window_selector);
+    json_bool(o, "cluster_member_emit", cluster_member_emit);
+    json_bool(o, "seed_elitism", seed_elitism);
+    o << "\"seed_elitism_delta_cf\":" << seed_elitism_delta_cf << ',';
+    json_bool(o, "freqsel", freqsel);
+    o << "\"freqsel_alpha\":" << freqsel_alpha << ',';
+    o << "\"freqsel_rmsd\":" << freqsel_rmsd << ',';
+    json_bool(o, "consensus_scorer", consensus_scorer);
+    json_bool(o, "hvib_enabled", hvib_enabled);
+    json_bool(o, "ring_flex", ring_flex);
+    o << "\"eval_scale_dihedral\":" << eval_scale_dihedral << ',';
+    json_bool(o, "budget_scale", budget_scale);
+    json_bool(o, "fine_grid", fine_grid);
+    o << "\"multi_cleft\":" << multi_cleft << ',';
+    json_bool(o, "cognate_site", cognate_site);
+    json_bool(o, "score_native", score_native);
+    json_bool(o, "native_only", native_only);
+    json_bool(o, "use_dp", use_dp);
+    json_bool(o, "ignore_cache", ignore_cache);
+    json_bool(o, "thermo_csv", thermo_csv);
+    o << "\"hbond_weight\":" << hbond_weight << ',';
+    json_bool(o, "no_sec", no_sec);
+    json_bool(o, "benchmark_mode", benchmark_mode);
+    o << "\"t_hot\":" << t_hot << ',';
+    o << "\"instream_interval\":" << instream_interval << ',';
+    json_bool(o, "chain_norm", chain_norm);
+    json_bool(o, "smfree_require_t", smfree_require_t, /*trailing_comma=*/false);
     o << '}';
     return o.str();
 }
@@ -212,12 +327,66 @@ ProtocolConfig ProtocolConfig::from_json(const std::string& json_text) {
         cfg.tencom_scale = root["tencom_scale"].as_float(1.0f);
     if (!root["data_dir"].is_null())
         cfg.data_dir = root["data_dir"].as_string("");
+    if (!root["oracle_site_dir"].is_null())
+        cfg.oracle_site_dir = root["oracle_site_dir"].as_string("");
+    if (!root["oracle_site"].is_null())
+        cfg.oracle_site = root["oracle_site"].as_string("");
+    if (!root["cleft_sphere_file"].is_null())
+        cfg.cleft_sphere_file = root["cleft_sphere_file"].as_string("");
     if (!root["cf_window_selector"].is_null())
         cfg.cf_window_selector = root["cf_window_selector"].as_bool(false);
     if (!root["cluster_member_emit"].is_null())
         cfg.cluster_member_emit = root["cluster_member_emit"].as_bool(false);
+    if (!root["seed_elitism"].is_null())
+        cfg.seed_elitism = root["seed_elitism"].as_bool(true);
+    if (!root["seed_elitism_delta_cf"].is_null())
+        cfg.seed_elitism_delta_cf = root["seed_elitism_delta_cf"].as_double(10.0);
+    if (!root["freqsel"].is_null())
+        cfg.freqsel = root["freqsel"].as_bool(false);
+    if (!root["freqsel_alpha"].is_null())
+        cfg.freqsel_alpha = root["freqsel_alpha"].as_double(12.0);
+    if (!root["freqsel_rmsd"].is_null())
+        cfg.freqsel_rmsd = root["freqsel_rmsd"].as_float(1.5f);
+    if (!root["consensus_scorer"].is_null())
+        cfg.consensus_scorer = root["consensus_scorer"].as_bool(false);
+    if (!root["hvib_enabled"].is_null())
+        cfg.hvib_enabled = root["hvib_enabled"].as_bool(true);
+    if (!root["ring_flex"].is_null())
+        cfg.ring_flex = root["ring_flex"].as_bool(false);
+    if (!root["eval_scale_dihedral"].is_null())
+        cfg.eval_scale_dihedral = root["eval_scale_dihedral"].as_int(1);
+    if (!root["budget_scale"].is_null())
+        cfg.budget_scale = root["budget_scale"].as_bool(true);
+    if (!root["fine_grid"].is_null())
+        cfg.fine_grid = root["fine_grid"].as_bool(false);
+    if (!root["multi_cleft"].is_null())
+        cfg.multi_cleft = root["multi_cleft"].as_int(0);
+    if (!root["cognate_site"].is_null())
+        cfg.cognate_site = root["cognate_site"].as_bool(false);
+    if (!root["score_native"].is_null())
+        cfg.score_native = root["score_native"].as_bool(false);
+    if (!root["native_only"].is_null())
+        cfg.native_only = root["native_only"].as_bool(false);
+    if (!root["use_dp"].is_null())
+        cfg.use_dp = root["use_dp"].as_bool(false);
+    if (!root["ignore_cache"].is_null())
+        cfg.ignore_cache = root["ignore_cache"].as_bool(false);
+    if (!root["thermo_csv"].is_null())
+        cfg.thermo_csv = root["thermo_csv"].as_bool(false);
     if (!root["hbond_weight"].is_null())
         cfg.hbond_weight = root["hbond_weight"].as_double(-2.5);
+    if (!root["no_sec"].is_null())
+        cfg.no_sec = root["no_sec"].as_bool(false);
+    if (!root["benchmark_mode"].is_null())
+        cfg.benchmark_mode = root["benchmark_mode"].as_bool(false);
+    if (!root["t_hot"].is_null())
+        cfg.t_hot = root["t_hot"].as_double(0.0);
+    if (!root["instream_interval"].is_null())
+        cfg.instream_interval = root["instream_interval"].as_int(0);
+    if (!root["chain_norm"].is_null())
+        cfg.chain_norm = root["chain_norm"].as_bool(false);
+    if (!root["smfree_require_t"].is_null())
+        cfg.smfree_require_t = root["smfree_require_t"].as_bool(false);
 
     return cfg;
 }

--- a/LIB/ProtocolConfig.h
+++ b/LIB/ProtocolConfig.h
@@ -45,13 +45,47 @@ struct ProtocolConfig {
 
     // ── Paths ────────────────────────────────────────────────────────────
     std::string data_dir;             ///< FLEXAIDDS_DATA_DIR (empty = unset)
+    std::string oracle_site_dir;      ///< FLEXAIDDS_ORACLE_SITE_DIR
+    std::string oracle_site;          ///< FLEXAIDDS_ORACLE_SITE
+    std::string cleft_sphere_file;    ///< FLEXAIDDS_CLEFT_SPHERE_FILE
 
     // ── DatasetRunner pose-selector gates ────────────────────────────────
     bool cf_window_selector{false};   ///< FLEXAIDDS_CF_WINDOW_SELECTOR
     bool cluster_member_emit{false};  ///< FLEXAIDDS_CLUSTER_MEMBER_EMIT
+    bool seed_elitism{true};          ///< FLEXAIDDS_SEED_ELITISM (default ON)
+    double seed_elitism_delta_cf{10.0}; ///< FLEXAIDDS_SEED_ELITISM_DELTA_CF
+    bool freqsel{false};              ///< FLEXAIDDS_FREQSEL
+    double freqsel_alpha{12.0};       ///< FLEXAIDDS_FREQSEL_ALPHA
+    float freqsel_rmsd{1.5f};         ///< FLEXAIDDS_FREQSEL_RMSD
+    bool consensus_scorer{false};     ///< FLEXAIDDS_CONSENSUS_SCORER
+    /// tENCoM/H(ω) validator; default ON, disable with FLEXAIDDS_HVIB=0.
+    bool hvib_enabled{true};
+
+    // ── Budget / grid (DatasetRunner dock path) ──────────────────────────
+    bool ring_flex{false};            ///< FLEXAIDDS_RING_FLEX
+    /// 1=pop-scale (default), 0=legacy gen-scale, -1=fixed (off/none/fixed).
+    int eval_scale_dihedral{1};       ///< FLEXAIDDS_EVAL_SCALE_DIHEDRAL
+    bool budget_scale{true};          ///< FLEXAIDDS_BUDGET_SCALE (default ON)
+    bool fine_grid{false};            ///< FLEXAIDDS_FINE_GRID (presence)
+    int multi_cleft{0};               ///< FLEXAIDDS_MULTI_CLEFT (0 = off)
+    bool cognate_site{false};         ///< FLEXAIDDS_COGNATE_SITE (presence)
+    bool score_native{false};         ///< FLEXAIDDS_SCORE_NATIVE (truthy)
+    bool native_only{false};          ///< FLEXAIDDS_NATIVE_ONLY (truthy)
+    bool use_dp{false};               ///< FLEXAIDDS_USE_DP (=1)
+    bool ignore_cache{false};         ///< FLEXAIDDS_IGNORE_CACHE
+    bool thermo_csv{false};           ///< FLEXAIDDS_THERMO_CSV (presence)
 
     // ── Engine init (top.cpp) ────────────────────────────────────────────
     double hbond_weight{-2.5};        ///< FLEXAIDDS_HBOND_WEIGHT
+
+    // ── GA engine (gaboom.cpp) ───────────────────────────────────────────
+    bool no_sec{false};               ///< FLEXAIDDS_NO_SEC (presence)
+    bool benchmark_mode{false};       ///< FLEXAIDDS_BENCHMARK (presence)
+    double t_hot{0.0};                ///< FLEXAIDDS_T_HOT (0 = annealing off)
+    /// 0 → keep compile-time GA_INSTREAM_INTERVAL; else override (>=1).
+    int instream_interval{0};         ///< FLEXAIDDS_INSTREAM_INTERVAL
+    bool chain_norm{false};           ///< FLEXAIDDS_CHAIN_NORM
+    bool smfree_require_t{false};     ///< FLEXAIDDS_SMFREE_REQUIRE_T
 
     /// Built-in defaults (no env consultation).
     static ProtocolConfig defaults();

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -9,6 +9,7 @@
 #include "CavityDetect/SpatialGrid.h"
 #include "RngSeed.h"
 #include "ensemble_pipeline.h"
+#include "ProtocolConfig.h"
 
 #include <random>
 #include <functional>
@@ -161,9 +162,12 @@ static inline void ring_load_chrom_to_fa(FA_Global* FA, const chromosome* c) {
 // number of receptor chains changes the effective selection temperature and
 // regresses multichain Astex cases. Keep production/default scoring extensive;
 // enable this only with FLEXAIDDS_CHAIN_NORM=1 for targeted ablations.
-static int count_receptor_chains(FA_Global* FA, const resid* residue) {
-    const char* env = std::getenv("FLEXAIDDS_CHAIN_NORM");
-    if (!env || env[0] == '\0' || env[0] == '0') return 1;
+static int count_receptor_chains(FA_Global* FA, const resid* residue,
+                                 bool chain_norm_enabled = false) {
+    // When chain_norm_enabled is false (default), preserve the historical
+    // extensive scoring path (return 1). Callers that want the diagnostic
+    // multi-chain normalisation pass ProtocolConfig::chain_norm.
+    if (!chain_norm_enabled) return 1;
 
     std::unordered_set<char> seen;
     for (int r = 0; r < FA->res_cnt; ++r) {
@@ -201,8 +205,12 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	GAContext local_ctx;
 	if (!ctx) ctx = &local_ctx;
 
+	// Typed protocol snapshot (env remains the compatibility adapter).
+	const flexaids::ProtocolConfig proto = flexaids::ProtocolConfig::from_env();
+
 	// ── OMP thread default: 2/worker if OMP_NUM_THREADS not set in environment.
 	// Leaves headroom for Metal dispatch and OS scheduling on M3 Pro 11 P-cores.
+	// OMP_NUM_THREADS is a platform OpenMP contract — left as raw getenv.
 #ifdef _OPENMP
 	if (!std::getenv("OMP_NUM_THREADS")) {
 		omp_set_num_threads(2);
@@ -217,7 +225,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	// divides every evalue/app_evalue by the number of explicit receptor chain
 	// IDs. Do not enable for production benchmarks without a target-specific
 	// justification: it changes GA selection pressure and regressed Astex smoke.
-	const int n_receptor_chains = count_receptor_chains(FA, residue);
+	const int n_receptor_chains = count_receptor_chains(FA, residue, proto.chain_norm);
 	if (n_receptor_chains > 1)
 		fprintf(stderr, "[CHAIN] %d receptor chains detected — "
 		        "normalising VCT evalue by chain count (diagnostic)\n", n_receptor_chains);
@@ -227,13 +235,11 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	// monitor (per-generation [HVIB] lines) even on the bare binary, mirroring the
 	// DatasetRunner config toggle.  Engine-side env wins, matching FLEXAIDDS_N_ELITE.
 	// Purely diagnostic — does NOT enter CF or fitness.  Default stays OFF.
-	if (const char* _hv = std::getenv("FLEXAIDDS_USE_SHANNON")) {
-		if (_hv[0] != '\0' && _hv[0] != '0') {
-			if (!GB->use_shannon)
-				fprintf(stderr, "[HVIB] FLEXAIDDS_USE_SHANNON set: enabling ligand "
-				        "vibrational-entropy H(ω) monitor (diagnostic only)\n");
-			GB->use_shannon = 1;
-		}
+	if (proto.use_shannon) {
+		if (!GB->use_shannon)
+			fprintf(stderr, "[HVIB] FLEXAIDDS_USE_SHANNON set: enabling ligand "
+			        "vibrational-entropy H(ω) monitor (diagnostic only)\n");
+		GB->use_shannon = 1;
 	}
 
 	//char tmp_rrgfile[MAX_PATH__];
@@ -565,13 +571,10 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	// early exit (which can trigger well before generation 100).  Default behaviour
 	// for production benchmarks is unchanged.
 	int instream_interval = GA_INSTREAM_INTERVAL;
-	if (const char* _ii = std::getenv("FLEXAIDDS_INSTREAM_INTERVAL")) {
-		int v = std::atoi(_ii);
-		if (v >= 1) {
-			instream_interval = v;
-			fprintf(stderr, "[INSTREAM] merge/H(ω) cadence overridden to every %d "
-			        "generation(s) via FLEXAIDDS_INSTREAM_INTERVAL\n", instream_interval);
-		}
+	if (proto.instream_interval >= 1) {
+		instream_interval = proto.instream_interval;
+		fprintf(stderr, "[INSTREAM] merge/H(ω) cadence overridden to every %d "
+		        "generation(s) via FLEXAIDDS_INSTREAM_INTERVAL\n", instream_interval);
 	}
 
 	////// Genetic Algorithm ///////
@@ -582,7 +585,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	// During benchmarking this ensures equal search effort vs other methods.
 	// "Spare" generations after a plateau are used with boosted mutation/exploration
 	// (see stagnation handling) to search conformational space more effectively.
-	const bool no_sec = (std::getenv("FLEXAIDDS_NO_SEC") != nullptr);
+	const bool no_sec = proto.no_sec;
 	if (no_sec)
 		fprintf(stderr, "[SEC] All entropy-convergence early exits DISABLED "
 		        "(FLEXAIDDS_NO_SEC=1) — GA will run to max_generations.\n");
@@ -603,7 +606,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 		fprintf(stderr, "[ELITE] GA-internal elitism active: protecting %d "
 		        "lowest-CF individual(s) per generation\n", n_elite);
 
-	// ── Temperature annealing (FLEXAIDDS_T_HOT) ──────────────────────────────
+	// ── Temperature annealing (FLEXAIDDS_T_HOT via ProtocolConfig) ────────────
 	// Exponential decay T_hot -> target K:
 	//   T(alpha) = T_hot*exp(-5alpha) + T_target*(1-exp(-5alpha)).
 	// Affects SMFREE Boltzmann-weight selection only; post-GA thermodynamics
@@ -612,10 +615,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	// → native basin gravitationally dominant.  Annealing targets near-miss
 	// false-minimum escape early in the run while native seeds lock in.
 	// Useful calibration range: 500–2000 K.
-	const double t_hot_anneal = []() -> double {
-		const char* env = std::getenv("FLEXAIDDS_T_HOT");
-		return (env && env[0] != '\0') ? std::atof(env) : 0.0;
-	}();
+	const double t_hot_anneal = proto.t_hot;
 	const double target_temperature_d = static_cast<double>(target_temperature_K);
 	const bool do_anneal = (target_temperature_K > 0) &&
 	                        (t_hot_anneal > target_temperature_d);
@@ -817,7 +817,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 			if (stagnant) {
 				stagnation_count += STAGNATION_WINDOW;
 				if (stagnation_count >= STAGNATION_LIMIT) {
-					const bool benchmark_full = (std::getenv("FLEXAIDDS_NO_SEC") != nullptr) || (std::getenv("FLEXAIDDS_BENCHMARK") != nullptr);
+					const bool benchmark_full = proto.no_sec || proto.benchmark_mode;
 					if (benchmark_full) {
 						printf("GA plateau at gen %d (stagnant %d gens, best_CF=%.4f); "
 						       "BENCHMARK mode: continuing with exploration boost for remaining gens.\n",
@@ -2736,9 +2736,7 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 					"[SMFREE] WARN: temperature=0 → rank-only fitness "
 					"(no soft-β sampling). Set thermodynamics.temperature>0 "
 					"for reproducible ensemble layer 3 (β=1/T).\n");
-				const char* req = std::getenv("FLEXAIDDS_SMFREE_REQUIRE_T");
-				if (req && (req[0] == '1' || req[0] == 't' || req[0] == 'T'
-				            || req[0] == 'y' || req[0] == 'Y')) {
+				if (flexaids::ProtocolConfig::from_env().smfree_require_t) {
 					fprintf(stderr,
 						"[SMFREE] FATAL: FLEXAIDDS_SMFREE_REQUIRE_T set and T=0\n");
 					Terminate(2);

--- a/LIB/shell_exec.h
+++ b/LIB/shell_exec.h
@@ -1,0 +1,246 @@
+// shell_exec.h — Path-safe shell quoting + argv-based process helpers
+//
+// Prefer fork/execvp (or SubprocessGuard::fork_exec_argv) with argv arrays.
+// When a shell is unavoidable (env KEY=VAL prefixes, stdout/stderr
+// redirection), interpolate paths only through shell_quote() after
+// validate_exec_path() succeeds.
+//
+// Security focus:
+//   - Command injection via FLEXAIDDS_DATA_DIR or malicious manifest paths
+//   - Provenance integrity (receipts must record real resolved paths, not
+//     shell-mutated strings)
+//
+// Copyright 2026 Le Bonhomme Pharma. Licensed under Apache-2.0.
+#pragma once
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace flexaids {
+namespace shell_exec {
+
+/// Why a path was refused for shell interpolation or exec argv.
+enum class PathReject : int {
+    Ok = 0,
+    Empty,
+    ContainsNul,
+    ContainsNewline,   // '\n' or '\r' — breaks sh -c line structure
+    ContainsControl,   // other C0 controls (except TAB, which is allowed)
+};
+
+[[nodiscard]] inline const char* path_reject_message(PathReject r) {
+    switch (r) {
+        case PathReject::Ok:               return "ok";
+        case PathReject::Empty:            return "path is empty";
+        case PathReject::ContainsNul:      return "path contains NUL byte";
+        case PathReject::ContainsNewline:  return "path contains newline/CR";
+        case PathReject::ContainsControl:  return "path contains control character";
+    }
+    return "unknown path reject";
+}
+
+/// Inspect *path* for characters that must never reach a shell string or that
+/// would corrupt path provenance. TAB is allowed (rare but valid in paths on
+/// some filesystems); NUL, CR, LF, and other C0 controls are refused.
+[[nodiscard]] inline PathReject validate_exec_path(std::string_view path) {
+    if (path.empty()) return PathReject::Empty;
+    for (unsigned char c : path) {
+        if (c == '\0') return PathReject::ContainsNul;
+        if (c == '\n' || c == '\r') return PathReject::ContainsNewline;
+        // C0 controls except TAB (0x09)
+        if (c < 0x20 && c != '\t') return PathReject::ContainsControl;
+        if (c == 0x7f) return PathReject::ContainsControl;
+    }
+    return PathReject::Ok;
+}
+
+[[nodiscard]] inline bool is_safe_exec_path(std::string_view path) {
+    return validate_exec_path(path) == PathReject::Ok;
+}
+
+/// POSIX-shell single-quote escape: `foo'bar` → `'foo'\''bar'`.
+/// Does **not** validate; use shell_quote() for validated quoting.
+[[nodiscard]] inline std::string shell_quote_raw(std::string_view s) {
+    std::string o;
+    o.reserve(s.size() + 8);
+    o.push_back('\'');
+    for (char c : s) {
+        if (c == '\'') {
+            // end quote, escaped literal quote, reopen quote
+            o += "'\\''";
+        } else {
+            o.push_back(c);
+        }
+    }
+    o.push_back('\'');
+    return o;
+}
+
+/// Validate then single-quote. Returns nullopt if the path is unsafe.
+[[nodiscard]] inline std::optional<std::string>
+shell_quote_checked(std::string_view path) {
+    if (validate_exec_path(path) != PathReject::Ok) return std::nullopt;
+    return shell_quote_raw(path);
+}
+
+/// Validate then single-quote. Throws std::invalid_argument on unsafe paths.
+[[nodiscard]] inline std::string shell_quote(std::string_view path) {
+    PathReject r = validate_exec_path(path);
+    if (r != PathReject::Ok) {
+        throw std::invalid_argument(
+            std::string("unsafe path for shell: ") + path_reject_message(r));
+    }
+    return shell_quote_raw(path);
+}
+
+/// Result of capturing a child process stdout (no shell).
+struct CapturedOutput {
+    int         exit_code = -1;
+    std::string stdout_text;
+    bool        ok = false;  // true if process started and exited normally
+};
+
+/// Run argv via fork+execvp with no shell. Captures stdout; stderr is
+/// inherited (or discarded if discard_stderr). Returns empty-ok=false on
+/// fork/exec failure. On Windows, returns ok=false (not implemented).
+[[nodiscard]] inline CapturedOutput
+run_argv_capture(const std::vector<std::string>& argv,
+                 bool discard_stderr = true) {
+    CapturedOutput out;
+    if (argv.empty() || argv[0].empty()) return out;
+    for (const auto& a : argv) {
+        if (validate_exec_path(a) != PathReject::Ok) return out;
+    }
+#ifndef _WIN32
+    int pipefd[2];
+    if (::pipe(pipefd) != 0) return out;
+
+    pid_t pid = ::fork();
+    if (pid < 0) {
+        ::close(pipefd[0]);
+        ::close(pipefd[1]);
+        return out;
+    }
+    if (pid == 0) {
+        ::close(pipefd[0]);
+        ::dup2(pipefd[1], STDOUT_FILENO);
+        ::close(pipefd[1]);
+        if (discard_stderr) {
+            int devnull = ::open("/dev/null", O_WRONLY);
+            if (devnull >= 0) {
+                ::dup2(devnull, STDERR_FILENO);
+                ::close(devnull);
+            }
+        }
+        ::close(STDIN_FILENO);
+        int devnull_in = ::open("/dev/null", O_RDONLY);
+        if (devnull_in >= 0 && devnull_in != STDIN_FILENO) {
+            ::dup2(devnull_in, STDIN_FILENO);
+            ::close(devnull_in);
+        }
+
+        std::vector<char*> c_argv;
+        c_argv.reserve(argv.size() + 1);
+        for (const auto& s : argv) {
+            c_argv.push_back(const_cast<char*>(s.c_str()));
+        }
+        c_argv.push_back(nullptr);
+        ::execvp(c_argv[0], c_argv.data());
+        ::_exit(127);
+    }
+
+    ::close(pipefd[1]);
+    char buf[4096];
+    ssize_t n;
+    while ((n = ::read(pipefd[0], buf, sizeof(buf))) > 0) {
+        out.stdout_text.append(buf, static_cast<size_t>(n));
+    }
+    ::close(pipefd[0]);
+
+    int status = 0;
+    while (::waitpid(pid, &status, 0) == -1) {
+        if (errno != EINTR) {
+            out.ok = false;
+            return out;
+        }
+    }
+    if (WIFEXITED(status)) {
+        out.exit_code = WEXITSTATUS(status);
+        out.ok = true;
+    } else {
+        out.exit_code = -1;
+        out.ok = false;
+    }
+    return out;
+#else
+    (void)discard_stderr;
+    return out;
+#endif
+}
+
+/// First whitespace-delimited token of stdout from run_argv_capture, or "".
+[[nodiscard]] inline std::string
+run_argv_first_token(const std::vector<std::string>& argv) {
+    auto cap = run_argv_capture(argv, /*discard_stderr=*/true);
+    if (!cap.ok || cap.exit_code != 0) return {};
+    std::string tok;
+    for (char c : cap.stdout_text) {
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+            if (!tok.empty()) break;
+        } else {
+            tok.push_back(c);
+        }
+    }
+    return tok;
+}
+
+/// Run argv and wait for exit code (no shell, no capture). -1 on failure.
+[[nodiscard]] inline int run_argv(const std::vector<std::string>& argv) {
+    if (argv.empty() || argv[0].empty()) return -1;
+    for (const auto& a : argv) {
+        if (validate_exec_path(a) != PathReject::Ok) return -1;
+    }
+#ifndef _WIN32
+    pid_t pid = ::fork();
+    if (pid < 0) return -1;
+    if (pid == 0) {
+        ::close(STDIN_FILENO);
+        int devnull = ::open("/dev/null", O_RDONLY);
+        if (devnull >= 0 && devnull != STDIN_FILENO) {
+            ::dup2(devnull, STDIN_FILENO);
+            ::close(devnull);
+        }
+        std::vector<char*> c_argv;
+        c_argv.reserve(argv.size() + 1);
+        for (const auto& s : argv) {
+            c_argv.push_back(const_cast<char*>(s.c_str()));
+        }
+        c_argv.push_back(nullptr);
+        ::execvp(c_argv[0], c_argv.data());
+        ::_exit(127);
+    }
+    int status = 0;
+    while (::waitpid(pid, &status, 0) == -1) {
+        if (errno != EINTR) return -1;
+    }
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+#else
+    return -1;
+#endif
+}
+
+}  // namespace shell_exec
+}  // namespace flexaids

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -29,6 +29,7 @@
 #include "RngSeed.h"
 #include "ensemble_pipeline.h"
 #include "ProtocolConfig.h"
+#include "shell_exec.h"
 
 #include <algorithm>
 #include <cmath>
@@ -729,16 +730,22 @@ int main(int argc, char **argv){
 			fprintf(stderr, "  Also: doi:<DOI>, pdb_list:<file>\n");
 			Terminate(1);
 		}
-		// Forward to benchmark_datasets executable or run inline
-		// Build the command to invoke the benchmark_datasets binary
-		std::string cmd = "benchmark_datasets";
+		// Forward to benchmark_datasets via argv exec (no shell).
+		// Single child only -- never dual-launch.
+		std::vector<std::string> bench_argv;
+		bench_argv.reserve(static_cast<size_t>(argc));
+		bench_argv.emplace_back("benchmark_datasets");
 		for (int a = 1; a < argc; a++) {
-			cmd += " ";
-			cmd += argv[a];
+			if (!flexaids::shell_exec::is_safe_exec_path(argv[a])) {
+				fprintf(stderr,
+				        "ERROR: unsafe argument for --benchmark (NUL/newline/control)\n");
+				Terminate(1);
+			}
+			bench_argv.emplace_back(argv[a]);
 		}
-		printf("Launching benchmark runner: %s\n", cmd.c_str());
-		int ret = system(cmd.c_str());
-		Terminate(WEXITSTATUS(ret));
+		printf("Launching benchmark runner (argv exec, no shell)\n");
+		int ret = flexaids::shell_exec::run_argv(bench_argv);
+		Terminate(ret < 0 ? 127 : ret);
 	}
 
 	// Check for --legacy mode first

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -1623,7 +1623,10 @@ int main(int argc, char **argv){
 			// process-per-cleft docking.  Each child process receives one ranked
 			// Get_Cleft/FlexAID sphere file and builds its grid from that cleft
 			// only, reproducing the old independent-GA-per-major-cleft behavior.
-			const char* explicit_cleft_env = std::getenv("FLEXAIDDS_CLEFT_SPHERE_FILE");
+			const flexaids::ProtocolConfig proto_grid = flexaids::ProtocolConfig::from_env();
+			const char* explicit_cleft_env =
+			    proto_grid.cleft_sphere_file.empty() ? nullptr
+			                                        : proto_grid.cleft_sphere_file.c_str();
 			const bool explicit_cleft_requested =
 			    explicit_cleft_env && explicit_cleft_env[0] != '\0';
 			if (explicit_cleft_requested &&
@@ -1637,9 +1640,12 @@ int main(int argc, char **argv){
 			// ── Probe FLEXAIDDS_GRID_CACHE_DIR (content-hash keyed) ─────────────
 			// Used by Strategy B batch children: the first child builds and saves;
 			// subsequent children of the same receptor load and skip the grid build.
+			// GRID_CACHE_DIR stays raw getenv (infra path, not a science knob).
+			const char* oracle_site_for_cache =
+			    proto_grid.oracle_site.empty() ? nullptr : proto_grid.oracle_site.c_str();
 			const std::string gc_vct_path = explicit_cleft_requested
 			    ? std::string()
-			    : gridcache::cache_path(receptor_file, std::getenv("FLEXAIDDS_ORACLE_SITE"),
+			    : gridcache::cache_path(receptor_file, oracle_site_for_cache,
 			                            FA->spacer_length, FA->permeability);
 			if (!explicit_cleft_requested && !gc_vct_path.empty()) {
 				if (gridcache::load(gc_vct_path, &cleftgrid, &FA->num_grd)) {
@@ -1740,11 +1746,12 @@ int main(int argc, char **argv){
 			};
 
 			if (!grid_loaded_from_cache) {
-			// Oracle mode: FLEXAIDDS_ORACLE_SITE env var points to a binding
+			// Oracle mode: FLEXAIDDS_ORACLE_SITE (ProtocolConfig) points to a binding
 			// site PDB.  Parse for centroid only — SURFNET void-space detection
 			// always runs (probes placed in void between atoms, not on atoms).
 			// Oracle centroid guides cleft selection and site-confinement.
-			const char* oracle_site_env = std::getenv("FLEXAIDDS_ORACLE_SITE");
+			const char* oracle_site_env =
+			    proto_grid.oracle_site.empty() ? nullptr : proto_grid.oracle_site.c_str();
 			bool using_oracle = false;
 			float oracle_cx = 0.0f, oracle_cy = 0.0f, oracle_cz = 0.0f;
 			sphere* spheres = NULL;
@@ -2333,13 +2340,11 @@ int main(int argc, char **argv){
 	// DatasetRunner uses FLEXAIDDS_SCORE_NATIVE=1 alone so the GA still runs and
 	// produces pose files that DatasetRunner parses alongside [NATIVE_CF].
 	{
-		const char* _native_env  = std::getenv("FLEXAIDDS_SCORE_NATIVE");
-		const char* _native_only = std::getenv("FLEXAIDDS_NATIVE_ONLY");
-		const bool  do_native    = (_native_env  && _native_env[0]  != '\0' && std::strcmp(_native_env,  "0") != 0)
-		                        || (_native_only && _native_only[0] != '\0' && std::strcmp(_native_only, "0") != 0);
+		const flexaids::ProtocolConfig native_proto = flexaids::ProtocolConfig::from_env();
+		const bool do_native = native_proto.score_native || native_proto.native_only;
 		if (do_native) {
 			score_native_pose(FA, VC, atoms, residue, cleftgrid);
-			if (_native_only && _native_only[0] != '\0' && std::strcmp(_native_only, "0") != 0) {
+			if (native_proto.native_only) {
 				std::exit(0);  // native-only mode: bail before GA (does not write pose files)
 			}
 		}

--- a/build_sources.ignore
+++ b/build_sources.ignore
@@ -145,3 +145,4 @@ LIB/coarse_init.h
 LIB/native_score.h
 LIB/receptor_prep.h
 LIB/ensemble_pipeline.h
+LIB/shell_exec.h

--- a/docs/implementation/protocol-config.md
+++ b/docs/implementation/protocol-config.md
@@ -1,10 +1,8 @@
 # ProtocolConfig — typed protocol knobs (getenv consolidation)
 
-**Status:** Chunk 1 (foundation)  
+**Status:** Chunk 2 (pose/budget/GA high-value knobs)  
 **Owner path:** `LIB/ProtocolConfig.{h,cpp}`  
-**Related audit:** ~64 `getenv` / `std::getenv` call sites in
-`LIB/DatasetRunner.cpp`, `LIB/gaboom.cpp`, `LIB/top.cpp` (repo-wide getenv
-surface is larger; this doc tracks the audit trio first).
+**Related audit:** DatasetRunner / gaboom / top getenv consolidation.
 
 ## Goal
 
@@ -13,128 +11,117 @@ Replace ad-hoc `FLEXAIDDS_*` environment reads with **one typed, serializable
 adapter only** (`ProtocolConfig::from_env()`). Future chunks can load JSON /
 CLI / skill configs into the same struct without touching call sites again.
 
-## What landed in chunk 1
+## Snapshot policy
 
-| Piece | Location |
-|-------|----------|
-| Typed struct + `defaults()` / `from_env()` / `to_json()` / `from_json()` | `LIB/ProtocolConfig.h`, `LIB/ProtocolConfig.cpp` |
-| Unit tests (defaults, env overrides, JSON round-trip) | `tests/test_protocol_config.cpp` |
-| DatasetRunner constructor + dock-config emission path | `LIB/DatasetRunner.cpp` / `.h` |
-| Engine init: `FLEXAIDDS_DATA_DIR`, `FLEXAIDDS_HBOND_WEIGHT` | `LIB/top.cpp` |
+| When | What |
+|------|------|
+| `DatasetRunner` constructor | `protocol_cfg_ = ProtocolConfig::from_env()` |
+| `DatasetRunner::run()` entry | **Re-snapshot** `protocol_cfg_` (chunk 2) so long-lived runners pick up env changes after construction |
+| `GA()` (gaboom) entry | Local `ProtocolConfig::from_env()` for engine-side knobs |
+| `top.cpp` site/grid paths | Local snapshot at use site |
 
-### Migrated env vars (go through `ProtocolConfig`)
+Chunk 1 only snapshotted the constructor; chunk 2 re-snapshots at `run()`.
 
-| Env var | Field | Default | Migrated call sites |
-|---------|-------|---------|---------------------|
-| `FLEXAIDDS_SEED_BASE` | `seed_base` | `0` | DatasetRunner `deterministic_ga_seed` |
-| `FLEXAIDDS_RESTARTS` | `restarts` | `5` | DatasetRunner multi-restart loop |
-| `FLEXAIDDS_PARALLEL_RESTARTS` | `parallel_restarts` | `restarts > 1` | DatasetRunner restart launcher |
-| `FLEXAIDDS_VCT_R0` | `vct_r0` | `7.0` | DatasetRunner dock_config scoring |
-| `FLEXAIDDS_VCT_NORM` | `vct_normalize_contacts` | off (presence) | DatasetRunner dock_config scoring |
-| `FLEXAIDDS_VCT_ENTROPY_WEIGHT` | `vct_entropy_weight` | `0.0` | DatasetRunner dock_config scoring |
-| `FLEXAIDDS_SHARING_ALPHA` | `sharing_alpha` (optional) | pop-scaled `4.0` | DatasetRunner GA section |
-| `FLEXAIDDS_BOOM_FRAC` | `boom_frac` (optional) | `1.0` | DatasetRunner GA section |
-| `FLEXAIDDS_N_ELITE` | `n_elite` | `1` | DatasetRunner GA section |
-| `FLEXAIDDS_USE_SHANNON` | `use_shannon` | off (presence) | DatasetRunner dock_config |
-| `FLEXAIDDS_THERMO` | `thermo_enabled` | off (presence) | DatasetRunner dock_config |
-| `FLEXAIDDS_T_EFF` | `t_eff` | `0.596` | DatasetRunner thermo_engine |
-| `FLEXAIDDS_TENCOM_SCALE` | `tencom_scale` | `1.0` | DatasetRunner thermo_engine |
-| `FLEXAIDDS_DATA_DIR` | `data_dir` | empty | DatasetRunner matrix + `--data-dir`; `top.cpp` auto-detect |
-| `FLEXAIDDS_CF_WINDOW_SELECTOR` | `cf_window_selector` | `false` | DatasetRunner ctor |
-| `FLEXAIDDS_CLUSTER_MEMBER_EMIT` | `cluster_member_emit` | `false` | DatasetRunner ctor |
-| `FLEXAIDDS_HBOND_WEIGHT` | `hbond_weight` | `-2.5` | `top.cpp` FA init |
+## Migrated env vars (chunk 1 + 2)
 
-**Estimate:** ~17 unique vars / ~22 call sites migrated; residual in the audit
-trio is roughly **~42 getenv call sites** (including `HOME` / `OMP_*` and
-double-reads).
+### Chunk 1
 
-## Residual getenv inventory (TODO — later chunks)
+| Env var | Field | Default |
+|---------|-------|---------|
+| `FLEXAIDDS_SEED_BASE` | `seed_base` | `0` |
+| `FLEXAIDDS_RESTARTS` | `restarts` | `5` |
+| `FLEXAIDDS_PARALLEL_RESTARTS` | `parallel_restarts` | `restarts > 1` |
+| `FLEXAIDDS_VCT_R0` | `vct_r0` | `7.0` |
+| `FLEXAIDDS_VCT_NORM` | `vct_normalize_contacts` | off |
+| `FLEXAIDDS_VCT_ENTROPY_WEIGHT` | `vct_entropy_weight` | `0.0` |
+| `FLEXAIDDS_SHARING_ALPHA` | `sharing_alpha` | pop-scaled `4.0` |
+| `FLEXAIDDS_BOOM_FRAC` | `boom_frac` | `1.0` |
+| `FLEXAIDDS_N_ELITE` | `n_elite` | `1` |
+| `FLEXAIDDS_USE_SHANNON` | `use_shannon` | off |
+| `FLEXAIDDS_THERMO` | `thermo_enabled` | off |
+| `FLEXAIDDS_T_EFF` | `t_eff` | `0.596` |
+| `FLEXAIDDS_TENCOM_SCALE` | `tencom_scale` | `1.0` |
+| `FLEXAIDDS_DATA_DIR` | `data_dir` | empty |
+| `FLEXAIDDS_CF_WINDOW_SELECTOR` | `cf_window_selector` | `false` |
+| `FLEXAIDDS_CLUSTER_MEMBER_EMIT` | `cluster_member_emit` | `false` |
+| `FLEXAIDDS_HBOND_WEIGHT` | `hbond_weight` | `-2.5` |
 
-### `LIB/DatasetRunner.cpp` (owner: benchmark / DatasetRunner)
+### Chunk 2
 
-| Env var | Purpose | Default / notes | Priority |
-|---------|---------|-----------------|----------|
-| `FLEXAIDDS_SEED_ELITISM` | Crystal seed elitism gate | mode-dependent | P1 |
-| `FLEXAIDDS_FREQSEL` | Frequency-gated pose selector | off | P1 |
-| `FLEXAIDDS_FREQSEL_ALPHA` | Freqsel soft weight | `12.0` | P1 |
-| `FLEXAIDDS_FREQSEL_RMSD` | Freqsel RMSD bin | `1.5` | P1 |
-| `FLEXAIDDS_SEED_ELITISM_DELTA_CF` | Seed elitism CF window | `10.0` | P1 |
-| `FLEXAIDDS_HTTP_RETRIES` | RCSB download retries | `3` | P2 |
-| `FLEXAIDDS_ORACLE_SITE_DIR` | Oracle sphere directory | unset | P1 |
-| `FLEXAIDDS_USE_DP` | Force DensityPeak clustering | off | P2 |
-| `FLEXAIDDS_BINARY` / `_BUILD` / `_REPO` | FlexAIDdS binary resolution | path search | P2 |
-| `FLEXAIDDS_PRIORITY_TARGETS` | Target priority list | unset | P2 |
-| `FLEXAIDDS_IGNORE_CACHE` | Skip completed-cache | off | P2 |
-| `FLEXAIDDS_RING_FLEX` | Ring pucker DoF | off | P1 |
-| `FLEXAIDDS_EVAL_SCALE_DIHEDRAL` | DoF budget scaling mode | `1` | P1 |
-| `FLEXAIDDS_BUDGET_SCALE` | Extra budget scale | on | P1 |
-| `FLEXAIDDS_FINE_GRID` | Finer angle/dihedral steps | off (presence) | P2 |
-| `OMP_NUM_THREADS` | Worker OMP sizing | hardware | leave (OpenMP contract) |
-| `HOME` | `~` expansion | `/tmp` | leave (platform) |
-| `FLEXAIDDS_COGNATE_SITE` | Cognate redock site inject | off | P1 |
-| `FLEXAIDDS_SCORE_NATIVE` | Native CF diagnostic | off | P1 |
-| `FLEXAIDDS_MULTI_CLEFT` | Parallel cleft regions | off | P2 |
-| `FLEXAIDDS_CONSENSUS_SCORER` | Cross-restart consensus | off | P1 |
-| `FLEXAIDDS_HVIB` | tENCoM/H(ω) validator | on unless `=0` | P1 |
-| `FLEXAIDDS_THERMO_CSV` | Extra thermo CSV columns | off | P2 |
+| Env var | Field | Default | Call sites |
+|---------|-------|---------|------------|
+| `FLEXAIDDS_SEED_ELITISM` | `seed_elitism` | `true` | pose selector |
+| `FLEXAIDDS_SEED_ELITISM_DELTA_CF` | `seed_elitism_delta_cf` | `10.0` | pose selector |
+| `FLEXAIDDS_FREQSEL` | `freqsel` | `false` | pose selector |
+| `FLEXAIDDS_FREQSEL_ALPHA` | `freqsel_alpha` | `12.0` | pose selector |
+| `FLEXAIDDS_FREQSEL_RMSD` | `freqsel_rmsd` | `1.5` | pose selector |
+| `FLEXAIDDS_CONSENSUS_SCORER` | `consensus_scorer` | `false` | DatasetRunner election |
+| `FLEXAIDDS_HVIB` | `hvib_enabled` | ON unless `=0` | DatasetRunner |
+| `FLEXAIDDS_RING_FLEX` | `ring_flex` | `false` | budget scaling |
+| `FLEXAIDDS_EVAL_SCALE_DIHEDRAL` | `eval_scale_dihedral` | `1` (`off`→`-1`) | budget scaling |
+| `FLEXAIDDS_BUDGET_SCALE` | `budget_scale` | `true` | budget scaling |
+| `FLEXAIDDS_FINE_GRID` | `fine_grid` | off (presence) | dock_config |
+| `FLEXAIDDS_MULTI_CLEFT` | `multi_cleft` | `0` | dock cmd |
+| `FLEXAIDDS_COGNATE_SITE` | `cognate_site` | off (presence) | dock cmd |
+| `FLEXAIDDS_SCORE_NATIVE` | `score_native` | off | DatasetRunner + top |
+| `FLEXAIDDS_NATIVE_ONLY` | `native_only` | off | top |
+| `FLEXAIDDS_USE_DP` | `use_dp` | off (`=1`) | clustering |
+| `FLEXAIDDS_IGNORE_CACHE` | `ignore_cache` | off | DatasetRunner |
+| `FLEXAIDDS_THERMO_CSV` | `thermo_csv` | off (presence) | CSV export |
+| `FLEXAIDDS_ORACLE_SITE_DIR` | `oracle_site_dir` | empty | Astex prep / provenance |
+| `FLEXAIDDS_ORACLE_SITE` | `oracle_site` | empty | top grid/site |
+| `FLEXAIDDS_CLEFT_SPHERE_FILE` | `cleft_sphere_file` | empty | top |
+| `FLEXAIDDS_NO_SEC` | `no_sec` | off (presence) | gaboom |
+| `FLEXAIDDS_BENCHMARK` | `benchmark_mode` | off (presence) | gaboom |
+| `FLEXAIDDS_T_HOT` | `t_hot` | `0.0` | gaboom anneal |
+| `FLEXAIDDS_INSTREAM_INTERVAL` | `instream_interval` | `0` (= compile default) | gaboom |
+| `FLEXAIDDS_CHAIN_NORM` | `chain_norm` | off | gaboom |
+| `FLEXAIDDS_SMFREE_REQUIRE_T` | `smfree_require_t` | off | gaboom fitness |
 
-### `LIB/gaboom.cpp` (owner: GA engine)
+## Residual getenv inventory (after chunk 2)
 
-| Env var | Purpose | Default / notes | Priority |
-|---------|---------|-----------------|----------|
-| `FLEXAIDDS_CHAIN_NORM` | Multi-chain receptor norm | off | P2 |
-| `OMP_NUM_THREADS` | Default OMP=2 if unset | platform | leave |
-| `FLEXAIDDS_USE_SHANNON` | Enable Shannon in fitness | off | P1 (already on ProtocolConfig; wire gaboom) |
-| `FLEXAIDDS_INSTREAM_INTERVAL` | In-stream clustering interval | compile default | P2 |
-| `FLEXAIDDS_NO_SEC` | Disable SEC early exits | off | P1 |
-| `FLEXAIDDS_T_HOT` | Hot anneal temperature | `0.0` | P1 |
-| `FLEXAIDDS_BENCHMARK` | Full-gen benchmark mode | off | P1 |
-| `FLEXAIDDS_SMFREE_REQUIRE_T` | Require T for SMFREE | off | P2 |
+**Audit trio call-site estimate: ~11** (down from ~42 after chunk 1 / ~64 baseline).
 
-### `LIB/top.cpp` (owner: engine entry)
+### `LIB/DatasetRunner.cpp` (~7)
 
-| Env var | Purpose | Default / notes | Priority |
-|---------|---------|-----------------|----------|
-| `FLEXAIDDS_GRID_CACHE_DIR` | Grid cache directory | unset | P2 |
-| `FLEXAIDDS_LIGAND_BATCH` | Batch ligand directory | unset | P2 |
-| `FLEXAIDS_VH_DEBUG` | Vector H-bond debug dump | off | P3 |
-| `FLEXAIDDS_CLEFT_SPHERE_FILE` | Explicit cleft spheres | unset | P1 |
-| `FLEXAIDDS_ORACLE_SITE` | Oracle site path | unset | P1 |
-| `FLEXAIDDS_SCORE_NATIVE` / `FLEXAIDDS_NATIVE_ONLY` | Native scoring path | off | P1 |
+| Env var | Purpose | Priority |
+|---------|---------|----------|
+| `HOME` | `~` expansion | leave (platform) |
+| `OMP_NUM_THREADS` | Worker OMP sizing | leave (OpenMP contract) |
+| `FLEXAIDDS_HTTP_RETRIES` | RCSB download retries | P2 |
+| `FLEXAIDDS_BINARY` / `_BUILD` / `_REPO` | Binary resolution | P2 (infra paths) |
+| `FLEXAIDDS_PRIORITY_TARGETS` | Target priority list | P2 |
 
-### Also still env-backed (out of chunk-1 audit trio but related)
+### `LIB/gaboom.cpp` (~1)
 
-`LIB/config_parser.cpp` still applies `FLEXAIDDS_VCT_ENTROPY_WEIGHT`,
-`FLEXAIDDS_N_ELITE`, `FLEXAIDDS_SHARING_ALPHA`, `FLEXAIDDS_BOOM_FRAC`,
-`FLEXAIDDS_ENTROPY_WEIGHT`, `FLEXAIDDS_DIVERSITY_MONITORING`, ranking flags.
-**Chunk 2 recommendation:** have `apply_config()` accept an optional
-`const ProtocolConfig*` so engine-side overrides share the same typed source
-as DatasetRunner (env adapter still works for standalone CLI).
+| Env var | Purpose | Priority |
+|---------|---------|----------|
+| `OMP_NUM_THREADS` | Default OMP=2 if unset | leave |
 
-## Migration rules (for later PRs)
+### `LIB/top.cpp` (~3)
+
+| Env var | Purpose | Priority |
+|---------|---------|----------|
+| `FLEXAIDDS_GRID_CACHE_DIR` | Grid cache directory | P2 (infra) |
+| `FLEXAIDDS_LIGAND_BATCH` | Batch ligand directory | P2 |
+| `FLEXAIDS_VH_DEBUG` | Vector H-bond debug dump | P3 |
+
+### Related but out of audit trio
+
+`LIB/config_parser.cpp` still applies several `FLEXAIDDS_*` overrides at
+JSON-parse time (`VCT_ENTROPY_WEIGHT`, `N_ELITE`, `SHARING_ALPHA`,
+`BOOM_FRAC`, `ENTROPY_WEIGHT`, ranking flags). **Chunk 3 recommendation:**
+have `apply_config()` accept an optional `const ProtocolConfig*` so
+engine-side overrides share the same typed source.
+
+## Migration rules
 
 1. **Do not rewrite DatasetRunner in one PR.** One cluster of related knobs per chunk.
 2. Add fields to `ProtocolConfig` first, extend `from_env()` / JSON, then flip call sites.
-3. Keep default values byte-identical when env is unset (tests + golden dock_config when practical).
+3. Keep default values byte-identical when env is unset (tests).
 4. Prefer reading `protocol_cfg_` (or a passed-in snapshot) over re-calling `getenv` in loops.
 5. Leave platform env (`HOME`, `PATH`, `OMP_*`) as raw getenv unless a strong reason exists.
-6. Document each migrated var in the table above and drop it from Residual.
-
-## Usage sketch
-
-```cpp
-#include "ProtocolConfig.h"
-
-// Compatibility (benchmarks / CLI):
-auto cfg = flexaids::ProtocolConfig::from_env();
-
-// Future: skill / JSON protocol file
-// auto cfg = flexaids::ProtocolConfig::from_json(text);
-
-// Engine or runner:
-int n = cfg.restarts;
-double alpha = cfg.effective_sharing_alpha(pop_base, pop_scaled);
-```
+6. Document each migrated var and drop it from Residual.
 
 ## Tests
 

--- a/python/flexaidds/dataset_runner/data_paths.py
+++ b/python/flexaidds/dataset_runner/data_paths.py
@@ -148,3 +148,33 @@ def resolve_benchmark_paths(
                 + list(target_dir.glob("*.sdf"))
             )
     return receptor, ligands
+
+
+def validate_exec_path(path: str | Path) -> None:
+    """Refuse paths that must never reach a shell or corrupt provenance.
+
+    Raises ValueError on empty path, embedded NUL, newlines, or other C0
+    control characters (TAB is allowed). Mirrors ``LIB/shell_exec.h``.
+    """
+    s = str(path)
+    if not s:
+        raise ValueError("path is empty")
+    if '\x00' in s:
+        raise ValueError("path contains NUL byte")
+    for ch in s:
+        if ch in ('\n', '\r'):
+            raise ValueError("path contains newline/CR")
+        o = ord(ch)
+        if o < 0x20 and ch != '\t':
+            raise ValueError("path contains control character")
+        if o == 0x7F:
+            raise ValueError("path contains control character")
+
+
+def is_safe_exec_path(path: str | Path) -> bool:
+    try:
+        validate_exec_path(path)
+        return True
+    except ValueError:
+        return False
+

--- a/python/tests/test_shell_exec_paths.py
+++ b/python/tests/test_shell_exec_paths.py
@@ -1,0 +1,40 @@
+"""Unit tests for dataset_runner path safety helpers (mirrors LIB/shell_exec.h)."""
+
+from __future__ import annotations
+
+import pytest
+
+from flexaidds.dataset_runner.data_paths import is_safe_exec_path, validate_exec_path
+
+
+def test_accept_normal_paths():
+    validate_exec_path("/tmp/data/MC_st0r5.2_6.dat")
+    validate_exec_path("relative/path with spaces.pdb")
+    assert is_safe_exec_path("/tmp/ligand.sdf")
+
+
+def test_accept_tab():
+    validate_exec_path("name\twith\ttab")
+
+
+def test_reject_empty():
+    with pytest.raises(ValueError, match="empty"):
+        validate_exec_path("")
+    assert not is_safe_exec_path("")
+
+
+def test_reject_nul():
+    with pytest.raises(ValueError, match="NUL"):
+        validate_exec_path("evil\x00payload")
+
+
+def test_reject_newline():
+    with pytest.raises(ValueError, match="newline"):
+        validate_exec_path("a\nb")
+    with pytest.raises(ValueError, match="newline"):
+        validate_exec_path("a\rb")
+
+
+def test_reject_control():
+    with pytest.raises(ValueError, match="control"):
+        validate_exec_path("a\x01b")

--- a/tests/test_protocol_config.cpp
+++ b/tests/test_protocol_config.cpp
@@ -70,13 +70,44 @@ struct ClearProtocolEnv {
         , t_eff("FLEXAIDDS_T_EFF", nullptr)
         , tencom("FLEXAIDDS_TENCOM_SCALE", nullptr)
         , data_dir("FLEXAIDDS_DATA_DIR", nullptr)
+        , oracle_dir("FLEXAIDDS_ORACLE_SITE_DIR", nullptr)
+        , oracle_site("FLEXAIDDS_ORACLE_SITE", nullptr)
+        , cleft("FLEXAIDDS_CLEFT_SPHERE_FILE", nullptr)
         , cf_win("FLEXAIDDS_CF_WINDOW_SELECTOR", nullptr)
         , cluster("FLEXAIDDS_CLUSTER_MEMBER_EMIT", nullptr)
-        , hbond("FLEXAIDDS_HBOND_WEIGHT", nullptr) {}
+        , seed_elit("FLEXAIDDS_SEED_ELITISM", nullptr)
+        , seed_delta("FLEXAIDDS_SEED_ELITISM_DELTA_CF", nullptr)
+        , freqsel("FLEXAIDDS_FREQSEL", nullptr)
+        , freq_a("FLEXAIDDS_FREQSEL_ALPHA", nullptr)
+        , freq_r("FLEXAIDDS_FREQSEL_RMSD", nullptr)
+        , consensus("FLEXAIDDS_CONSENSUS_SCORER", nullptr)
+        , hvib("FLEXAIDDS_HVIB", nullptr)
+        , ring("FLEXAIDDS_RING_FLEX", nullptr)
+        , eval_scale("FLEXAIDDS_EVAL_SCALE_DIHEDRAL", nullptr)
+        , budget("FLEXAIDDS_BUDGET_SCALE", nullptr)
+        , fine("FLEXAIDDS_FINE_GRID", nullptr)
+        , multi("FLEXAIDDS_MULTI_CLEFT", nullptr)
+        , cognate("FLEXAIDDS_COGNATE_SITE", nullptr)
+        , score_n("FLEXAIDDS_SCORE_NATIVE", nullptr)
+        , native_o("FLEXAIDDS_NATIVE_ONLY", nullptr)
+        , use_dp("FLEXAIDDS_USE_DP", nullptr)
+        , ignore("FLEXAIDDS_IGNORE_CACHE", nullptr)
+        , thermo_csv("FLEXAIDDS_THERMO_CSV", nullptr)
+        , hbond("FLEXAIDDS_HBOND_WEIGHT", nullptr)
+        , no_sec("FLEXAIDDS_NO_SEC", nullptr)
+        , bench("FLEXAIDDS_BENCHMARK", nullptr)
+        , t_hot("FLEXAIDDS_T_HOT", nullptr)
+        , instream("FLEXAIDDS_INSTREAM_INTERVAL", nullptr)
+        , chain("FLEXAIDDS_CHAIN_NORM", nullptr)
+        , smfree("FLEXAIDDS_SMFREE_REQUIRE_T", nullptr) {}
 
     ScopedEnv seed_base, restarts, parallel, vct_r0, vct_norm, vct_ew,
               sharing, boom, n_elite, shannon, thermo, t_eff, tencom,
-              data_dir, cf_win, cluster, hbond;
+              data_dir, oracle_dir, oracle_site, cleft, cf_win, cluster,
+              seed_elit, seed_delta, freqsel, freq_a, freq_r, consensus,
+              hvib, ring, eval_scale, budget, fine, multi, cognate, score_n,
+              native_o, use_dp, ignore, thermo_csv, hbond, no_sec, bench,
+              t_hot, instream, chain, smfree;
 };
 
 }  // namespace
@@ -103,6 +134,32 @@ TEST(ProtocolConfig, DefaultsMatchHistoricalFallbacks) {
     EXPECT_FALSE(e.cf_window_selector);
     EXPECT_FALSE(e.cluster_member_emit);
     EXPECT_DOUBLE_EQ(e.hbond_weight, -2.5);
+
+    // Chunk 2 defaults
+    EXPECT_TRUE(e.seed_elitism);
+    EXPECT_DOUBLE_EQ(e.seed_elitism_delta_cf, 10.0);
+    EXPECT_FALSE(e.freqsel);
+    EXPECT_DOUBLE_EQ(e.freqsel_alpha, 12.0);
+    EXPECT_FLOAT_EQ(e.freqsel_rmsd, 1.5f);
+    EXPECT_FALSE(e.consensus_scorer);
+    EXPECT_TRUE(e.hvib_enabled);
+    EXPECT_FALSE(e.ring_flex);
+    EXPECT_EQ(e.eval_scale_dihedral, 1);
+    EXPECT_TRUE(e.budget_scale);
+    EXPECT_FALSE(e.fine_grid);
+    EXPECT_EQ(e.multi_cleft, 0);
+    EXPECT_FALSE(e.cognate_site);
+    EXPECT_FALSE(e.score_native);
+    EXPECT_FALSE(e.native_only);
+    EXPECT_FALSE(e.use_dp);
+    EXPECT_FALSE(e.ignore_cache);
+    EXPECT_FALSE(e.thermo_csv);
+    EXPECT_FALSE(e.no_sec);
+    EXPECT_FALSE(e.benchmark_mode);
+    EXPECT_DOUBLE_EQ(e.t_hot, 0.0);
+    EXPECT_EQ(e.instream_interval, 0);
+    EXPECT_FALSE(e.chain_norm);
+    EXPECT_FALSE(e.smfree_require_t);
 
     EXPECT_DOUBLE_EQ(e.effective_sharing_alpha(1000, 1000), 4.0);
     EXPECT_DOUBLE_EQ(e.effective_sharing_alpha(1000, 2000), 2.0);
@@ -157,17 +214,57 @@ TEST(ProtocolConfig, PresenceFlagsAndParallelRestarts) {
     EXPECT_TRUE(cfg.parallel_restarts_explicit);
 }
 
+TEST(ProtocolConfig, Chunk2PoseAndBudgetKnobs) {
+    ClearProtocolEnv clear;
+    ScopedEnv elit("FLEXAIDDS_SEED_ELITISM", "0");
+    ScopedEnv delta("FLEXAIDDS_SEED_ELITISM_DELTA_CF", "7.5");
+    ScopedEnv freq("FLEXAIDDS_FREQSEL", "1");
+    ScopedEnv fa("FLEXAIDDS_FREQSEL_ALPHA", "9.0");
+    ScopedEnv fr("FLEXAIDDS_FREQSEL_RMSD", "2.0");
+    ScopedEnv ring("FLEXAIDDS_RING_FLEX", "1");
+    ScopedEnv eval("FLEXAIDDS_EVAL_SCALE_DIHEDRAL", "off");
+    ScopedEnv budget("FLEXAIDDS_BUDGET_SCALE", "0");
+    ScopedEnv fine("FLEXAIDDS_FINE_GRID", "1");
+    ScopedEnv multi("FLEXAIDDS_MULTI_CLEFT", "8");
+    ScopedEnv hvib("FLEXAIDDS_HVIB", "0");
+    ScopedEnv cons("FLEXAIDDS_CONSENSUS_SCORER", "1");
+    ScopedEnv hot("FLEXAIDDS_T_HOT", "1500");
+    ScopedEnv nosec("FLEXAIDDS_NO_SEC", "1");
+    ScopedEnv bench("FLEXAIDDS_BENCHMARK", "1");
+
+    const auto cfg = flexaids::ProtocolConfig::from_env();
+    EXPECT_FALSE(cfg.seed_elitism);
+    EXPECT_DOUBLE_EQ(cfg.seed_elitism_delta_cf, 7.5);
+    EXPECT_TRUE(cfg.freqsel);
+    EXPECT_DOUBLE_EQ(cfg.freqsel_alpha, 9.0);
+    EXPECT_FLOAT_EQ(cfg.freqsel_rmsd, 2.0f);
+    EXPECT_TRUE(cfg.ring_flex);
+    EXPECT_EQ(cfg.eval_scale_dihedral, -1);
+    EXPECT_FALSE(cfg.budget_scale);
+    EXPECT_TRUE(cfg.fine_grid);
+    EXPECT_EQ(cfg.multi_cleft, 8);
+    EXPECT_FALSE(cfg.hvib_enabled);
+    EXPECT_TRUE(cfg.consensus_scorer);
+    EXPECT_DOUBLE_EQ(cfg.t_hot, 1500.0);
+    EXPECT_TRUE(cfg.no_sec);
+    EXPECT_TRUE(cfg.benchmark_mode);
+}
+
 TEST(ProtocolConfig, JsonRoundTrip) {
     ClearProtocolEnv clear;
     ScopedEnv seed("FLEXAIDDS_SEED_BASE", "99");
     ScopedEnv restarts("FLEXAIDDS_RESTARTS", "7");
     ScopedEnv alpha("FLEXAIDDS_SHARING_ALPHA", "3.25");
     ScopedEnv data("FLEXAIDDS_DATA_DIR", "/opt/share/flexaidds");
+    ScopedEnv hot("FLEXAIDDS_T_HOT", "900");
+    ScopedEnv multi("FLEXAIDDS_MULTI_CLEFT", "4");
 
     const auto a = flexaids::ProtocolConfig::from_env();
     const std::string json = a.to_json();
     EXPECT_NE(json.find("\"seed_base\":99"), std::string::npos);
     EXPECT_NE(json.find("\"restarts\":7"), std::string::npos);
+    EXPECT_NE(json.find("\"t_hot\":"), std::string::npos);
+    EXPECT_NE(json.find("\"multi_cleft\":4"), std::string::npos);
 
     const auto b = flexaids::ProtocolConfig::from_json(json);
     EXPECT_EQ(b.seed_base, a.seed_base);
@@ -175,4 +272,6 @@ TEST(ProtocolConfig, JsonRoundTrip) {
     ASSERT_TRUE(b.sharing_alpha.has_value());
     EXPECT_DOUBLE_EQ(*b.sharing_alpha, 3.25);
     EXPECT_EQ(b.data_dir, "/opt/share/flexaidds");
+    EXPECT_DOUBLE_EQ(b.t_hot, 900.0);
+    EXPECT_EQ(b.multi_cleft, 4);
 }

--- a/tests/test_shell_exec.cpp
+++ b/tests/test_shell_exec.cpp
@@ -1,0 +1,121 @@
+// test_shell_exec.cpp — unit tests for path-safe shell quoting / argv exec helpers
+// Apache-2.0 © 2026 Le Bonhomme Pharma
+
+#include <gtest/gtest.h>
+
+#include "shell_exec.h"
+
+#include <stdexcept>
+#include <string>
+
+using flexaids::shell_exec::PathReject;
+using flexaids::shell_exec::is_safe_exec_path;
+using flexaids::shell_exec::run_argv_first_token;
+using flexaids::shell_exec::shell_quote;
+using flexaids::shell_exec::shell_quote_checked;
+using flexaids::shell_exec::shell_quote_raw;
+using flexaids::shell_exec::validate_exec_path;
+
+// ---------------------------------------------------------------------------
+// shell_quote_raw — single-quote rule
+// ---------------------------------------------------------------------------
+
+TEST(ShellExec, QuoteSimplePath) {
+    EXPECT_EQ(shell_quote_raw("/tmp/data"), "'/tmp/data'");
+}
+
+TEST(ShellExec, QuoteEmbeddedSingleQuote) {
+    // foo'bar → 'foo'\''bar'
+    EXPECT_EQ(shell_quote_raw("foo'bar"), "'foo'\\''bar'");
+}
+
+TEST(ShellExec, QuoteSpacesAndMetacharacters) {
+    // Single-quoting neutralizes spaces, $, `, ;, |, &, etc.
+    EXPECT_EQ(shell_quote_raw("a b;c$(x)"), "'a b;c$(x)'");
+    EXPECT_EQ(shell_quote_raw("x`id`y"), "'x`id`y'");
+    EXPECT_EQ(shell_quote_raw("p|q&r"), "'p|q&r'");
+}
+
+TEST(ShellExec, QuoteEmptyIsEmptyQuoted) {
+    EXPECT_EQ(shell_quote_raw(""), "''");
+}
+
+// ---------------------------------------------------------------------------
+// validate_exec_path — refuse NUL / newlines / controls
+// ---------------------------------------------------------------------------
+
+TEST(ShellExec, AcceptNormalPaths) {
+    EXPECT_EQ(validate_exec_path("/Users/me/data/MC_st0r5.2_6.dat"), PathReject::Ok);
+    EXPECT_EQ(validate_exec_path("relative/path with spaces.pdb"), PathReject::Ok);
+    EXPECT_TRUE(is_safe_exec_path("/tmp/ligand.sdf"));
+}
+
+TEST(ShellExec, AcceptTabInPath) {
+    EXPECT_EQ(validate_exec_path("name\twith\ttab"), PathReject::Ok);
+}
+
+TEST(ShellExec, RejectEmpty) {
+    EXPECT_EQ(validate_exec_path(""), PathReject::Empty);
+    EXPECT_FALSE(is_safe_exec_path(""));
+}
+
+TEST(ShellExec, RejectNul) {
+    std::string p = "evil";
+    p.push_back('\0');
+    p += "payload";
+    EXPECT_EQ(validate_exec_path(p), PathReject::ContainsNul);
+}
+
+TEST(ShellExec, RejectNewlineAndCr) {
+    EXPECT_EQ(validate_exec_path("a\nb"), PathReject::ContainsNewline);
+    EXPECT_EQ(validate_exec_path("a\rb"), PathReject::ContainsNewline);
+}
+
+TEST(ShellExec, RejectOtherControls) {
+    EXPECT_EQ(validate_exec_path(std::string("a") + '\x01' + "b"),
+              PathReject::ContainsControl);
+    EXPECT_EQ(validate_exec_path(std::string("a") + '\x7f' + "b"),
+              PathReject::ContainsControl);
+}
+
+// ---------------------------------------------------------------------------
+// shell_quote / shell_quote_checked — validate then quote
+// ---------------------------------------------------------------------------
+
+TEST(ShellExec, ShellQuoteThrowsOnNewline) {
+    EXPECT_THROW(
+        { auto q = shell_quote("a\nb"); (void)q; },
+        std::invalid_argument);
+}
+
+TEST(ShellExec, ShellQuoteCheckedNulloptOnNul) {
+    std::string p = "x";
+    p.push_back('\0');
+    p += "y";
+    EXPECT_FALSE(shell_quote_checked(p).has_value());
+}
+
+TEST(ShellExec, ShellQuoteCheckedOk) {
+    auto q = shell_quote_checked("/data/dir");
+    ASSERT_TRUE(q.has_value());
+    EXPECT_EQ(*q, "'/data/dir'");
+}
+
+TEST(ShellExec, ShellQuoteHandlesEmbeddedQuote) {
+    EXPECT_EQ(shell_quote("o'reilly"), "'o'\\''reilly'");
+}
+
+// ---------------------------------------------------------------------------
+// run_argv_first_token — no shell; injection cannot expand
+// ---------------------------------------------------------------------------
+
+TEST(ShellExec, RunArgvFirstTokenEcho) {
+    // argv form: metacharacters are literal args, not shell syntax.
+    auto t = run_argv_first_token({"printf", "%s", "hello_world"});
+    EXPECT_EQ(t, "hello_world");
+}
+
+TEST(ShellExec, RunArgvRejectsUnsafeArg) {
+    auto t = run_argv_first_token({"printf", "%s", "a\nb"});
+    EXPECT_TRUE(t.empty());
+}


### PR DESCRIPTION
## Summary

Hardens shell/exec path handling so malicious or malformed paths (e.g. via `FLEXAIDDS_DATA_DIR` or manifest paths) cannot inject shell commands or corrupt provenance receipts.

### New helper (`LIB/shell_exec.h`)
- `validate_exec_path` / `is_safe_exec_path` — refuse empty, NUL, newline/CR, other C0 controls (TAB allowed)
- `shell_quote` / `shell_quote_raw` — POSIX single-quote rule (`foo'bar` → `'foo'\''bar'`) after validation
- `run_argv` / `run_argv_capture` / `run_argv_first_token` — fork+execvp, **no shell**

### Hardened call sites
| Site | Change |
|------|--------|
| `DatasetRunner` dock cmd | paths already `shell_quote`’d; now validate data_dir; throws on unsafe paths |
| `DatasetRunner::http_download` | `curl` via argv (was double-quoted `sh -c` string) |
| Provenance md5/sha256/git | argv-only (`md5`/`md5sum`, `shasum`/`sha256sum`, `git rev-parse`) — no `popen` shell |
| `PoseBust/BustCli` | `openssl dgst` + `bust` CLI via argv |
| `PoseBust/ChecksChemistry` | `inchi-1` via argv |
| `top.cpp --benchmark` | argv exec to `benchmark_datasets` (single child; no `system()` dual-launch risk) |

### Residual shell uses (documented)
- **Dock launch still uses `/bin/sh -c`** for env prefixes (`OMP_*`, `FLEXAIDDS_CLEFT_SPHERE_FILE`, …) + stdout/stderr redirection. All interpolated paths go through validated `shell_quote`. Prefer `fork_exec_argv` when no shell metacharacters are needed.
- `DatasetRunner::exec_cmd` / `fork_exec` remain shell-based for legacy non-dock commands that still pass pre-built shell strings.
- `ChecksChemistry` `command -v inchi-1` remains a fixed-string `popen` (no path interpolation).
- Windows `_MSC_VER` paths still use `std::system` where noted.

### Tests
- `tests/test_shell_exec.cpp` — 16 gtests for quote/validate/argv helpers (**all passed**)
- `python/tests/test_shell_exec_paths.py` — mirrors C++ validation rules
- FlexAID + `test_dataset_runner` link successfully after changes

### Science defaults
**No change** to docking GA, scoring, clustering, or thermodynamic defaults.

## Test plan
- [x] `cmake --build … --target test_shell_exec && ./test_shell_exec` (16/16)
- [x] Build `FlexAID` and `test_dataset_runner`
- [ ] CI ctest / full suite on PR