### PR TITLE
Add: ProtocolConfig chunk 3 + RUN_RECEIPT on every DatasetRunner path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1076,11 +1076,12 @@ if(BUILD_TESTING)
         TEST_NAME JsonConfigTests
     )
 
-    # test_protocol_config — typed ProtocolConfig env adapter + JSON round-trip
+    # test_protocol_config — typed ProtocolConfig env adapter + RUN_RECEIPT keys
     flexaids_add_unit_test(test_protocol_config
         SOURCES
             tests/test_protocol_config.cpp
             LIB/ProtocolConfig.cpp
+            LIB/RunReceipt.cpp
         TEST_NAME ProtocolConfigTests
     )
 

--- a/LIB/CMakeLists.txt
+++ b/LIB/CMakeLists.txt
@@ -141,6 +141,8 @@ set(FLEXAID_CORE_SOURCES
     config_parser.cpp
     # ── Typed protocol knobs (env adapter; audit getenv consolidation) ──
     ProtocolConfig.cpp
+    # ── Campaign RUN_RECEIPT.json provenance (DatasetRunner + C0 schema) ──
+    RunReceipt.cpp
     # ── ThermodynamicEngine: G_bind decomposition (disabled by default) ──
     ThermodynamicEngine.cpp
     # ── Coarse pocket-scan gen-0 seeding ──

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -17,6 +17,7 @@
 #include "AsyncPipeline.h"
 #include "BenchmarkRunner.h"
 #include "ProtocolConfig.h"
+#include "RunReceipt.h"
 #include "statmech.h"
 #include "receptor_prep.h"
 #include "tENCoM/tencm.h"   // tencm::TorsionalENM — ligand Cartesian ANM for H(ω)
@@ -61,6 +62,11 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <cerrno>
+#endif
+
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#include <cstdint>
 #endif
 
 #ifdef _OPENMP
@@ -4893,13 +4899,11 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         std::cout << "[DatasetRunner] BenchmarkMode:    " << mode_label << "\n";
     }
 
