### PR TITLE
Fix: Homebrew install recovery docs and formula-scoped tap trust

### DIFF
--- a/Formula/flexaidds.rb
+++ b/Formula/flexaidds.rb
@@ -152,27 +152,33 @@ class Flexaidds < Formula
       Wrappers under #{bin} set FLEXAIDDS_DATA_DIR=#{libexec}/share so PATH
       symlinks still find MC matrices and AMINO.def.
 
-      Stable v2.0.2+ includes the production docking matrix (atom typing works
-      out of the box). Upgrade from broken v2.0.0 installs with:
+      Stable v2.0.3+ includes the production docking matrix (atom typing works
+      out of the box). Upgrade from broken v2.0.0 / stale HEAD installs with:
         brew update && brew reinstall lebonhommepharma/flexaidds/flexaidds
 
       Install / reinstall path (Homebrew 6+ requires a real tap; raw URL installs
       are rejected). The tap is this monorepo — keep the tap checkout on main:
         brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
-        cd "$(brew --repo lebonhommepharma/flexaidds)" && git checkout main && git pull --ff-only
-        brew trust --formula lebonhommepharma/flexaidds/flexaidds   # Homebrew Tap-Trust
+        # Prefer formula-scoped trust when HOMEBREW_REQUIRE_TAP_TRUST is set
+        # (https://docs.brew.sh/Tap-Trust). Do not use HOMEBREW_NO_REQUIRE_TAP_TRUST.
+        brew trust --formula lebonhommepharma/flexaidds/flexaidds
         brew install lebonhommepharma/flexaidds/flexaidds
 
       Default brew build uses CPU + OpenMP (no Metal) and is the portable path.
