### PR TITLE
Add: FlexAID A/B0/B pilot harness for three-engine campaign

### DIFF
--- a/scripts/generate_flexaid_inp.py
+++ b/scripts/generate_flexaid_inp.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""Generate classic FlexAID CONFIG.inp + ga.inp work trees for arms A / B0 / B.
+
+Three-engine entropy comparison protocol (TIER-1 cognate, no native seed):
+  A  = FlexAID 2015-era binary  (CF election; TEMPER 0)
+  B0 = FlexAID master           (TEMPER 0 → CF clustering forced)
+  B  = FlexAID master           (TEMPER 298 → BindingMode/colony entropy)
+
+Inputs per target (from queue):
+  <PDB>_apo.pdb, <PDB>_ligand.sdf, cleft spheres (GetCleft or queue site)
+
+ProcessLigand (processligand-py) produces ligand .inp/.ic and typed target PDB.
+Sphere files with HETATM records are rewritten as ATOM for classic FlexAID
+read_spheres (A/B binaries only accept ATOM in some builds).
+
+Seed note: staged FlexAID A/B binaries seed with time(0); STRTSEED is written
+into ga.inp for provenance / future binaries, but may be ignored by current
+Mach-O pins. Restarts are separate process invocations.
+
+Usage:
+  python3 scripts/generate_flexaid_inp.py \\
+    --queue-root "$FLEXAIDDS_QUEUE_ROOT" \\
+    --pdb 1GPK --arm B0 \\
+    --work-dir /path/to/work/B0/1GPK
+
+  python3 scripts/generate_flexaid_inp.py --queue-root "$Q" --pilot8 --arms A,B0,B
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+# Protocol defaults (three_engine_entropy_comparison.md)
+SEED_BASE = 20260714
+DEFAULT_POP = 1000
+DEFAULT_GEN = 6000
+DEFAULT_RESTARTS = 5
+MATRIX_NAME = "MC_st0r5.2_6.dat"
+MATRIX_MD5_PIN = "72d7c7396702331d96ff12d18f831796"
+LIGAND_RESNUM = 9999
+ATOM_INDEX = 90000
+
+PILOT8 = ["1G9V", "1GPK", "1MEH", "1P62", "1Q4G", "1R9O", "1T40", "2BYS"]
+
+ARM_SPEC = {
+    "A": {"bin_arm": "A", "temper": 0, "label": "FlexAID-2015 CF"},
+    "B0": {"bin_arm": "B", "temper": 0, "label": "FlexAID-master TEMPER 0 / CF"},
+    "B": {"bin_arm": "B", "temper": 298, "label": "FlexAID-master TEMPER 298"},
+}
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def stable_seed(pdb_id: str, restart_i: int, seed_base: int = SEED_BASE) -> int:
+    """Protocol: SEED_BASE + stable_hash(pdb_id, restart_i) → positive 31-bit int."""
+    h = hashlib.sha256(f"{pdb_id.upper()}:{restart_i}".encode()).hexdigest()
+    return int(seed_base + (int(h[:8], 16) % 1_000_000_000))
+
+
+def md5_file(path: Path) -> str:
+    h = hashlib.md5()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def resolve_processligand() -> Path:
+    """Locate ProcessLigand binary without baking in machine-specific defaults."""
+    env = os.environ.get("FLEXAIDDS_PROCESSLIGAND")
+    if env and Path(env).is_file() and os.access(env, os.X_OK):
+        return Path(env).resolve()
+
+    try:
+        import processligandpy  # type: ignore
+
+        cand = Path(processligandpy.__file__).resolve().parent / "bin" / "ProcessLigand"
+        if cand.is_file() and os.access(cand, os.X_OK):
+            return cand
+    except ImportError:
+        pass
+
+    for base in (repo_root() / ".venv-processligand", Path.home() / ".venv-processligand"):
+        if base.is_dir():
+            matches = list(
+                base.glob("lib/python*/site-packages/processligandpy/bin/ProcessLigand")
+            )
+            if matches and os.access(matches[0], os.X_OK):
+                return matches[0].resolve()
+
+    which = shutil.which("ProcessLigand")
+    if which:
+        return Path(which).resolve()
+
+    raise FileNotFoundError(
+        "ProcessLigand not found. Install with: "
+        "python3 -m venv .venv-processligand && "
+        ".venv-processligand/bin/pip install processligand-py\n"
+        "Or set FLEXAIDDS_PROCESSLIGAND to the binary path."
+    )
+
+
+def ensure_babel_env(processligand: Path) -> None:
+    if os.environ.get("BABEL_DATADIR"):
+        return
+    root = processligand.parent.parent
+    for cand in (root / "share" / "openbabel" / "3.1.1", root / "bin" / "data"):
+        if cand.is_dir():
+            os.environ["BABEL_DATADIR"] = str(cand)
+            return
+
+
+def run_processligand(
+    processligand: Path,
+    input_file: Path,
+    out_prefix: Path,
+    *,
+    target: bool = False,
+    atom_index: int = ATOM_INDEX,
+    ref: bool = True,
+) -> None:
+    ensure_babel_env(processligand)
+    out_prefix.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        str(processligand),
+        "-f",
+        str(input_file),
+        "-o",
+        str(out_prefix),
+        "-d",
+        "-pf",
+    ]
+    if target:
+        cmd.append("-target")
+    else:
+        cmd.extend(
+            ["--atom_index", str(atom_index), "--res_number", str(LIGAND_RESNUM)]
+        )
+        if ref:
+            cmd.append("-ref")
+
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"ProcessLigand failed (rc={proc.returncode}) for {input_file}\n"
+            f"stdout:\n{proc.stdout[-2000:]}\nstderr:\n{proc.stderr[-2000:]}"
+        )
+
+
+def convert_spheres_to_atom(src: Path, dst: Path) -> int:
+    """Rewrite HETATM→ATOM so classic FlexAID read_spheres accepts the file."""
+    n = 0
+    lines_out: List[str] = []
+    for line in src.read_text(errors="replace").splitlines():
+        if line.startswith("HETATM"):
+            lines_out.append("ATOM  " + line[6:])
+            n += 1
+        elif line.startswith("ATOM  "):
+            lines_out.append(line)
+            n += 1
+        else:
+            lines_out.append(line)
+    if n == 0:
+        raise ValueError(f"no sphere ATOM/HETATM records in {src}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text("\n".join(lines_out) + "\n")
+    return n
+
+
+def parse_fledih_count(ligand_inp: Path) -> int:
+    text = ligand_inp.read_text(errors="replace")
+    return sum(1 for line in text.splitlines() if line.startswith("FLEDIH"))
+
+
+def write_config(
+    path: Path,
+    *,
+    target_pdb: Path,
+    ligand_inp: Path,
+    spheres_pdb: Path,
+    matrix_path: Path,
+    depspa: Path,
+    statep: Path,
+    tempop: Path,
+    rmsd_ref: Optional[Path],
+    temper: int,
+    n_flex: int,
+    maxres: int = 10,
+) -> None:
+    lines: List[str] = [
+        "# generated by scripts/generate_flexaid_inp.py",
+        f"PDBNAM {target_pdb}",
+        f"INPLIG {ligand_inp}",
+        "COMPLF VCT",
+        f"RNGOPT LOCCLF {spheres_pdb}",
+        f"OPTIMZ {LIGAND_RESNUM} - -1",
+        f"OPTIMZ {LIGAND_RESNUM} - 0",
+    ]
+    for i in range(1, n_flex + 1):
+        lines.append(f"OPTIMZ {LIGAND_RESNUM} - {i}")
+
+    if rmsd_ref is not None:
+        lines.append(f"RMSDST {rmsd_ref}")
+
+    lines.extend(
+        [
+            f"IMATRX {matrix_path}",
+            "PERMEA 0.9",
+            "VARANG 5.0",
+            "VARDIH 5.0",
+            "VARFLX 10.0",
+            "SPACER 0.375",
+            "SLVTYP 40",
+            "EXCHET",
+            "METOPT GA",
+            "VCTPLA R",
+            "NORMAR",
+            "VINDEX",
+            f"STATEP {statep}",
+            f"TEMPOP {tempop}",
+            f"DEPSPA {depspa}",
+            f"MAXRES {maxres}",
+            f"TEMPER {temper}",
+            "CLUSTA CF" if temper <= 0 else "CLUSTA FO",
+            "CLRMSD 2.0",
+            "ENDINP",
+        ]
+    )
+    path.write_text("\n".join(lines) + "\n")
+
+
+def write_ga(path: Path, *, pop: int, gen: int, seed: int) -> None:
+    lines = [
+        "# generated by scripts/generate_flexaid_inp.py",
+        "# STRTSEED may be ignored by staged A/B binaries (time-based srand); kept for provenance",
+        f"NUMCHROM {pop}",
+        f"NUMGENER {gen}",
+        "ADAPTVGA 1",
+        "ADAPTKCO 0.95 0.50 0.95 0.20",
+        "CROSRATE 0.900",
+        "MUTARATE 0.025",
+        "POPINIMT RANDOM",
+        "FITMODEL PSHARE",
+        "SHAREALF 4.00",
+        "SHAREPEK 3.00",
+        "SHARESCL 0.20",
+        "REPMODEL BOOM",
+        "BOOMFRAC 1.00",
+        f"PRINTCHR {min(10, pop)}",
+        "OUTGENER 1",
+        f"STRTSEED {seed}",
+    ]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def find_sphere_file(queue_root: Path, pdb_id: str) -> Path:
+    pdb = pdb_id.upper()
+    env_root = os.environ.get("FLEXAIDDS_SPHERE_ROOT")
+    candidates: List[Path] = []
+    if env_root:
+        candidates.extend(Path(env_root).glob(f"{pdb}/**/*_occupied_sph_1.pdb"))
+        candidates.extend(Path(env_root).glob(f"{pdb}/*sph*.pdb"))
+
+    q_in = queue_root / "inputs" / "astex_diverse" / pdb
+    candidates.extend(q_in.glob("*_sph*.pdb"))
+    candidates.extend(q_in.glob("*_cleft*.pdb"))
+
+    icloud = os.environ.get("FLEXAIDDS_ICLOUD")
+    if not icloud:
+        icloud = str(
+            Path.home()
+            / "Library"
+            / "Mobile Documents"
+            / "com~apple~CloudDocs"
+            / "FlexAIDdS_benchmarks"
+        )
+    cav = (
+        Path(icloud)
+        / "astex_entropy"
+        / "native_headtohead_20260707"
+        / "cavities"
+        / "native"
+        / pdb
+        / "native_occupied"
+        / f"{pdb}_occupied_sph_1.pdb"
+    )
+    candidates.append(cav)
+
+    for c in candidates:
+        if c.is_file():
+            return c.resolve()
+
+    site = q_in / f"{pdb}_site.pdb"
+    if site.is_file():
+        return site.resolve()
+
+    raise FileNotFoundError(
+        f"No sphere/site file for {pdb}. Set FLEXAIDDS_SPHERE_ROOT or stage GetCleft spheres."
+    )
+
+
+def prepare_target(
+    queue_root: Path,
+    pdb_id: str,
+    arm: str,
+    work_root: Path,
+    *,
+    pop: int = DEFAULT_POP,
+    gen: int = DEFAULT_GEN,
+    restarts: int = DEFAULT_RESTARTS,
+    seed_base: int = SEED_BASE,
+    processligand: Optional[Path] = None,
+    force: bool = False,
+) -> Path:
+    if arm not in ARM_SPEC:
+        raise ValueError(f"unknown arm {arm}; expected one of {list(ARM_SPEC)}")
+
+    spec = ARM_SPEC[arm]
+    pdb = pdb_id.upper()
+    inp = queue_root / "inputs" / "astex_diverse" / pdb
+    apo = inp / f"{pdb}_apo.pdb"
+    lig = inp / f"{pdb}_ligand.sdf"
+    if not apo.is_file() or not lig.is_file():
+        raise FileNotFoundError(f"missing apo/ligand under {inp}")
+
+    matrix = queue_root / "data" / MATRIX_NAME
+    if not matrix.is_file():
+        raise FileNotFoundError(f"matrix missing: {matrix}")
+    got = md5_file(matrix)
+    if got != MATRIX_MD5_PIN:
+        raise RuntimeError(f"matrix MD5 {got} != pin {MATRIX_MD5_PIN}")
+
+    depspa = (queue_root / "data").resolve()
+    work = work_root / arm / pdb
+    if work.exists() and force:
+        shutil.rmtree(work)
+    work.mkdir(parents=True, exist_ok=True)
+
+    pl = processligand or resolve_processligand()
+
+    lig_work = work / f"{pdb}_ligand.sdf"
+    if not lig_work.exists() or force:
+        shutil.copy2(lig, lig_work)
+    lig_prefix = work / "LIG"
+    if not (work / "LIG.inp").is_file() or force:
+        run_processligand(pl, lig_work, lig_prefix, target=False, ref=True)
+
+    ligand_inp = work / "LIG.inp"
+    ligand_ic = work / "LIG.ic"
+    ligand_ref = work / "LIG_ref.pdb"
+    if not ligand_inp.is_file():
+        raise RuntimeError(f"ProcessLigand did not produce {ligand_inp}")
+    if not ligand_ic.is_file():
+        raise RuntimeError(f"ProcessLigand did not produce {ligand_ic}")
+
+    apo_work = work / f"{pdb}_apo.pdb"
+    if not apo_work.exists() or force:
+        shutil.copy2(apo, apo_work)
+    tgt_prefix = work / "TARGET"
+    target_pdb = work / "TARGET.inp.pdb"
+    if not target_pdb.is_file() or force:
+        run_processligand(pl, apo_work, tgt_prefix, target=True)
+    if not target_pdb.is_file():
+        alt = work / f"{pdb}_apo.inp.pdb"
+        if alt.is_file():
+            shutil.copy2(alt, target_pdb)
+        else:
+            found = list(work.glob("*.inp.pdb"))
+            if found:
+                shutil.copy2(found[0], target_pdb)
+            else:
+                raise RuntimeError(
+                    f"ProcessLigand did not produce target .inp.pdb under {work}"
+                )
+
+    sph_src = find_sphere_file(queue_root, pdb)
+    sph_dst = work / f"{pdb}_spheres.pdb"
+    if sph_src.name.endswith("_site.pdb") and "sph" not in sph_src.name.lower():
+        (work / "SPHERE_SOURCE_WARNING.txt").write_text(
+            f"WARNING: using pocket-atom site file (not GetCleft spheres): {sph_src}\n"
+            "Classic FlexAID LOCCLF expects sphere radii in B-factor; results may be invalid.\n"
+        )
+        shutil.copy2(sph_src, sph_dst)
+    else:
+        convert_spheres_to_atom(sph_src, sph_dst)
+        (work / "sphere_source.txt").write_text(str(sph_src) + "\n")
+
+    n_flex = parse_fledih_count(ligand_inp)
+    temper = int(spec["temper"])
+
+    statep = work / "state"
+    tempop = work / "tmp"
+    statep.mkdir(exist_ok=True)
+    tempop.mkdir(exist_ok=True)
+
+    write_config(
+        work / "CONFIG.inp",
+        target_pdb=target_pdb.resolve(),
+        ligand_inp=ligand_inp.resolve(),
+        spheres_pdb=sph_dst.resolve(),
+        matrix_path=matrix.resolve(),
+        depspa=depspa,
+        statep=statep.resolve(),
+        tempop=tempop.resolve(),
+        rmsd_ref=ligand_ref.resolve() if ligand_ref.is_file() else None,
+        temper=temper,
+        n_flex=n_flex,
+    )
+
+    for r in range(restarts):
+        seed = stable_seed(pdb, r, seed_base)
+        rdir = work / f"restart_{r}"
+        rdir.mkdir(exist_ok=True)
+        write_ga(rdir / "ga.inp", pop=pop, gen=gen, seed=seed)
+        r_state = rdir / "state"
+        r_tmp = rdir / "tmp"
+        r_state.mkdir(exist_ok=True)
+        r_tmp.mkdir(exist_ok=True)
+        write_config(
+            rdir / "CONFIG.inp",
+            target_pdb=target_pdb.resolve(),
+            ligand_inp=ligand_inp.resolve(),
+            spheres_pdb=sph_dst.resolve(),
+            matrix_path=matrix.resolve(),
+            depspa=depspa,
+            statep=r_state.resolve(),
+            tempop=r_tmp.resolve(),
+            rmsd_ref=ligand_ref.resolve() if ligand_ref.is_file() else None,
+            temper=temper,
+            n_flex=n_flex,
+        )
+        (rdir / "seed.txt").write_text(f"{seed}\n")
+
+    meta = {
+        "arm": arm,
+        "bin_arm": spec["bin_arm"],
+        "label": spec["label"],
+        "pdb_id": pdb,
+        "temper": temper,
+        "pop": pop,
+        "gen": gen,
+        "restarts": restarts,
+        "seed_base": seed_base,
+        "n_flex_bonds": n_flex,
+        "matrix_md5": got,
+        "matrix_path": str(matrix.resolve()),
+        "sphere_source": str(sph_src),
+        "processligand": str(pl),
+        "work_dir": str(work.resolve()),
+        "seeds": [stable_seed(pdb, r, seed_base) for r in range(restarts)],
+        "cli": "FlexAID CONFIG.inp ga.inp output_prefix",
+        "seed_limitation": (
+            "Staged A/B FlexAID binaries use time(0) srand; STRTSEED in ga.inp "
+            "is provenance-only unless the binary implements it."
+        ),
+    }
+    (work / "meta.json").write_text(json.dumps(meta, indent=2) + "\n")
+    return work
+
+
+def load_pdb_list(
+    queue_root: Path, pilot8: bool, pdb: Optional[str], list_file: Optional[str]
+) -> List[str]:
+    if pdb:
+        return [pdb.upper()]
+    if pilot8:
+        return list(PILOT8)
+    if list_file:
+        return [
+            line.strip().upper()
+            for line in Path(list_file).read_text().splitlines()
+            if line.strip() and not line.startswith("#")
+        ]
+    d = queue_root / "inputs" / "astex_diverse"
+    return sorted(
+        p.name
+        for p in d.iterdir()
+        if p.is_dir() and (p / f"{p.name}_apo.pdb").is_file()
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--queue-root",
+        default=os.environ.get("FLEXAIDDS_QUEUE_ROOT", ""),
+        help="Three-engine queue root",
+    )
+    ap.add_argument(
+        "--work-root", default="", help="Work tree root (default: $QUEUE/work)"
+    )
+    ap.add_argument("--pdb", default="", help="Single PDB id")
+    ap.add_argument("--pilot8", action="store_true", help="Generate pilot8 panel")
+    ap.add_argument("--list-file", default="", help="File with one PDB id per line")
+    ap.add_argument("--arms", default="A,B0,B", help="Comma-separated arms")
+    ap.add_argument("--pop", type=int, default=DEFAULT_POP)
+    ap.add_argument("--gen", type=int, default=DEFAULT_GEN)
+    ap.add_argument("--restarts", type=int, default=DEFAULT_RESTARTS)
+    ap.add_argument("--seed-base", type=int, default=SEED_BASE)
+    ap.add_argument("--force", action="store_true")
+    ap.add_argument("--dry-run", action="store_true", help="Print plan only")
+    args = ap.parse_args(argv)
+
+    if not args.queue_root:
+        print("ERROR: --queue-root or FLEXAIDDS_QUEUE_ROOT required", file=sys.stderr)
+        return 2
+    q = Path(args.queue_root).expanduser().resolve()
+    if not q.is_dir():
+        print(f"ERROR: queue root missing: {q}", file=sys.stderr)
+        return 2
+
+    work_root = (
+        Path(args.work_root).expanduser().resolve()
+        if args.work_root
+        else (q / "work")
+    )
+    arms = [a.strip() for a in args.arms.split(",") if a.strip()]
+    pdbs = load_pdb_list(q, args.pilot8, args.pdb or None, args.list_file or None)
+
+    print(f"queue={q}")
+    print(f"work_root={work_root}")
+    print(f"arms={arms} pdbs={len(pdbs)} pop={args.pop} gen={args.gen} R={args.restarts}")
+
+    if args.dry_run:
+        try:
+            pl = resolve_processligand()
+            print(f"ProcessLigand={pl}")
+        except FileNotFoundError as e:
+            print(f"ProcessLigand MISSING: {e}")
+        for arm in arms:
+            for pdb in pdbs:
+                try:
+                    sph = find_sphere_file(q, pdb)
+                except FileNotFoundError as e:
+                    sph = f"MISSING: {e}"
+                print(f"  would prepare arm={arm} pdb={pdb} sphere={sph}")
+        return 0
+
+    pl = resolve_processligand()
+    print(f"ProcessLigand={pl}")
+    n_ok = 0
+    for arm in arms:
+        for pdb in pdbs:
+            try:
+                w = prepare_target(
+                    q,
+                    pdb,
+                    arm,
+                    work_root,
+                    pop=args.pop,
+                    gen=args.gen,
+                    restarts=args.restarts,
+                    seed_base=args.seed_base,
+                    processligand=pl,
+                    force=args.force,
+                )
+                print(f"OK {arm}/{pdb} → {w}")
+                n_ok += 1
+            except Exception as exc:
+                print(f"FAIL {arm}/{pdb}: {exc}", file=sys.stderr)
+    print(f"done: {n_ok}/{len(arms)*len(pdbs)}")
+    return 0 if n_ok == len(arms) * len(pdbs) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/parse_flexaid_arm_results.py
+++ b/scripts/parse_flexaid_arm_results.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Parse classic FlexAID pilot outputs into a normalized result.csv row.
+
+Reads ``*_r*_0.pdb`` (cluster rank 0) REMARK lines for CF and RMSD when
+RMSDST was set. Elects best CF.app among restart rank-0 poses.
+
+Does not claim PoseBusters or thermodynamic ΔG.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import re
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+RMSD_RE = re.compile(
+    r"REMARK\s+([-+]?\d+\.?\d*)\s+RMSD to ref\. structure\s+\(symmetry corrected\)",
+    re.I,
+)
+RMSD_NS_RE = re.compile(
+    r"REMARK\s+([-+]?\d+\.?\d*)\s+RMSD to ref\. structure\s+\(no symmetry",
+    re.I,
+)
+CF_RE = re.compile(r"REMARK\s+CF=([-+]?\d+\.?\d*)", re.I)
+CF_APP_RE = re.compile(r"REMARK\s+CF\.app=([-+]?\d+\.?\d*)", re.I)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def parse_pose_pdb(path: Path) -> Dict[str, Optional[float]]:
+    text = path.read_text(errors="replace")
+    out: Dict[str, Optional[float]] = {
+        "rmsd_sym": None,
+        "rmsd_nosym": None,
+        "cf": None,
+        "cf_app": None,
+    }
+    m = RMSD_RE.search(text)
+    if m:
+        out["rmsd_sym"] = float(m.group(1))
+    m = RMSD_NS_RE.search(text)
+    if m:
+        out["rmsd_nosym"] = float(m.group(1))
+    m = CF_RE.search(text)
+    if m:
+        out["cf"] = float(m.group(1))
+    m = CF_APP_RE.search(text)
+    if m:
+        out["cf_app"] = float(m.group(1))
+    return out
+
+
+def collect_restart_poses(out_dir: Path, pdb: str) -> List[Tuple[int, Path, Dict]]:
+    rows = []
+    for rdir_pdb in sorted(out_dir.glob(f"{pdb}_r*_0.pdb")):
+        name = rdir_pdb.name
+        try:
+            r = int(name.split("_r")[1].split("_")[0])
+        except (IndexError, ValueError):
+            r = -1
+        rows.append((r, rdir_pdb, parse_pose_pdb(rdir_pdb)))
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--arm", required=True)
+    ap.add_argument("--pdb", required=True)
+    ap.add_argument("--out-dir", required=True, type=Path)
+    ap.add_argument("--work-dir", type=Path, default=None)
+    ap.add_argument("--matrix-md5", default="")
+    ap.add_argument("--binary", type=Path, default=None)
+    args = ap.parse_args()
+
+    pdb = args.pdb.upper()
+    poses = collect_restart_poses(args.out_dir, pdb)
+    if not poses:
+        for p in sorted(args.out_dir.glob("*_0.pdb")):
+            poses.append((0, p, parse_pose_pdb(p)))
+
+    best = None
+    for r, path, meta in poses:
+        cf = meta.get("cf_app") if meta.get("cf_app") is not None else meta.get("cf")
+        if cf is None:
+            continue
+        if best is None or cf < best[0]:
+            best = (cf, r, path, meta)
+
+    rmsd_top1 = None
+    score_top1 = None
+    elected_path = ""
+    restarts_finished = len(poses)
+    rmsd_bcr = None
+    if best:
+        score_top1 = best[0]
+        elected_path = str(best[2])
+        m = best[3]
+        rmsd_top1 = m.get("rmsd_sym") if m.get("rmsd_sym") is not None else m.get("rmsd_nosym")
+
+    all_rmsds = []
+    for p in args.out_dir.glob(f"{pdb}_r*_*.pdb"):
+        if p.name.endswith("_INI.pdb"):
+            continue
+        meta = parse_pose_pdb(p)
+        v = meta.get("rmsd_sym") if meta.get("rmsd_sym") is not None else meta.get("rmsd_nosym")
+        if v is not None:
+            all_rmsds.append(v)
+    if all_rmsds:
+        rmsd_bcr = min(all_rmsds)
+
+    success_s1 = int(rmsd_top1 is not None and rmsd_top1 <= 2.0)
+    success_s3 = int(rmsd_bcr is not None and rmsd_bcr <= 2.0)
+
+    bin_sha = ""
+    if args.binary and args.binary.is_file():
+        bin_sha = sha256_file(args.binary.resolve())
+
+    row = {
+        "arm": args.arm,
+        "engine_sha": bin_sha,
+        "matrix_md5": args.matrix_md5,
+        "pdb_id": pdb,
+        "rmsd_top1": "" if rmsd_top1 is None else f"{rmsd_top1:.4f}",
+        "rmsd_bcr": "" if rmsd_bcr is None else f"{rmsd_bcr:.4f}",
+        "success_s1": success_s1,
+        "success_s2": "",
+        "success_s3": success_s3,
+        "rank_native_mode": "",
+        "n_poses": restarts_finished,
+        "n_modes": restarts_finished,
+        "score_top1": "" if score_top1 is None else f"{score_top1:.5f}",
+        "H": "",
+        "TS": "",
+        "F": "",
+        "pb_pass": "",
+        "tencom_status": "NA",
+        "seed_echo": 0,
+        "native_pose_seeded": 0,
+        "protocol_claim_eligible": 1 if args.matrix_md5 else 0,
+        "wall_s": "",
+        "restarts_finished": restarts_finished,
+        "evals_actual": "",
+        "budget_class": "full",
+        "elected_path": elected_path,
+        "parsed_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+    out_csv = args.out_dir / "result.csv"
+    with out_csv.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(row.keys()))
+        w.writeheader()
+        w.writerow(row)
+    print(f"wrote {out_csv} s1={success_s1} rmsd_top1={row['rmsd_top1']} bcr={row['rmsd_bcr']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare_arm_AB.sh
+++ b/scripts/prepare_arm_AB.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Prepare FlexAID work trees for arms A / B0 / B (ProcessLigand + CONFIG + ga).
+#
+# Usage:
+#   scripts/prepare_arm_AB.sh                 # pilot8, all three arms
+#   scripts/prepare_arm_AB.sh --pdb 1GPK
+#   scripts/prepare_arm_AB.sh --full85
+#   scripts/prepare_arm_AB.sh --dry-run
+set -euo pipefail
+
+# shellcheck disable=SC1090
+[[ -f "${HOME}/.flexaidds_env" ]] && source "${HOME}/.flexaidds_env"
+
+ICLOUD_DEFAULT="${HOME}/Library/Mobile Documents/com~apple~CloudDocs/FlexAIDdS_benchmarks"
+export FLEXAIDDS_ICLOUD="${FLEXAIDDS_ICLOUD:-$ICLOUD_DEFAULT}"
+Q="${QUEUE_ROOT:-${FLEXAIDDS_QUEUE_ROOT:-$FLEXAIDDS_ICLOUD/queues/three_engine_entropy_q1}}"
+export FLEXAIDDS_QUEUE_ROOT="$Q"
+
+REPO="${FLEXAIDDS_ROOT:-}"
+if [[ -z "$REPO" ]]; then
+  REPO="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+
+if [[ -z "${FLEXAIDDS_PROCESSLIGAND:-}" ]]; then
+  for m in "$REPO"/.venv-processligand/lib/python*/site-packages/processligandpy/bin/ProcessLigand; do
+    if [[ -x "$m" ]]; then
+      export FLEXAIDDS_PROCESSLIGAND="$m"
+      break
+    fi
+  done
+fi
+
+ARGS=(--queue-root "$Q" --work-root "$Q/work" --arms A,B0,B --pop 1000 --gen 6000 --restarts 5)
+MODE=pilot8
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) ARGS+=(--dry-run); shift ;;
+    --force) ARGS+=(--force); shift ;;
+    --pdb) ARGS+=(--pdb "$2"); MODE=single; shift 2 ;;
+    --full85) MODE=full; shift ;;
+    --arms) ARGS+=(--arms "$2"); shift 2 ;;
+    *) echo "Unknown: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ "$MODE" == "pilot8" ]]; then
+  ARGS+=(--pilot8)
+fi
+
+echo "ProcessLigand=${FLEXAIDDS_PROCESSLIGAND:-unset}"
+exec python3 "$REPO/scripts/generate_flexaid_inp.py" "${ARGS[@]}"