-    // ── Fix 4: per-run provenance.json ────────────────────────────────────
-    // Record the exact scoring matrix, binary, and source revision used for
-    // this run so results are reproducible without relying on /tmp staging or
-    // file timestamps (which do not survive a reboot). Best-effort: any
-    // failure here is non-fatal and must not block docking.
+    // ── RUN_RECEIPT.json + legacy provenance.json ─────────────────────────
+    // Align with C0 iCloud launch scripts: matrix/binary hashes, GA knobs,
+    // mode, seed flags, and a full ProtocolConfig JSON snapshot. Best-effort:
+    // failure here must not block docking.
     {
-        // First non-empty whitespace token of a shell command's stdout, or "".
         auto cmd_token = [](const std::string& cmd) -> std::string {
             std::string out;
             FILE* p = popen(cmd.c_str(), "r");
@@ -4928,14 +4932,15 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         };
         auto sha256_of = [&](const std::string& path) -> std::string {
             if (path.empty() || !fs::exists(path)) return "";
-            std::string t = cmd_token("shasum -a 256 " + shell_quote(path) + " 2>/dev/null");
-            if (t.empty()) t = cmd_token("sha256sum " + shell_quote(path) + " 2>/dev/null");
+            // Prefer in-process hasher when available (PoseBust); shell fallback.
+            std::string t = flexaids::posebust::sha256_file(path);
+            if (t.empty()) {
+                t = cmd_token("shasum -a 256 " + shell_quote(path) + " 2>/dev/null");
+                if (t.empty()) t = cmd_token("sha256sum " + shell_quote(path) + " 2>/dev/null");
+            }
             return t;
         };
 
-        // Resolve the scoring matrix with the same precedence as each child:
-        // explicit override, immutable data staged beside the binary, then the
-        // mutable source-tree WRK directory as a development fallback.
         std::string matrix_path;
         if (!protocol_cfg_.data_dir.empty()) {
             std::string cand = protocol_cfg_.data_dir + "/MC_st0r5.2_6.dat";
@@ -4951,43 +4956,73 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             else if (fs::exists(source)) matrix_path = source;
         }
 
-        const char* oracle_env =
-            protocol_cfg_.oracle_site_dir.empty() ? nullptr
-                                                 : protocol_cfg_.oracle_site_dir.c_str();
-        std::string git_commit = cmd_token(
-            "git rev-parse HEAD 2>/dev/null");
+        const char* mode_label =
+            (config.mode == BenchmarkMode::ORACLE_CEILING)       ? "oracle-ceiling" :
+            (config.mode == BenchmarkMode::DEFINED_CLEFT_REDOCK) ? "defined-cleft-redock" :
+            (config.mode == BenchmarkMode::AUTONOMOUS)           ? "autonomous" :
+                                                                   "unset";
 
-        auto json_esc = [](const std::string& s) {
-            std::string r;
-            for (char c : s) {
-                if (c == '\\' || c == '"') { r += '\\'; r += c; }
-                else if (c == '\n') r += "\\n";
-                else r += c;
+        // Mode forces seed_elitism regardless of env for oracle vs production.
+        bool receipt_seed_elitism = protocol_cfg_.seed_elitism;
+        if (config.mode == BenchmarkMode::ORACLE_CEILING) receipt_seed_elitism = true;
+        if (config.mode == BenchmarkMode::DEFINED_CLEFT_REDOCK ||
+            config.mode == BenchmarkMode::AUTONOMOUS) {
+            receipt_seed_elitism = false;
+        }
+
+        flexaids::RunReceiptInput receipt;
+        receipt.run_id = report.dataset_name.empty()
+            ? fs::path(config.output_dir).filename().string()
+            : report.dataset_name;
+        if (receipt.run_id.empty()) receipt.run_id = "dataset_run";
+        receipt.started_utc = flexaids::utc_now_iso8601();
+        receipt.output = config.output_dir;
+        receipt.dataset = report.dataset_name;
+        receipt.mode = mode_label;
+        receipt.temperature_K = static_cast<double>(config.temperature);
+        receipt.pop = config.ga_population;
+        receipt.gen = config.ga_generations;
+        receipt.restarts = std::max(1, protocol_cfg_.restarts);
+        receipt.seed_base = protocol_cfg_.seed_base;
+        receipt.seed_elitism = receipt_seed_elitism;
+        receipt.matrix_path = matrix_path;
+        receipt.matrix_md5 = md5_of(matrix_path);
+        receipt.matrix_sha256 = sha256_of(matrix_path);
+        receipt.binary_path = flexaidds_bin;
+        receipt.binary_sha256 = sha256_of(flexaidds_bin);
+        receipt.git_commit = cmd_token("git rev-parse HEAD 2>/dev/null");
+        receipt.oracle_site_dir = protocol_cfg_.oracle_site_dir;
+        receipt.oracle_site_dir_set = !protocol_cfg_.oracle_site_dir.empty();
+        receipt.protocol = protocol_cfg_;
+
+        // Self-path for runner_sha256 when available (benchmark_datasets / host).
+#if defined(__APPLE__)
+        {
+            char self_path[4096];
+            uint32_t size = sizeof(self_path);
+            if (_NSGetExecutablePath(self_path, &size) == 0) {
+                receipt.runner_path = self_path;
+                receipt.runner_sha256 = sha256_of(receipt.runner_path);
             }
-            return r;
-        };
+        }
+#elif defined(__linux__)
+        {
+            std::error_code lec;
+            auto self = fs::read_symlink("/proc/self/exe", lec);
+            if (!lec) {
+                receipt.runner_path = self.string();
+                receipt.runner_sha256 = sha256_of(receipt.runner_path);
+            }
+        }
+#endif
 
-        std::error_code mk_ec;
-        fs::create_directories(config.output_dir, mk_ec);
-        std::string prov_path = config.output_dir + "/provenance.json";
-        std::ofstream pj(prov_path);
-        if (pj.is_open()) {
-            pj << "{\n"
-               << "  \"dataset\": \""        << json_esc(report.dataset_name)   << "\",\n"
-               << "  \"matrix_path\": \""    << json_esc(matrix_path)           << "\",\n"
-               << "  \"matrix_md5\": \""     << json_esc(md5_of(matrix_path))   << "\",\n"
-               << "  \"matrix_sha256\": \""  << json_esc(sha256_of(matrix_path)) << "\",\n"
-               << "  \"binary_path\": \""    << json_esc(flexaidds_bin)         << "\",\n"
-               << "  \"binary_sha256\": \""  << json_esc(sha256_of(flexaidds_bin)) << "\",\n"
-               << "  \"git_commit\": \""     << json_esc(git_commit)            << "\",\n"
-               << "  \"oracle_site_dir\": \""<< json_esc(oracle_env ? oracle_env : "") << "\",\n"
-               << "  \"oracle_site_dir_set\": " << (oracle_env && oracle_env[0] ? "true" : "false") << "\n"
-               << "}\n";
-            pj.close();
-            std::cout << "[DatasetRunner] Wrote provenance: " << prov_path << "\n";
+        if (flexaids::write_run_receipt(config.output_dir, receipt,
+                                        /*also_write_provenance_json=*/true)) {
+            std::cout << "[DatasetRunner] Wrote RUN_RECEIPT.json + provenance.json → "
+                      << config.output_dir << "\n";
         } else {
-            std::cerr << "[WARN] Could not write provenance.json to "
-                      << prov_path << "\n";
+            std::cerr << "[WARN] Could not write RUN_RECEIPT.json to "
+                      << config.output_dir << "\n";
         }
     }
 

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -835,9 +835,17 @@ static std::pair<std::string,float> select_pose_freq_gated(const std::string& ou
 // larger, more diverse set for Fix B to select from (v25 multi-restart pooling).
 static std::pair<std::string,float> select_pose_freq_gated_pooled(
         const std::vector<std::string>& prefixes,
-        int seed_elitism_override = -1,  // -1=read env var, 0=force off, 1=force on
-        bool cf_window_selector = false) // Fix A: CF-window gate (see header member)
+        int seed_elitism_override = -1,  // -1=ProtocolConfig default, 0=force off, 1=force on
+        bool cf_window_selector = false, // Fix A: CF-window gate (see header member)
+        const flexaids::ProtocolConfig* protocol = nullptr)
 {
+    // Pose-selector knobs come from ProtocolConfig (env adapter). Prefer a
+    // caller-supplied snapshot (DatasetRunner::protocol_cfg_); fall back to a
+    // fresh from_env() for standalone / legacy call sites.
+    const flexaids::ProtocolConfig local_proto =
+        protocol ? flexaids::ProtocolConfig{} : flexaids::ProtocolConfig::from_env();
+    const flexaids::ProtocolConfig& proto = protocol ? *protocol : local_proto;
+
     // ── Boltzmann Z+H composite cluster selection (Options B+C) ─────────────
     // Instead of pure CF-rank-0, score each cluster by:
     //   Z_cluster  = sum_{i in members} exp(-CF_i / kT)        [partition fn]
@@ -967,9 +975,7 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
     if (seed_elitism_override >= 0) {
         seed_elitism = (seed_elitism_override != 0);
     } else {
-        seed_elitism = true;
-        if (const char* e = std::getenv("FLEXAIDDS_SEED_ELITISM"))
-            seed_elitism = (std::atoi(e) != 0);
+        seed_elitism = proto.seed_elitism;
     }
     std::vector<PoseInfo> seeds;
     if (seed_elitism) {
@@ -1052,15 +1058,9 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
         // pose — it broke 1J3J/1SG0 and never flipped 1Q4G/1MEH. The real lever
         // is the CF scoring false minimum, not pose selection. Kept env-gated
         // (FLEXAIDDS_FREQSEL=1) for experimentation only.
-        bool freqsel = false;
-        if (const char* e = std::getenv("FLEXAIDDS_FREQSEL"))
-            freqsel = (std::atoi(e) != 0);
-        double freqsel_alpha = 12.0;
-        if (const char* e = std::getenv("FLEXAIDDS_FREQSEL_ALPHA"))
-            try { freqsel_alpha = std::stod(e); } catch (...) {}
-        float freqsel_rmsd = 1.5f;
-        if (const char* e = std::getenv("FLEXAIDDS_FREQSEL_RMSD"))
-            try { freqsel_rmsd = std::stof(e); } catch (...) {}
+        const bool freqsel = proto.freqsel;
+        const double freqsel_alpha = proto.freqsel_alpha;
+        const float freqsel_rmsd = proto.freqsel_rmsd;
 
         if (freqsel && chosen.size() > 1) {
             const int n = static_cast<int>(chosen.size());
@@ -1128,12 +1128,8 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
     // no GA pose qualified at all.  The threshold prevents IC-round-trip error
     // from overriding geometrically superior GA poses when the CF gap is small
     // (e.g. 1XM6: crystal IC 2.60 Å vs GA 0.96 Å with ΔCF ≈ 5).
-    // Env: FLEXAIDDS_SEED_ELITISM_DELTA_CF (float, default 10.0).
-    static const double DELTA_CF = [](){
-        if (const char* e = std::getenv("FLEXAIDDS_SEED_ELITISM_DELTA_CF"))
-            try { return std::stod(e); } catch (...) {}
-        return 10.0;
-    }();
+    // Env: FLEXAIDDS_SEED_ELITISM_DELTA_CF via ProtocolConfig (default 10.0).
+    const double DELTA_CF = proto.seed_elitism_delta_cf;
     const PoseInfo* best = freq_best;
     for (const auto& s : seeds)
         if (best == nullptr || s.cf < best->cf - DELTA_CF) best = &s;
@@ -3714,8 +3710,10 @@ std::vector<DatasetEntry> DatasetRunner::fetch_astex() {
     std::vector<DatasetEntry> entries;
     entries.reserve(codes.size());
 
-    // Fallback oracle site directory from env var (used when cache != source tree)
-    const char* oracle_site_dir_env = std::getenv("FLEXAIDDS_ORACLE_SITE_DIR");
+    // Fallback oracle site directory (ProtocolConfig / FLEXAIDDS_ORACLE_SITE_DIR)
+    const char* oracle_site_dir_env =
+        protocol_cfg_.oracle_site_dir.empty() ? nullptr
+                                             : protocol_cfg_.oracle_site_dir.c_str();
 
     int oracle_count = 0;
     for (const auto& pdb : codes) {
@@ -4819,14 +4817,19 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
     report.dataset_name = entries.front().source;
     report.total_systems = static_cast<int>(entries.size());
 
+    // Re-snapshot protocol knobs at run() entry so long-lived runners pick up
+    // env changes after construction (chunk 1 only snapshotted the ctor).
+    protocol_cfg_ = flexaids::ProtocolConfig::from_env();
+    cf_window_selector_ = protocol_cfg_.cf_window_selector;
+    cluster_member_emit_ = protocol_cfg_.cluster_member_emit;
+
     // ── Clustering algorithm override ─────────────────────────────────────
     // FLEXAIDDS_USE_DP=1  → use Density Peak (DP) clustering instead of the
     // default CF.  DP elects the highest-density region as cluster head
     // (OUTPUT_CLUSTER_CENTER=true in DensityPeak_Cluster.cpp) which is more
     // representative of the fitness landscape than the lowest-CF outlier.
-    const char* use_dp_env = std::getenv("FLEXAIDDS_USE_DP");
     const std::string effective_clustering_algo =
-        (use_dp_env && std::strcmp(use_dp_env, "1") == 0) ? "DP" : config.clustering_algorithm;
+        protocol_cfg_.use_dp ? "DP" : config.clustering_algorithm;
     if (effective_clustering_algo != config.clustering_algorithm) {
         std::cout << "[DatasetRunner] FLEXAIDDS_USE_DP=1 → clustering_algorithm overridden to DP\n";
     }
@@ -4948,7 +4951,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             else if (fs::exists(source)) matrix_path = source;
         }
 
-        const char* oracle_env = std::getenv("FLEXAIDDS_ORACLE_SITE_DIR");
+        const char* oracle_env =
+            protocol_cfg_.oracle_site_dir.empty() ? nullptr
+                                                 : protocol_cfg_.oracle_site_dir.c_str();
         std::string git_commit = cmd_token(
             "git rev-parse HEAD 2>/dev/null");
 
@@ -5249,10 +5254,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         // FLEXAIDDS_IGNORE_CACHE=1 forces re-run regardless of cached result.csv.
         // Use when the binary or scoring parameters changed between runs so stale
         // cached results from a different binary are not silently reused.
-        const bool ignore_cache = []() -> bool {
-            const char* e = std::getenv("FLEXAIDDS_IGNORE_CACHE");
-            return e && std::atoi(e) != 0;
-        }();
+        const bool ignore_cache = protocol_cfg_.ignore_cache;
         bool skip = false;
         bool cached_csv_success = false;
         float cached_csv_best_score = 0.0f;
@@ -5380,9 +5382,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // Ring pucker (LigandRingFlex Phase 2) adds DoF via a side-channel
             // gene that does NOT pass through FA->npar — so fold its DoF into the
             // budget scaling input here, but only when ring flex is enabled.
-            const char* ring_flex_env = std::getenv("FLEXAIDDS_RING_FLEX");
             const int   ring_dof_est =
-                (ring_flex_env && std::atoi(ring_flex_env) != 0)
+                protocol_cfg_.ring_flex
                 ? count_ring_pucker_dof_sdf(entry.ligand_path) : 0;
             const int n_genes  = 4 + fdih_est + ring_dof_est;
 
@@ -5394,21 +5395,11 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // one (which caused stochastic search failure for flexible ligands).
             //   n_flex_bonds   = perceived rotatable bonds = dihedral genes (fdih)
             //   n_gen_effective = n_gen_base × max(1.0, n_flex_bonds / 4.0)
-            // Gated by FLEXAIDDS_EVAL_SCALE_DIHEDRAL:
+            // Gated by FLEXAIDDS_EVAL_SCALE_DIHEDRAL (ProtocolConfig):
             //   1 (default) = pop-scale by DoF (iso-budget chromosome swap)
             //   0           = legacy gen-scale ceil(n_genes/4)
             //   -1 / "off"  = fixed pop+gen (no DoF scaling) — v43 oracle-ceiling restore
-            const char* eval_scale_env = std::getenv("FLEXAIDDS_EVAL_SCALE_DIHEDRAL");
-            int eval_scale_mode = 1;
-            if (eval_scale_env) {
-                if (std::strcmp(eval_scale_env, "off") == 0 ||
-                    std::strcmp(eval_scale_env, "none") == 0 ||
-                    std::strcmp(eval_scale_env, "fixed") == 0) {
-                    eval_scale_mode = -1;
-                } else {
-                    eval_scale_mode = std::atoi(eval_scale_env);
-                }
-            }
+            const int eval_scale_mode = protocol_cfg_.eval_scale_dihedral;
             const int   n_flex_bonds   = fdih_est;
             const int   n_gen_base     = config.ga_generations;
             const int   pop_base       = config.ga_population;
@@ -5446,11 +5437,10 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                         entry.pdb_id.c_str(), pop_scaled, n_gen_scaled);
             }
 
-            // ── v27 high-DoF budget scaling (FLEXAIDDS_BUDGET_SCALE) ──
+            // ── v27 high-DoF budget scaling (FLEXAIDDS_BUDGET_SCALE via ProtocolConfig) ──
             // High-DoF ligands (n_genes >= 14, i.e. >=10 rotatable bonds): same
             // population-scaling logic absorbs the extra budget multiplier.
-            const char* bscale_env = std::getenv("FLEXAIDDS_BUDGET_SCALE");
-            const int   budget_scale_on = bscale_env ? std::atoi(bscale_env) : 1;
+            const bool budget_scale_on = protocol_cfg_.budget_scale;
             double budget_scale_factor = 1.0;
             if (budget_scale_on && n_genes >= 14) {
                 budget_scale_factor = std::max(1.0,
@@ -5500,7 +5490,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // rotation step (5->2.5 deg) and tighten torsion/side-chain steps.
             // Emitted into the optimization block below so the arm is greppable.
             std::string opt_extra;
-            if (std::getenv("FLEXAIDDS_FINE_GRID")) {
+            if (protocol_cfg_.fine_grid) {
                 opt_extra = ",\n    \"angle_step\": 2.5,"
                             "\n    \"dihedral_step\": 5.0,"
                             "\n    \"flexible_step\": 5.0";
@@ -5956,8 +5946,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // no FLEXAIDDS_SCORE_NATIVE channel.  This is the protocol directly
             // comparable to rDock/GOLD/Vina Astex redocking numbers (known site,
             // ligand pose searched from scratch — NOT a crystal-pose ceiling).
-            const bool cognate_site_opt_in =
-                std::getenv("FLEXAIDDS_COGNATE_SITE") != nullptr;
+            const bool cognate_site_opt_in = protocol_cfg_.cognate_site;
             const bool inject_oracle_site =
                 (config.mode != BenchmarkMode::AUTONOMOUS) || cognate_site_opt_in;
             if (entry.cleft_sphere_path.empty() &&
@@ -5978,10 +5967,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // scorer sees the correct reference pose, not the blinded input.
             // Skip in AUTONOMOUS mode so blind runs have no native/reference
             // scoring channel in the child process environment.
-            const char* native_diag_env = std::getenv("FLEXAIDDS_SCORE_NATIVE");
-            const bool native_diag_requested =
-                native_diag_env && native_diag_env[0] != '\0' &&
-                std::strcmp(native_diag_env, "0") != 0;
+            const bool native_diag_requested = protocol_cfg_.score_native;
             if (config.mode != BenchmarkMode::AUTONOMOUS &&
                 (config.mode != BenchmarkMode::DEFINED_CLEFT_REDOCK ||
                  native_diag_requested) &&
@@ -6006,10 +5992,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // the fixed ParallelDockManager::get_best_chromosome() path.
             // N=8 is recommended for M3 Pro (leaves headroom for DatasetRunner).
             {
-                const char* mc_env = std::getenv("FLEXAIDDS_MULTI_CLEFT");
-                if (mc_env && std::atoi(mc_env) > 1) {
-                    int n_regions = std::atoi(mc_env);
-                    cmd << "--parallel-dock --parallel-dock-regions " << n_regions << " ";
+                if (protocol_cfg_.multi_cleft > 1) {
+                    cmd << "--parallel-dock --parallel-dock-regions "
+                        << protocol_cfg_.multi_cleft << " ";
                 }
             }
 
@@ -6364,7 +6349,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         // min only if no emitted pose with a REMARK CF is found.
         {
             auto sel = select_pose_freq_gated_pooled(all_prefixes, sel_elitism_ovr,
-                                                     cf_window_selector_);
+                                                     cf_window_selector_,
+                                                     &protocol_cfg_);
             if (!sel.first.empty() && std::isfinite(sel.second))
                 best_cf = sel.second;
         }
@@ -6461,7 +6447,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // clusters with Frequency>1, and returns the min-CF pose within that
             // pool (see helper definition near compute_pose_ligand_rmsd).
             // elected_pose_for_pb lives outside this block for PoseBust post-pass.
-            std::string best_pose_pdb = select_pose_freq_gated_pooled(all_prefixes, sel_elitism_ovr, cf_window_selector_).first;
+            std::string best_pose_pdb = select_pose_freq_gated_pooled(
+                all_prefixes, sel_elitism_ovr, cf_window_selector_, &protocol_cfg_).first;
             // Fallback: no scored pose found — take first available pose file from any restart.
             if (best_pose_pdb.empty()) {
                 for (const auto& pfx : all_prefixes) {
@@ -6488,8 +6475,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // benchmark endpoint. It needs at least two restart
             // prefixes to carry any cross-restart signal.
             {
-                const char* consensus_env = std::getenv("FLEXAIDDS_CONSENSUS_SCORER");
-                const int   consensus_on  = consensus_env ? std::atoi(consensus_env) : 0;
+                const bool consensus_on = protocol_cfg_.consensus_scorer;
                 if (consensus_on && all_prefixes.size() >= 2 && !best_pose_pdb.empty()) {
                     constexpr float kConsensusDelta = 1.5f;
                     struct Cand {
@@ -6948,7 +6934,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // Still try to elect a pose for PoseBust even without crystal RMSD ref.
             if (docking_completed) {
                 elected_pose_pdb = select_pose_freq_gated_pooled(
-                    all_prefixes, sel_elitism_ovr, cf_window_selector_).first;
+                    all_prefixes, sel_elitism_ovr, cf_window_selector_,
+                    &protocol_cfg_).first;
             }
         }
 
@@ -7263,8 +7250,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         // not alter pose election; exact-pose status is hash-joined to the same
         // elected_pose.pdb used by RMSD and PoseBusters.
         {
-            const char* hvib_env = std::getenv("FLEXAIDDS_HVIB");
-            const bool hvib_enabled = !(hvib_env && std::strcmp(hvib_env, "0") == 0);
+            const bool hvib_enabled = protocol_cfg_.hvib_enabled;
             if (hvib_enabled) {
                 HvibColumns hv = compute_target_hvib(all_prefixes);
                 result.H_rep_rank0 = hv.H_rep_rank0;
@@ -7796,7 +7782,7 @@ void DatasetRunner::write_report(const BenchmarkReport& report,
         // thermodynamic decomposition columns (H_vct/TdS_vib/TdS_shannon/G_bind)
         // to the aggregate results CSV so benchmarks/calibrate_itc.py can fit the
         // α (enthalpy) and β (entropy) scaling factors directly from one file.
-        const bool thermo_csv = (std::getenv("FLEXAIDDS_THERMO_CSV") != nullptr);
+        const bool thermo_csv = protocol_cfg_.thermo_csv;
 
         ofs << "pdb_id,best_score,rmsd_to_crystal,rmsd_hungarian,predicted_dG,"
                "predicted_dH,predicted_TdS,shannon_entropy,search_entropy_proxy,num_poses,wall_time_s,success,"

--- a/LIB/DatasetRunner.h
+++ b/LIB/DatasetRunner.h
@@ -488,11 +488,10 @@ public:
 private:
     std::string cache_dir_;
 
-    /// Typed protocol snapshot (seed/restarts/VCT/GA/thermo/data_dir).
-    /// Loaded once via ProtocolConfig::from_env() in the constructor so
-    /// high-traffic getenv fragments go through one adapter (see
-    /// docs/implementation/protocol-config.md). Residual getenv sites remain
-    /// until later migration chunks.
+    /// Typed protocol snapshot (seed/restarts/VCT/GA/thermo/data_dir + chunk-2
+    /// pose/budget/site knobs). Loaded via ProtocolConfig::from_env() in the
+    /// constructor and re-snapshotted at run() entry so long-lived runners pick
+    /// up env changes (see docs/implementation/protocol-config.md).
     flexaids::ProtocolConfig protocol_cfg_{};
 
     // ── Pose selector tuning ─────────────────────────────────────────

--- a/LIB/ProtocolConfig.cpp
+++ b/LIB/ProtocolConfig.cpp
@@ -109,15 +109,45 @@ ProtocolConfig ProtocolConfig::from_env() {
     cfg.vct_normalize_contacts = env_present("FLEXAIDDS_VCT_NORM");
     if (auto v = env_opt_double("FLEXAIDDS_VCT_ENTROPY_WEIGHT")) {
         cfg.vct_entropy_weight = *v;
+        cfg.vct_entropy_weight_set = true;
     }
 
     cfg.sharing_alpha = env_opt_double("FLEXAIDDS_SHARING_ALPHA");
     cfg.boom_frac = env_opt_double("FLEXAIDDS_BOOM_FRAC");
     if (auto n = env_opt_int("FLEXAIDDS_N_ELITE")) {
         cfg.n_elite = *n;
+        cfg.n_elite_set = true;
     }
     // Historical DatasetRunner: presence of FLEXAIDDS_USE_SHANNON enables.
     cfg.use_shannon = env_present("FLEXAIDDS_USE_SHANNON");
+
+    // Ranking / emission + GA ablation (config_parser historical getenv sites).
+    // Presence-only: unset keeps JSON/defaults; set applies override.
+    {
+        const char* e = env_raw("FLEXAIDDS_FORCE_CF_RANK_EMISSION");
+        if (e && e[0] != '\0') {
+            if (e[0] == '1' || e[0] == 't' || e[0] == 'T' || e[0] == 'y' || e[0] == 'Y')
+                cfg.force_cf_rank_emission = true;
+            else if (e[0] == '0' || e[0] == 'f' || e[0] == 'F' || e[0] == 'n' || e[0] == 'N')
+                cfg.force_cf_rank_emission = false;
+        }
+    }
+    {
+        const char* e = env_raw("FLEXAIDDS_CLASSIC_ENTROPY_RANKING");
+        if (e && e[0] != '\0') {
+            if (e[0] == '0' || e[0] == 'f' || e[0] == 'F' || e[0] == 'n' || e[0] == 'N')
+                cfg.classic_entropy_ranking = false;
+            else if (e[0] == '1' || e[0] == 't' || e[0] == 'T' || e[0] == 'y' || e[0] == 'Y')
+                cfg.classic_entropy_ranking = true;
+        }
+    }
+    cfg.entropy_weight = env_opt_double("FLEXAIDDS_ENTROPY_WEIGHT");
+    {
+        const char* e = env_raw("FLEXAIDDS_DIVERSITY_MONITORING");
+        if (e && e[0] != '\0') {
+            cfg.diversity_monitoring = (std::atoi(e) != 0);
+        }
+    }
 
     cfg.thermo_enabled = env_present("FLEXAIDDS_THERMO");
     if (auto v = env_opt_double("FLEXAIDDS_T_EFF")) {
@@ -242,6 +272,7 @@ std::string ProtocolConfig::to_json() const {
     o << "\"vct_r0\":" << vct_r0 << ',';
     json_bool(o, "vct_normalize_contacts", vct_normalize_contacts);
     o << "\"vct_entropy_weight\":" << vct_entropy_weight << ',';
+    json_bool(o, "vct_entropy_weight_set", vct_entropy_weight_set);
     if (sharing_alpha) {
         o << "\"sharing_alpha\":" << *sharing_alpha << ',';
     } else {
@@ -253,6 +284,27 @@ std::string ProtocolConfig::to_json() const {
         o << "\"boom_frac\":null,";
     }
     o << "\"n_elite\":" << n_elite << ',';
+    json_bool(o, "n_elite_set", n_elite_set);
+    if (force_cf_rank_emission) {
+        json_bool(o, "force_cf_rank_emission", *force_cf_rank_emission);
+    } else {
+        o << "\"force_cf_rank_emission\":null,";
+    }
+    if (classic_entropy_ranking) {
+        json_bool(o, "classic_entropy_ranking", *classic_entropy_ranking);
+    } else {
+        o << "\"classic_entropy_ranking\":null,";
+    }
+    if (entropy_weight) {
+        o << "\"entropy_weight\":" << *entropy_weight << ',';
+    } else {
+        o << "\"entropy_weight\":null,";
+    }
+    if (diversity_monitoring) {
+        json_bool(o, "diversity_monitoring", *diversity_monitoring);
+    } else {
+        o << "\"diversity_monitoring\":null,";
+    }
     json_bool(o, "use_shannon", use_shannon);
     json_bool(o, "thermo_enabled", thermo_enabled);
     o << "\"t_eff\":" << t_eff << ',';
@@ -309,14 +361,30 @@ ProtocolConfig ProtocolConfig::from_json(const std::string& json_text) {
         cfg.vct_r0 = root["vct_r0"].as_double(7.0);
     if (!root["vct_normalize_contacts"].is_null())
         cfg.vct_normalize_contacts = root["vct_normalize_contacts"].as_bool(false);
-    if (!root["vct_entropy_weight"].is_null())
+    if (!root["vct_entropy_weight"].is_null()) {
         cfg.vct_entropy_weight = root["vct_entropy_weight"].as_double(0.0);
+        cfg.vct_entropy_weight_set = true;
+    }
+    if (!root["vct_entropy_weight_set"].is_null())
+        cfg.vct_entropy_weight_set = root["vct_entropy_weight_set"].as_bool(false);
     if (!root["sharing_alpha"].is_null())
         cfg.sharing_alpha = root["sharing_alpha"].as_double(4.0);
     if (!root["boom_frac"].is_null())
         cfg.boom_frac = root["boom_frac"].as_double(1.0);
-    if (!root["n_elite"].is_null())
+    if (!root["n_elite"].is_null()) {
         cfg.n_elite = root["n_elite"].as_int(1);
+        cfg.n_elite_set = true;
+    }
+    if (!root["n_elite_set"].is_null())
+        cfg.n_elite_set = root["n_elite_set"].as_bool(false);
+    if (!root["force_cf_rank_emission"].is_null())
+        cfg.force_cf_rank_emission = root["force_cf_rank_emission"].as_bool(false);
+    if (!root["classic_entropy_ranking"].is_null())
+        cfg.classic_entropy_ranking = root["classic_entropy_ranking"].as_bool(true);
+    if (!root["entropy_weight"].is_null())
+        cfg.entropy_weight = root["entropy_weight"].as_double(0.5);
+    if (!root["diversity_monitoring"].is_null())
+        cfg.diversity_monitoring = root["diversity_monitoring"].as_bool(true);
     if (!root["use_shannon"].is_null())
         cfg.use_shannon = root["use_shannon"].as_bool(false);
     if (!root["thermo_enabled"].is_null())

--- a/LIB/ProtocolConfig.cpp
+++ b/LIB/ProtocolConfig.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <cstring>
 #include <sstream>
 #include <stdexcept>
 
@@ -30,6 +31,11 @@ bool env_truthy_int(const char* name, bool default_value) {
     const char* e = env_raw(name);
     if (!e || e[0] == '\0') return default_value;
     return std::atoi(e) != 0;
+}
+
+// Presence-only historical gates: any non-null getenv is ON (even "0").
+bool env_present_any(const char* name) {
+    return env_raw(name) != nullptr;
 }
 
 std::optional<double> env_opt_double(const char* name) {
@@ -62,6 +68,11 @@ std::string json_escape(const std::string& s) {
         }
     }
     return out;
+}
+
+void json_bool(std::ostringstream& o, const char* key, bool v, bool trailing_comma = true) {
+    o << '"' << key << "\":" << (v ? "true" : "false");
+    if (trailing_comma) o << ',';
 }
 
 }  // namespace
@@ -119,15 +130,93 @@ ProtocolConfig ProtocolConfig::from_env() {
     if (const char* e = env_raw("FLEXAIDDS_DATA_DIR")) {
         if (e[0] != '\0') cfg.data_dir = e;
     }
+    if (const char* e = env_raw("FLEXAIDDS_ORACLE_SITE_DIR")) {
+        if (e[0] != '\0') cfg.oracle_site_dir = e;
+    }
+    if (const char* e = env_raw("FLEXAIDDS_ORACLE_SITE")) {
+        if (e[0] != '\0') cfg.oracle_site = e;
+    }
+    if (const char* e = env_raw("FLEXAIDDS_CLEFT_SPHERE_FILE")) {
+        if (e[0] != '\0') cfg.cleft_sphere_file = e;
+    }
 
     cfg.cf_window_selector =
         env_truthy_int("FLEXAIDDS_CF_WINDOW_SELECTOR", /*default_value=*/false);
     cfg.cluster_member_emit =
         env_truthy_int("FLEXAIDDS_CLUSTER_MEMBER_EMIT", /*default_value=*/false);
 
+    cfg.seed_elitism = env_truthy_int("FLEXAIDDS_SEED_ELITISM", /*default_value=*/true);
+    if (auto v = env_opt_double("FLEXAIDDS_SEED_ELITISM_DELTA_CF")) {
+        cfg.seed_elitism_delta_cf = *v;
+    }
+    cfg.freqsel = env_truthy_int("FLEXAIDDS_FREQSEL", /*default_value=*/false);
+    if (auto v = env_opt_double("FLEXAIDDS_FREQSEL_ALPHA")) {
+        cfg.freqsel_alpha = *v;
+    }
+    if (auto v = env_opt_double("FLEXAIDDS_FREQSEL_RMSD")) {
+        cfg.freqsel_rmsd = static_cast<float>(*v);
+    }
+    cfg.consensus_scorer =
+        env_truthy_int("FLEXAIDDS_CONSENSUS_SCORER", /*default_value=*/false);
+    // HVIB default ON; only FLEXAIDDS_HVIB=0 disables (historical strcmp).
+    {
+        const char* e = env_raw("FLEXAIDDS_HVIB");
+        cfg.hvib_enabled = !(e && std::strcmp(e, "0") == 0);
+    }
+
+    cfg.ring_flex = env_truthy_int("FLEXAIDDS_RING_FLEX", /*default_value=*/false);
+    {
+        const char* e = env_raw("FLEXAIDDS_EVAL_SCALE_DIHEDRAL");
+        if (!e || e[0] == '\0') {
+            cfg.eval_scale_dihedral = 1;
+        } else if (std::strcmp(e, "off") == 0 ||
+                   std::strcmp(e, "none") == 0 ||
+                   std::strcmp(e, "fixed") == 0) {
+            cfg.eval_scale_dihedral = -1;
+        } else {
+            cfg.eval_scale_dihedral = std::atoi(e);
+        }
+    }
+    cfg.budget_scale = env_truthy_int("FLEXAIDDS_BUDGET_SCALE", /*default_value=*/true);
+    cfg.fine_grid = env_present_any("FLEXAIDDS_FINE_GRID");
+    if (auto n = env_opt_int("FLEXAIDDS_MULTI_CLEFT")) {
+        cfg.multi_cleft = *n;
+    }
+    // COGNATE_SITE: historical presence gate (any non-null).
+    cfg.cognate_site = env_present_any("FLEXAIDDS_COGNATE_SITE");
+    {
+        const char* e = env_raw("FLEXAIDDS_SCORE_NATIVE");
+        cfg.score_native = e && e[0] != '\0' && std::strcmp(e, "0") != 0;
+    }
+    {
+        const char* e = env_raw("FLEXAIDDS_NATIVE_ONLY");
+        cfg.native_only = e && e[0] != '\0' && std::strcmp(e, "0") != 0;
+    }
+    {
+        const char* e = env_raw("FLEXAIDDS_USE_DP");
+        cfg.use_dp = e && std::strcmp(e, "1") == 0;
+    }
+    cfg.ignore_cache = env_truthy_int("FLEXAIDDS_IGNORE_CACHE", /*default_value=*/false);
+    cfg.thermo_csv = env_present_any("FLEXAIDDS_THERMO_CSV");
+
     if (auto v = env_opt_double("FLEXAIDDS_HBOND_WEIGHT")) {
         cfg.hbond_weight = *v;
     }
+
+    // gaboom / GA
+    cfg.no_sec = env_present_any("FLEXAIDDS_NO_SEC");
+    cfg.benchmark_mode = env_present_any("FLEXAIDDS_BENCHMARK");
+    if (auto v = env_opt_double("FLEXAIDDS_T_HOT")) {
+        cfg.t_hot = *v;
+    }
+    if (auto n = env_opt_int("FLEXAIDDS_INSTREAM_INTERVAL")) {
+        if (*n >= 1) cfg.instream_interval = *n;
+    }
+    {
+        const char* e = env_raw("FLEXAIDDS_CHAIN_NORM");
+        cfg.chain_norm = e && e[0] != '\0' && e[0] != '0';
+    }
+    cfg.smfree_require_t = env_present("FLEXAIDDS_SMFREE_REQUIRE_T");
 
     return cfg;
 }
@@ -149,10 +238,9 @@ std::string ProtocolConfig::to_json() const {
     o << '{';
     o << "\"seed_base\":" << seed_base << ',';
     o << "\"restarts\":" << restarts << ',';
-    o << "\"parallel_restarts\":" << (parallel_restarts ? "true" : "false") << ',';
+    json_bool(o, "parallel_restarts", parallel_restarts);
     o << "\"vct_r0\":" << vct_r0 << ',';
-    o << "\"vct_normalize_contacts\":"
-      << (vct_normalize_contacts ? "true" : "false") << ',';
+    json_bool(o, "vct_normalize_contacts", vct_normalize_contacts);
     o << "\"vct_entropy_weight\":" << vct_entropy_weight << ',';
     if (sharing_alpha) {
         o << "\"sharing_alpha\":" << *sharing_alpha << ',';
@@ -165,14 +253,41 @@ std::string ProtocolConfig::to_json() const {
         o << "\"boom_frac\":null,";
     }
     o << "\"n_elite\":" << n_elite << ',';
-    o << "\"use_shannon\":" << (use_shannon ? "true" : "false") << ',';
-    o << "\"thermo_enabled\":" << (thermo_enabled ? "true" : "false") << ',';
+    json_bool(o, "use_shannon", use_shannon);
+    json_bool(o, "thermo_enabled", thermo_enabled);
     o << "\"t_eff\":" << t_eff << ',';
     o << "\"tencom_scale\":" << tencom_scale << ',';
     o << "\"data_dir\":\"" << json_escape(data_dir) << "\",";
-    o << "\"cf_window_selector\":" << (cf_window_selector ? "true" : "false") << ',';
-    o << "\"cluster_member_emit\":" << (cluster_member_emit ? "true" : "false") << ',';
-    o << "\"hbond_weight\":" << hbond_weight;
+    o << "\"oracle_site_dir\":\"" << json_escape(oracle_site_dir) << "\",";
+    o << "\"oracle_site\":\"" << json_escape(oracle_site) << "\",";
+    o << "\"cleft_sphere_file\":\"" << json_escape(cleft_sphere_file) << "\",";
+    json_bool(o, "cf_window_selector", cf_window_selector);
+    json_bool(o, "cluster_member_emit", cluster_member_emit);
+    json_bool(o, "seed_elitism", seed_elitism);
+    o << "\"seed_elitism_delta_cf\":" << seed_elitism_delta_cf << ',';
+    json_bool(o, "freqsel", freqsel);
+    o << "\"freqsel_alpha\":" << freqsel_alpha << ',';
+    o << "\"freqsel_rmsd\":" << freqsel_rmsd << ',';
+    json_bool(o, "consensus_scorer", consensus_scorer);
+    json_bool(o, "hvib_enabled", hvib_enabled);
+    json_bool(o, "ring_flex", ring_flex);
+    o << "\"eval_scale_dihedral\":" << eval_scale_dihedral << ',';
+    json_bool(o, "budget_scale", budget_scale);
+    json_bool(o, "fine_grid", fine_grid);
+    o << "\"multi_cleft\":" << multi_cleft << ',';
+    json_bool(o, "cognate_site", cognate_site);
+    json_bool(o, "score_native", score_native);
+    json_bool(o, "native_only", native_only);
+    json_bool(o, "use_dp", use_dp);
+    json_bool(o, "ignore_cache", ignore_cache);
+    json_bool(o, "thermo_csv", thermo_csv);
+    o << "\"hbond_weight\":" << hbond_weight << ',';
+    json_bool(o, "no_sec", no_sec);
+    json_bool(o, "benchmark_mode", benchmark_mode);
+    o << "\"t_hot\":" << t_hot << ',';
+    o << "\"instream_interval\":" << instream_interval << ',';
+    json_bool(o, "chain_norm", chain_norm);
+    json_bool(o, "smfree_require_t", smfree_require_t, /*trailing_comma=*/false);
     o << '}';
     return o.str();
 }
@@ -212,12 +327,66 @@ ProtocolConfig ProtocolConfig::from_json(const std::string& json_text) {
         cfg.tencom_scale = root["tencom_scale"].as_float(1.0f);
     if (!root["data_dir"].is_null())
         cfg.data_dir = root["data_dir"].as_string("");
+    if (!root["oracle_site_dir"].is_null())
+        cfg.oracle_site_dir = root["oracle_site_dir"].as_string("");
+    if (!root["oracle_site"].is_null())
+        cfg.oracle_site = root["oracle_site"].as_string("");
+    if (!root["cleft_sphere_file"].is_null())
+        cfg.cleft_sphere_file = root["cleft_sphere_file"].as_string("");
     if (!root["cf_window_selector"].is_null())
         cfg.cf_window_selector = root["cf_window_selector"].as_bool(false);
     if (!root["cluster_member_emit"].is_null())
         cfg.cluster_member_emit = root["cluster_member_emit"].as_bool(false);
+    if (!root["seed_elitism"].is_null())
+        cfg.seed_elitism = root["seed_elitism"].as_bool(true);
+    if (!root["seed_elitism_delta_cf"].is_null())
+        cfg.seed_elitism_delta_cf = root["seed_elitism_delta_cf"].as_double(10.0);
+    if (!root["freqsel"].is_null())
+        cfg.freqsel = root["freqsel"].as_bool(false);
+    if (!root["freqsel_alpha"].is_null())
+        cfg.freqsel_alpha = root["freqsel_alpha"].as_double(12.0);
+    if (!root["freqsel_rmsd"].is_null())
+        cfg.freqsel_rmsd = root["freqsel_rmsd"].as_float(1.5f);
+    if (!root["consensus_scorer"].is_null())
+        cfg.consensus_scorer = root["consensus_scorer"].as_bool(false);
+    if (!root["hvib_enabled"].is_null())
+        cfg.hvib_enabled = root["hvib_enabled"].as_bool(true);
+    if (!root["ring_flex"].is_null())
+        cfg.ring_flex = root["ring_flex"].as_bool(false);
+    if (!root["eval_scale_dihedral"].is_null())
+        cfg.eval_scale_dihedral = root["eval_scale_dihedral"].as_int(1);
+    if (!root["budget_scale"].is_null())
+        cfg.budget_scale = root["budget_scale"].as_bool(true);
+    if (!root["fine_grid"].is_null())
+        cfg.fine_grid = root["fine_grid"].as_bool(false);
+    if (!root["multi_cleft"].is_null())
+        cfg.multi_cleft = root["multi_cleft"].as_int(0);
+    if (!root["cognate_site"].is_null())
+        cfg.cognate_site = root["cognate_site"].as_bool(false);
+    if (!root["score_native"].is_null())
+        cfg.score_native = root["score_native"].as_bool(false);
+    if (!root["native_only"].is_null())
+        cfg.native_only = root["native_only"].as_bool(false);
+    if (!root["use_dp"].is_null())
+        cfg.use_dp = root["use_dp"].as_bool(false);
+    if (!root["ignore_cache"].is_null())
+        cfg.ignore_cache = root["ignore_cache"].as_bool(false);
+    if (!root["thermo_csv"].is_null())
+        cfg.thermo_csv = root["thermo_csv"].as_bool(false);
     if (!root["hbond_weight"].is_null())
         cfg.hbond_weight = root["hbond_weight"].as_double(-2.5);
+    if (!root["no_sec"].is_null())
+        cfg.no_sec = root["no_sec"].as_bool(false);
+    if (!root["benchmark_mode"].is_null())
+        cfg.benchmark_mode = root["benchmark_mode"].as_bool(false);
+    if (!root["t_hot"].is_null())
+        cfg.t_hot = root["t_hot"].as_double(0.0);
+    if (!root["instream_interval"].is_null())
+        cfg.instream_interval = root["instream_interval"].as_int(0);
+    if (!root["chain_norm"].is_null())
+        cfg.chain_norm = root["chain_norm"].as_bool(false);
+    if (!root["smfree_require_t"].is_null())
+        cfg.smfree_require_t = root["smfree_require_t"].as_bool(false);
 
     return cfg;
 }

--- a/LIB/ProtocolConfig.h
+++ b/LIB/ProtocolConfig.h
@@ -36,7 +36,21 @@ struct ProtocolConfig {
     /// Boom inject fraction for legacy seed modes. nullopt → 1.0.
     std::optional<double> boom_frac;  ///< FLEXAIDDS_BOOM_FRAC
     int n_elite{1};                   ///< FLEXAIDDS_N_ELITE
+    /// True when FLEXAIDDS_N_ELITE was present (apply_config override gate).
+    bool n_elite_set{false};
+    /// True when FLEXAIDDS_VCT_ENTROPY_WEIGHT was present (apply_config gate).
+    bool vct_entropy_weight_set{false};
     bool use_shannon{false};          ///< FLEXAIDDS_USE_SHANNON (presence)
+
+    // ── Ranking / emission + GA ablation (config_parser / engine) ─────────
+    /// nullopt = env unset (keep JSON/default). true/false = explicit override.
+    std::optional<bool> force_cf_rank_emission;   ///< FLEXAIDDS_FORCE_CF_RANK_EMISSION
+    /// nullopt = unset. false forces CF emission (historical classic=0 path).
+    std::optional<bool> classic_entropy_ranking;  ///< FLEXAIDDS_CLASSIC_ENTROPY_RANKING
+    /// nullopt = unset → keep JSON ga.entropy_weight; else override.
+    std::optional<double> entropy_weight;         ///< FLEXAIDDS_ENTROPY_WEIGHT
+    /// nullopt = unset → keep JSON ga.diversity_monitoring; else override.
+    std::optional<bool> diversity_monitoring;     ///< FLEXAIDDS_DIVERSITY_MONITORING
 
     // ── Thermo engine (dock_config emission) ─────────────────────────────
     bool thermo_enabled{false};       ///< FLEXAIDDS_THERMO (presence)

--- a/LIB/ProtocolConfig.h
+++ b/LIB/ProtocolConfig.h
@@ -45,13 +45,47 @@ struct ProtocolConfig {
 
     // ── Paths ────────────────────────────────────────────────────────────
     std::string data_dir;             ///< FLEXAIDDS_DATA_DIR (empty = unset)
+    std::string oracle_site_dir;      ///< FLEXAIDDS_ORACLE_SITE_DIR
+    std::string oracle_site;          ///< FLEXAIDDS_ORACLE_SITE
+    std::string cleft_sphere_file;    ///< FLEXAIDDS_CLEFT_SPHERE_FILE
 
     // ── DatasetRunner pose-selector gates ────────────────────────────────
     bool cf_window_selector{false};   ///< FLEXAIDDS_CF_WINDOW_SELECTOR
     bool cluster_member_emit{false};  ///< FLEXAIDDS_CLUSTER_MEMBER_EMIT
+    bool seed_elitism{true};          ///< FLEXAIDDS_SEED_ELITISM (default ON)
+    double seed_elitism_delta_cf{10.0}; ///< FLEXAIDDS_SEED_ELITISM_DELTA_CF
+    bool freqsel{false};              ///< FLEXAIDDS_FREQSEL
+    double freqsel_alpha{12.0};       ///< FLEXAIDDS_FREQSEL_ALPHA
+    float freqsel_rmsd{1.5f};         ///< FLEXAIDDS_FREQSEL_RMSD
+    bool consensus_scorer{false};     ///< FLEXAIDDS_CONSENSUS_SCORER
+    /// tENCoM/H(ω) validator; default ON, disable with FLEXAIDDS_HVIB=0.
+    bool hvib_enabled{true};
+
+    // ── Budget / grid (DatasetRunner dock path) ──────────────────────────
+    bool ring_flex{false};            ///< FLEXAIDDS_RING_FLEX
+    /// 1=pop-scale (default), 0=legacy gen-scale, -1=fixed (off/none/fixed).
+    int eval_scale_dihedral{1};       ///< FLEXAIDDS_EVAL_SCALE_DIHEDRAL
+    bool budget_scale{true};          ///< FLEXAIDDS_BUDGET_SCALE (default ON)
+    bool fine_grid{false};            ///< FLEXAIDDS_FINE_GRID (presence)
+    int multi_cleft{0};               ///< FLEXAIDDS_MULTI_CLEFT (0 = off)
+    bool cognate_site{false};         ///< FLEXAIDDS_COGNATE_SITE (presence)
+    bool score_native{false};         ///< FLEXAIDDS_SCORE_NATIVE (truthy)
+    bool native_only{false};          ///< FLEXAIDDS_NATIVE_ONLY (truthy)
+    bool use_dp{false};               ///< FLEXAIDDS_USE_DP (=1)
+    bool ignore_cache{false};         ///< FLEXAIDDS_IGNORE_CACHE
+    bool thermo_csv{false};           ///< FLEXAIDDS_THERMO_CSV (presence)
 
     // ── Engine init (top.cpp) ────────────────────────────────────────────
     double hbond_weight{-2.5};        ///< FLEXAIDDS_HBOND_WEIGHT
+
+    // ── GA engine (gaboom.cpp) ───────────────────────────────────────────
+    bool no_sec{false};               ///< FLEXAIDDS_NO_SEC (presence)
+    bool benchmark_mode{false};       ///< FLEXAIDDS_BENCHMARK (presence)
+    double t_hot{0.0};                ///< FLEXAIDDS_T_HOT (0 = annealing off)
+    /// 0 → keep compile-time GA_INSTREAM_INTERVAL; else override (>=1).
+    int instream_interval{0};         ///< FLEXAIDDS_INSTREAM_INTERVAL
+    bool chain_norm{false};           ///< FLEXAIDDS_CHAIN_NORM
+    bool smfree_require_t{false};     ///< FLEXAIDDS_SMFREE_REQUIRE_T
 
     /// Built-in defaults (no env consultation).
     static ProtocolConfig defaults();

--- a/LIB/RunReceipt.cpp
+++ b/LIB/RunReceipt.cpp
@@ -1,0 +1,123 @@
+// RunReceipt.cpp — RUN_RECEIPT.json builder/writer
+//
+// Copyright 2026 Le Bonhomme Pharma. Licensed under Apache-2.0.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "RunReceipt.h"
+
+#include <chrono>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+
+namespace flexaids {
+namespace {
+
+namespace fs = std::filesystem;
+
+std::string json_escape(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 8);
+    for (char c : s) {
+        switch (c) {
+            case '\\': out += "\\\\"; break;
+            case '"':  out += "\\\""; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:   out += c; break;
+        }
+    }
+    return out;
+}
+
+}  // namespace
+
+std::string utc_now_iso8601() {
+    using clock = std::chrono::system_clock;
+    const auto now = clock::now();
+    const std::time_t t = clock::to_time_t(now);
+    std::tm tm{};
+#if defined(_WIN32)
+    gmtime_s(&tm, &t);
+#else
+    gmtime_r(&t, &tm);
+#endif
+    std::ostringstream o;
+    o << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
+    return o.str();
+}
+
+std::string build_run_receipt_json(const RunReceiptInput& in) {
+    std::ostringstream o;
+    o.setf(std::ios::fixed);
+    o.precision(6);
+    o << "{\n";
+    o << "  \"schema_version\": " << kRunReceiptSchemaVersion << ",\n";
+    o << "  \"run_id\": \"" << json_escape(in.run_id) << "\",\n";
+    o << "  \"started_utc\": \"" << json_escape(in.started_utc) << "\",\n";
+    o << "  \"output\": \"" << json_escape(in.output) << "\",\n";
+    o << "  \"dataset\": \"" << json_escape(in.dataset) << "\",\n";
+    o << "  \"mode\": \"" << json_escape(in.mode) << "\",\n";
+    o << "  \"temperature_K\": " << in.temperature_K << ",\n";
+    o << "  \"pop\": " << in.pop << ",\n";
+    o << "  \"gen\": " << in.gen << ",\n";
+    o << "  \"restarts\": " << in.restarts << ",\n";
+    o << "  \"seed_base\": " << in.seed_base << ",\n";
+    o << "  \"seed_elitism\": " << (in.seed_elitism ? 1 : 0) << ",\n";
+    o << "  \"matrix_path\": \"" << json_escape(in.matrix_path) << "\",\n";
+    o << "  \"matrix_md5\": \"" << json_escape(in.matrix_md5) << "\",\n";
+    o << "  \"matrix_sha256\": \"" << json_escape(in.matrix_sha256) << "\",\n";
+    o << "  \"binary_path\": \"" << json_escape(in.binary_path) << "\",\n";
+    o << "  \"binary_sha256\": \"" << json_escape(in.binary_sha256) << "\",\n";
+    o << "  \"runner_path\": \"" << json_escape(in.runner_path) << "\",\n";
+    o << "  \"runner_sha256\": \"" << json_escape(in.runner_sha256) << "\",\n";
+    o << "  \"git_commit\": \"" << json_escape(in.git_commit) << "\",\n";
+    o << "  \"oracle_site_dir\": \"" << json_escape(in.oracle_site_dir) << "\",\n";
+    o << "  \"oracle_site_dir_set\": " << (in.oracle_site_dir_set ? "true" : "false") << ",\n";
+    // Embed ProtocolConfig snapshot as a nested object (already JSON object text).
+    o << "  \"protocol_config\": " << in.protocol.to_json() << "\n";
+    o << "}";
+    return o.str();
+}
+
+bool write_run_receipt(const std::string& output_dir,
+                       const RunReceiptInput& in,
+                       bool also_write_provenance_json) {
+    std::error_code ec;
+    fs::create_directories(output_dir, ec);
+
+    const std::string body = build_run_receipt_json(in);
+    const std::string receipt_path = output_dir + "/RUN_RECEIPT.json";
+    {
+        std::ofstream out(receipt_path);
+        if (!out.is_open()) return false;
+        out << body << "\n";
+    }
+
+    if (also_write_provenance_json) {
+        // Legacy slim provenance.json — keep keys that older tools expect.
+        const std::string prov_path = output_dir + "/provenance.json";
+        std::ofstream pj(prov_path);
+        if (pj.is_open()) {
+            pj << "{\n"
+               << "  \"dataset\": \"" << json_escape(in.dataset) << "\",\n"
+               << "  \"matrix_path\": \"" << json_escape(in.matrix_path) << "\",\n"
+               << "  \"matrix_md5\": \"" << json_escape(in.matrix_md5) << "\",\n"
+               << "  \"matrix_sha256\": \"" << json_escape(in.matrix_sha256) << "\",\n"
+               << "  \"binary_path\": \"" << json_escape(in.binary_path) << "\",\n"
+               << "  \"binary_sha256\": \"" << json_escape(in.binary_sha256) << "\",\n"
+               << "  \"git_commit\": \"" << json_escape(in.git_commit) << "\",\n"
+               << "  \"oracle_site_dir\": \"" << json_escape(in.oracle_site_dir) << "\",\n"
+               << "  \"oracle_site_dir_set\": "
+               << (in.oracle_site_dir_set ? "true" : "false") << ",\n"
+               << "  \"protocol_config\": " << in.protocol.to_json() << "\n"
+               << "}\n";
+        }
+    }
+    return true;
+}
+
+}  // namespace flexaids

--- a/LIB/RunReceipt.h
+++ b/LIB/RunReceipt.h
@@ -1,0 +1,61 @@
+// RunReceipt.h — Campaign / DatasetRunner RUN_RECEIPT.json provenance
+//
+// Aligns the C++ DatasetRunner path with C0 iCloud launch scripts
+// (RUN_RECEIPT.json schema: matrix/binary hashes, GA knobs, ProtocolConfig).
+//
+// Copyright 2026 Le Bonhomme Pharma. Licensed under Apache-2.0.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "ProtocolConfig.h"
+
+#include <cstdint>
+#include <string>
+
+namespace flexaids {
+
+/// Inputs for a campaign/run receipt. Hash fields may be precomputed or left
+/// empty for the writer to fill when paths exist.
+struct RunReceiptInput {
+    std::string run_id;
+    std::string started_utc;   ///< ISO-8601 UTC, e.g. 2026-07-15T02:54:52Z
+    std::string output;
+    std::string dataset;
+    std::string mode;          ///< e.g. defined-cleft-redock
+    double temperature_K{300.0};
+    int pop{1000};
+    int gen{2000};
+    int restarts{5};
+    std::uint64_t seed_base{0};
+    bool seed_elitism{true};
+
+    std::string matrix_path;
+    std::string matrix_md5;
+    std::string matrix_sha256;
+    std::string binary_path;
+    std::string binary_sha256;
+    std::string runner_path;
+    std::string runner_sha256;
+    std::string git_commit;
+    std::string oracle_site_dir;
+    bool oracle_site_dir_set{false};
+
+    ProtocolConfig protocol;
+};
+
+/// schema_version for RUN_RECEIPT.json (bump when keys change incompatibly).
+inline constexpr int kRunReceiptSchemaVersion = 1;
+
+/// Build a JSON object string (pretty-printed, trailing newline not included).
+[[nodiscard]] std::string build_run_receipt_json(const RunReceiptInput& in);
+
+/// Write RUN_RECEIPT.json (and optional legacy provenance.json) under output_dir.
+/// Returns true if RUN_RECEIPT.json was written successfully.
+bool write_run_receipt(const std::string& output_dir,
+                       const RunReceiptInput& in,
+                       bool also_write_provenance_json = true);
+
+/// Current UTC time as YYYY-MM-DDTHH:MM:SSZ (best-effort; empty on failure).
+[[nodiscard]] std::string utc_now_iso8601();
+
+}  // namespace flexaids

--- a/LIB/config_parser.cpp
+++ b/LIB/config_parser.cpp
@@ -10,7 +10,6 @@
 #include "statmech.h"
 
 #include <cstring>
-#include <cstdlib>
 #include <stdexcept>
 
 // ─── Helper: safely get a value from section.key with fallback ───────────
@@ -43,7 +42,12 @@ json::Value load_config(const std::string& config_path) {
     return json::merge(defaults, user_config);
 }
 
-void apply_config(const json::Value& config, FA_Global* FA, GB_Global* GB) {
+void apply_config(const json::Value& config, FA_Global* FA, GB_Global* GB,
+                  const flexaids::ProtocolConfig* protocol) {
+    // Single snapshot at entry: avoids dual-protocol if env mutates mid-apply.
+    const flexaids::ProtocolConfig local_proto =
+        protocol ? flexaids::ProtocolConfig{} : flexaids::ProtocolConfig::from_env();
+    const flexaids::ProtocolConfig& proto = protocol ? *protocol : local_proto;
 
     // ── Scoring ──
     {
@@ -64,8 +68,8 @@ void apply_config(const json::Value& config, FA_Global* FA, GB_Global* GB) {
         // keeps the extensive score so existing arms stay byte-for-byte stable.
         FA->vct_normalize_contacts = jbool(config, "scoring", "vct_normalize_contacts", false) ? 1 : 0;
         FA->vct_entropy_weight = jdbl(config, "scoring", "vct_entropy_weight", 0.0);
-        if (const char* e = std::getenv("FLEXAIDDS_VCT_ENTROPY_WEIGHT"))
-            FA->vct_entropy_weight = std::atof(e);
+        if (proto.vct_entropy_weight_set)
+            FA->vct_entropy_weight = proto.vct_entropy_weight;
         FA->useacs          = jbool(config, "scoring", "accessible_surface", false) ? 1 : 0;
         FA->acsweight       = jflt(config, "scoring", "acs_weight", 1.0f);
         FA->solventterm     = jflt(config, "scoring", "solvent_penalty", 0.0f);
@@ -153,18 +157,13 @@ void apply_config(const json::Value& config, FA_Global* FA, GB_Global* GB) {
         if (!jbool(config, "thermodynamics", "classic_entropy_ranking", true)) {
             FA->force_cf_rank_emission = true;
         }
-        if (const char* e = std::getenv("FLEXAIDDS_FORCE_CF_RANK_EMISSION")) {
-            if (e[0] == '1' || e[0] == 't' || e[0] == 'T' || e[0] == 'y' || e[0] == 'Y')
-                FA->force_cf_rank_emission = true;
-            else if (e[0] == '0' || e[0] == 'f' || e[0] == 'F' || e[0] == 'n' || e[0] == 'N')
-                FA->force_cf_rank_emission = false;
+        // ProtocolConfig overrides (snapshot); nullopt = leave JSON-derived value.
+        if (proto.force_cf_rank_emission.has_value()) {
+            FA->force_cf_rank_emission = *proto.force_cf_rank_emission;
         }
-        if (const char* e = std::getenv("FLEXAIDDS_CLASSIC_ENTROPY_RANKING")) {
-            // 0/false → CF emission (rollback); 1/true → classic entropy (default)
-            if (e[0] == '0' || e[0] == 'f' || e[0] == 'F' || e[0] == 'n' || e[0] == 'N')
-                FA->force_cf_rank_emission = true;
-            else if (e[0] == '1' || e[0] == 't' || e[0] == 'T' || e[0] == 'y' || e[0] == 'Y')
-                FA->force_cf_rank_emission = false;
+        if (proto.classic_entropy_ranking.has_value()) {
+            // classic=false → CF emission; classic=true → entropy ranking (default).
+            FA->force_cf_rank_emission = !*proto.classic_entropy_ranking;
         }
         FA->use_tqcm  = jbool(config, "turboquant", "compressed_contact_matrix", false);
         FA->use_tqens = jbool(config, "turboquant", "ensemble_compression", false);
@@ -239,33 +238,21 @@ void apply_config(const json::Value& config, FA_Global* FA, GB_Global* GB) {
         // ── True GA elitism (v27) ──
         GB->n_elite                       = jint(config, "ga", "n_elite", 1);
 
-        // Env-var overrides for the three v27 GA-internal elitism knobs.  These
-        // win over the JSON config so a single benchmark binary can sweep them
-        // without re-emitting dock_config.json:
-        //   FLEXAIDDS_N_ELITE       — number of protected elites (GB->n_elite)
-        //   FLEXAIDDS_SHARING_ALPHA — niche-sharing exponent     (GB->alpha)
-        //   FLEXAIDDS_BOOM_FRAC     — boom-injection fraction     (GB->boom_inject_fraction)
-        if (const char* e = std::getenv("FLEXAIDDS_N_ELITE"))
-            GB->n_elite = std::atoi(e);
-        if (const char* e = std::getenv("FLEXAIDDS_SHARING_ALPHA"))
-            GB->alpha = std::atof(e);
-        if (const char* e = std::getenv("FLEXAIDDS_BOOM_FRAC"))
-            GB->boom_inject_fraction = std::atof(e);
+        // ProtocolConfig overrides for v27 GA-internal elitism knobs. These win
+        // over JSON so a single binary can sweep them without re-emitting
+        // dock_config.json (env adapter via ProtocolConfig::from_env).
+        if (proto.n_elite_set)
+            GB->n_elite = proto.n_elite;
+        if (proto.sharing_alpha.has_value())
+            GB->alpha = *proto.sharing_alpha;
+        if (proto.boom_frac.has_value())
+            GB->boom_inject_fraction = *proto.boom_frac;
 
-        // ── Entropy-ablation hooks (default-off: unset → byte-identical run) ──
-        // FLEXAIDDS_ENTROPY_WEIGHT — SMFREE Boltzmann/rank blend w∈[0,1]
-        //   (gaboom.cpp:2151). w=0 collapses SMFREE fitness to pure rank
-        //   selection (no thermodynamic free-energy bias) — ablates the
-        //   StatMech selection-entropy channel without changing β/T.
-        if (const char* e = std::getenv("FLEXAIDDS_ENTROPY_WEIGHT"))
-            GB->entropy_weight = std::atof(e);
-        // FLEXAIDDS_DIVERSITY_MONITORING — 0 disables the gene-space Shannon
-        //   diversity machinery: SEC termination reverts to energy-histogram
-        //   only (sec_may_terminate→true, gaboom.cpp:411) AND the
-        //   catastrophic-mutation rescue is switched off (gaboom.cpp:672).
-        //   Isolates the configurational-diversity (allele-entropy) channel.
-        if (const char* e = std::getenv("FLEXAIDDS_DIVERSITY_MONITORING"))
-            GB->diversity_monitoring = (std::atoi(e) != 0) ? 1 : 0;
+        // Entropy-ablation hooks (unset → byte-identical to JSON defaults).
+        if (proto.entropy_weight.has_value())
+            GB->entropy_weight = *proto.entropy_weight;
+        if (proto.diversity_monitoring.has_value())
+            GB->diversity_monitoring = *proto.diversity_monitoring ? 1 : 0;
     }
 
     // ── Output ──

--- a/LIB/config_parser.h
+++ b/LIB/config_parser.h
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "ProtocolConfig.h"
 #include "json_value.h"
 #include <string>
 
@@ -21,4 +22,8 @@ typedef struct GB_Global_struct GB_Global;
 json::Value load_config(const std::string& config_path);
 
 // Apply merged JSON config to FA_Global and GB_Global structs.
-void apply_config(const json::Value& config, FA_Global* FA, GB_Global* GB);
+// Optional `protocol` is a pre-snapshotted ProtocolConfig (no mid-apply getenv).
+// When null, apply_config takes a single ProtocolConfig::from_env() snapshot at
+// entry so env overrides stay dual-protocol-safe for this apply path.
+void apply_config(const json::Value& config, FA_Global* FA, GB_Global* GB,
+                  const flexaids::ProtocolConfig* protocol = nullptr);

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -9,6 +9,7 @@
 #include "CavityDetect/SpatialGrid.h"
 #include "RngSeed.h"
 #include "ensemble_pipeline.h"
+#include "ProtocolConfig.h"
 
 #include <random>
 #include <functional>
@@ -161,9 +162,12 @@ static inline void ring_load_chrom_to_fa(FA_Global* FA, const chromosome* c) {
 // number of receptor chains changes the effective selection temperature and
 // regresses multichain Astex cases. Keep production/default scoring extensive;
 // enable this only with FLEXAIDDS_CHAIN_NORM=1 for targeted ablations.
-static int count_receptor_chains(FA_Global* FA, const resid* residue) {
-    const char* env = std::getenv("FLEXAIDDS_CHAIN_NORM");
-    if (!env || env[0] == '\0' || env[0] == '0') return 1;
+static int count_receptor_chains(FA_Global* FA, const resid* residue,
+                                 bool chain_norm_enabled = false) {
+    // When chain_norm_enabled is false (default), preserve the historical
+    // extensive scoring path (return 1). Callers that want the diagnostic
+    // multi-chain normalisation pass ProtocolConfig::chain_norm.
+    if (!chain_norm_enabled) return 1;
 
     std::unordered_set<char> seen;
     for (int r = 0; r < FA->res_cnt; ++r) {
@@ -201,8 +205,12 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	GAContext local_ctx;
 	if (!ctx) ctx = &local_ctx;
 
+	// Typed protocol snapshot (env remains the compatibility adapter).
+	const flexaids::ProtocolConfig proto = flexaids::ProtocolConfig::from_env();
+
 	// ── OMP thread default: 2/worker if OMP_NUM_THREADS not set in environment.
 	// Leaves headroom for Metal dispatch and OS scheduling on M3 Pro 11 P-cores.
+	// OMP_NUM_THREADS is a platform OpenMP contract — left as raw getenv.
 #ifdef _OPENMP
 	if (!std::getenv("OMP_NUM_THREADS")) {
 		omp_set_num_threads(2);
@@ -217,7 +225,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	// divides every evalue/app_evalue by the number of explicit receptor chain
 	// IDs. Do not enable for production benchmarks without a target-specific
 	// justification: it changes GA selection pressure and regressed Astex smoke.
-	const int n_receptor_chains = count_receptor_chains(FA, residue);
+	const int n_receptor_chains = count_receptor_chains(FA, residue, proto.chain_norm);
 	if (n_receptor_chains > 1)
 		fprintf(stderr, "[CHAIN] %d receptor chains detected — "
 		        "normalising VCT evalue by chain count (diagnostic)\n", n_receptor_chains);
@@ -227,13 +235,11 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	// monitor (per-generation [HVIB] lines) even on the bare binary, mirroring the
 	// DatasetRunner config toggle.  Engine-side env wins, matching FLEXAIDDS_N_ELITE.
 	// Purely diagnostic — does NOT enter CF or fitness.  Default stays OFF.
-	if (const char* _hv = std::getenv("FLEXAIDDS_USE_SHANNON")) {
-		if (_hv[0] != '\0' && _hv[0] != '0') {
-			if (!GB->use_shannon)
-				fprintf(stderr, "[HVIB] FLEXAIDDS_USE_SHANNON set: enabling ligand "
-				        "vibrational-entropy H(ω) monitor (diagnostic only)\n");
-			GB->use_shannon = 1;
-		}
+	if (proto.use_shannon) {
+		if (!GB->use_shannon)
+			fprintf(stderr, "[HVIB] FLEXAIDDS_USE_SHANNON set: enabling ligand "
+			        "vibrational-entropy H(ω) monitor (diagnostic only)\n");
+		GB->use_shannon = 1;
 	}
 
 	//char tmp_rrgfile[MAX_PATH__];
@@ -565,13 +571,10 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	// early exit (which can trigger well before generation 100).  Default behaviour
 	// for production benchmarks is unchanged.
 	int instream_interval = GA_INSTREAM_INTERVAL;
-	if (const char* _ii = std::getenv("FLEXAIDDS_INSTREAM_INTERVAL")) {
-		int v = std::atoi(_ii);
-		if (v >= 1) {
-			instream_interval = v;
-			fprintf(stderr, "[INSTREAM] merge/H(ω) cadence overridden to every %d "
-			        "generation(s) via FLEXAIDDS_INSTREAM_INTERVAL\n", instream_interval);
-		}
+	if (proto.instream_interval >= 1) {
+		instream_interval = proto.instream_interval;
+		fprintf(stderr, "[INSTREAM] merge/H(ω) cadence overridden to every %d "
+		        "generation(s) via FLEXAIDDS_INSTREAM_INTERVAL\n", instream_interval);
 	}
 
 	////// Genetic Algorithm ///////
@@ -582,7 +585,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	// During benchmarking this ensures equal search effort vs other methods.
 	// "Spare" generations after a plateau are used with boosted mutation/exploration
 	// (see stagnation handling) to search conformational space more effectively.
-	const bool no_sec = (std::getenv("FLEXAIDDS_NO_SEC") != nullptr);
+	const bool no_sec = proto.no_sec;
 	if (no_sec)
 		fprintf(stderr, "[SEC] All entropy-convergence early exits DISABLED "
 		        "(FLEXAIDDS_NO_SEC=1) — GA will run to max_generations.\n");
@@ -603,7 +606,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 		fprintf(stderr, "[ELITE] GA-internal elitism active: protecting %d "
 		        "lowest-CF individual(s) per generation\n", n_elite);
 
-	// ── Temperature annealing (FLEXAIDDS_T_HOT) ──────────────────────────────
+	// ── Temperature annealing (FLEXAIDDS_T_HOT via ProtocolConfig) ────────────
 	// Exponential decay T_hot -> target K:
 	//   T(alpha) = T_hot*exp(-5alpha) + T_target*(1-exp(-5alpha)).
 	// Affects SMFREE Boltzmann-weight selection only; post-GA thermodynamics
@@ -612,10 +615,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	// → native basin gravitationally dominant.  Annealing targets near-miss
 	// false-minimum escape early in the run while native seeds lock in.
 	// Useful calibration range: 500–2000 K.
-	const double t_hot_anneal = []() -> double {
-		const char* env = std::getenv("FLEXAIDDS_T_HOT");
-		return (env && env[0] != '\0') ? std::atof(env) : 0.0;
-	}();
+	const double t_hot_anneal = proto.t_hot;
 	const double target_temperature_d = static_cast<double>(target_temperature_K);
 	const bool do_anneal = (target_temperature_K > 0) &&
 	                        (t_hot_anneal > target_temperature_d);
@@ -817,7 +817,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 			if (stagnant) {
 				stagnation_count += STAGNATION_WINDOW;
 				if (stagnation_count >= STAGNATION_LIMIT) {
-					const bool benchmark_full = (std::getenv("FLEXAIDDS_NO_SEC") != nullptr) || (std::getenv("FLEXAIDDS_BENCHMARK") != nullptr);
+					const bool benchmark_full = proto.no_sec || proto.benchmark_mode;
 					if (benchmark_full) {
 						printf("GA plateau at gen %d (stagnant %d gens, best_CF=%.4f); "
 						       "BENCHMARK mode: continuing with exploration boost for remaining gens.\n",
@@ -2736,9 +2736,7 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 					"[SMFREE] WARN: temperature=0 → rank-only fitness "
 					"(no soft-β sampling). Set thermodynamics.temperature>0 "
 					"for reproducible ensemble layer 3 (β=1/T).\n");
-				const char* req = std::getenv("FLEXAIDDS_SMFREE_REQUIRE_T");
-				if (req && (req[0] == '1' || req[0] == 't' || req[0] == 'T'
-				            || req[0] == 'y' || req[0] == 'Y')) {
+				if (flexaids::ProtocolConfig::from_env().smfree_require_t) {
 					fprintf(stderr,
 						"[SMFREE] FATAL: FLEXAIDDS_SMFREE_REQUIRE_T set and T=0\n");
 					Terminate(2);

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -1623,7 +1623,10 @@ int main(int argc, char **argv){
 			// process-per-cleft docking.  Each child process receives one ranked
 			// Get_Cleft/FlexAID sphere file and builds its grid from that cleft
 			// only, reproducing the old independent-GA-per-major-cleft behavior.
-			const char* explicit_cleft_env = std::getenv("FLEXAIDDS_CLEFT_SPHERE_FILE");
+			const flexaids::ProtocolConfig proto_grid = flexaids::ProtocolConfig::from_env();
+			const char* explicit_cleft_env =
+			    proto_grid.cleft_sphere_file.empty() ? nullptr
+			                                        : proto_grid.cleft_sphere_file.c_str();
 			const bool explicit_cleft_requested =
 			    explicit_cleft_env && explicit_cleft_env[0] != '\0';
 			if (explicit_cleft_requested &&
@@ -1637,9 +1640,12 @@ int main(int argc, char **argv){
 			// ── Probe FLEXAIDDS_GRID_CACHE_DIR (content-hash keyed) ─────────────
 			// Used by Strategy B batch children: the first child builds and saves;
 			// subsequent children of the same receptor load and skip the grid build.
+			// GRID_CACHE_DIR stays raw getenv (infra path, not a science knob).
+			const char* oracle_site_for_cache =
+			    proto_grid.oracle_site.empty() ? nullptr : proto_grid.oracle_site.c_str();
 			const std::string gc_vct_path = explicit_cleft_requested
 			    ? std::string()
-			    : gridcache::cache_path(receptor_file, std::getenv("FLEXAIDDS_ORACLE_SITE"),
+			    : gridcache::cache_path(receptor_file, oracle_site_for_cache,
 			                            FA->spacer_length, FA->permeability);
 			if (!explicit_cleft_requested && !gc_vct_path.empty()) {
 				if (gridcache::load(gc_vct_path, &cleftgrid, &FA->num_grd)) {
@@ -1740,11 +1746,12 @@ int main(int argc, char **argv){
 			};
 
 			if (!grid_loaded_from_cache) {
-			// Oracle mode: FLEXAIDDS_ORACLE_SITE env var points to a binding
+			// Oracle mode: FLEXAIDDS_ORACLE_SITE (ProtocolConfig) points to a binding
 			// site PDB.  Parse for centroid only — SURFNET void-space detection
 			// always runs (probes placed in void between atoms, not on atoms).
 			// Oracle centroid guides cleft selection and site-confinement.
-			const char* oracle_site_env = std::getenv("FLEXAIDDS_ORACLE_SITE");
+			const char* oracle_site_env =
+			    proto_grid.oracle_site.empty() ? nullptr : proto_grid.oracle_site.c_str();
 			bool using_oracle = false;
 			float oracle_cx = 0.0f, oracle_cy = 0.0f, oracle_cz = 0.0f;
 			sphere* spheres = NULL;
@@ -2333,13 +2340,11 @@ int main(int argc, char **argv){
 	// DatasetRunner uses FLEXAIDDS_SCORE_NATIVE=1 alone so the GA still runs and
 	// produces pose files that DatasetRunner parses alongside [NATIVE_CF].
 	{
-		const char* _native_env  = std::getenv("FLEXAIDDS_SCORE_NATIVE");
-		const char* _native_only = std::getenv("FLEXAIDDS_NATIVE_ONLY");
-		const bool  do_native    = (_native_env  && _native_env[0]  != '\0' && std::strcmp(_native_env,  "0") != 0)
-		                        || (_native_only && _native_only[0] != '\0' && std::strcmp(_native_only, "0") != 0);
+		const flexaids::ProtocolConfig native_proto = flexaids::ProtocolConfig::from_env();
+		const bool do_native = native_proto.score_native || native_proto.native_only;
 		if (do_native) {
 			score_native_pose(FA, VC, atoms, residue, cleftgrid);
-			if (_native_only && _native_only[0] != '\0' && std::strcmp(_native_only, "0") != 0) {
+			if (native_proto.native_only) {
 				std::exit(0);  // native-only mode: bail before GA (does not write pose files)
 			}
 		}

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -881,7 +881,9 @@ int main(int argc, char **argv){
 				using O = json::Object;
 				config = json::merge(config, V(O{{"advanced", V(O{{"assume_folded", V(true)}})}}));
 			}
-			apply_config(config, FA, GB);
+			// Snapshot protocol once for apply_config (no mid-apply getenv dual path).
+			const flexaids::ProtocolConfig apply_proto = flexaids::ProtocolConfig::from_env();
+			apply_config(config, FA, GB, &apply_proto);
 			if (GB->seed != 0) {
 				flexaids_rng::set_master_seed(static_cast<std::uint64_t>(GB->seed));
 			}

--- a/docs/implementation/protocol-config.md
+++ b/docs/implementation/protocol-config.md
@@ -1,10 +1,8 @@
 # ProtocolConfig — typed protocol knobs (getenv consolidation)
 
-**Status:** Chunk 1 (foundation)  
+**Status:** Chunk 2 (pose/budget/GA high-value knobs)  
 **Owner path:** `LIB/ProtocolConfig.{h,cpp}`  
-**Related audit:** ~64 `getenv` / `std::getenv` call sites in
-`LIB/DatasetRunner.cpp`, `LIB/gaboom.cpp`, `LIB/top.cpp` (repo-wide getenv
-surface is larger; this doc tracks the audit trio first).
+**Related audit:** DatasetRunner / gaboom / top getenv consolidation.
 
 ## Goal
 
@@ -13,128 +11,117 @@ Replace ad-hoc `FLEXAIDDS_*` environment reads with **one typed, serializable
 adapter only** (`ProtocolConfig::from_env()`). Future chunks can load JSON /
 CLI / skill configs into the same struct without touching call sites again.
 
-## What landed in chunk 1
+## Snapshot policy
 
-| Piece | Location |
-|-------|----------|
-| Typed struct + `defaults()` / `from_env()` / `to_json()` / `from_json()` | `LIB/ProtocolConfig.h`, `LIB/ProtocolConfig.cpp` |
-| Unit tests (defaults, env overrides, JSON round-trip) | `tests/test_protocol_config.cpp` |
-| DatasetRunner constructor + dock-config emission path | `LIB/DatasetRunner.cpp` / `.h` |
-| Engine init: `FLEXAIDDS_DATA_DIR`, `FLEXAIDDS_HBOND_WEIGHT` | `LIB/top.cpp` |
+| When | What |
+|------|------|
+| `DatasetRunner` constructor | `protocol_cfg_ = ProtocolConfig::from_env()` |
+| `DatasetRunner::run()` entry | **Re-snapshot** `protocol_cfg_` (chunk 2) so long-lived runners pick up env changes after construction |
+| `GA()` (gaboom) entry | Local `ProtocolConfig::from_env()` for engine-side knobs |
+| `top.cpp` site/grid paths | Local snapshot at use site |
 
-### Migrated env vars (go through `ProtocolConfig`)
+Chunk 1 only snapshotted the constructor; chunk 2 re-snapshots at `run()`.
 
-| Env var | Field | Default | Migrated call sites |
-|---------|-------|---------|---------------------|
-| `FLEXAIDDS_SEED_BASE` | `seed_base` | `0` | DatasetRunner `deterministic_ga_seed` |
-| `FLEXAIDDS_RESTARTS` | `restarts` | `5` | DatasetRunner multi-restart loop |
-| `FLEXAIDDS_PARALLEL_RESTARTS` | `parallel_restarts` | `restarts > 1` | DatasetRunner restart launcher |
-| `FLEXAIDDS_VCT_R0` | `vct_r0` | `7.0` | DatasetRunner dock_config scoring |
-| `FLEXAIDDS_VCT_NORM` | `vct_normalize_contacts` | off (presence) | DatasetRunner dock_config scoring |
-| `FLEXAIDDS_VCT_ENTROPY_WEIGHT` | `vct_entropy_weight` | `0.0` | DatasetRunner dock_config scoring |
-| `FLEXAIDDS_SHARING_ALPHA` | `sharing_alpha` (optional) | pop-scaled `4.0` | DatasetRunner GA section |
-| `FLEXAIDDS_BOOM_FRAC` | `boom_frac` (optional) | `1.0` | DatasetRunner GA section |
-| `FLEXAIDDS_N_ELITE` | `n_elite` | `1` | DatasetRunner GA section |
-| `FLEXAIDDS_USE_SHANNON` | `use_shannon` | off (presence) | DatasetRunner dock_config |
-| `FLEXAIDDS_THERMO` | `thermo_enabled` | off (presence) | DatasetRunner dock_config |
-| `FLEXAIDDS_T_EFF` | `t_eff` | `0.596` | DatasetRunner thermo_engine |
-| `FLEXAIDDS_TENCOM_SCALE` | `tencom_scale` | `1.0` | DatasetRunner thermo_engine |
-| `FLEXAIDDS_DATA_DIR` | `data_dir` | empty | DatasetRunner matrix + `--data-dir`; `top.cpp` auto-detect |
-| `FLEXAIDDS_CF_WINDOW_SELECTOR` | `cf_window_selector` | `false` | DatasetRunner ctor |
-| `FLEXAIDDS_CLUSTER_MEMBER_EMIT` | `cluster_member_emit` | `false` | DatasetRunner ctor |
-| `FLEXAIDDS_HBOND_WEIGHT` | `hbond_weight` | `-2.5` | `top.cpp` FA init |
+## Migrated env vars (chunk 1 + 2)
 
-**Estimate:** ~17 unique vars / ~22 call sites migrated; residual in the audit
-trio is roughly **~42 getenv call sites** (including `HOME` / `OMP_*` and
-double-reads).
+### Chunk 1
 
-## Residual getenv inventory (TODO — later chunks)
+| Env var | Field | Default |
+|---------|-------|---------|
+| `FLEXAIDDS_SEED_BASE` | `seed_base` | `0` |
+| `FLEXAIDDS_RESTARTS` | `restarts` | `5` |
+| `FLEXAIDDS_PARALLEL_RESTARTS` | `parallel_restarts` | `restarts > 1` |
+| `FLEXAIDDS_VCT_R0` | `vct_r0` | `7.0` |
+| `FLEXAIDDS_VCT_NORM` | `vct_normalize_contacts` | off |
+| `FLEXAIDDS_VCT_ENTROPY_WEIGHT` | `vct_entropy_weight` | `0.0` |
+| `FLEXAIDDS_SHARING_ALPHA` | `sharing_alpha` | pop-scaled `4.0` |
+| `FLEXAIDDS_BOOM_FRAC` | `boom_frac` | `1.0` |
+| `FLEXAIDDS_N_ELITE` | `n_elite` | `1` |
+| `FLEXAIDDS_USE_SHANNON` | `use_shannon` | off |
+| `FLEXAIDDS_THERMO` | `thermo_enabled` | off |
+| `FLEXAIDDS_T_EFF` | `t_eff` | `0.596` |
+| `FLEXAIDDS_TENCOM_SCALE` | `tencom_scale` | `1.0` |
+| `FLEXAIDDS_DATA_DIR` | `data_dir` | empty |
+| `FLEXAIDDS_CF_WINDOW_SELECTOR` | `cf_window_selector` | `false` |
+| `FLEXAIDDS_CLUSTER_MEMBER_EMIT` | `cluster_member_emit` | `false` |
+| `FLEXAIDDS_HBOND_WEIGHT` | `hbond_weight` | `-2.5` |
 
-### `LIB/DatasetRunner.cpp` (owner: benchmark / DatasetRunner)
+### Chunk 2
 
-| Env var | Purpose | Default / notes | Priority |
-|---------|---------|-----------------|----------|
-| `FLEXAIDDS_SEED_ELITISM` | Crystal seed elitism gate | mode-dependent | P1 |
-| `FLEXAIDDS_FREQSEL` | Frequency-gated pose selector | off | P1 |
-| `FLEXAIDDS_FREQSEL_ALPHA` | Freqsel soft weight | `12.0` | P1 |
-| `FLEXAIDDS_FREQSEL_RMSD` | Freqsel RMSD bin | `1.5` | P1 |
-| `FLEXAIDDS_SEED_ELITISM_DELTA_CF` | Seed elitism CF window | `10.0` | P1 |
-| `FLEXAIDDS_HTTP_RETRIES` | RCSB download retries | `3` | P2 |
-| `FLEXAIDDS_ORACLE_SITE_DIR` | Oracle sphere directory | unset | P1 |
-| `FLEXAIDDS_USE_DP` | Force DensityPeak clustering | off | P2 |
-| `FLEXAIDDS_BINARY` / `_BUILD` / `_REPO` | FlexAIDdS binary resolution | path search | P2 |
-| `FLEXAIDDS_PRIORITY_TARGETS` | Target priority list | unset | P2 |
-| `FLEXAIDDS_IGNORE_CACHE` | Skip completed-cache | off | P2 |
-| `FLEXAIDDS_RING_FLEX` | Ring pucker DoF | off | P1 |
-| `FLEXAIDDS_EVAL_SCALE_DIHEDRAL` | DoF budget scaling mode | `1` | P1 |
-| `FLEXAIDDS_BUDGET_SCALE` | Extra budget scale | on | P1 |
-| `FLEXAIDDS_FINE_GRID` | Finer angle/dihedral steps | off (presence) | P2 |
-| `OMP_NUM_THREADS` | Worker OMP sizing | hardware | leave (OpenMP contract) |
-| `HOME` | `~` expansion | `/tmp` | leave (platform) |
-| `FLEXAIDDS_COGNATE_SITE` | Cognate redock site inject | off | P1 |
-| `FLEXAIDDS_SCORE_NATIVE` | Native CF diagnostic | off | P1 |
-| `FLEXAIDDS_MULTI_CLEFT` | Parallel cleft regions | off | P2 |
-| `FLEXAIDDS_CONSENSUS_SCORER` | Cross-restart consensus | off | P1 |
-| `FLEXAIDDS_HVIB` | tENCoM/H(ω) validator | on unless `=0` | P1 |
-| `FLEXAIDDS_THERMO_CSV` | Extra thermo CSV columns | off | P2 |
+| Env var | Field | Default | Call sites |
+|---------|-------|---------|------------|
+| `FLEXAIDDS_SEED_ELITISM` | `seed_elitism` | `true` | pose selector |
+| `FLEXAIDDS_SEED_ELITISM_DELTA_CF` | `seed_elitism_delta_cf` | `10.0` | pose selector |
+| `FLEXAIDDS_FREQSEL` | `freqsel` | `false` | pose selector |
+| `FLEXAIDDS_FREQSEL_ALPHA` | `freqsel_alpha` | `12.0` | pose selector |
+| `FLEXAIDDS_FREQSEL_RMSD` | `freqsel_rmsd` | `1.5` | pose selector |
+| `FLEXAIDDS_CONSENSUS_SCORER` | `consensus_scorer` | `false` | DatasetRunner election |
+| `FLEXAIDDS_HVIB` | `hvib_enabled` | ON unless `=0` | DatasetRunner |
+| `FLEXAIDDS_RING_FLEX` | `ring_flex` | `false` | budget scaling |
+| `FLEXAIDDS_EVAL_SCALE_DIHEDRAL` | `eval_scale_dihedral` | `1` (`off`→`-1`) | budget scaling |
+| `FLEXAIDDS_BUDGET_SCALE` | `budget_scale` | `true` | budget scaling |
+| `FLEXAIDDS_FINE_GRID` | `fine_grid` | off (presence) | dock_config |
+| `FLEXAIDDS_MULTI_CLEFT` | `multi_cleft` | `0` | dock cmd |
+| `FLEXAIDDS_COGNATE_SITE` | `cognate_site` | off (presence) | dock cmd |
+| `FLEXAIDDS_SCORE_NATIVE` | `score_native` | off | DatasetRunner + top |
+| `FLEXAIDDS_NATIVE_ONLY` | `native_only` | off | top |
+| `FLEXAIDDS_USE_DP` | `use_dp` | off (`=1`) | clustering |
+| `FLEXAIDDS_IGNORE_CACHE` | `ignore_cache` | off | DatasetRunner |
+| `FLEXAIDDS_THERMO_CSV` | `thermo_csv` | off (presence) | CSV export |
+| `FLEXAIDDS_ORACLE_SITE_DIR` | `oracle_site_dir` | empty | Astex prep / provenance |
+| `FLEXAIDDS_ORACLE_SITE` | `oracle_site` | empty | top grid/site |
+| `FLEXAIDDS_CLEFT_SPHERE_FILE` | `cleft_sphere_file` | empty | top |
+| `FLEXAIDDS_NO_SEC` | `no_sec` | off (presence) | gaboom |
+| `FLEXAIDDS_BENCHMARK` | `benchmark_mode` | off (presence) | gaboom |
+| `FLEXAIDDS_T_HOT` | `t_hot` | `0.0` | gaboom anneal |
+| `FLEXAIDDS_INSTREAM_INTERVAL` | `instream_interval` | `0` (= compile default) | gaboom |
+| `FLEXAIDDS_CHAIN_NORM` | `chain_norm` | off | gaboom |
+| `FLEXAIDDS_SMFREE_REQUIRE_T` | `smfree_require_t` | off | gaboom fitness |
 
-### `LIB/gaboom.cpp` (owner: GA engine)
+## Residual getenv inventory (after chunk 2)
 
-| Env var | Purpose | Default / notes | Priority |
-|---------|---------|-----------------|----------|
-| `FLEXAIDDS_CHAIN_NORM` | Multi-chain receptor norm | off | P2 |
-| `OMP_NUM_THREADS` | Default OMP=2 if unset | platform | leave |
-| `FLEXAIDDS_USE_SHANNON` | Enable Shannon in fitness | off | P1 (already on ProtocolConfig; wire gaboom) |
-| `FLEXAIDDS_INSTREAM_INTERVAL` | In-stream clustering interval | compile default | P2 |
-| `FLEXAIDDS_NO_SEC` | Disable SEC early exits | off | P1 |
-| `FLEXAIDDS_T_HOT` | Hot anneal temperature | `0.0` | P1 |
-| `FLEXAIDDS_BENCHMARK` | Full-gen benchmark mode | off | P1 |
-| `FLEXAIDDS_SMFREE_REQUIRE_T` | Require T for SMFREE | off | P2 |
+**Audit trio call-site estimate: ~11** (down from ~42 after chunk 1 / ~64 baseline).
 
-### `LIB/top.cpp` (owner: engine entry)
+### `LIB/DatasetRunner.cpp` (~7)
 
-| Env var | Purpose | Default / notes | Priority |
-|---------|---------|-----------------|----------|
-| `FLEXAIDDS_GRID_CACHE_DIR` | Grid cache directory | unset | P2 |
-| `FLEXAIDDS_LIGAND_BATCH` | Batch ligand directory | unset | P2 |
-| `FLEXAIDS_VH_DEBUG` | Vector H-bond debug dump | off | P3 |
-| `FLEXAIDDS_CLEFT_SPHERE_FILE` | Explicit cleft spheres | unset | P1 |
-| `FLEXAIDDS_ORACLE_SITE` | Oracle site path | unset | P1 |
-| `FLEXAIDDS_SCORE_NATIVE` / `FLEXAIDDS_NATIVE_ONLY` | Native scoring path | off | P1 |
+| Env var | Purpose | Priority |
+|---------|---------|----------|
+| `HOME` | `~` expansion | leave (platform) |
+| `OMP_NUM_THREADS` | Worker OMP sizing | leave (OpenMP contract) |
+| `FLEXAIDDS_HTTP_RETRIES` | RCSB download retries | P2 |
+| `FLEXAIDDS_BINARY` / `_BUILD` / `_REPO` | Binary resolution | P2 (infra paths) |
+| `FLEXAIDDS_PRIORITY_TARGETS` | Target priority list | P2 |
 
-### Also still env-backed (out of chunk-1 audit trio but related)
+### `LIB/gaboom.cpp` (~1)
 
-`LIB/config_parser.cpp` still applies `FLEXAIDDS_VCT_ENTROPY_WEIGHT`,
-`FLEXAIDDS_N_ELITE`, `FLEXAIDDS_SHARING_ALPHA`, `FLEXAIDDS_BOOM_FRAC`,
-`FLEXAIDDS_ENTROPY_WEIGHT`, `FLEXAIDDS_DIVERSITY_MONITORING`, ranking flags.
-**Chunk 2 recommendation:** have `apply_config()` accept an optional
-`const ProtocolConfig*` so engine-side overrides share the same typed source
-as DatasetRunner (env adapter still works for standalone CLI).
+| Env var | Purpose | Priority |
+|---------|---------|----------|
+| `OMP_NUM_THREADS` | Default OMP=2 if unset | leave |
 
-## Migration rules (for later PRs)
+### `LIB/top.cpp` (~3)
+
+| Env var | Purpose | Priority |
+|---------|---------|----------|
+| `FLEXAIDDS_GRID_CACHE_DIR` | Grid cache directory | P2 (infra) |
+| `FLEXAIDDS_LIGAND_BATCH` | Batch ligand directory | P2 |
+| `FLEXAIDS_VH_DEBUG` | Vector H-bond debug dump | P3 |
+
+### Related but out of audit trio
+
+`LIB/config_parser.cpp` still applies several `FLEXAIDDS_*` overrides at
+JSON-parse time (`VCT_ENTROPY_WEIGHT`, `N_ELITE`, `SHARING_ALPHA`,
+`BOOM_FRAC`, `ENTROPY_WEIGHT`, ranking flags). **Chunk 3 recommendation:**
+have `apply_config()` accept an optional `const ProtocolConfig*` so
+engine-side overrides share the same typed source.
+
+## Migration rules
 
 1. **Do not rewrite DatasetRunner in one PR.** One cluster of related knobs per chunk.
 2. Add fields to `ProtocolConfig` first, extend `from_env()` / JSON, then flip call sites.
-3. Keep default values byte-identical when env is unset (tests + golden dock_config when practical).
+3. Keep default values byte-identical when env is unset (tests).
 4. Prefer reading `protocol_cfg_` (or a passed-in snapshot) over re-calling `getenv` in loops.
 5. Leave platform env (`HOME`, `PATH`, `OMP_*`) as raw getenv unless a strong reason exists.
-6. Document each migrated var in the table above and drop it from Residual.
-
-## Usage sketch
-
-```cpp
-#include "ProtocolConfig.h"
-
-// Compatibility (benchmarks / CLI):
-auto cfg = flexaids::ProtocolConfig::from_env();
-
-// Future: skill / JSON protocol file
-// auto cfg = flexaids::ProtocolConfig::from_json(text);
-
-// Engine or runner:
-int n = cfg.restarts;
-double alpha = cfg.effective_sharing_alpha(pop_base, pop_scaled);
-```
+6. Document each migrated var and drop it from Residual.
 
 ## Tests
 

--- a/docs/implementation/protocol-config.md
+++ b/docs/implementation/protocol-config.md
@@ -1,28 +1,60 @@
 # ProtocolConfig — typed protocol knobs (getenv consolidation)
 
-**Status:** Chunk 2 (pose/budget/GA high-value knobs)  
-**Owner path:** `LIB/ProtocolConfig.{h,cpp}`  
-**Related audit:** DatasetRunner / gaboom / top getenv consolidation.
+**Status:** Chunk 3 (config_parser science knobs + RUN_RECEIPT)  
+**Owner path:** `LIB/ProtocolConfig.{h,cpp}`, `LIB/RunReceipt.{h,cpp}`  
+**Related audit:** DatasetRunner / gaboom / top / config_parser getenv consolidation.
 
 ## Goal
 
 Replace ad-hoc `FLEXAIDDS_*` environment reads with **one typed, serializable
 `flexaids::ProtocolConfig`**. Environment variables remain a **compatibility
-adapter only** (`ProtocolConfig::from_env()`). Future chunks can load JSON /
-CLI / skill configs into the same struct without touching call sites again.
+adapter only** (`ProtocolConfig::from_env()`). Campaigns also write
+`RUN_RECEIPT.json` (C0 schema-aligned) with a ProtocolConfig snapshot so mid-run
+`setenv` cannot create dual-protocol provenance.
 
 ## Snapshot policy
 
 | When | What |
 |------|------|
 | `DatasetRunner` constructor | `protocol_cfg_ = ProtocolConfig::from_env()` |
-| `DatasetRunner::run()` entry | **Re-snapshot** `protocol_cfg_` (chunk 2) so long-lived runners pick up env changes after construction |
+| `DatasetRunner::run()` entry | **Re-snapshot** `protocol_cfg_` so long-lived runners pick up env changes after construction |
+| `apply_config()` | Single snapshot at entry (or caller-supplied `const ProtocolConfig*`) — **no mid-apply getenv** |
 | `GA()` (gaboom) entry | Local `ProtocolConfig::from_env()` for engine-side knobs |
-| `top.cpp` site/grid paths | Local snapshot at use site |
+| `top.cpp` site/grid paths | Local snapshot at use site; apply_config receives explicit snapshot |
 
-Chunk 1 only snapshotted the constructor; chunk 2 re-snapshots at `run()`.
+Chunk 1 only snapshotted the constructor; chunk 2 re-snapshots at `run()`;
+chunk 3 eliminates dual getenv inside `apply_config` and emits RUN_RECEIPT.
 
-## Migrated env vars (chunk 1 + 2)
+## RUN_RECEIPT.json schema (C0-aligned)
+
+Written by `DatasetRunner::run()` via `flexaids::write_run_receipt()` to
+`<output_dir>/RUN_RECEIPT.json` (also keeps legacy `provenance.json`).
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `schema_version` | int | `1` |
+| `run_id` | string | Dataset name or output basename |
+| `started_utc` | string | ISO-8601 UTC |
+| `output` | string | Output directory |
+| `dataset` | string | Dataset label |
+| `mode` | string | `oracle-ceiling` / `defined-cleft-redock` / `autonomous` / `unset` |
+| `temperature_K` | number | DockingConfig temperature |
+| `pop` | int | GA population |
+| `gen` | int | GA generations |
+| `restarts` | int | From ProtocolConfig |
+| `seed_base` | uint | From ProtocolConfig |
+| `seed_elitism` | 0/1 | Mode-aware (oracle ON; defined-cleft/autonomous OFF) |
+| `matrix_path` / `matrix_md5` / `matrix_sha256` | string | Scoring matrix |
+| `binary_path` / `binary_sha256` | string | FlexAIDdS docking binary |
+| `runner_path` / `runner_sha256` | string | Host process when resolvable |
+| `git_commit` | string | `git rev-parse HEAD` if available |
+| `oracle_site_dir` / `oracle_site_dir_set` | string/bool | Oracle site |
+| `protocol_config` | object | Full `ProtocolConfig::to_json()` snapshot |
+
+C0 launch scripts under the iCloud queue may still write a thinner receipt before
+start; the C++ path is a superset (adds `protocol_config`, hashes, git, schema).
+
+## Migrated env vars
 
 ### Chunk 1
 
@@ -78,9 +110,26 @@ Chunk 1 only snapshotted the constructor; chunk 2 re-snapshots at `run()`.
 | `FLEXAIDDS_CHAIN_NORM` | `chain_norm` | off | gaboom |
 | `FLEXAIDDS_SMFREE_REQUIRE_T` | `smfree_require_t` | off | gaboom fitness |
 
-## Residual getenv inventory (after chunk 2)
+### Chunk 3 (config_parser science knobs)
 
-**Audit trio call-site estimate: ~11** (down from ~42 after chunk 1 / ~64 baseline).
+| Env var | Field | Default when unset | Call sites |
+|---------|-------|--------------------|------------|
+| `FLEXAIDDS_VCT_ENTROPY_WEIGHT` | `vct_entropy_weight` + `vct_entropy_weight_set` | no override | apply_config |
+| `FLEXAIDDS_N_ELITE` | `n_elite` + `n_elite_set` | no override | apply_config |
+| `FLEXAIDDS_SHARING_ALPHA` | `sharing_alpha` optional | no override | apply_config |
+| `FLEXAIDDS_BOOM_FRAC` | `boom_frac` optional | no override | apply_config |
+| `FLEXAIDDS_FORCE_CF_RANK_EMISSION` | `force_cf_rank_emission` optional | no override | apply_config |
+| `FLEXAIDDS_CLASSIC_ENTROPY_RANKING` | `classic_entropy_ranking` optional | no override | apply_config |
+| `FLEXAIDDS_ENTROPY_WEIGHT` | `entropy_weight` optional | no override | apply_config |
+| `FLEXAIDDS_DIVERSITY_MONITORING` | `diversity_monitoring` optional | no override | apply_config |
+
+**Ranking algorithm is unchanged** — only the source of the override moves from
+raw `getenv` to a single ProtocolConfig snapshot.
+
+## Residual getenv inventory (after chunk 3)
+
+**Audit files residual science-knob getenv: 0 in config_parser.**  
+**Audit trio (DatasetRunner / gaboom / top) residual: ~11 platform/infra paths.**
 
 ### `LIB/DatasetRunner.cpp` (~7)
 
@@ -106,13 +155,9 @@ Chunk 1 only snapshotted the constructor; chunk 2 re-snapshots at `run()`.
 | `FLEXAIDDS_LIGAND_BATCH` | Batch ligand directory | P2 |
 | `FLEXAIDS_VH_DEBUG` | Vector H-bond debug dump | P3 |
 
-### Related but out of audit trio
+### `LIB/config_parser.cpp` (~0)
 
-`LIB/config_parser.cpp` still applies several `FLEXAIDDS_*` overrides at
-JSON-parse time (`VCT_ENTROPY_WEIGHT`, `N_ELITE`, `SHARING_ALPHA`,
-`BOOM_FRAC`, `ENTROPY_WEIGHT`, ranking flags). **Chunk 3 recommendation:**
-have `apply_config()` accept an optional `const ProtocolConfig*` so
-engine-side overrides share the same typed source.
+All former FLEXAIDDS_* overrides go through ProtocolConfig.
 
 ## Migration rules
 
@@ -122,6 +167,7 @@ engine-side overrides share the same typed source.
 4. Prefer reading `protocol_cfg_` (or a passed-in snapshot) over re-calling `getenv` in loops.
 5. Leave platform env (`HOME`, `PATH`, `OMP_*`) as raw getenv unless a strong reason exists.
 6. Document each migrated var and drop it from Residual.
+7. Do not change pose ranking / clustering order without an explicit request + feature flag.
 
 ## Tests
 

--- a/tests/test_protocol_config.cpp
+++ b/tests/test_protocol_config.cpp
@@ -4,9 +4,13 @@
 #include <gtest/gtest.h>
 
 #include "ProtocolConfig.h"
+#include "RunReceipt.h"
 
 #include <cstdlib>
+#include <filesystem>
+#include <fstream>
 #include <string>
+#include <unistd.h>
 
 namespace {
 
@@ -99,7 +103,11 @@ struct ClearProtocolEnv {
         , t_hot("FLEXAIDDS_T_HOT", nullptr)
         , instream("FLEXAIDDS_INSTREAM_INTERVAL", nullptr)
         , chain("FLEXAIDDS_CHAIN_NORM", nullptr)
-        , smfree("FLEXAIDDS_SMFREE_REQUIRE_T", nullptr) {}
+        , smfree("FLEXAIDDS_SMFREE_REQUIRE_T", nullptr)
+        , force_cf("FLEXAIDDS_FORCE_CF_RANK_EMISSION", nullptr)
+        , classic("FLEXAIDDS_CLASSIC_ENTROPY_RANKING", nullptr)
+        , ent_w("FLEXAIDDS_ENTROPY_WEIGHT", nullptr)
+        , div_m("FLEXAIDDS_DIVERSITY_MONITORING", nullptr) {}
 
     ScopedEnv seed_base, restarts, parallel, vct_r0, vct_norm, vct_ew,
               sharing, boom, n_elite, shannon, thermo, t_eff, tencom,
@@ -107,7 +115,7 @@ struct ClearProtocolEnv {
               seed_elit, seed_delta, freqsel, freq_a, freq_r, consensus,
               hvib, ring, eval_scale, budget, fine, multi, cognate, score_n,
               native_o, use_dp, ignore, thermo_csv, hbond, no_sec, bench,
-              t_hot, instream, chain, smfree;
+              t_hot, instream, chain, smfree, force_cf, classic, ent_w, div_m;
 };
 
 }  // namespace
@@ -161,6 +169,14 @@ TEST(ProtocolConfig, DefaultsMatchHistoricalFallbacks) {
     EXPECT_FALSE(e.chain_norm);
     EXPECT_FALSE(e.smfree_require_t);
 
+    // Chunk 3 defaults (optional ranking/ablation knobs)
+    EXPECT_FALSE(e.n_elite_set);
+    EXPECT_FALSE(e.vct_entropy_weight_set);
+    EXPECT_FALSE(e.force_cf_rank_emission.has_value());
+    EXPECT_FALSE(e.classic_entropy_ranking.has_value());
+    EXPECT_FALSE(e.entropy_weight.has_value());
+    EXPECT_FALSE(e.diversity_monitoring.has_value());
+
     EXPECT_DOUBLE_EQ(e.effective_sharing_alpha(1000, 1000), 4.0);
     EXPECT_DOUBLE_EQ(e.effective_sharing_alpha(1000, 2000), 2.0);
     EXPECT_DOUBLE_EQ(e.effective_boom_frac(), 1.0);
@@ -184,6 +200,7 @@ TEST(ProtocolConfig, FromEnvOverridesKeyVars) {
     EXPECT_DOUBLE_EQ(*cfg.sharing_alpha, 2.5);
     EXPECT_DOUBLE_EQ(cfg.effective_sharing_alpha(1000, 2000), 2.5);
     EXPECT_EQ(cfg.n_elite, 4);
+    EXPECT_TRUE(cfg.n_elite_set);
     EXPECT_EQ(cfg.data_dir, "/tmp/flexaidds-data");
     EXPECT_DOUBLE_EQ(cfg.hbond_weight, -3.1);
 }
@@ -274,4 +291,103 @@ TEST(ProtocolConfig, JsonRoundTrip) {
     EXPECT_EQ(b.data_dir, "/opt/share/flexaidds");
     EXPECT_DOUBLE_EQ(b.t_hot, 900.0);
     EXPECT_EQ(b.multi_cleft, 4);
+}
+
+TEST(ProtocolConfig, Chunk3RankingAndAblationKnobs) {
+    ClearProtocolEnv clear;
+    ScopedEnv force("FLEXAIDDS_FORCE_CF_RANK_EMISSION", "1");
+    ScopedEnv classic("FLEXAIDDS_CLASSIC_ENTROPY_RANKING", "0");
+    ScopedEnv ew("FLEXAIDDS_ENTROPY_WEIGHT", "0.25");
+    ScopedEnv div("FLEXAIDDS_DIVERSITY_MONITORING", "0");
+    ScopedEnv vctew("FLEXAIDDS_VCT_ENTROPY_WEIGHT", "0.7");
+    ScopedEnv elite("FLEXAIDDS_N_ELITE", "3");
+
+    const auto cfg = flexaids::ProtocolConfig::from_env();
+    ASSERT_TRUE(cfg.force_cf_rank_emission.has_value());
+    EXPECT_TRUE(*cfg.force_cf_rank_emission);
+    ASSERT_TRUE(cfg.classic_entropy_ranking.has_value());
+    EXPECT_FALSE(*cfg.classic_entropy_ranking);
+    ASSERT_TRUE(cfg.entropy_weight.has_value());
+    EXPECT_DOUBLE_EQ(*cfg.entropy_weight, 0.25);
+    ASSERT_TRUE(cfg.diversity_monitoring.has_value());
+    EXPECT_FALSE(*cfg.diversity_monitoring);
+    EXPECT_TRUE(cfg.vct_entropy_weight_set);
+    EXPECT_DOUBLE_EQ(cfg.vct_entropy_weight, 0.7);
+    EXPECT_TRUE(cfg.n_elite_set);
+    EXPECT_EQ(cfg.n_elite, 3);
+}
+
+TEST(RunReceipt, BuildJsonHasRequiredKeys) {
+    ClearProtocolEnv clear;
+    flexaids::RunReceiptInput in;
+    in.run_id = "unit_test_run";
+    in.started_utc = "2026-07-15T00:00:00Z";
+    in.output = "/tmp/flexaidds_receipt_test";
+    in.dataset = "astex_diverse";
+    in.mode = "defined-cleft-redock";
+    in.temperature_K = 298.0;
+    in.pop = 1000;
+    in.gen = 6000;
+    in.restarts = 5;
+    in.seed_base = 42;
+    in.seed_elitism = false;
+    in.matrix_path = "/data/MC_st0r5.2_6.dat";
+    in.matrix_md5 = "deadbeef";
+    in.matrix_sha256 = "cafebabe";
+    in.binary_path = "/bin/FlexAIDdS";
+    in.binary_sha256 = "0123456789abcdef";
+    in.git_commit = "abc123";
+    in.protocol = flexaids::ProtocolConfig::from_env();
+    in.protocol.seed_base = 42;
+    in.protocol.restarts = 5;
+
+    const std::string json = flexaids::build_run_receipt_json(in);
+    EXPECT_NE(json.find("\"schema_version\": 1"), std::string::npos);
+    EXPECT_NE(json.find("\"run_id\": \"unit_test_run\""), std::string::npos);
+    EXPECT_NE(json.find("\"mode\": \"defined-cleft-redock\""), std::string::npos);
+    EXPECT_NE(json.find("\"temperature_K\":"), std::string::npos);
+    EXPECT_NE(json.find("\"pop\": 1000"), std::string::npos);
+    EXPECT_NE(json.find("\"gen\": 6000"), std::string::npos);
+    EXPECT_NE(json.find("\"restarts\": 5"), std::string::npos);
+    EXPECT_NE(json.find("\"seed_base\": 42"), std::string::npos);
+    EXPECT_NE(json.find("\"seed_elitism\": 0"), std::string::npos);
+    EXPECT_NE(json.find("\"matrix_md5\": \"deadbeef\""), std::string::npos);
+    EXPECT_NE(json.find("\"matrix_sha256\": \"cafebabe\""), std::string::npos);
+    EXPECT_NE(json.find("\"binary_sha256\": \"0123456789abcdef\""), std::string::npos);
+    EXPECT_NE(json.find("\"git_commit\": \"abc123\""), std::string::npos);
+    EXPECT_NE(json.find("\"protocol_config\":"), std::string::npos);
+    EXPECT_NE(json.find("\"seed_base\":42"), std::string::npos);
+}
+
+TEST(RunReceipt, WriteReceiptFiles) {
+    ClearProtocolEnv clear;
+    namespace fs = std::filesystem;
+    const auto tmp = fs::temp_directory_path() /
+        ("flexaidds_receipt_" + std::to_string(::getpid()));
+    fs::create_directories(tmp);
+
+    flexaids::RunReceiptInput in;
+    in.run_id = "write_test";
+    in.started_utc = flexaids::utc_now_iso8601();
+    in.output = tmp.string();
+    in.dataset = "smoke";
+    in.mode = "autonomous";
+    in.temperature_K = 300.0;
+    in.pop = 500;
+    in.gen = 1000;
+    in.restarts = 2;
+    in.seed_elitism = true;
+    in.protocol = flexaids::ProtocolConfig::defaults();
+
+    ASSERT_TRUE(flexaids::write_run_receipt(tmp.string(), in, true));
+    EXPECT_TRUE(fs::exists(tmp / "RUN_RECEIPT.json"));
+    EXPECT_TRUE(fs::exists(tmp / "provenance.json"));
+
+    std::ifstream rf(tmp / "RUN_RECEIPT.json");
+    std::string body((std::istreambuf_iterator<char>(rf)),
+                     std::istreambuf_iterator<char>());
+    EXPECT_NE(body.find("\"run_id\": \"write_test\""), std::string::npos);
+    EXPECT_NE(body.find("\"protocol_config\":"), std::string::npos);
+
+    fs::remove_all(tmp);
 }

--- a/tests/test_protocol_config.cpp
+++ b/tests/test_protocol_config.cpp
@@ -70,13 +70,44 @@ struct ClearProtocolEnv {
         , t_eff("FLEXAIDDS_T_EFF", nullptr)
         , tencom("FLEXAIDDS_TENCOM_SCALE", nullptr)
         , data_dir("FLEXAIDDS_DATA_DIR", nullptr)
+        , oracle_dir("FLEXAIDDS_ORACLE_SITE_DIR", nullptr)
+        , oracle_site("FLEXAIDDS_ORACLE_SITE", nullptr)
+        , cleft("FLEXAIDDS_CLEFT_SPHERE_FILE", nullptr)
         , cf_win("FLEXAIDDS_CF_WINDOW_SELECTOR", nullptr)
         , cluster("FLEXAIDDS_CLUSTER_MEMBER_EMIT", nullptr)
-        , hbond("FLEXAIDDS_HBOND_WEIGHT", nullptr) {}
+        , seed_elit("FLEXAIDDS_SEED_ELITISM", nullptr)
+        , seed_delta("FLEXAIDDS_SEED_ELITISM_DELTA_CF", nullptr)
+        , freqsel("FLEXAIDDS_FREQSEL", nullptr)
+        , freq_a("FLEXAIDDS_FREQSEL_ALPHA", nullptr)
+        , freq_r("FLEXAIDDS_FREQSEL_RMSD", nullptr)
+        , consensus("FLEXAIDDS_CONSENSUS_SCORER", nullptr)
+        , hvib("FLEXAIDDS_HVIB", nullptr)
+        , ring("FLEXAIDDS_RING_FLEX", nullptr)
+        , eval_scale("FLEXAIDDS_EVAL_SCALE_DIHEDRAL", nullptr)
+        , budget("FLEXAIDDS_BUDGET_SCALE", nullptr)
+        , fine("FLEXAIDDS_FINE_GRID", nullptr)
+        , multi("FLEXAIDDS_MULTI_CLEFT", nullptr)
+        , cognate("FLEXAIDDS_COGNATE_SITE", nullptr)
+        , score_n("FLEXAIDDS_SCORE_NATIVE", nullptr)
+        , native_o("FLEXAIDDS_NATIVE_ONLY", nullptr)
+        , use_dp("FLEXAIDDS_USE_DP", nullptr)
+        , ignore("FLEXAIDDS_IGNORE_CACHE", nullptr)
+        , thermo_csv("FLEXAIDDS_THERMO_CSV", nullptr)
+        , hbond("FLEXAIDDS_HBOND_WEIGHT", nullptr)
+        , no_sec("FLEXAIDDS_NO_SEC", nullptr)
+        , bench("FLEXAIDDS_BENCHMARK", nullptr)
+        , t_hot("FLEXAIDDS_T_HOT", nullptr)
+        , instream("FLEXAIDDS_INSTREAM_INTERVAL", nullptr)
+        , chain("FLEXAIDDS_CHAIN_NORM", nullptr)
+        , smfree("FLEXAIDDS_SMFREE_REQUIRE_T", nullptr) {}
 
     ScopedEnv seed_base, restarts, parallel, vct_r0, vct_norm, vct_ew,
               sharing, boom, n_elite, shannon, thermo, t_eff, tencom,
-              data_dir, cf_win, cluster, hbond;
+              data_dir, oracle_dir, oracle_site, cleft, cf_win, cluster,
+              seed_elit, seed_delta, freqsel, freq_a, freq_r, consensus,
+              hvib, ring, eval_scale, budget, fine, multi, cognate, score_n,
+              native_o, use_dp, ignore, thermo_csv, hbond, no_sec, bench,
+              t_hot, instream, chain, smfree;
 };
 
 }  // namespace
@@ -103,6 +134,32 @@ TEST(ProtocolConfig, DefaultsMatchHistoricalFallbacks) {
     EXPECT_FALSE(e.cf_window_selector);
     EXPECT_FALSE(e.cluster_member_emit);
     EXPECT_DOUBLE_EQ(e.hbond_weight, -2.5);
+
+    // Chunk 2 defaults
+    EXPECT_TRUE(e.seed_elitism);
+    EXPECT_DOUBLE_EQ(e.seed_elitism_delta_cf, 10.0);
+    EXPECT_FALSE(e.freqsel);
+    EXPECT_DOUBLE_EQ(e.freqsel_alpha, 12.0);
+    EXPECT_FLOAT_EQ(e.freqsel_rmsd, 1.5f);
+    EXPECT_FALSE(e.consensus_scorer);
+    EXPECT_TRUE(e.hvib_enabled);
+    EXPECT_FALSE(e.ring_flex);
+    EXPECT_EQ(e.eval_scale_dihedral, 1);
+    EXPECT_TRUE(e.budget_scale);
+    EXPECT_FALSE(e.fine_grid);
+    EXPECT_EQ(e.multi_cleft, 0);
+    EXPECT_FALSE(e.cognate_site);
+    EXPECT_FALSE(e.score_native);
+    EXPECT_FALSE(e.native_only);
+    EXPECT_FALSE(e.use_dp);
+    EXPECT_FALSE(e.ignore_cache);
+    EXPECT_FALSE(e.thermo_csv);
+    EXPECT_FALSE(e.no_sec);
+    EXPECT_FALSE(e.benchmark_mode);
+    EXPECT_DOUBLE_EQ(e.t_hot, 0.0);
+    EXPECT_EQ(e.instream_interval, 0);
+    EXPECT_FALSE(e.chain_norm);
+    EXPECT_FALSE(e.smfree_require_t);
 
     EXPECT_DOUBLE_EQ(e.effective_sharing_alpha(1000, 1000), 4.0);
     EXPECT_DOUBLE_EQ(e.effective_sharing_alpha(1000, 2000), 2.0);
@@ -157,17 +214,57 @@ TEST(ProtocolConfig, PresenceFlagsAndParallelRestarts) {
     EXPECT_TRUE(cfg.parallel_restarts_explicit);
 }
 
+TEST(ProtocolConfig, Chunk2PoseAndBudgetKnobs) {
+    ClearProtocolEnv clear;
+    ScopedEnv elit("FLEXAIDDS_SEED_ELITISM", "0");
+    ScopedEnv delta("FLEXAIDDS_SEED_ELITISM_DELTA_CF", "7.5");
+    ScopedEnv freq("FLEXAIDDS_FREQSEL", "1");
+    ScopedEnv fa("FLEXAIDDS_FREQSEL_ALPHA", "9.0");
+    ScopedEnv fr("FLEXAIDDS_FREQSEL_RMSD", "2.0");
+    ScopedEnv ring("FLEXAIDDS_RING_FLEX", "1");
+    ScopedEnv eval("FLEXAIDDS_EVAL_SCALE_DIHEDRAL", "off");
+    ScopedEnv budget("FLEXAIDDS_BUDGET_SCALE", "0");
+    ScopedEnv fine("FLEXAIDDS_FINE_GRID", "1");
+    ScopedEnv multi("FLEXAIDDS_MULTI_CLEFT", "8");
+    ScopedEnv hvib("FLEXAIDDS_HVIB", "0");
+    ScopedEnv cons("FLEXAIDDS_CONSENSUS_SCORER", "1");
+    ScopedEnv hot("FLEXAIDDS_T_HOT", "1500");
+    ScopedEnv nosec("FLEXAIDDS_NO_SEC", "1");
+    ScopedEnv bench("FLEXAIDDS_BENCHMARK", "1");
+
+    const auto cfg = flexaids::ProtocolConfig::from_env();
+    EXPECT_FALSE(cfg.seed_elitism);
+    EXPECT_DOUBLE_EQ(cfg.seed_elitism_delta_cf, 7.5);
+    EXPECT_TRUE(cfg.freqsel);
+    EXPECT_DOUBLE_EQ(cfg.freqsel_alpha, 9.0);
+    EXPECT_FLOAT_EQ(cfg.freqsel_rmsd, 2.0f);
+    EXPECT_TRUE(cfg.ring_flex);
+    EXPECT_EQ(cfg.eval_scale_dihedral, -1);
+    EXPECT_FALSE(cfg.budget_scale);
+    EXPECT_TRUE(cfg.fine_grid);
+    EXPECT_EQ(cfg.multi_cleft, 8);
+    EXPECT_FALSE(cfg.hvib_enabled);
+    EXPECT_TRUE(cfg.consensus_scorer);
+    EXPECT_DOUBLE_EQ(cfg.t_hot, 1500.0);
+    EXPECT_TRUE(cfg.no_sec);
+    EXPECT_TRUE(cfg.benchmark_mode);
+}
+
 TEST(ProtocolConfig, JsonRoundTrip) {
     ClearProtocolEnv clear;
     ScopedEnv seed("FLEXAIDDS_SEED_BASE", "99");
     ScopedEnv restarts("FLEXAIDDS_RESTARTS", "7");
     ScopedEnv alpha("FLEXAIDDS_SHARING_ALPHA", "3.25");
     ScopedEnv data("FLEXAIDDS_DATA_DIR", "/opt/share/flexaidds");
+    ScopedEnv hot("FLEXAIDDS_T_HOT", "900");
+    ScopedEnv multi("FLEXAIDDS_MULTI_CLEFT", "4");
 
     const auto a = flexaids::ProtocolConfig::from_env();
     const std::string json = a.to_json();
     EXPECT_NE(json.find("\"seed_base\":99"), std::string::npos);
     EXPECT_NE(json.find("\"restarts\":7"), std::string::npos);
+    EXPECT_NE(json.find("\"t_hot\":"), std::string::npos);
+    EXPECT_NE(json.find("\"multi_cleft\":4"), std::string::npos);
 
     const auto b = flexaids::ProtocolConfig::from_json(json);
     EXPECT_EQ(b.seed_base, a.seed_base);
@@ -175,4 +272,6 @@ TEST(ProtocolConfig, JsonRoundTrip) {
     ASSERT_TRUE(b.sharing_alpha.has_value());
     EXPECT_DOUBLE_EQ(*b.sharing_alpha, 3.25);
     EXPECT_EQ(b.data_dir, "/opt/share/flexaidds");
+    EXPECT_DOUBLE_EQ(b.t_hot, 900.0);
+    EXPECT_EQ(b.multi_cleft, 4);
 }


### PR DESCRIPTION
## Summary

Science priority #2: complete **ProtocolConfig** dual-protocol hardening and write **RUN_RECEIPT.json** on every DatasetRunner / `benchmark_datasets` campaign path.

- **Chunk 2** (included): pose/budget/GA knobs + **re-snapshot at `run()` entry**
- **Chunk 3**: migrate remaining high-traffic science knobs in `config_parser` through a single ProtocolConfig snapshot (no mid-apply `getenv`)
- **RUN_RECEIPT.json**: C0-aligned provenance on every `DatasetRunner::run()` (plus legacy `provenance.json`)
- **Does not change ranking** — only the override source path

## Residual getenv count (audit files)

| File | Count | Notes |
|------|------:|-------|
| `LIB/config_parser.cpp` | **0** | all FLEXAIDDS_* via ProtocolConfig |
| `LIB/DatasetRunner.cpp` | 7 | HOME, OMP, BINARY/BUILD/REPO, HTTP_RETRIES, PRIORITY_TARGETS |
| `LIB/gaboom.cpp` | 1 | OMP_NUM_THREADS |
| `LIB/top.cpp` | 3 | GRID_CACHE_DIR, LIGAND_BATCH, VH_DEBUG |
| **Total residual** | **11** | platform/infra only |

## RUN_RECEIPT.json schema (schema_version=1)

Keys written by C++ (`flexaids::write_run_receipt`):

- `run_id`, `started_utc`, `output`, `dataset`, `mode`
- `temperature_K`, `pop`, `gen`, `restarts`, `seed_base`, `seed_elitism`
- `matrix_path`, `matrix_md5`, `matrix_sha256`
- `binary_path`, `binary_sha256`, `runner_path`, `runner_sha256`
- `git_commit`, `oracle_site_dir`, `oracle_site_dir_set`
- `protocol_config` — full `ProtocolConfig::to_json()` snapshot

Aligned with C0 iCloud launch receipts (`RUN_RECEIPT.json`) as a **superset**.

## Snapshot policy

| When | What |
|------|------|
| DatasetRunner ctor | `from_env()` |
| `DatasetRunner::run()` entry | **re-snapshot** |
| `apply_config()` | single snapshot or caller pointer — no dual getenv mid-apply |
| gaboom / top local paths | local snapshot at use site |

## Test plan

- [x] `ctest -R ProtocolConfigTests` — 8 tests (chunk 1–3 + RunReceipt keys/files)
- [x] `cmake --build --target test_protocol_config benchmark_datasets flexaid_core` links clean
- [ ] CI green on PR

## Docs

- Updated `docs/implementation/protocol-config.md` (chunk 3 + residual inventory + receipt schema)