-      HEAD builds always use branch "main" (never fix/*).
+      Formula head tracks main only (never ephemeral fix/* branches).
+
+      If reinstall fails with "couldn't find remote ref" after an old --HEAD
+      install that pinned a deleted branch (e.g. fix/homebrew-metal-link):
+        cd "$(brew --repository lebonhommepharma/flexaidds)"
+        git fetch --prune && git checkout main && git reset --hard origin/main
+        brew uninstall --force lebonhommepharma/flexaidds/flexaidds
+        brew install --build-from-source lebonhommepharma/flexaidds/flexaidds
 
       Metal GPU (macOS + Xcode Metal toolchain). Stable v2.0.3+ links Metal
-      bridges via flexaid_core (PR #260):
+      bridges via flexaid_core (PR #260); no special git branch required:
         brew install --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds
       Or after tap update if already installed:
         brew reinstall --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds
-      Optional HEAD (main) Metal:
-        brew reinstall --build-from-source --HEAD --with-metal lebonhommepharma/flexaidds/flexaidds
 
       Example:
         FlexAIDdS receptor.pdb ligand.sdf --rigid -o /tmp/out

--- a/README.md
+++ b/README.md
@@ -136,12 +136,14 @@ print(fd.__version__)  # 2.0.3
 
 ```bash
 brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
+# Homebrew 6+ tap trust (formula-scoped; required when HOMEBREW_REQUIRE_TAP_TRUST is set):
+brew trust --formula lebonhommepharma/flexaidds/flexaidds
 brew install lebonhommepharma/flexaidds/flexaidds
-# Metal-enabled builds: brew install lebonhommepharma/flexaidds/flexaidds --with-metal
-# (requires sufficient free disk; see formula notes for v2.0.3+)
+# Metal (stable v2.0.3+ on main/tag — no feature branch):
+#   brew install --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds
 ```
 
-Native tools and the Python package are separate installs. Full platform notes: [`docs/INSTALLATION.md`](docs/INSTALLATION.md).
+Native tools and the Python package are separate installs. Full platform notes (including recovery if a stale HEAD branch breaks reinstall): [`docs/INSTALLATION.md`](docs/INSTALLATION.md).
 
 ---
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -131,15 +131,20 @@ orphan-tap doctor warnings).
 # One-time: tap the monorepo (Formula/flexaidds.rb lives at repo root)
 brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
 
+# Homebrew 6+ tap trust (when HOMEBREW_REQUIRE_TAP_TRUST is set). Prefer
+# formula-scoped trust — do NOT set HOMEBREW_NO_REQUIRE_TAP_TRUST as the fix:
+brew trust --formula lebonhommepharma/flexaidds/flexaidds
+# Fully-qualified install also trusts just that package for the install path.
+
 # Stable tagged release (v2.0.3+). Qualified name always works.
 brew install lebonhommepharma/flexaidds/flexaidds
-# short form after tap: brew install flexaidds
+# short form after tap + trust: brew install flexaidds
 
 # Metal GPU (macOS + Xcode Metal toolchain). Stable v2.0.3+ links bridges via
-# flexaid_core (PR #260) — no longer requires --HEAD for a clean Metal link.
+# flexaid_core (PR #260) on main / the release tag — never a feature branch.
 brew install --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds
 
-# Or latest development tip (head tracks main)
+# Or latest development tip (formula head tracks main only)
 brew install --HEAD lebonhommepharma/flexaidds/flexaidds
 
 # Update later
@@ -147,6 +152,22 @@ brew update && brew reinstall lebonhommepharma/flexaidds/flexaidds
 # or, for HEAD builds (Homebrew 6+: --HEAD is install-only; reinstall --HEAD is invalid):
 brew install -s --HEAD lebonhommepharma/flexaidds/flexaidds
 # Metal reinstall after tap update:
+# brew reinstall --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds
+```
+
+**Recovery — dead HEAD branch / “couldn't find remote ref”:** An older formula
+briefly pinned `head` to an ephemeral branch (`fix/homebrew-metal-link`). That
+branch is gone; current formula uses stable `v2.0.3` + `head` → `main`. If your
+local tap is stuck and reinstall fails:
+
+```bash
+cd "$(brew --repository lebonhommepharma/flexaidds)"
+git fetch --prune
+git checkout main
+git reset --hard origin/main
+brew uninstall --force lebonhommepharma/flexaidds/flexaidds
+brew install --build-from-source lebonhommepharma/flexaidds/flexaidds
+# optional Metal:
 # brew reinstall --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds
 ```
 
@@ -221,14 +242,17 @@ The formula provides the high-performance native executables with data files sta
 # One-time tap (required on Homebrew 6+; raw URL / bare path installs are rejected)
 brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
 
+# Homebrew 6+ / HOMEBREW_REQUIRE_TAP_TRUST: trust this formula only
+brew trust --formula lebonhommepharma/flexaidds/flexaidds
+
 # Stable release (qualified name always works)
 brew install lebonhommepharma/flexaidds/flexaidds
-# short form after tap: brew install flexaidds
+# short form after tap + trust: brew install flexaidds
 
-# Metal GPU (stable v2.0.3+ — flexaid_core Metal link fix, PR #260)
+# Metal GPU (stable v2.0.3+ — flexaid_core Metal link fix, PR #260; no feature branch)
 brew install --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds
 
-# Development / latest (formula head tracks main)
+# Development / latest (formula head tracks main only — never ephemeral branches)
 brew install --HEAD lebonhommepharma/flexaidds/flexaidds
 
 # After install, add the Python package (GitHub until PyPI publish):
@@ -296,7 +320,7 @@ curl -sL "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/${TAG}
   python -c "import flexaidds as fd; print(fd.__version__, fd.HAS_CORE_BINDINGS)"
   ```
 
-- **Homebrew**: Update `Formula/flexaidds.rb` (`url` + `sha256` for stable; `head` tracks `main`) when cutting releases. Users install via `brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS` then `brew install flexaidds` (Homebrew 6+ requires a real tap with `origin`; raw formula URLs are rejected). For Metal: `brew install --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds` (stable v2.0.3+).
+- **Homebrew**: Update `Formula/flexaidds.rb` (`url` + `sha256` for stable; `head` must track default branch `main` only — never ephemeral feature branches) when cutting releases. Users install via `brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS`, then `brew trust --formula lebonhommepharma/flexaidds/flexaidds` when `HOMEBREW_REQUIRE_TAP_TRUST` is set, then `brew install flexaidds` (Homebrew 6+ requires a real tap with `origin`; raw formula URLs are rejected). For Metal: `brew install --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds` (stable v2.0.3+ on main/tag).
 - **Native binaries**: Existing release workflow attaches platform archives on tag.
 
 - **In-package updater**: `python -m flexaidds --check-update` / `--self-update` uses the GitHub Releases API and `pip install --upgrade flexaidds` (falls back to the GitHub VCS URL when the package is not yet on the default index).


### PR DESCRIPTION
## Summary
- Document formula-scoped `brew trust --formula lebonhommepharma/flexaidds/flexaidds` (Homebrew 6+ Tap Trust; no `HOMEBREW_NO_REQUIRE_TAP_TRUST` default).
- Document recovery when a stale local tap/HEAD pin to deleted `fix/homebrew-metal-link` breaks reinstall.
- Formula already tracks `head` → `main` and stable `v2.0.3`; caveats now match that contract.

## Root cause (already fixed on main for the branch pin)
An older formula temporarily set `head` to `fix/homebrew-metal-link` so Metal could build before the flexaid_core fix shipped. That branch was deleted; local taps stuck on it failed with `fatal: couldn't find remote ref refs/heads/fix/homebrew-metal-link`. Commit `d280a8fc` pinned HEAD to `main`; this PR hardens operator docs/caveats.

## Test plan
- [x] Local tap reset to main
- [x] `brew install --build-from-source lebonhommepharma/flexaidds/flexaidds` → 2.0.3
- [x] `brew reinstall --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds`
- [x] `/opt/homebrew/opt/flexaidds/bin/FlexAIDdS --help` + `brew test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS/Homebrew installation instructions for Homebrew 6+ tap trust requirements.
  * Clarified stable and Metal installation guidance for v2.0.3 and later.
  * Added recovery steps for reinstall failures caused by outdated or missing development branches.
  * Refreshed release and distribution instructions to reflect the current installation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->