--- a/scripts/run_A_pilot8.sh
+++ b/scripts/run_A_pilot8.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Arm A (FlexAID 2015-era) pilot8 → iCloud.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+exec bash "$ROOT/scripts/run_flexaid_arm_pilot8.sh" A "$@"

--- a/scripts/run_B0_pilot8.sh
+++ b/scripts/run_B0_pilot8.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Arm B0 (FlexAID master, TEMPER 0 / CF) pilot8 → iCloud.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+exec bash "$ROOT/scripts/run_flexaid_arm_pilot8.sh" B0 "$@"

--- a/scripts/run_B_pilot8.sh
+++ b/scripts/run_B_pilot8.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Arm B (FlexAID master, TEMPER 298 / entropy ranking) pilot8 → iCloud.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+exec bash "$ROOT/scripts/run_flexaid_arm_pilot8.sh" B "$@"

--- a/scripts/run_flexaid_arm_pilot8.sh
+++ b/scripts/run_flexaid_arm_pilot8.sh
@@ -72,6 +72,11 @@ GEN="$REPO/scripts/generate_flexaid_inp.py"
 PARSE="$REPO/scripts/parse_flexaid_arm_results.py"
 
 OUT="${FLEXAID_ARM_OUT:-$FLEXAIDDS_RESULTS/campaigns/three_engine/$ARM/pilot8}"
+# Smoke must NEVER share pilot8 OUT (skip would keep tiny-GA result.csv).
+if (( SMOKE )) && [[ -z "${FLEXAID_ARM_OUT:-}" ]]; then
+  OUT="$FLEXAIDDS_RESULTS/campaigns/three_engine/$ARM/smoke"
+fi
+
 WORK_ROOT="${FLEXAID_WORK_ROOT:-$Q/work}"
 LOGDIR="$Q/logs"
 mkdir -p "$OUT" "$LOGDIR" "$WORK_ROOT" "$FLEXAIDDS_RESULTS/campaigns/three_engine/$ARM"
@@ -205,6 +210,15 @@ run_one() {
   local odir="$OUT/$pdb"
   mkdir -p "$odir"
   if [[ -f "$odir/result.csv" && "$FORCE" -eq 0 ]]; then
+    # Refuse skip when existing receipt is smoke-budget (prevents contamination)
+    if [[ -f "$odir/RUN_RECEIPT.json" ]] && grep -q '"smoke"[[:space:]]*:[[:space:]]*true' "$odir/RUN_RECEIPT.json" 2>/dev/null; then
+      echo "REFUSE SKIP $ARM/$pdb: existing result is smoke-budget — use --force or remove $odir"
+      return 1
+    fi
+    if (( ! SMOKE )) && [[ -f "$odir/meta.json" ]] && grep -q '"smoke"[[:space:]]*:[[:space:]]*true' "$odir/meta.json" 2>/dev/null; then
+      echo "REFUSE SKIP $ARM/$pdb: meta marks smoke — use --force or remove $odir"
+      return 1
+    fi
     echo "SKIP $ARM/$pdb (result.csv exists)"
     return 0
   fi

--- a/scripts/run_flexaid_arm_pilot8.sh
+++ b/scripts/run_flexaid_arm_pilot8.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Run FlexAID arm A / B0 / B pilot8 → iCloud results only.
+#
+# Usage:
+#   scripts/run_flexaid_arm_pilot8.sh A            # real pilot8
+#   scripts/run_flexaid_arm_pilot8.sh B0 --dry-run
+#   scripts/run_flexaid_arm_pilot8.sh B --pdb 1GPK # single target
+#   scripts/run_flexaid_arm_pilot8.sh A --smoke    # tiny pop/gen smoke (1 target)
+#
+# Outputs:
+#   $FLEXAIDDS_RESULTS/campaigns/three_engine/{A,B0,B}/pilot8/<PDB>/
+# Work/scratch:
+#   $FLEXAIDDS_QUEUE_ROOT/work/{A,B0,B}/<PDB>/
+#
+# Does NOT touch C0 full85 outputs. Separate lock per arm.
+set -euo pipefail
+
+# shellcheck disable=SC1090
+[[ -f "${HOME}/.flexaidds_env" ]] && source "${HOME}/.flexaidds_env"
+
+ICLOUD_DEFAULT="${HOME}/Library/Mobile Documents/com~apple~CloudDocs/FlexAIDdS_benchmarks"
+export FLEXAIDDS_ICLOUD="${FLEXAIDDS_ICLOUD:-$ICLOUD_DEFAULT}"
+export FLEXAIDDS_RESULTS="${FLEXAIDDS_RESULTS:-$FLEXAIDDS_ICLOUD/results}"
+Q="${QUEUE_ROOT:-${FLEXAIDDS_QUEUE_ROOT:-$FLEXAIDDS_ICLOUD/queues/three_engine_entropy_q1}}"
+export QUEUE_ROOT="$Q"
+export FLEXAIDDS_QUEUE_ROOT="$Q"
+
+ARM="${1:-}"
+if [[ -z "$ARM" || "$ARM" == -* ]]; then
+  echo "Usage: $0 <A|B0|B> [--dry-run|--smoke|--pdb ID|--force|--no-prepare]" >&2
+  exit 2
+fi
+shift || true
+
+DRY=0
+SMOKE=0
+FORCE=0
+NOPREP=0
+ONLY_PDB=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY=1; shift ;;
+    --smoke) SMOKE=1; shift ;;
+    --force) FORCE=1; shift ;;
+    --no-prepare) NOPREP=1; shift ;;
+    --pdb) ONLY_PDB="${2:-}"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$ARM" in
+  A|B0|B) ;;
+  *) echo "ERROR: arm must be A, B0, or B (got $ARM)" >&2; exit 2 ;;
+esac
+
+BIN_ARM="B"
+[[ "$ARM" == "A" ]] && BIN_ARM="A"
+BINARY="$Q/bin/$BIN_ARM/FlexAID"
+MATRIX="$Q/data/MC_st0r5.2_6.dat"
+MATRIX_PIN="72d7c7396702331d96ff12d18f831796"
+
+REPO="${FLEXAIDDS_ROOT:-}"
+if [[ -z "$REPO" ]]; then
+  if git -C "${HOME}/Projects/FlexAIDdS" rev-parse --show-toplevel >/dev/null 2>&1; then
+    REPO="$(git -C "${HOME}/Projects/FlexAIDdS" rev-parse --show-toplevel)"
+  else
+    REPO="$(cd "$(dirname "$0")/.." && pwd)"
+  fi
+fi
+export FLEXAIDDS_ROOT="$REPO"
+GEN="$REPO/scripts/generate_flexaid_inp.py"
+PARSE="$REPO/scripts/parse_flexaid_arm_results.py"
+
+OUT="${FLEXAID_ARM_OUT:-$FLEXAIDDS_RESULTS/campaigns/three_engine/$ARM/pilot8}"
+WORK_ROOT="${FLEXAID_WORK_ROOT:-$Q/work}"
+LOGDIR="$Q/logs"
+mkdir -p "$OUT" "$LOGDIR" "$WORK_ROOT" "$FLEXAIDDS_RESULTS/campaigns/three_engine/$ARM"
+
+case "$OUT" in
+  *"/Mobile Documents/com~apple~CloudDocs/"*) ;;
+  *) echo "REFUSE: output must be under iCloud Drive, got: $OUT" >&2; exit 91 ;;
+esac
+
+echo "=== FlexAID arm $ARM pilot8 ==="
+echo "Q=$Q"
+echo "OUT=$OUT"
+echo "BINARY=$BINARY"
+echo "WORK_ROOT=$WORK_ROOT"
+
+[[ -x "$BINARY" ]] || { echo "FAIL: not executable: $BINARY" >&2; exit 1; }
+[[ -f "$MATRIX" ]] || { echo "FAIL: matrix missing: $MATRIX" >&2; exit 1; }
+GOT=$(md5 -q "$MATRIX")
+[[ "$GOT" == "$MATRIX_PIN" ]] || { echo "FAIL: matrix MD5 $GOT != $MATRIX_PIN" >&2; exit 90; }
+echo "OK: matrix md5=$GOT"
+[[ -f "$GEN" ]] || { echo "FAIL: missing $GEN" >&2; exit 1; }
+
+if [[ -z "${FLEXAIDDS_PROCESSLIGAND:-}" ]]; then
+  for m in "$REPO"/.venv-processligand/lib/python*/site-packages/processligandpy/bin/ProcessLigand "$Q/bin/ProcessLigand"; do
+    if [[ -x "$m" ]]; then
+      export FLEXAIDDS_PROCESSLIGAND="$m"
+      break
+    fi
+  done
+fi
+if [[ -z "${FLEXAIDDS_PROCESSLIGAND:-}" ]]; then
+  echo "FAIL: ProcessLigand not found. Install processligand-py or set FLEXAIDDS_PROCESSLIGAND" >&2
+  exit 1
+fi
+echo "OK: ProcessLigand=$FLEXAIDDS_PROCESSLIGAND"
+
+LOCK="$LOGDIR/run_${ARM}_pilot8.lock"
+if [[ -f "$LOCK" ]] && kill -0 "$(cat "$LOCK" 2>/dev/null)" 2>/dev/null; then
+  echo "REFUSE: arm $ARM pilot already running pid $(cat "$LOCK")" >&2
+  exit 92
+fi
+if [[ -f "$LOGDIR/C0_full85.lock" ]] && kill -0 "$(cat "$LOGDIR/C0_full85.lock" 2>/dev/null)" 2>/dev/null; then
+  echo "NOTE: C0 full85 is live (pid $(cat "$LOGDIR/C0_full85.lock")) — proceeding for arm $ARM only (separate OUT)."
+fi
+
+PILOT8=(1G9V 1GPK 1MEH 1P62 1Q4G 1R9O 1T40 2BYS)
+if [[ -n "$ONLY_PDB" ]]; then
+  TARGETS=("${ONLY_PDB^^}")
+elif (( SMOKE )); then
+  TARGETS=(1GPK)
+else
+  TARGETS=("${PILOT8[@]}")
+fi
+
+POP="${FLEXAID_POP:-1000}"
+GENS="${FLEXAID_GEN:-6000}"
+RESTARTS="${FLEXAID_RESTARTS:-5}"
+if (( SMOKE )); then
+  POP="${FLEXAID_SMOKE_POP:-20}"
+  GENS="${FLEXAID_SMOKE_GEN:-5}"
+  RESTARTS="${FLEXAID_SMOKE_RESTARTS:-1}"
+  echo "SMOKE mode: pop=$POP gen=$GENS R=$RESTARTS targets=${TARGETS[*]}"
+fi
+
+echo "targets=${TARGETS[*]} pop=$POP gen=$GENS R=$RESTARTS"
+
+if (( DRY )); then
+  echo "DRY-RUN: prepare plan only (no FlexAID exec)"
+  PREP_ARGS=(--queue-root "$Q" --work-root "$WORK_ROOT" --arms "$ARM" --pop "$POP" --gen "$GENS" --restarts "$RESTARTS" --dry-run)
+  if [[ -n "$ONLY_PDB" ]]; then
+    PREP_ARGS+=(--pdb "$ONLY_PDB")
+  elif (( SMOKE )); then
+    PREP_ARGS+=(--pdb 1GPK)
+  else
+    PREP_ARGS+=(--pilot8)
+  fi
+  python3 "$GEN" "${PREP_ARGS[@]}"
+  echo "DRY-RUN complete (no launch)"
+  exit 0
+fi
+
+if (( NOPREP == 0 )); then
+  PREP_ARGS=(--queue-root "$Q" --work-root "$WORK_ROOT" --arms "$ARM" --pop "$POP" --gen "$GENS" --restarts "$RESTARTS")
+  (( FORCE )) && PREP_ARGS+=(--force)
+  if [[ ${#TARGETS[@]} -eq 1 ]]; then
+    PREP_ARGS+=(--pdb "${TARGETS[0]}")
+  else
+    PREP_ARGS+=(--pilot8)
+  fi
+  python3 "$GEN" "${PREP_ARGS[@]}"
+fi
+
+python3 - <<PY
+import hashlib, json, time
+from pathlib import Path
+out = Path(r'''$OUT''')
+q = Path(r'''$Q''')
+binp = Path(r'''$BINARY''').resolve()
+mat = Path(r'''$MATRIX''')
+def sha(p):
+    h = hashlib.sha256()
+    with open(p, 'rb') as f:
+        for c in iter(lambda: f.read(1 << 20), b''):
+            h.update(c)
+    return h.hexdigest()
+receipt = {
+    "run_id": f"flexaid_{'''$ARM'''}_pilot8",
+    "arm": '''$ARM''',
+    "started_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    "output": str(out),
+    "storage": "icloud_drive",
+    "pop": int('''$POP'''),
+    "gen": int('''$GENS'''),
+    "restarts": int('''$RESTARTS'''),
+    "targets": '''${TARGETS[*]}'''.split(),
+    "matrix_md5": hashlib.md5(mat.read_bytes()).hexdigest(),
+    "binary_sha256": sha(binp),
+    "binary": str(binp),
+    "smoke": bool(int('''$SMOKE''')),
+    "seed_note": "STRTSEED written; staged binaries may use time(0)",
+}
+(out / "RUN_RECEIPT.json").write_text(json.dumps(receipt, indent=2) + "\n")
+(q / f"provenance_run_{'''$ARM'''}_pilot8.json").write_text(json.dumps(receipt, indent=2) + "\n")
+print("wrote", out / "RUN_RECEIPT.json")
+PY
+
+LOG="$LOGDIR/run_${ARM}_pilot8.log"
+run_one() {
+  local pdb="$1"
+  local wdir="$WORK_ROOT/$ARM/$pdb"
+  local odir="$OUT/$pdb"
+  mkdir -p "$odir"
+  if [[ -f "$odir/result.csv" && "$FORCE" -eq 0 ]]; then
+    echo "SKIP $ARM/$pdb (result.csv exists)"
+    return 0
+  fi
+  if [[ ! -f "$wdir/meta.json" ]]; then
+    echo "FAIL: missing prepared work $wdir" >&2
+    return 1
+  fi
+
+  local r=0
+  local n_ok=0
+  while (( r < RESTARTS )); do
+    local rdir="$wdir/restart_$r"
+    local prefix="$odir/${pdb}_r${r}"
+    echo "=== $ARM $pdb restart $r ==="
+    echo "CMD: $BINARY $rdir/CONFIG.inp $rdir/ga.inp $prefix"
+    if ! (
+      cd "$rdir"
+      caffeinate -i -s "$BINARY" "$rdir/CONFIG.inp" "$rdir/ga.inp" "$prefix"
+    ); then
+      echo "WARN: FlexAID exit non-zero for $ARM $pdb r$r" >&2
+    else
+      n_ok=$((n_ok + 1))
+    fi
+    r=$((r + 1))
+  done
+
+  if [[ -f "$PARSE" ]]; then
+    python3 "$PARSE" --arm "$ARM" --pdb "$pdb" --out-dir "$odir" --work-dir "$wdir" \
+      --matrix-md5 "$MATRIX_PIN" --binary "$BINARY" || true
+  fi
+  echo "DONE $ARM/$pdb restarts_ok=$n_ok/$RESTARTS"
+}
+
+if [[ "${NOHUP:-0}" == "1" ]]; then
+  {
+    echo "$$" >"$LOCK"
+    for pdb in "${TARGETS[@]}"; do
+      run_one "$pdb" || true
+    done
+    rm -f "$LOCK"
+  } >>"$LOG" 2>&1 &
+  echo "STARTED background pid=$! log=$LOG out=$OUT"
+else
+  echo "$$" >"$LOCK"
+  trap 'rm -f "$LOCK"' EXIT
+  for pdb in "${TARGETS[@]}"; do
+    run_one "$pdb" || true
+  done
+  echo "COMPLETE arm=$ARM out=$OUT log=$LOG"
+fi


### PR DESCRIPTION
## Summary
- Wire classic FlexAID arms **A / B0 / B** for the three-engine entropy comparison so the same pilot (and later full) targets can run beside FlexAIDdS arm C.
- `scripts/generate_flexaid_inp.py`: ProcessLigand → ligand `.inp`/`.ic` + typed target; CONFIG with LOCCLF spheres (HETATM→ATOM), TEMPER 0/298, matched pop/gen/R, matrix MD5 pin `72d7c739…`, seed_base `20260714`.
- `scripts/run_{A,B0,B}_pilot8.sh` + shared runner write to **iCloud only**: `$FLEXAIDDS_RESULTS/campaigns/three_engine/{A,B0,B}/pilot8/`.
- `scripts/parse_flexaid_arm_results.py` → normalized `result.csv` (S1/S3, seed flags 0).
- Queue `scripts/` staged + `STATUS.md` updated. **Does not touch C0 full85.**

## Smoke (verified)
- B0 / 1GPK tiny GA (pop=20, gen=5, R=1): FlexAID exit 0; rank-0 REMARK RMSD + CF present; OUT under iCloud.
- Full pilot8 budget (1000/6000/5) **not launched** — ready after operator review.

## How to launch pilot A/B0/B
```bash
source ~/.flexaidds_env
export FLEXAIDDS_ROOT=~/Projects/FlexAIDdS
export FLEXAIDDS_PROCESSLIGAND="$FLEXAIDDS_ROOT/.venv-processligand/lib/python3.14/site-packages/processligandpy/bin/ProcessLigand"
# one-time: python3 -m venv $FLEXAIDDS_ROOT/.venv-processligand && $FLEXAIDDS_ROOT/.venv-processligand/bin/pip install processligand-py

bash $FLEXAIDDS_ROOT/scripts/run_A_pilot8.sh --dry-run
bash $FLEXAIDDS_ROOT/scripts/run_B0_pilot8.sh --smoke
# Full pilot8 after gate:
bash $FLEXAIDDS_ROOT/scripts/run_A_pilot8.sh
bash $FLEXAIDDS_ROOT/scripts/run_B0_pilot8.sh
bash $FLEXAIDDS_ROOT/scripts/run_B_pilot8.sh
```

## Blockers / limits
| Item | Status |
|------|--------|
| ProcessLigand | Required via `processligand-py` or `FLEXAIDDS_PROCESSLIGAND` |
| GetCleft spheres | Used from `$FLEXAIDDS_ICLOUD/astex_entropy/.../native_occupied/*_sph_1.pdb` (85 present) |
| STRTSEED | Written for provenance; **staged A/B binaries use time(0) srand** |
| Full pilot8 | Not auto-started (smoke only) |
| C0 full85 | Untouched |

## Test plan
- [x] Matrix MD5 pin preflight
- [x] ProcessLigand prepare B0/1GPK
- [x] FlexAID B0 smoke exit 0 + RMSD REMARK
- [x] iCloud OUT path refusal for non-iCloud
- [ ] Operator-run full pilot8 A/B0/B (1000/6000/5)