### PR TITLE
Fix: P0 science stack — SoftBeta identity, FO packaging, S_top10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1676,6 +1676,7 @@ flexaids_add_unit_test(test_protocol_config
         tests/test_binding_mode_advanced.cpp
         tests/stubs.cpp
         LIB/gaboom.cpp
+        LIB/ProtocolConfig.cpp
         LIB/coarse_init.cpp
         LIB/ThermodynamicEngine.cpp
         LIB/LigandRingFlex/RingConformerLibrary.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2142,6 +2142,7 @@ flexaids_add_unit_test(test_protocol_config
         tests/test_dataset_runner.cpp
         LIB/DatasetRunner.cpp
         LIB/DatasetRunnerStats.cpp
+        LIB/DatasetRunnerProvenance.cpp
         LIB/AsyncPipeline.cpp
         ${FLEXAIDDS_POSEBUST_SOURCES}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1092,6 +1092,7 @@ flexaids_add_unit_test(test_protocol_config
         SOURCES
             tests/test_protocol_config.cpp
             LIB/ProtocolConfig.cpp
+            LIB/RunReceipt.cpp
         TEST_NAME ProtocolConfigTests
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1567,6 +1567,7 @@ flexaids_add_unit_test(test_protocol_config
         tests/test_classic_entropy_ranking.cpp
         tests/stubs.cpp
         LIB/gaboom.cpp
+        LIB/ProtocolConfig.cpp
         LIB/coarse_init.cpp
         LIB/ThermodynamicEngine.cpp
         LIB/LigandRingFlex/RingConformerLibrary.cpp

--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -1,5 +1,6 @@
 #include "BindingMode.h"
 #include "fast_optics.hpp"
+#include "SoftBetaFreeEnergy.h"
 
 #include <algorithm>
 #include <cfloat>
@@ -286,6 +287,20 @@ bool BindingMode::use_classic_entropy_ranking() const noexcept
 }
 
 
+// Collect mode-member CF values for SoftBeta (3Dsig / DatasetRunner identity).
+static std::vector<double> soft_beta_mode_energies(const std::vector<Pose>& poses)
+{
+	std::vector<double> energies;
+	energies.reserve(poses.size());
+	for (const auto& pose : poses) {
+		const double e = static_cast<double>(pose.CF);
+		if (std::isfinite(e))
+			energies.push_back(e);
+	}
+	return energies;
+}
+
+
 double BindingMode::compute_enthalpy() const
 {
 	if (!use_classic_entropy_ranking())
@@ -293,17 +308,12 @@ double BindingMode::compute_enthalpy() const
 		rebuild_engine();
 		return engine_.compute().mean_energy;
 	}
-	// Classic FlexAID: H = Σ_{i in mode} p_i E_i with p_i = w_i / Z_global
-	double enthalpy = 0.0;
-	const double Z = Population->PartitionFunction;
-	if (Z <= 0.0 || Poses.empty())
+	// Soft-β H̃ over mode members only (≡ SoftBetaFreeEnergy / cluster ACF / DatasetRunner).
+	// Local re-normalization — not global PartitionFunction weights.
+	if (!Population || Poses.empty())
 		return 0.0;
-	for (const auto& pose : Poses)
-	{
-		const double p = pose.boltzmann_weight / Z;
-		enthalpy += p * static_cast<double>(pose.CF);
-	}
-	return enthalpy;
+	const double T = static_cast<double>(Population->Temperature);
+	return flexaids::soft_beta::free_energy(soft_beta_mode_energies(Poses), T).H;
 }
 
 
@@ -314,18 +324,11 @@ double BindingMode::compute_entropy() const
 		rebuild_engine();
 		return engine_.compute().entropy;
 	}
-	// Classic FlexAID: S = −Σ_{i in mode} p_i ln p_i  (Shannon, global p_i)
-	double entropy = 0.0;
-	const double Z = Population->PartitionFunction;
-	if (Z <= 0.0 || Poses.empty())
+	// Soft-β S̃ = −Σ p_i ln p_i over mode members (nats). Same T as ACF / 3Dsig.
+	if (!Population || Poses.empty())
 		return 0.0;
-	for (const auto& pose : Poses)
-	{
-		const double p = pose.boltzmann_weight / Z;
-		if (p > 0.0)
-			entropy += p * std::log(p);
-	}
-	return -entropy;
+	const double T = static_cast<double>(Population->Temperature);
+	return flexaids::soft_beta::free_energy(soft_beta_mode_energies(Poses), T).S;
 }
 
 
@@ -337,17 +340,18 @@ double BindingMode::compute_energy() const
 		double nat_dg = (Population && Population->FA) ? Population->FA->natural_deltaG : 0.0;
 		return engine_.compute().free_energy + compute_vibrational_correction() + nat_dg;
 	}
-	// Classic FlexAID configurational free energy: F_conf = H − T·S
-	// (soft-β, global Z, T without kB) — this is what elects modes.
-	// FlexAIDdS keeps vibrational entropy on the ranking path as well:
-	// F = F_conf + (−T·S_vib) [ENCoM/tENCoM] + optional NATURaL ΔG.
-	// Vib is additive; it does not replace classic soft-β ranking.
+	// Ranking objective: G̃ = H̃ − T·S̃ over mode members (SoftBetaFreeEnergy.h).
+	// Identity: G̃ ≡ ACF ≡ E_min − T ln Z_local. Same formula as cluster.cpp emission
+	// order and DatasetRunner S1 election. FlexAIDdS adds vib + optional NATURaL:
+	//   F_rank = G̃_conf + (−T·S_vib) + ΔG_NATURaL
+	// Vib is additive; it does not replace soft-β configurational ranking.
+	if (!Population)
+		return 0.0;
+	const double T = static_cast<double>(Population->Temperature);
+	const auto fe = flexaids::soft_beta::free_energy(soft_beta_mode_energies(Poses), T);
 	const double nat_dg =
-		(Population && Population->FA) ? Population->FA->natural_deltaG : 0.0;
-	return compute_enthalpy()
-		- (static_cast<double>(Population->Temperature) * compute_entropy())
-		+ compute_vibrational_correction()
-		+ nat_dg;
+		(Population->FA) ? Population->FA->natural_deltaG : 0.0;
+	return fe.G + compute_vibrational_correction() + nat_dg;
 }
 
 
@@ -646,6 +650,9 @@ void BindingMode::output_BindingMode(int num_result, char* end_strfile, char* tm
 		}
 		snprintf(tmpremark, MAX_REMARK, "REMARK free_energy = %.6f\n", td.free_energy);
 		safe_remark_cat(remark, tmpremark, &remark_len);
+		// Ranking objective (soft-β G̃); free_energy above is physical StatMech ledger.
+		snprintf(tmpremark, MAX_REMARK, "REMARK soft_beta_G = %.6f\n", this->compute_energy());
+		safe_remark_cat(remark, tmpremark, &remark_len);
 		snprintf(tmpremark, MAX_REMARK, "REMARK enthalpy = %.6f\n", td.mean_energy);
 		safe_remark_cat(remark, tmpremark, &remark_len);
 		snprintf(tmpremark, MAX_REMARK, "REMARK entropy = %.8f\n", td.entropy);
@@ -762,6 +769,8 @@ void BindingMode::output_dynamic_BindingMode(int num_result, char* end_strfile, 
 				num_result, this->Poses.empty() ? 0.0 : this->Poses.front().CF, this->get_BindingMode_size());
 			safe_remark_cat(remark, tmpremark, &remark_len);
 			snprintf(tmpremark, MAX_REMARK, "REMARK free_energy = %.6f\n", td.free_energy);
+			safe_remark_cat(remark, tmpremark, &remark_len);
+			snprintf(tmpremark, MAX_REMARK, "REMARK soft_beta_G = %.6f\n", this->compute_energy());
 			safe_remark_cat(remark, tmpremark, &remark_len);
 			snprintf(tmpremark, MAX_REMARK, "REMARK enthalpy = %.6f\n", td.mean_energy);
 			safe_remark_cat(remark, tmpremark, &remark_len);

--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -4,12 +4,35 @@
 #include <algorithm>
 #include <cfloat>
 #include <cmath>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <map>
 #include <stdexcept>
 #include <string>
+
+// DatasetRunner reads sibling `.mcf` files (one app_evalue per line, head first)
+// to build multi-member Shannon G̃. Format matches LIB/cluster.cpp exactly.
+bool write_mcf_sidecar(const char* pdb_path,
+                       const std::vector<double>& app_evalues_head_first)
+{
+	if (pdb_path == nullptr || pdb_path[0] == '\0') return false;
+	std::string mcf_path(pdb_path);
+	if (mcf_path.size() > 4 &&
+	    mcf_path.substr(mcf_path.size() - 4) == ".pdb")
+		mcf_path = mcf_path.substr(0, mcf_path.size() - 4) + ".mcf";
+	else
+		mcf_path += ".mcf";
+	FILE* mf = std::fopen(mcf_path.c_str(), "w");
+	if (!mf) return false;
+	for (double v : app_evalues_head_first) {
+		if (std::isfinite(v))
+			std::fprintf(mf, "%.6f\n", v);
+	}
+	std::fclose(mf);
+	return true;
+}
 
 /*****************************************\\
 			BindingPopulation  
@@ -685,6 +708,27 @@ void BindingMode::output_BindingMode(int num_result, char* end_strfile, char* tm
 	snprintf(sufix, sizeof(sufix), "_%d_%d.pdb", minPoints, num_result);
 	snprintf(tmp_end_strfile, MAX_PATH__, "%s%s", end_strfile, sufix);
 	write_pdb(this->Population->FA, this->Population->atoms, this->Population->residue, tmp_end_strfile, remark);
+
+	// ── Write member-CF sidecar (.mcf) for DatasetRunner Shannon G̃ ──
+	// Same format as cluster.cpp: one app_evalue per line; head first, then
+	// remaining finite members. Without this, FO path collapses to S̃=0, G̃=CF.
+	{
+		std::vector<double> mcf_vals;
+		mcf_vals.reserve(this->Poses.size());
+		if (Rep != this->Poses.end() && Rep->chrom != nullptr &&
+		    std::isfinite(Rep->chrom->app_evalue)) {
+			mcf_vals.push_back(Rep->chrom->app_evalue);
+		}
+		for (std::vector<Pose>::const_iterator it = this->Poses.begin();
+		     it != this->Poses.end(); ++it) {
+			if (it == Rep) continue;
+			if (it->chrom == nullptr) continue;
+			if (!std::isfinite(it->chrom->app_evalue)) continue;
+			mcf_vals.push_back(it->chrom->app_evalue);
+		}
+		if (!mcf_vals.empty())
+			(void)write_mcf_sidecar(tmp_end_strfile, mcf_vals);
+	}
 }
 
 

--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -277,8 +277,9 @@ void BindingMode::rebuild_engine() const
 
 bool BindingMode::use_classic_entropy_ranking() const noexcept
 {
-	// Classic FlexAID: soft-β global-Z free energy elects modes when T>0.
-	// force_cf_rank_emission restores physical per-mode StatMech ranking (rollback).
+	// Classic FlexAID: soft-β free energy over mode members (local Z) elects modes
+	// when T>0 (SoftBetaFreeEnergy.h ≡ ACF). force_cf_rank_emission restores
+	// physical per-mode StatMech ranking (rollback).
 	if (!Population || Population->Temperature == 0)
 		return false;
 	if (Population->FA && Population->FA->force_cf_rank_emission)

--- a/LIB/BindingMode.h
+++ b/LIB/BindingMode.h
@@ -12,6 +12,13 @@
 #define isUndefinedDist(a) ((a - UNDEFINED_DIST) <= FLT_EPSILON)
 
 class BindingPopulation; // forward-declaration in order to access BindingPopulation* Population pointer
+
+/// Write DatasetRunner-compatible member-CF sidecar next to a FO/cluster PDB.
+/// Format matches cluster.cpp: one app_evalue per line (head first); finite only.
+/// Replaces trailing `.pdb` with `.mcf`. Returns true if the file was written.
+bool write_mcf_sidecar(const char* pdb_path,
+                       const std::vector<double>& app_evalues_head_first);
+
 /*****************************************\
 			  Pose
 \*****************************************/

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -17,6 +17,7 @@
 #include "AsyncPipeline.h"
 #include "BenchmarkRunner.h"
 #include "ProtocolConfig.h"
+#include "SoftBetaFreeEnergy.h"
 #include "shell_exec.h"
 #include "RunReceipt.h"
 #include "statmech.h"
@@ -891,7 +892,8 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
         const std::vector<std::string>& prefixes,
         int seed_elitism_override = -1,  // -1=ProtocolConfig default, 0=force off, 1=force on
         bool cf_window_selector = false, // Fix A: CF-window gate (see header member)
-        const flexaids::ProtocolConfig* protocol = nullptr)
+        const flexaids::ProtocolConfig* protocol = nullptr,
+        double dock_temperature_K = 0.0)  // dock T for soft-β when election_soft_T unset
 {
     // Pose-selector knobs come from ProtocolConfig (env adapter). Prefer a
     // caller-supplied snapshot (DatasetRunner::protocol_cfg_); fall back to a
@@ -919,11 +921,14 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
     const bool use_shannon_G = proto.election_shannon_free_energy;
     const bool include_singletons =
         proto.election_include_singletons || proto.election_v135 || use_shannon_G;
-    // Soft-β T (3Dsig poster / FlexAID): dock temperature in K, β=1/T.
-    // Override with FLEXAIDDS_ELECTION_SOFT_T. Legacy ZH may use SCORE_TAU.
+    // Soft-β T (3Dsig poster / FlexAID): same T as engine FA->temperature when
+    // available. Priority: FLEXAIDDS_ELECTION_SOFT_T > dock_temperature_K >
+    // (legacy ZH only) SCORE_TAU > 298 K fallback.
     double soft_T = 298.0;
     if (proto.election_soft_T > 0.0)
         soft_T = proto.election_soft_T;
+    else if (dock_temperature_K > 0.0)
+        soft_T = dock_temperature_K;
     else if (!use_shannon_G && proto.election_score_tau > 0.0)
         soft_T = proto.election_score_tau;
     soft_T = std::max(soft_T, 1e-6);
@@ -992,10 +997,9 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
         return true;
     };
 
-    // Build soft-β p_i over member CFs (or single head CF).
-    // Returns {H̃, S̃, G̃=H̃−T·S̃}  (G̃ lower is better — elect min G̃).
+    // Soft-β free energy via shared SoftBetaFreeEnergy.h (≡ cluster ACF /
+    // BindingMode classic G̃). G̃ lower is better — elect min G̃.
     auto soft_free_energy = [&](const PoseInfo& p, double& H_out, double& S_out) -> double {
-        const double T = soft_T;
         std::vector<double> energies;
         if (!p.member_cfs.empty()) {
             energies.reserve(p.member_cfs.size());
@@ -1004,32 +1008,12 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
         }
         if (energies.empty()) {
             // No members: singleton head — S̃=0, G̃=CF (matches paper for N=1).
-            H_out = static_cast<double>(p.cf);
-            S_out = 0.0;
-            return H_out;
+            energies.push_back(static_cast<double>(p.cf));
         }
-        // Numerically stable Z: shift by E_min
-        double Emin = energies[0];
-        for (double e : energies) Emin = std::min(Emin, e);
-        double Z = 0.0;
-        for (double e : energies)
-            Z += std::exp(-(e - Emin) / T);
-        if (!(Z > 0.0) || !std::isfinite(Z)) {
-            H_out = static_cast<double>(p.cf);
-            S_out = 0.0;
-            return H_out;
-        }
-        double H = 0.0;
-        double S = 0.0;
-        for (double e : energies) {
-            const double p_i = std::exp(-(e - Emin) / T) / Z;
-            if (p_i <= 0.0) continue;
-            H += p_i * e;
-            S -= p_i * std::log(p_i);
-        }
-        H_out = H;
-        S_out = S;
-        return H - T * S;  // G̃
+        const auto fe = flexaids::soft_beta::free_energy(energies, soft_T);
+        H_out = fe.H;
+        S_out = fe.S;
+        return fe.G;
     };
 
     // Legacy Z+H composite (maximize). Only when election_shannon_free_energy=false.
@@ -6533,7 +6517,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         {
             auto sel = select_pose_freq_gated_pooled(all_prefixes, sel_elitism_ovr,
                                                      cf_window_selector_,
-                                                     &protocol_cfg_);
+                                                     &protocol_cfg_,
+                                                     static_cast<double>(config.temperature));
             if (!sel.first.empty() && std::isfinite(sel.second))
                 best_cf = sel.second;
         }
@@ -6631,7 +6616,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // pool (see helper definition near compute_pose_ligand_rmsd).
             // elected_pose_for_pb lives outside this block for PoseBust post-pass.
             std::string best_pose_pdb = select_pose_freq_gated_pooled(
-                all_prefixes, sel_elitism_ovr, cf_window_selector_, &protocol_cfg_).first;
+                all_prefixes, sel_elitism_ovr, cf_window_selector_, &protocol_cfg_,
+                static_cast<double>(config.temperature)).first;
             // Fallback: no scored pose found — take first available pose file from any restart.
             if (best_pose_pdb.empty()) {
                 for (const auto& pfx : all_prefixes) {
@@ -7118,7 +7104,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             if (docking_completed) {
                 elected_pose_pdb = select_pose_freq_gated_pooled(
                     all_prefixes, sel_elitism_ovr, cf_window_selector_,
-                    &protocol_cfg_).first;
+                    &protocol_cfg_, static_cast<double>(config.temperature)).first;
             }
         }
 

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -17,7 +17,6 @@
 #include "AsyncPipeline.h"
 #include "BenchmarkRunner.h"
 #include "ProtocolConfig.h"
-#include "SoftBetaFreeEnergy.h"
 #include "shell_exec.h"
 #include "RunReceipt.h"
 #include "statmech.h"
@@ -82,6 +81,79 @@ namespace dataset {
 // Preserve a broad, fixed candidate set before any post-docking validator or
 // reranker runs. Candidate RMSD is diagnostic only and never affects retention.
 constexpr int kBenchmarkPoseLimit = 50;
+
+// ── Cluster-head enumeration (CF/DP single-suffix + FO dual-suffix) ─────────
+// Engine emission (BindingMode.cpp / FastOPTICS_cluster.cpp):
+//   CLUSTA CF/DP → <prefix>_<rank>.pdb
+//   CLUSTA FO    → <prefix>_<minPts>_<rank>.pdb
+// Election and BCR must both see FO dual-suffix heads; otherwise packaging
+// reports empty election / best_cluster_rmsd=-1 on FO-only runs.
+std::vector<EmittedClusterHead>
+enumerate_emitted_cluster_heads(const std::string& out_prefix)
+{
+    std::vector<EmittedClusterHead> out;
+    std::set<std::string> seen;
+    auto try_add = [&](const std::string& path, int rank, int min_pts) {
+        if (path.empty() || !fs::exists(path) || !seen.insert(path).second) return;
+        out.push_back(EmittedClusterHead{path, rank, min_pts});
+    };
+
+    // CF / DensityPeak single-suffix: <prefix>_<rank>.pdb
+    for (int pi = 0; pi < kBenchmarkPoseLimit; ++pi) {
+        try_add(out_prefix + "_" + std::to_string(pi) + ".pdb", pi, /*min_pts=*/-1);
+    }
+
+    // FastOPTICS dual-suffix: <prefix>_<minPts>_<rank>.pdb
+    try {
+        const fs::path pfx(out_prefix);
+        const fs::path dir = pfx.parent_path().empty() ? fs::path(".") : pfx.parent_path();
+        const std::string base = pfx.filename().string();
+        if (!base.empty() && fs::is_directory(dir)) {
+            const std::string prefix_match = base + "_";
+            for (const auto& ent : fs::directory_iterator(dir)) {
+                if (!ent.is_regular_file()) continue;
+                const std::string fname = ent.path().filename().string();
+                if (fname.size() < prefix_match.size() + 6) continue;
+                if (fname.compare(0, prefix_match.size(), prefix_match) != 0) continue;
+                if (fname.size() < 4 || fname.compare(fname.size() - 4, 4, ".pdb") != 0)
+                    continue;
+                const std::string mid = fname.substr(
+                    prefix_match.size(), fname.size() - prefix_match.size() - 4);
+                const auto us = mid.find('_');
+                if (us == std::string::npos || us == 0 || us + 1 >= mid.size())
+                    continue;
+                if (mid.find('_', us + 1) != std::string::npos)
+                    continue;
+                bool ok = true;
+                for (size_t k = 0; k < mid.size(); ++k) {
+                    if (k == us) continue;
+                    if (!std::isdigit(static_cast<unsigned char>(mid[k]))) {
+                        ok = false;
+                        break;
+                    }
+                }
+                if (!ok) continue;
+                int min_pts = -1;
+                int rank = -1;
+                try {
+                    min_pts = std::stoi(mid.substr(0, us));
+                    rank = std::stoi(mid.substr(us + 1));
+                } catch (...) {
+                    continue;
+                }
+                if (min_pts < 0 || rank < 0) continue;
+                try_add(ent.path().string(), rank, min_pts);
+            }
+        }
+    } catch (...) {
+    }
+    return out;
+}
+
+bool has_emitted_cluster_heads(const std::string& out_prefix)
+{
+    return !enumerate_emitted_cluster_heads(out_prefix).empty();
+}
 
 static std::uint64_t stable_seed_hash(const std::string& label,
                                       std::uint64_t stream = 0) {
@@ -776,9 +848,8 @@ static HvibColumns compute_target_hvib(const std::vector<std::string>& all_prefi
     struct PosePath { std::string path; float cf; };
     std::vector<PosePath> pool;
     for (const auto& pfx : all_prefixes) {
-        for (int pi = 0; pi < kBenchmarkPoseLimit; ++pi) {
-            std::string cand = pfx + "_" + std::to_string(pi) + ".pdb";
-            if (!fs::exists(cand)) continue;
+        for (const auto& head : enumerate_emitted_cluster_heads(pfx)) {
+            const std::string& cand = head.path;
             float cf = std::numeric_limits<float>::infinity();
             std::ifstream pf(cand);
             std::string   pl;
@@ -837,9 +908,8 @@ static std::pair<std::string,float> select_pose_freq_gated(const std::string& ou
 {
     struct PoseInfo { std::string path; float cf; int freq; };
     std::vector<PoseInfo> poses;
-    for (int pi = 0; pi < kBenchmarkPoseLimit; ++pi) {
-        std::string cand = out_prefix + "_" + std::to_string(pi) + ".pdb";
-        if (!fs::exists(cand)) continue;
+    for (const auto& head : enumerate_emitted_cluster_heads(out_prefix)) {
+        const std::string& cand = head.path;
         float cf = std::numeric_limits<float>::infinity();
         int   freq = 1;
         bool  have_cf = false;
@@ -892,8 +962,7 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
         const std::vector<std::string>& prefixes,
         int seed_elitism_override = -1,  // -1=ProtocolConfig default, 0=force off, 1=force on
         bool cf_window_selector = false, // Fix A: CF-window gate (see header member)
-        const flexaids::ProtocolConfig* protocol = nullptr,
-        double dock_temperature_K = 0.0)  // dock T for soft-β when election_soft_T unset
+        const flexaids::ProtocolConfig* protocol = nullptr)
 {
     // Pose-selector knobs come from ProtocolConfig (env adapter). Prefer a
     // caller-supplied snapshot (DatasetRunner::protocol_cfg_); fall back to a
@@ -921,14 +990,11 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
     const bool use_shannon_G = proto.election_shannon_free_energy;
     const bool include_singletons =
         proto.election_include_singletons || proto.election_v135 || use_shannon_G;
-    // Soft-β T (3Dsig poster / FlexAID): same T as engine FA->temperature when
-    // available. Priority: FLEXAIDDS_ELECTION_SOFT_T > dock_temperature_K >
-    // (legacy ZH only) SCORE_TAU > 298 K fallback.
+    // Soft-β T (3Dsig poster / FlexAID): dock temperature in K, β=1/T.
+    // Override with FLEXAIDDS_ELECTION_SOFT_T. Legacy ZH may use SCORE_TAU.
     double soft_T = 298.0;
     if (proto.election_soft_T > 0.0)
         soft_T = proto.election_soft_T;
-    else if (dock_temperature_K > 0.0)
-        soft_T = dock_temperature_K;
     else if (!use_shannon_G && proto.election_score_tau > 0.0)
         soft_T = proto.election_score_tau;
     soft_T = std::max(soft_T, 1e-6);
@@ -997,9 +1063,10 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
         return true;
     };
 
-    // Soft-β free energy via shared SoftBetaFreeEnergy.h (≡ cluster ACF /
-    // BindingMode classic G̃). G̃ lower is better — elect min G̃.
+    // Build soft-β p_i over member CFs (or single head CF).
+    // Returns {H̃, S̃, G̃=H̃−T·S̃}  (G̃ lower is better — elect min G̃).
     auto soft_free_energy = [&](const PoseInfo& p, double& H_out, double& S_out) -> double {
+        const double T = soft_T;
         std::vector<double> energies;
         if (!p.member_cfs.empty()) {
             energies.reserve(p.member_cfs.size());
@@ -1008,12 +1075,32 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
         }
         if (energies.empty()) {
             // No members: singleton head — S̃=0, G̃=CF (matches paper for N=1).
-            energies.push_back(static_cast<double>(p.cf));
+            H_out = static_cast<double>(p.cf);
+            S_out = 0.0;
+            return H_out;
         }
-        const auto fe = flexaids::soft_beta::free_energy(energies, soft_T);
-        H_out = fe.H;
-        S_out = fe.S;
-        return fe.G;
+        // Numerically stable Z: shift by E_min
+        double Emin = energies[0];
+        for (double e : energies) Emin = std::min(Emin, e);
+        double Z = 0.0;
+        for (double e : energies)
+            Z += std::exp(-(e - Emin) / T);
+        if (!(Z > 0.0) || !std::isfinite(Z)) {
+            H_out = static_cast<double>(p.cf);
+            S_out = 0.0;
+            return H_out;
+        }
+        double H = 0.0;
+        double S = 0.0;
+        for (double e : energies) {
+            const double p_i = std::exp(-(e - Emin) / T) / Z;
+            if (p_i <= 0.0) continue;
+            H += p_i * e;
+            S -= p_i * std::log(p_i);
+        }
+        H_out = H;
+        S_out = S;
+        return H - T * S;  // G̃
     };
 
     // Legacy Z+H composite (maximize). Only when election_shannon_free_energy=false.
@@ -1042,48 +1129,13 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
     std::vector<PoseInfo> poses;
     for (size_t ri = 0; ri < prefixes.size(); ++ri) {
         const auto& out_prefix = prefixes[ri];
-        std::set<std::string> seen;
-        auto try_add = [&](const std::string& cand) {
-            if (!fs::exists(cand) || !seen.insert(cand).second) return;
+        // Shared CF/DP + FO dual-suffix enumeration (see enumerate_emitted_cluster_heads).
+        for (const auto& head : enumerate_emitted_cluster_heads(out_prefix)) {
             float cf; int freq; std::vector<float> mcfs;
-            if (!parse_pose(cand, cf, freq, mcfs)) return;
-            poses.push_back({cand, cf, freq, std::move(mcfs), /*is_seed=*/false,
+            if (!parse_pose(head.path, cf, freq, mcfs)) continue;
+            poses.push_back({head.path, cf, freq, std::move(mcfs), /*is_seed=*/false,
                              /*restart=*/static_cast<int>(ri)});
-        };
-        // CF / DensityPeak: <prefix>_<rank>.pdb
-        for (int pi = 0; pi < kBenchmarkPoseLimit; ++pi)
-            try_add(out_prefix + "_" + std::to_string(pi) + ".pdb");
-        // FastOPTICS dual-suffix: <prefix>_<minPts>_<rank>.pdb (BindingMode.cpp)
-        try {
-            const fs::path pfx(out_prefix);
-            const fs::path dir = pfx.parent_path().empty() ? fs::path(".") : pfx.parent_path();
-            const std::string base = pfx.filename().string();
-            if (!base.empty() && fs::is_directory(dir)) {
-                const std::string prefix_match = base + "_";
-                for (const auto& ent : fs::directory_iterator(dir)) {
-                    if (!ent.is_regular_file()) continue;
-                    const std::string fname = ent.path().filename().string();
-                    if (fname.size() < prefix_match.size() + 6) continue;
-                    if (fname.compare(0, prefix_match.size(), prefix_match) != 0) continue;
-                    if (fname.size() < 4 || fname.compare(fname.size() - 4, 4, ".pdb") != 0)
-                        continue;
-                    // Require two underscores after base: _digits_digits.pdb
-                    const std::string mid = fname.substr(
-                        prefix_match.size(), fname.size() - prefix_match.size() - 4);
-                    const auto us = mid.find('_');
-                    if (us == std::string::npos || us == 0 || us + 1 >= mid.size())
-                        continue;
-                    bool ok = true;
-                    for (size_t k = 0; k < mid.size(); ++k) {
-                        if (k == us) continue;
-                        if (!std::isdigit(static_cast<unsigned char>(mid[k]))) {
-                            ok = false; break;
-                        }
-                    }
-                    if (ok) try_add(ent.path().string());
-                }
-            }
-        } catch (...) {}
+        }
     }
 
     // ── Seed-anchored elitism (FLEXAIDDS_SEED_ELITISM, default ON) ──────────
@@ -6239,12 +6291,10 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                     : (out_dir + "/r" + std::to_string(ri));
                 std::string ri_prefix2 = (ri == 0) ? out_prefix
                     : (ri_dir2 + "/" + entry.pdb_id);
-                bool has_poses = false;
-                for (int pi = 0; pi < kBenchmarkPoseLimit && !has_poses; pi++) {
-                    if (fs::exists(ri_prefix2 + "_" + std::to_string(pi) + ".pdb"))
-                        has_poses = true;
-                }
-                if (has_poses) all_prefixes.push_back(ri_prefix2);
+                // FO dual-suffix heads (prefix_minPts_rank.pdb) must count too —
+                // otherwise FO-only restarts are dropped from the election/BCR pool.
+                if (has_emitted_cluster_heads(ri_prefix2))
+                    all_prefixes.push_back(ri_prefix2);
             }
             if (all_prefixes.empty()) all_prefixes.push_back(out_prefix);
         }
@@ -6517,8 +6567,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         {
             auto sel = select_pose_freq_gated_pooled(all_prefixes, sel_elitism_ovr,
                                                      cf_window_selector_,
-                                                     &protocol_cfg_,
-                                                     static_cast<double>(config.temperature));
+                                                     &protocol_cfg_);
             if (!sel.first.empty() && std::isfinite(sel.second))
                 best_cf = sel.second;
         }
@@ -6616,16 +6665,15 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // pool (see helper definition near compute_pose_ligand_rmsd).
             // elected_pose_for_pb lives outside this block for PoseBust post-pass.
             std::string best_pose_pdb = select_pose_freq_gated_pooled(
-                all_prefixes, sel_elitism_ovr, cf_window_selector_, &protocol_cfg_,
-                static_cast<double>(config.temperature)).first;
+                all_prefixes, sel_elitism_ovr, cf_window_selector_, &protocol_cfg_).first;
             // Fallback: no scored pose found — take first available pose file from any restart.
             if (best_pose_pdb.empty()) {
                 for (const auto& pfx : all_prefixes) {
-                    for (int pi = 0; pi < kBenchmarkPoseLimit; pi++) {
-                        std::string cand = pfx + "_" + std::to_string(pi) + ".pdb";
-                        if (fs::exists(cand)) { best_pose_pdb = cand; break; }
+                    auto heads = enumerate_emitted_cluster_heads(pfx);
+                    if (!heads.empty()) {
+                        best_pose_pdb = heads.front().path;
+                        break;
                     }
-                    if (!best_pose_pdb.empty()) break;
                 }
             }
 
@@ -6659,9 +6707,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                     std::vector<Cand> pool;
                     for (size_t ip = 0; ip < all_prefixes.size(); ++ip) {
                         const std::string& pfx = all_prefixes[ip];
-                        for (int pi = 0; pi < kBenchmarkPoseLimit; ++pi) {
-                            std::string cand = pfx + "_" + std::to_string(pi) + ".pdb";
-                            if (!fs::exists(cand)) continue;
+                        for (const auto& head : enumerate_emitted_cluster_heads(pfx)) {
+                            const std::string& cand = head.path;
                             Cand c;
                             c.path   = cand;
                             c.pfx_id = static_cast<int>(ip);
@@ -6873,6 +6920,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                 // Declared here so BCR-gate below can reference it (inner block scope
                 // would make it invisible to the BCR-gate at this outer level).
                 std::string best_cluster_pfx;   // prefix that achieved best_cluster_rmsd
+                std::string best_cluster_path;  // full path (single- or dual-suffix FO)
                 // Parse "REMARK CF=" from a pose PDB (election-gap diagnostic).
                 auto parse_pose_cf = [](const std::string& cand) -> float {
                     std::ifstream pf(cand);
@@ -6893,65 +6941,35 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                     result.rmsd_to_crystal = r0.first;
                     result.rmsd_hungarian  = r0.second;
 
-                    // P4: oracle best-of-N ceiling — scan every emitted cluster pose
-                    // and record the minimum Hungarian RMSD and which pose
-                    // index achieved it.  This is the best a perfect cluster-selector
-                    // could have reached given the poses the GA actually emitted;
-                    // the gap to rank-0 measures selection (not search) headroom.
-                    //
-                    // Fix 3: scan the SAME pooled prefix set (all_prefixes) that the
-                    // freq-gated selector draws rmsd_hungarian from — not just this
-                    // one restart's out_prefix. Previously best_cluster_rmsd scanned
-                    // a single restart while rmsd_hungarian pooled across restarts,
-                    // so the two columns measured different candidate sets (hence
-                    // rmsd_hungarian=0.0 next to best_cluster_rmsd=5.97). Now
-                    // best_cluster_rmsd is a true oracle-best ceiling over the same
-                    // pool. best_cluster_idx is the retained pose index within whichever
-                    // pooled restart achieved the minimum.
+                    // P4: oracle best-of-N ceiling over all emitted cluster heads.
+                    // FO dual-suffix: <prefix>_<minPts>_<rank>.pdb via shared helper
+                    // so BCR is not stuck at -1 on FO-only packaging.
                     for (const auto& pfx : all_prefixes) {
-                        for (int pi = 0; pi < kBenchmarkPoseLimit; ++pi) {
-                            std::string cand = pfx + "_" + std::to_string(pi) + ".pdb";
-                            if (!fs::exists(cand)) continue;
+                        for (const auto& head : enumerate_emitted_cluster_heads(pfx)) {
+                            const std::string& cand = head.path;
+                            const int pi = head.rank;
                             auto rp = compute_pose_ligand_rmsd(
                                 cand, crystal_xyz, crystal_elem, entry.pdb_id, false);
                             if (result.best_cluster_rmsd < 0.0f || rp.second < result.best_cluster_rmsd) {
                                 result.best_cluster_rmsd = rp.second;
                                 result.best_cluster_idx = pi;
                                 best_cluster_pfx = pfx;
+                                best_cluster_path = cand;
                                 result.cf_best_cluster = parse_pose_cf(cand);
                             }
 
-                            // ── Fix B: cluster member recovery for near-miss clusters ──
-                            // A near-native sub-Å pose can be swallowed into a clash-
-                            // attractor cluster whose representative (centroid) is
-                            // displaced far from native, so the cluster head scanned
-                            // above misses it (1OF6: head 14.2 Å, member 2.30 Å). For
-                            // any cluster whose representative Hungarian RMSD falls in
-                            // the near-miss window [2.0, 4.0] Å, also scan its member
-                            // poses, fold the minimum member RMSD into the oracle BCR,
-                            // and emit each member as a renamed PDB for inspection.
-                            //
-                            // Member poses use the same compute_pose_ligand_rmsd()
-                            // (Hungarian) employed for the representatives — no new
-                            // RMSD path is introduced.
-                            //
-                            // Coordinate availability: DatasetRunner runs FlexAIDdS as
-                            // a subprocess and holds no cluster struct with member
-                            // coordinates; the engine writes the representative PDB and
-                            // a `.mcf` sidecar of member CF values only. Reconstructing
-                            // member Cartesians from chromosome IC is intentionally out
-                            // of scope (too fragile), so this recovery activates only
-                            // when member pose PDBs following the
-                            // `<prefix>_<N>_member<M>.pdb` convention are present on
-                            // disk; otherwise it is a no-op (member loop finds nothing).
+                            // Fix B: cluster member recovery for near-miss clusters.
+                            // Members: <head_stem>_member<M>.pdb (single- and dual-suffix).
                             if (cluster_member_emit_ &&
                                 rp.second >= 2.0f && rp.second <= 4.0f) {
+                                std::string head_stem = cand;
+                                if (head_stem.size() > 4 &&
+                                    head_stem.compare(head_stem.size() - 4, 4, ".pdb") == 0)
+                                    head_stem = head_stem.substr(0, head_stem.size() - 4);
                                 for (int mi = 0; mi < 64; ++mi) {
-                                    std::string mcand = pfx + "_" + std::to_string(pi) +
+                                    std::string mcand = head_stem +
                                                         "_member" + std::to_string(mi) + ".pdb";
                                     if (!fs::exists(mcand)) {
-                                        // Members are written contiguously from 0; the
-                                        // first gap ends this cluster's member list.
                                         if (mi == 0) break;
                                         continue;
                                     }
@@ -6962,10 +6980,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                                         result.best_cluster_rmsd = mr.second;
                                         result.best_cluster_idx  = pi;
                                         best_cluster_pfx = pfx;
+                                        best_cluster_path = mcand;
                                         result.cf_best_cluster = parse_pose_cf(mcand);
                                     }
-                                    // Emit the member pose under a self-describing name
-                                    // alongside the representative for inspection.
                                     try {
                                         char rbuf[16];
                                         std::snprintf(rbuf, sizeof(rbuf), "%.2f", mr.second);
@@ -6976,7 +6993,6 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                                         fs::copy_file(mcand, dst,
                                             fs::copy_options::overwrite_existing);
                                     } catch (const std::exception&) {
-                                        // Non-fatal: emission is diagnostic only.
                                     }
                                 }
                             }
@@ -7038,11 +7054,11 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                     fs::exists(entry.binding_site_path);
 
                 if (bcr_gate_candidate && bcr_gate_enabled &&
-                    !best_cluster_pfx.empty() && result.best_cluster_idx >= 0) {
+                    !best_cluster_path.empty() && result.best_cluster_idx >= 0) {
                     const float old_rmsd = std::min(result.rmsd_to_crystal,
                                                     result.rmsd_hungarian);
-                    const std::string override_pdb = best_cluster_pfx + "_" +
-                        std::to_string(result.best_cluster_idx) + ".pdb";
+                    // Full path from dual-suffix-aware BCR scan (FO cannot rebuild from idx).
+                    const std::string& override_pdb = best_cluster_path;
                     if (fs::exists(override_pdb)) {
                         auto rov = compute_pose_ligand_rmsd(
                             override_pdb, crystal_xyz, crystal_elem,
@@ -7079,8 +7095,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                                   << "A (idx=" << result.best_cluster_idx << ")\n";
                     } else {
                         std::cerr << "  [BCR-GATE-WARN] " << entry.pdb_id
-                                  << ": candidate pose missing for pfx="
-                                  << best_cluster_pfx
+                                  << ": candidate pose missing path="
+                                  << best_cluster_path
+                                  << " pfx=" << best_cluster_pfx
                                   << " idx=" << result.best_cluster_idx << "\n";
                     }
                 } else if (bcr_gate_candidate) {
@@ -7104,7 +7121,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             if (docking_completed) {
                 elected_pose_pdb = select_pose_freq_gated_pooled(
                     all_prefixes, sel_elitism_ovr, cf_window_selector_,
-                    &protocol_cfg_, static_cast<double>(config.temperature)).first;
+                    &protocol_cfg_).first;
             }
         }
 

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -891,7 +891,8 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
         const std::vector<std::string>& prefixes,
         int seed_elitism_override = -1,  // -1=ProtocolConfig default, 0=force off, 1=force on
         bool cf_window_selector = false, // Fix A: CF-window gate (see header member)
-        const flexaids::ProtocolConfig* protocol = nullptr)
+        const flexaids::ProtocolConfig* protocol = nullptr,
+        double dock_temperature_K = 0.0)  // dock TEMPER / DockingConfig::temperature
 {
     // Pose-selector knobs come from ProtocolConfig (env adapter). Prefer a
     // caller-supplied snapshot (DatasetRunner::protocol_cfg_); fall back to a
@@ -919,25 +920,35 @@ static std::pair<std::string,float> select_pose_freq_gated_pooled(
     const bool use_shannon_G = proto.election_shannon_free_energy;
     const bool include_singletons =
         proto.election_include_singletons || proto.election_v135 || use_shannon_G;
-    // Soft-β T (3Dsig poster / FlexAID): dock temperature in K, β=1/T.
-    // Override with FLEXAIDDS_ELECTION_SOFT_T. Legacy ZH may use SCORE_TAU.
+    // Soft-β T priority (3Dsig / FlexAID soft-β, β=1/T, CF a.u.):
+    //   1. FLEXAIDDS_ELECTION_SOFT_T (env override)
+    //   2. dock TEMPER / DockingConfig::temperature (same T as the dock)
+    //   3. (legacy ZH only) FLEXAIDDS_ELECTION_SCORE_TAU
+    //   4. 298 K fallback
+    const char* soft_T_source = "fallback";
     double soft_T = 298.0;
-    if (proto.election_soft_T > 0.0)
+    if (proto.election_soft_T > 0.0) {
         soft_T = proto.election_soft_T;
-    else if (!use_shannon_G && proto.election_score_tau > 0.0)
+        soft_T_source = "env";
+    } else if (dock_temperature_K > 0.0) {
+        soft_T = dock_temperature_K;
+        soft_T_source = "dock";
+    } else if (!use_shannon_G && proto.election_score_tau > 0.0) {
         soft_T = proto.election_score_tau;
+        soft_T_source = "env";  // SCORE_TAU is also an env knob (legacy ZH only)
+    }
     soft_T = std::max(soft_T, 1e-6);
 
     if (use_shannon_G) {
         fprintf(stderr,
                 "[3DSIG-RANK] elect by G̃=H̃−T·S̃ (Shannon on ranking path): "
-                "T=%.4f (soft-β, CF a.u.) include_singletons=%d\n",
-                soft_T, include_singletons ? 1 : 0);
+                "T=%.4f source=%s (soft-β, CF a.u.) include_singletons=%d\n",
+                soft_T, soft_T_source, include_singletons ? 1 : 0);
     } else {
         fprintf(stderr,
-                "[Z+H-LEGACY] elect by Z·exp(−αH)·log1p(N) τ=%.4f "
+                "[Z+H-LEGACY] elect by Z·exp(−αH)·log1p(N) τ=%.4f source=%s "
                 "(Shannon NOT used for ranking — rollback path)\n",
-                soft_T);
+                soft_T, soft_T_source);
     }
 
     struct PoseInfo {
@@ -6531,9 +6542,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         // rmsd_to_crystal always describe one pose. Fall back to the stdout-trace
         // min only if no emitted pose with a REMARK CF is found.
         {
-            auto sel = select_pose_freq_gated_pooled(all_prefixes, sel_elitism_ovr,
-                                                     cf_window_selector_,
-                                                     &protocol_cfg_);
+            auto sel = select_pose_freq_gated_pooled(
+                all_prefixes, sel_elitism_ovr, cf_window_selector_,
+                &protocol_cfg_, static_cast<double>(config.temperature));
             if (!sel.first.empty() && std::isfinite(sel.second))
                 best_cf = sel.second;
         }
@@ -6631,7 +6642,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // pool (see helper definition near compute_pose_ligand_rmsd).
             // elected_pose_for_pb lives outside this block for PoseBust post-pass.
             std::string best_pose_pdb = select_pose_freq_gated_pooled(
-                all_prefixes, sel_elitism_ovr, cf_window_selector_, &protocol_cfg_).first;
+                all_prefixes, sel_elitism_ovr, cf_window_selector_,
+                &protocol_cfg_, static_cast<double>(config.temperature)).first;
             // Fallback: no scored pose found — take first available pose file from any restart.
             if (best_pose_pdb.empty()) {
                 for (const auto& pfx : all_prefixes) {
@@ -7118,7 +7130,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             if (docking_completed) {
                 elected_pose_pdb = select_pose_freq_gated_pooled(
                     all_prefixes, sel_elitism_ovr, cf_window_selector_,
-                    &protocol_cfg_).first;
+                    &protocol_cfg_, static_cast<double>(config.temperature)).first;
             }
         }
 

--- a/LIB/DatasetRunner.h
+++ b/LIB/DatasetRunner.h
@@ -525,7 +525,8 @@ private:
     /// of member CF values. Reconstructing member Cartesians from chromosome
     /// IC coordinates is intentionally out of scope (too fragile). This path
     /// consequently recovers members only when member pose PDBs following the
-    /// `<prefix>_<N>_member<M>.pdb` convention are present on disk.
+    /// `<head_stem>_member<M>.pdb` convention are present on disk (head_stem is
+    /// the CF/DP or FO dual-suffix head without `.pdb`).
     bool cluster_member_emit_ = false;
 
     // ── Subprocess lifecycle ─────────────────────────────────────────
@@ -611,5 +612,27 @@ struct AstexNonNativeTarget {
 
 /// Get the full Astex Non-Native target list (65 targets, 1112 structures)
 std::vector<AstexNonNativeTarget> astex_nonnative_targets();
+
+// =============================================================================
+// Emitting cluster-head enumeration (CF/DP single-suffix + FO dual-suffix)
+// =============================================================================
+
+/// One cluster-head PDB under a restart out_prefix.
+/// CF/DP: <prefix>_<rank>.pdb              → min_pts = -1
+/// FO:    <prefix>_<minPts>_<rank>.pdb     → min_pts >= 0  (BindingMode dual-suffix)
+struct EmittedClusterHead {
+    std::string path;
+    int rank{-1};     ///< trailing rank index (0..N)
+    int min_pts{-1};  ///< FO minPts; -1 for single-suffix CF/DP
+};
+
+/// Enumerate cluster-head PDBs for one restart prefix.
+/// Deduplicated. Single-suffix ranks first, then FO dual-suffix directory scan.
+/// Used by election AND oracle BCR so FO packaging does not leave BCR at -1.
+std::vector<EmittedClusterHead>
+enumerate_emitted_cluster_heads(const std::string& out_prefix);
+
+/// True if any CF/DP or FO dual-suffix cluster head exists for out_prefix.
+bool has_emitted_cluster_heads(const std::string& out_prefix);
 
 } // namespace dataset

--- a/LIB/ProtocolConfig.cpp
+++ b/LIB/ProtocolConfig.cpp
@@ -199,8 +199,10 @@ ProtocolConfig ProtocolConfig::from_env() {
     cfg.election_include_singletons =
         env_truthy_int("FLEXAIDDS_ELECTION_INCLUDE_SINGLETONS",
                        /*default_value=*/cfg.election_v135);
-    // 3Dsig 2017 ranking: G̃ = H̃ − T S̃ with Shannon S̃ (default ON).
-    // FLEXAIDDS_ELECTION_LEGACY_ZH=1 or ELECTION_SHANNON_F=0 restores Z+H.
+    // 3Dsig 2017 ranking: G̃ = H̃ − T S̃ with Shannon S̃ (default OFF until
+    // Astex pilot + SoftBeta identity). Opt in: FLEXAIDDS_ELECTION_SHANNON_F=1.
+    // FLEXAIDDS_ELECTION_LEGACY_ZH=1 forces legacy ZH (already the OFF path).
+    // When both unset → Shannon OFF (legacy ZH / pure CF for use_shannon_G=false).
     {
         const bool legacy_zh =
             env_truthy_int("FLEXAIDDS_ELECTION_LEGACY_ZH", /*default_value=*/false);
@@ -209,7 +211,7 @@ ProtocolConfig ProtocolConfig::from_env() {
         } else {
             cfg.election_shannon_free_energy =
                 env_truthy_int("FLEXAIDDS_ELECTION_SHANNON_F",
-                               /*default_value=*/true);
+                               /*default_value=*/false);
         }
     }
     if (auto v = env_opt_double("FLEXAIDDS_ELECTION_SOFT_T")) {
@@ -458,7 +460,7 @@ ProtocolConfig ProtocolConfig::from_json(const std::string& json_text) {
             root["election_include_singletons"].as_bool(false);
     if (!root["election_shannon_free_energy"].is_null())
         cfg.election_shannon_free_energy =
-            root["election_shannon_free_energy"].as_bool(true);
+            root["election_shannon_free_energy"].as_bool(false);
     if (!root["election_soft_T"].is_null())
         cfg.election_soft_T = root["election_soft_T"].as_double(0.0);
     if (!root["hvib_enabled"].is_null())

--- a/LIB/ProtocolConfig.h
+++ b/LIB/ProtocolConfig.h
@@ -85,9 +85,11 @@ struct ProtocolConfig {
     bool election_include_singletons{false}; ///< FLEXAIDDS_ELECTION_INCLUDE_SINGLETONS
     /// Rank cluster heads by 3Dsig/Morency 2017 soft free energy
     ///   G̃ = H̃ − T S̃,  H̃=Σ p_i CF_i,  S̃=−Σ p_i ln p_i,  p_i ∝ exp(−CF_i/T)
-    /// Default ON (Shannon entropy on the ranking path). Rollback:
-    /// FLEXAIDDS_ELECTION_LEGACY_ZH=1 restores inert Z+H composite (≈ min-CF).
-    bool election_shannon_free_energy{true}; ///< FLEXAIDDS_ELECTION_SHANNON_F (default ON)
+    /// Default OFF until Astex pilot + SoftBeta identity validation.
+    /// Opt in: FLEXAIDDS_ELECTION_SHANNON_F=1. Force legacy ZH (already OFF path):
+    /// FLEXAIDDS_ELECTION_LEGACY_ZH=1. When both unset → Shannon OFF (legacy ZH /
+    /// pure CF path as coded for use_shannon_G=false).
+    bool election_shannon_free_energy{false}; ///< FLEXAIDDS_ELECTION_SHANNON_F (default OFF)
     /// Soft-β temperature T for G̃ (same role as poster T). 0 → use dock temperature
     /// or 298 K. Units: CF is scoring-proxy a.u.; this is FlexAID soft-β, not k_B.
     double election_soft_T{0.0};      ///< FLEXAIDDS_ELECTION_SOFT_T

--- a/LIB/ProtocolConfig.h
+++ b/LIB/ProtocolConfig.h
@@ -88,8 +88,9 @@ struct ProtocolConfig {
     /// Default ON (Shannon entropy on the ranking path). Rollback:
     /// FLEXAIDDS_ELECTION_LEGACY_ZH=1 restores inert Z+H composite (≈ min-CF).
     bool election_shannon_free_energy{true}; ///< FLEXAIDDS_ELECTION_SHANNON_F (default ON)
-    /// Soft-β temperature T for G̃ (same role as poster T). 0 → use dock temperature
-    /// or 298 K. Units: CF is scoring-proxy a.u.; this is FlexAID soft-β, not k_B.
+    /// Soft-β temperature T for G̃ (same role as poster T). 0 → resolve at election:
+    /// dock TEMPER / DockingConfig::temperature, else (legacy ZH) SCORE_TAU, else 298 K.
+    /// Units: CF is scoring-proxy a.u.; this is FlexAID soft-β (β=1/T), not k_B.
     double election_soft_T{0.0};      ///< FLEXAIDDS_ELECTION_SOFT_T
     /// tENCoM/H(ω) validator; default ON, disable with FLEXAIDDS_HVIB=0.
     bool hvib_enabled{true};

--- a/LIB/SoftBetaFreeEnergy.h
+++ b/LIB/SoftBetaFreeEnergy.h
@@ -1,0 +1,110 @@
+// SoftBetaFreeEnergy.h — single ranking objective for FlexAIDdS + DatasetRunner
+//
+// Soft-β free energy on the CF/contact-function scoring proxy (arbitrary units).
+// Mathematically identical formulations (local members only):
+//
+//   ACF  = E_min − T · ln Σ_i exp(−(E_i − E_min)/T)     [cluster.cpp]
+//   G̃   = H̃ − T · S̃
+//        H̃ = Σ p_i E_i ,  S̃ = −Σ p_i ln p_i
+//        p_i = exp(−(E_i − E_min)/T) / Z
+//
+// Proof: G̃ = E_min − T ln Z = ACF.  β = 1/T (kelvin), NOT 1/(k_B T).
+//
+// Used by:
+//   - LIB/cluster.cpp          (ACF emission order)
+//   - LIB/BindingMode.cpp      (mode F_conf; vib may be added on top)
+//   - LIB/DatasetRunner.cpp    (S1 election across restarts)
+//
+// AGENTS.md: CF is a scoring proxy; this is not experimental ΔG unless a full
+// validated thermodynamic ledger is active.
+//
+// Copyright 2026 Le Bonhomme Pharma
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace flexaids {
+namespace soft_beta {
+
+struct FreeEnergy {
+    double G{0.0};  ///< H̃ − T·S̃  (lower is better) == ACF
+    double H{0.0};  ///< Σ p_i E_i
+    double S{0.0};  ///< −Σ p_i ln p_i  (nats)
+    double Z{0.0};  ///< partition sum in shifted frame (exp terms only)
+    double Emin{0.0};
+    int    n{0};
+};
+
+/// Soft-β free energy over a list of CF values (cluster members).
+/// Empty → G = +∞.  Single member → G = E, S = 0.
+inline FreeEnergy free_energy(const std::vector<double>& energies, double T_K) noexcept
+{
+    FreeEnergy out;
+    if (energies.empty()) {
+        out.G = std::numeric_limits<double>::infinity();
+        return out;
+    }
+    const double T = (T_K > 1e-12) ? T_K : 1e-12;
+    double Emin = energies[0];
+    for (double e : energies) {
+        if (std::isfinite(e) && e < Emin)
+            Emin = e;
+    }
+    if (!std::isfinite(Emin)) {
+        out.G = std::numeric_limits<double>::infinity();
+        return out;
+    }
+    double Z = 0.0;
+    int n = 0;
+    for (double e : energies) {
+        if (!std::isfinite(e))
+            continue;
+        Z += std::exp(-(e - Emin) / T);
+        ++n;
+    }
+    out.n = n;
+    out.Emin = Emin;
+    out.Z = Z;
+    if (!(Z > 0.0) || !std::isfinite(Z) || n == 0) {
+        out.G = Emin;
+        out.H = Emin;
+        out.S = 0.0;
+        return out;
+    }
+    // ACF form (numerically stable)
+    out.G = Emin - T * std::log(Z);
+    // Explicit H̃, S̃ for logging / 3Dsig identity checks
+    double H = 0.0;
+    double S = 0.0;
+    for (double e : energies) {
+        if (!std::isfinite(e))
+            continue;
+        const double p = std::exp(-(e - Emin) / T) / Z;
+        if (p <= 0.0)
+            continue;
+        H += p * e;
+        S -= p * std::log(p);
+    }
+    out.H = H;
+    out.S = S;
+    // Prefer ACF form for G (identical to H−TS analytically; more stable)
+    return out;
+}
+
+/// Convenience: G only (lower better).
+inline double free_energy_G(const std::vector<double>& energies, double T_K) noexcept
+{
+    return free_energy(energies, T_K).G;
+}
+
+/// ACF alias (cluster.cpp naming).
+inline double acf(const std::vector<double>& energies, double T_K) noexcept
+{
+    return free_energy_G(energies, T_K);
+}
+
+}  // namespace soft_beta
+}  // namespace flexaids

--- a/LIB/cluster.cpp
+++ b/LIB/cluster.cpp
@@ -2,6 +2,7 @@
 #include "fileio.h"
 #include "simd_distance.h"
 #include "statmech.h"
+#include "SoftBetaFreeEnergy.h"
 #include <cmath>
 #include <limits>
 #include <vector>
@@ -160,28 +161,20 @@ void cluster(FA_Global* FA, GB_Global* GB, VC_Global* VC, chromosome* chrom, gen
 				}
 			}
 		}
-		// Basin score: cluster-local log-sum-exp free energy. Unlike the former
-		// global-probability sum, this is invariant to a constant energy offset and
-		// keeps cluster membership separate from summary ordering.
+		// Basin score: cluster-local soft-β free energy G̃ = H̃ − T·S̃ ≡ ACF.
+		// Shared identity with BindingMode classic ranking and DatasetRunner S1
+		// (LIB/SoftBetaFreeEnergy.h). Soft-β: β = 1/T (FA->beta), not 1/(k_B T).
 		Clus_TCF[num_of_clusters] = chrom[j].app_evalue;
 		Clus_ACF[num_of_clusters] = chrom[j].app_evalue;
 		if (FA->temperature > 0 && FA->beta > 0.0) {
-			double local_origin = std::numeric_limits<double>::infinity();
+			std::vector<double> member_energies;
+			member_energies.reserve(static_cast<size_t>(num_chrom));
 			for (int k = 0; k < num_chrom; ++k) {
 				if (Clus_GAPOP[k] == j && std::isfinite(chrom[k].app_evalue))
-					local_origin = std::min(local_origin, chrom[k].app_evalue);
+					member_energies.push_back(chrom[k].app_evalue);
 			}
-			if (std::isfinite(local_origin)) {
-				double local_z = 0.0;
-				for (int k = 0; k < num_chrom; ++k) {
-					if (Clus_GAPOP[k] == j && std::isfinite(chrom[k].app_evalue))
-						local_z += std::exp(-FA->beta *
-						                    (chrom[k].app_evalue - local_origin));
-				}
-				if (local_z > 0.0)
-					Clus_ACF[num_of_clusters] = local_origin -
-					    std::log(local_z) / FA->beta;
-			}
+			Clus_ACF[num_of_clusters] = flexaids::soft_beta::acf(
+				member_energies, static_cast<double>(FA->temperature));
 		}
 		num_of_clusters++;
 
@@ -376,7 +369,10 @@ void cluster(FA_Global* FA, GB_Global* GB, VC_Global* VC, chromosome* chrom, gen
 					engine.add_sample(static_cast<double>(chrom[k].app_evalue));
 			}
 			const statmech::Thermodynamics td = engine.compute();
+			// Physical StatMech ledger (diagnostic). Ranking objective is soft_beta_G = ACF.
 			snprintf(tmpremark, MAX_REMARK, "REMARK free_energy = %.6f\n", td.free_energy);
+			safe_remark_cat(remark, tmpremark, &remark_len);
+			snprintf(tmpremark, MAX_REMARK, "REMARK soft_beta_G = %.6f\n", Clus_ACF[j]);
 			safe_remark_cat(remark, tmpremark, &remark_len);
 			snprintf(tmpremark, MAX_REMARK, "REMARK enthalpy = %.6f\n", td.mean_energy);
 			safe_remark_cat(remark, tmpremark, &remark_len);

--- a/build_sources.ignore
+++ b/build_sources.ignore
@@ -82,6 +82,7 @@ LIB/SdfReader.h
 LIB/ShannonThermoStack/ShannonMetalBridge.h
 LIB/ShannonThermoStack/ShannonThermoStack.h
 LIB/ShannonThermoStack/shannon_cuda.cuh
+LIB/SoftBetaFreeEnergy.h
 LIB/SharedPosePool.h
 LIB/soft_wall.h
 LIB/TargetKnowledgeBase.h

--- a/docs/classic_entropy_ranking.md
+++ b/docs/classic_entropy_ranking.md
@@ -12,8 +12,10 @@
 |--------|-----------------|---------------------------|
 | β | `1/T` (not `1/(kB T)`) | same for configurational weights |
 | Cluster free energy (ACF) | soft-β cluster free energy | same; elects CF-path emission |
-| BindingMode F | `H − T·S` (global Z) | `H − T·S_conf + (−T·S_vib) [+ NATURaL]` |
-| Rank-0 | lowest ACF / lowest F | same product role |
+| BindingMode F | `G̃ = H̃ − T·S̃` over **mode members** (≡ ACF) | `G̃ + (−T·S_vib) [+ NATURaL]` |
+| DatasetRunner S1 | — | same `G̃` over heads + `.mcf` members |
+| Shared math | — | `LIB/SoftBetaFreeEnergy.h` |
+| Rank-0 | lowest ACF / lowest F | same product role (elect lowest G̃) |
 
 | Layer | Elects rank-0? |
 |-------|----------------|
@@ -64,8 +66,10 @@ Full code revert of this feature: revert the PR / branch that touches:
 
 | File | Change |
 |------|--------|
-| `LIB/cluster.cpp` | Skip post-ACF CF re-sort unless `force_cf` or `T==0` |
-| `LIB/BindingMode.cpp` | Classic global-Z F for ranking; physical ledger unchanged |
+| `LIB/SoftBetaFreeEnergy.h` | Shared `G̃ = H̃ − T·S̃ ≡ E_min − T ln Z` |
+| `LIB/cluster.cpp` | ACF via SoftBeta; skip post-ACF CF re-sort unless `force_cf` or `T==0` |
+| `LIB/BindingMode.cpp` | Classic SoftBeta G̃ over mode members (+ vib); physical ledger unchanged |
+| `LIB/DatasetRunner.cpp` | S1 elect min SoftBeta G̃ (dock T); `LEGACY_ZH` rollback |
 | `LIB/flexaid.h` | `force_cf_rank_emission` |
 
 ## Success metric

--- a/docs/implementation/3dsig_red_pair_protocol.md
+++ b/docs/implementation/3dsig_red_pair_protocol.md
@@ -11,7 +11,7 @@
 
 | Item | Value |
 |------|--------|
-| Success | **S_top10**: min RMSD among **top 10** ranked modes **&lt; 2.0 Å** |
+| Success | **S_top10**: any of **top 10** ranked modes has RMSD **≤ 2.0 Å** (claim contract; inclusive) |
 | Sims / case | **10** independent runs |
 | Budget / sim | **2 000 000** energy evaluations (`pop × gen = 1000 × 2000`) |
 | Headline | **Median** success rate over **10 000** bootstrap resamples of N cases |
@@ -89,8 +89,17 @@ bash scripts/run_A_pilot8.sh
 After all arms complete on pilot8 (or full85):
 
 ```bash
-python3 scripts/bootstrap_3dsig_s_top10.py --arm-dir "$FLEXAIDDS_RESULTS/campaigns/three_engine/A/3dsig_r10" ...
+# Requires mode_rmsd_0..9 on each result.csv (from parse_flexaid_arm_results.py).
+# Fail-closed if those columns are missing — never treats rmsd_bcr as S_top10.
+python3 scripts/bootstrap_3dsig_s_top10.py \
+  --arm-dir "$FLEXAIDDS_RESULTS/campaigns/three_engine/A/3dsig_r10" \
+  --bootstraps 10000 \
+  --json-out /tmp/A_s_top10.json
 ```
+
+**CSV schema (parser):** `mode_rmsd_0`…`mode_rmsd_9` (emitted rank order, crystal-blind),
+`success_s_top10` (1 if any finite mode RMSD ≤ 2.0), plus existing `rmsd_top1` /
+`success_s1` / `rmsd_bcr` / `success_s3`.
 
 ---
 

--- a/docs/implementation/3dsig_shannon_ranking.md
+++ b/docs/implementation/3dsig_shannon_ranking.md
@@ -46,10 +46,19 @@ p_i = \frac{e^{-\mathrm{CF}_i / T}}{Z}
 |-----|---------|---------|
 | `FLEXAIDDS_ELECTION_SHANNON_F` | **1 (ON)** | Elect by \(\tilde G=H-TS\) |
 | `FLEXAIDDS_ELECTION_LEGACY_ZH` | 0 | Rollback ≈ min-CF (not 3Dsig) |
-| `FLEXAIDDS_ELECTION_SOFT_T` | 0 → **dock \(T\)** (else 298) | Soft-β \(T\) in K |
+| `FLEXAIDDS_ELECTION_SOFT_T` | 0 → resolve below | Soft-β \(T\) in K (env override) |
 | `FLEXAIDDS_FORCE_CF_RANK_EMISSION` | 0 | Engine emits min-CF (rollback) |
 
-**FlexAIDdS engine and DatasetRunner must not invent different ranking objectives.** Search still optimizes CF; ranking/election uses \(\tilde G\).
+**Soft-β \(T\) resolution** in `select_pose_freq_gated_pooled` (DatasetRunner S1):
+
+1. `FLEXAIDDS_ELECTION_SOFT_T` if set and \(>0\) → log `source=env`
+2. else **dock TEMPER** (`DockingConfig::temperature` / CONFIG `TEMPER`) if \(>0\) → log `source=dock`
+3. else (legacy ZH only) `FLEXAIDDS_ELECTION_SCORE_TAU` if \(>0\) → log `source=env`
+4. else **298 K** → log `source=fallback`
+
+Log line: `[3DSIG-RANK] … T=… source=dock|env|fallback …`. Soft-β is \(\beta=1/T\) on the CF scoring proxy (not \(k_B\)).
+
+**FlexAIDdS engine and DatasetRunner must not invent different ranking objectives.** Search still optimizes CF; ranking/election uses \(\tilde G\). Engine ACF and DatasetRunner election must share the same dock \(T\).
 
 ---
 

--- a/docs/implementation/3dsig_shannon_ranking.md
+++ b/docs/implementation/3dsig_shannon_ranking.md
@@ -63,7 +63,7 @@ Reuse **FlexAID JCIM 2015** comparative design (Gaudreault & Najmanovich, *J. Ch
 | **Also reported in deck** | Astex Non-Native (N=1112), HAP2 flexibility set — secondary |
 | **Per method, per case** | **10** independent simulations |
 | **Budget each sim** | **2 000 000** energy evaluations |
-| **Success (per case, bootstrap)** | RMSD **&lt; 2.0 Å** among the **top 10** predicted results |
+| **Success (per case, bootstrap)** | RMSD **≤ 2.0 Å** among the **top 10** predicted results (claim contract; inclusive) |
 | **Headline statistic** | **Median** success rate over **10 000** bootstrap resamples of the N cases (with replacement) |
 | **Arms on barplots** | FlexAID · FlexAID+entropy (FlexAIDdS) · AutoDock Vina · FlexX · rDock |
 
@@ -73,7 +73,7 @@ Reuse **FlexAID JCIM 2015** comparative design (Gaudreault & Najmanovich, *J. Ch
 |------------|---------------------------|
 | 2 000 000 evals / sim | e.g. pop×gen = 2e6 per restart (e.g. 1000×2000) with **fixed gen**, pop×DoF only if documented |
 | 10 sims / case | `FLEXAIDDS_RESTARTS=10` (or 10 independent jobs); **do not** silently use 5 without labeling |
-| Top-10 success | Track success if **any of top-10 emitted modes** has RMSD &lt; 2 Å (**S_top10**); S1 = top-1 only is extra modern KPI |
+| Top-10 success | Track success if **any of top-10 emitted modes** has RMSD ≤ 2.0 Å (**S_top10**); S1 = top-1 only is extra modern KPI |
 | Bootstrap 10k median | `scripts/` analysis: resample cases, recompute success rate, report median + CI |
 | Matrix | JCIM 2015 pin — **do not change mid-campaign** (see `docs/implementation/MATRIX_PIN_JCIM2015.md`) |
 | Site / seed | Cognate pocket, **no native-pose seed** for claim-style fair compare |
@@ -82,7 +82,7 @@ Reuse **FlexAID JCIM 2015** comparative design (Gaudreault & Najmanovich, *J. Ch
 
 | ID | Definition | 3Dsig deck |
 |----|------------|------------|
-| **S_top10** | Min RMSD among top-10 ranked modes ≤ 2 Å | **Primary in PDF bootstrap** |
+| **S_top10** | Any of top-10 ranked modes (emitted rank order) has RMSD ≤ 2.0 Å | **Primary in PDF bootstrap** |
 | **S1** | Rank-0 / elected mode RMSD ≤ 2 Å | Modern claim KPI (stricter) |
 | **S2** | S1 ∧ PoseBusters | Modern secondary (not in 2017 deck) |
 | **BCR** | Best cluster-head RMSD ≤ 2 Å | Diagnostic sampling ceiling |

--- a/docs/implementation/3dsig_shannon_ranking.md
+++ b/docs/implementation/3dsig_shannon_ranking.md
@@ -44,12 +44,14 @@ p_i = \frac{e^{-\mathrm{CF}_i / T}}{Z}
 
 | Env | Default | Meaning |
 |-----|---------|---------|
-| `FLEXAIDDS_ELECTION_SHANNON_F` | **1 (ON)** | Elect by \(\tilde G=H-TS\) |
-| `FLEXAIDDS_ELECTION_LEGACY_ZH` | 0 | Rollback ≈ min-CF (not 3Dsig) |
+| `FLEXAIDDS_ELECTION_SHANNON_F` | **0 (OFF)** | Elect by \(\tilde G=H-TS\) when set to `1` |
+| `FLEXAIDDS_ELECTION_LEGACY_ZH` | 0 | Force legacy ZH / ≈ min-CF (not 3Dsig); same OFF path when Shannon unset |
 | `FLEXAIDDS_ELECTION_SOFT_T` | 0 → **dock \(T\)** (else 298) | Soft-β \(T\) in K |
 | `FLEXAIDDS_FORCE_CF_RANK_EMISSION` | 0 | Engine emits min-CF (rollback) |
 
-**FlexAIDdS engine and DatasetRunner must not invent different ranking objectives.** Search still optimizes CF; ranking/election uses \(\tilde G\).
+**Default OFF until Astex pilot + SoftBeta identity.** Shannon S1 election (`election_shannon_free_energy`) stays **off** when both env knobs are unset (legacy ZH / pure CF path for `use_shannon_G=false`). Enable explicitly with `FLEXAIDDS_ELECTION_SHANNON_F=1` after Astex pilot validation and SoftBeta identity checks (`LIB/SoftBetaFreeEnergy.h`). Claim / 3Dsig launch scripts that need Shannon ON must export that env themselves (e.g. `scripts/run_C0_claim_clean.sh`).
+
+**FlexAIDdS engine and DatasetRunner must not invent different ranking objectives.** Search still optimizes CF; when Shannon ranking is enabled, ranking/election uses \(\tilde G\).
 
 ---
 

--- a/docs/implementation/3dsig_shannon_ranking.md
+++ b/docs/implementation/3dsig_shannon_ranking.md
@@ -32,24 +32,26 @@ p_i = \frac{e^{-\mathrm{CF}_i / T}}{Z}
 | \(T\) | Temperature in K; \(\beta=1/T\) (FlexAID soft-β, **not** \(1/(k_B T)\)) |
 | Elect | **Lowest** \(\tilde G\) binding mode / head |
 
-**Identity:** \(\tilde G = E_{\min}-T\ln Z_{\mathrm{local}}\) (cluster **ACF** in `cluster.cpp`). Shared implementation: `LIB/SoftBetaFreeEnergy.h`.
+**Identity:** \(\tilde G = \tilde H - T\cdot\tilde S \equiv E_{\min}-T\ln Z_{\mathrm{local}}\) (cluster **ACF**).  
+**Single implementation:** `LIB/SoftBetaFreeEnergy.h` (`flexaids::soft_beta::free_energy` / `acf`).  
+**Local Z only:** each cluster/mode re-normalizes \(p_i\) over **its own members** — never the global `BindingPopulation::PartitionFunction` for ranking H/S/\(\tilde G\). Physical StatMech REMARK `free_energy` is separate; optional REMARK `soft_beta_G` logs the ranking objective.
 
 ### Code layers (must stay identical)
 
 | Layer | Behavior | Log / API |
 |--------|----------|-----------|
-| `cluster.cpp` ACF | Local soft-β free energy; emission order when \(T>0\) | `[ENTROPY_RANK]` |
-| `BindingMode::compute_energy` | Same \(\tilde G\) over mode members (+ optional vib on FO path — document if on) | BindingMode sort |
-| `DatasetRunner` S1 | Same \(\tilde G\) over heads + `.mcf` members; dock \(T\) | `[3DSIG-RANK]` |
+| `cluster.cpp` ACF | `soft_beta::acf(member CFs, T)`; emission order when \(T>0\) | `[ENTROPY_RANK]`; REMARK `soft_beta_G` |
+| `BindingMode` classic H/S/F | Same \(\tilde G\) over **mode members** only (+ vib additive; not global Z) | BindingMode sort; REMARK `soft_beta_G` |
+| `DatasetRunner` S1 | Same `soft_beta::free_energy` over heads + `.mcf` members | `[3DSIG-RANK]` |
 
 | Env | Default | Meaning |
 |-----|---------|---------|
-| `FLEXAIDDS_ELECTION_SHANNON_F` | **1 (ON)** | Elect by \(\tilde G=H-TS\) |
+| `FLEXAIDDS_ELECTION_SHANNON_F` | **1 (ON)** | Elect by \(\tilde G=H-TS\) (do not flip default without P0.5) |
 | `FLEXAIDDS_ELECTION_LEGACY_ZH` | 0 | Rollback ≈ min-CF (not 3Dsig) |
-| `FLEXAIDDS_ELECTION_SOFT_T` | 0 → **dock \(T\)** (else 298) | Soft-β \(T\) in K |
-| `FLEXAIDDS_FORCE_CF_RANK_EMISSION` | 0 | Engine emits min-CF (rollback) |
+| `FLEXAIDDS_ELECTION_SOFT_T` | 0 → **dock \(T\)** (else 298) | Soft-β \(T\) in K (priority: SOFT_T > dock T > 298) |
+| `FLEXAIDDS_FORCE_CF_RANK_EMISSION` | 0 | Engine emits min-CF (rollback); classic SoftBeta path off |
 
-**FlexAIDdS engine and DatasetRunner must not invent different ranking objectives.** Search still optimizes CF; ranking/election uses \(\tilde G\).
+**FlexAIDdS engine and DatasetRunner must not invent different ranking objectives.** Search still optimizes CF; ranking/election uses \(\tilde G\). Unit gates: `SoftBetaIdentity::*` and `BindingModeMatchesSoftBetaLocal` in `tests/test_classic_entropy_ranking.cpp`.
 
 ---
 

--- a/scripts/bootstrap_3dsig_s_top10.py
+++ b/scripts/bootstrap_3dsig_s_top10.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
 """10k bootstrap median of S_top10 success rates (3Dsig 2017 metric).
 
-Per case: success if min(RMSD among top-10 ranked modes) < 2.0 Å.
-Headline: median of B bootstrap resamples of the case set (with replacement).
+Per case: success if **any** of the top-10 ranked modes has RMSD ≤ 2.0 Å
+(claim contract threshold; see docs/implementation/3dsig_red_pair_protocol.md).
+
+Headline: **median** of B bootstrap resamples of the case set (with replacement).
 
 Input formats (auto-detected):
-  - Directory of per-PDB result.csv with columns like top_k_rmsd / mode_rmsd_0..9
-  - TSV/CSV with columns: pdb_id, rank, rmsd  (rank 0..9)
-  - JSON list of {pdb_id, rmsds: [..]} 
+  - Directory of per-PDB result.csv with **mode_rmsd_0..9** columns (required)
+  - TSV/CSV with columns: pdb_id, rank, rmsd  (rank 0..9, emitted order)
+  - JSON list of {pdb_id, rmsds: [..]} or {cases: {...}}
+
+**Fail-closed:** arm-dir result.csv without mode_rmsd_* (or equivalent rank
+columns) is rejected. Do **not** silently treat rmsd_top1 / rmsd_bcr as S_top10.
 
 Usage:
   python3 scripts/bootstrap_3dsig_s_top10.py --cases cases.json --bootstraps 10000
   python3 scripts/bootstrap_3dsig_s_top10.py --arm-dir path/to/3dsig_r10
+  python3 scripts/bootstrap_3dsig_s_top10.py --rank-table ranks.csv
 
 Copyright 2026 Le Bonhomme Pharma
 SPDX-License-Identifier: Apache-2.0
@@ -26,118 +32,221 @@ import random
 import statistics
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence, Tuple
+
+# Claim contract: success if RMSD ≤ 2.0 Å (not strict <)
+DEFAULT_THRESH = 2.0
+DEFAULT_BOOTSTRAPS = 10_000
+TOP_N = 10
+
+# Column aliases accepted for mode RMSDs in result.csv (prefer mode_rmsd_i)
+MODE_RMSD_KEYS = (
+    "mode_rmsd_{i}",
+    "rmsd_{i}",
+    "top{i}_rmsd",
+    "rank{i}_rmsd",
+)
 
 
-def s_top10(rmsds: List[float], thresh: float = 2.0) -> bool:
-    vals = [r for r in rmsds[:10] if r is not None and math.isfinite(r) and r >= 0.0]
-    if not vals:
-        return False
-    return min(vals) < thresh
+class MissingModeRmsdError(ValueError):
+    """Raised when result.csv lacks mode_rmsd_* (fail-closed for S_top10)."""
 
 
-def load_cases_json(path: Path) -> Dict[str, List[float]]:
+def _finite_rmsd(value: object) -> Optional[float]:
+    if value is None or value == "" or value == "NA":
+        return None
+    try:
+        v = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(v) or v < 0.0:
+        return None
+    return v
+
+
+def s_top10(
+    rmsds: Sequence[Optional[float]], thresh: float = DEFAULT_THRESH
+) -> bool:
+    """True if any of the first 10 finite non-negative RMSDs is ≤ thresh."""
+    for r in list(rmsds)[:TOP_N]:
+        if r is None:
+            continue
+        if math.isfinite(r) and r >= 0.0 and r <= thresh:
+            return True
+    return False
+
+
+def extract_mode_rmsds_from_row(
+    row: dict, *, require_mode_columns: bool = True
+) -> List[Optional[float]]:
+    """Extract mode_rmsd_0..9 from a result.csv row.
+
+    Prefer exact ``mode_rmsd_i`` keys. Accept documented aliases.
+    If *require_mode_columns* and no mode/rank columns exist at all,
+    raise MissingModeRmsdError (fail-closed — no BCR / top1 fallback).
+    """
+    keys_lower = {k.lower(): k for k in row}
+
+    def _get_for_i(i: int) -> Tuple[bool, Optional[float]]:
+        """Return (column_present, value)."""
+        for template in MODE_RMSD_KEYS:
+            key = template.format(i=i)
+            if key in row:
+                return True, _finite_rmsd(row[key])
+            if key.lower() in keys_lower:
+                return True, _finite_rmsd(row[keys_lower[key.lower()]])
+        return False, None
+
+    any_mode_col = False
+    rmsds: List[Optional[float]] = []
+    for i in range(TOP_N):
+        present, val = _get_for_i(i)
+        if present:
+            any_mode_col = True
+        rmsds.append(val)
+
+    if not any_mode_col and require_mode_columns:
+        # Explicit fail-closed: never treat rmsd_top1 / rmsd_bcr as S_top10
+        sample_keys = sorted(row.keys())[:20]
+        raise MissingModeRmsdError(
+            "result.csv missing mode_rmsd_0..9 (or rmsd_i / top{i}_rmsd / "
+            f"rank{i}_rmsd). Refusing BCR/top1 fallback. Columns sample: {sample_keys}"
+        )
+    return rmsds
+
+
+def load_cases_json(path: Path) -> Dict[str, List[Optional[float]]]:
     data = json.loads(path.read_text())
-    out: Dict[str, List[float]] = {}
+    out: Dict[str, List[Optional[float]]] = {}
     if isinstance(data, dict) and "cases" in data:
         data = data["cases"]
     if isinstance(data, dict):
         for k, v in data.items():
             if isinstance(v, dict) and "rmsds" in v:
-                out[str(k)] = [float(x) for x in v["rmsds"]]
+                out[str(k)] = [_finite_rmsd(x) for x in v["rmsds"]]
             elif isinstance(v, list):
-                out[str(k)] = [float(x) for x in v]
+                out[str(k)] = [_finite_rmsd(x) for x in v]
     elif isinstance(data, list):
         for row in data:
             pid = str(row.get("pdb_id") or row.get("pdb") or row["id"])
-            out[pid] = [float(x) for x in row["rmsds"]]
+            out[pid] = [_finite_rmsd(x) for x in row["rmsds"]]
     return out
 
 
-def load_rank_table(path: Path) -> Dict[str, List[float]]:
-    """pdb_id, rank, rmsd rows → top-10 rmsds sorted by rank."""
-    by: Dict[str, List[tuple]] = {}
+def load_rank_table(path: Path) -> Dict[str, List[Optional[float]]]:
+    """pdb_id, rank, rmsd rows → top-10 rmsds sorted by **emitted rank** (not RMSD)."""
+    by: Dict[str, List[Tuple[int, Optional[float]]]] = {}
     with path.open(newline="") as f:
-        # sniff delimiter
         sample = f.read(2048)
         f.seek(0)
         delim = "\t" if sample.count("\t") > sample.count(",") else ","
         r = csv.DictReader(f, delimiter=delim)
         for row in r:
             keys = {k.lower(): k for k in row}
-            pid = row[keys.get("pdb_id") or keys.get("pdb") or keys.get("case") or list(row)[0]]
+            pid = row[
+                keys.get("pdb_id")
+                or keys.get("pdb")
+                or keys.get("case")
+                or list(row)[0]
+            ]
             rank = int(float(row[keys.get("rank") or list(row)[1]]))
-            rmsd = float(row[keys.get("rmsd") or list(row)[2]])
+            rmsd = _finite_rmsd(row[keys.get("rmsd") or list(row)[2]])
             by.setdefault(str(pid), []).append((rank, rmsd))
-    out: Dict[str, List[float]] = {}
+    out: Dict[str, List[Optional[float]]] = {}
     for pid, pairs in by.items():
-        pairs.sort(key=lambda x: x[0])
-        out[pid] = [r for _, r in pairs[:10]]
+        pairs.sort(key=lambda x: x[0])  # emitted rank order
+        slots: List[Optional[float]] = [None] * TOP_N
+        for rank, rmsd in pairs:
+            if 0 <= rank < TOP_N:
+                slots[rank] = rmsd
+        # If ranks were 1-based sparse, also pack first 10 in rank order
+        if all(v is None for v in slots) and pairs:
+            packed = [rmsd for _, rmsd in pairs[:TOP_N]]
+            slots = packed + [None] * (TOP_N - len(packed))
+        out[pid] = slots
     return out
 
 
-def load_arm_dir(arm_dir: Path) -> Dict[str, List[float]]:
-    """Scan result.csv under arm_dir/<PDB>/ for rmsd columns if present."""
-    out: Dict[str, List[float]] = {}
-    for csv_path in sorted(arm_dir.rglob("result.csv")):
+def load_arm_dir(
+    arm_dir: Path, *, strict: bool = True
+) -> Dict[str, List[Optional[float]]]:
+    """Scan result.csv under arm_dir for mode_rmsd_0..9.
+
+    Fail-closed when *strict* (default): missing mode columns → error, not
+    silent rmsd_top1 / rmsd_bcr substitution.
+    """
+    out: Dict[str, List[Optional[float]]] = {}
+    csv_paths = sorted(arm_dir.rglob("result.csv"))
+    if not csv_paths:
+        raise FileNotFoundError(f"no result.csv under {arm_dir}")
+
+    errors: List[str] = []
+    for csv_path in csv_paths:
         try:
             with csv_path.open(newline="") as f:
                 rows = list(csv.DictReader(f))
-        except OSError:
+        except OSError as e:
+            errors.append(f"{csv_path}: {e}")
             continue
         if not rows:
             continue
         row = rows[0]
         pdb = (
-            row.get("pdb_id")
-            or row.get("receptor_id")
-            or csv_path.parent.name
+            row.get("pdb_id") or row.get("receptor_id") or csv_path.parent.name
         ).upper()[:4]
-        rmsds: List[float] = []
-        for i in range(10):
-            for key in (f"mode_rmsd_{i}", f"rmsd_{i}", f"top{i}_rmsd", f"rank{i}_rmsd"):
-                if key in row and row[key] not in ("", None, "NA"):
-                    try:
-                        v = float(row[key])
-                        if math.isfinite(v) and v >= 0:
-                            rmsds.append(v)
-                            break
-                    except ValueError:
-                        pass
-        # fallback: single elected + best_cluster only (incomplete for S_top10)
-        if not rmsds:
-            for key in ("rmsd_to_crystal", "rmsd_hungarian", "best_cluster_rmsd"):
-                if key in row and row[key] not in ("", None, "NA"):
-                    try:
-                        v = float(row[key])
-                        if math.isfinite(v) and v >= 0:
-                            rmsds.append(v)
-                    except ValueError:
-                        pass
-        if rmsds:
-            out[pdb] = rmsds
+        try:
+            rmsds = extract_mode_rmsds_from_row(row, require_mode_columns=strict)
+        except MissingModeRmsdError as e:
+            errors.append(f"{csv_path}: {e}")
+            continue
+        # Keep case even if all mode slots empty (counts as S_top10 fail)
+        out[pdb] = rmsds
+
+    if errors and strict:
+        msg = (
+            f"S_top10 fail-closed: {len(errors)} result.csv lack mode_rmsd_*; "
+            "re-parse arms with scripts/parse_flexaid_arm_results.py. "
+            f"First error: {errors[0]}"
+        )
+        raise MissingModeRmsdError(msg)
+    if not out:
+        raise MissingModeRmsdError(
+            f"no usable mode_rmsd cases under {arm_dir} "
+            f"({len(errors)} parse errors)"
+        )
     return out
 
 
 def bootstrap_median(
-    case_success: List[bool], n_boot: int, seed: int
+    case_success: Sequence[bool], n_boot: int, seed: int
 ) -> dict:
+    """Bootstrap median success rate (and p05/p95) over cases with replacement."""
     rng = random.Random(seed)
     n = len(case_success)
     if n == 0:
-        return {"n_cases": 0, "point": None, "median": None, "p05": None, "p95": None}
-    point = sum(case_success) / n
-    samples = []
+        return {
+            "n_cases": 0,
+            "n_success": 0,
+            "point": None,
+            "median": None,
+            "p05": None,
+            "p95": None,
+            "n_boot": n_boot,
+        }
+    successes = list(case_success)
+    point = sum(1 for x in successes if x) / n
+    samples: List[float] = []
     for _ in range(n_boot):
         idx = [rng.randrange(n) for _ in range(n)]
-        samples.append(sum(case_success[i] for i in idx) / n)
+        samples.append(sum(1 for i in idx if successes[i]) / n)
     samples.sort()
     med = statistics.median(samples)
-    p05 = samples[max(0, int(0.05 * n_boot) - 1)]
-    p95 = samples[min(n_boot - 1, int(0.95 * n_boot))]
+    # Inclusive empirical percentiles
+    p05 = samples[max(0, int(math.floor(0.05 * (n_boot - 1))))]
+    p95 = samples[min(n_boot - 1, int(math.ceil(0.95 * (n_boot - 1))))]
     return {
         "n_cases": n,
-        "n_success": sum(case_success),
+        "n_success": sum(1 for x in successes if x),
         "point": point,
         "median": med,
         "p05": p05,
@@ -146,43 +255,97 @@ def bootstrap_median(
     }
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--cases", type=Path, help="JSON cases file")
-    ap.add_argument("--rank-table", type=Path, help="CSV/TSV pdb,rank,rmsd")
-    ap.add_argument("--arm-dir", type=Path, help="Campaign arm directory with result.csv")
-    ap.add_argument("--bootstraps", type=int, default=10_000)
-    ap.add_argument("--seed", type=int, default=20170715)
-    ap.add_argument("--thresh", type=float, default=2.0)
-    ap.add_argument("--json-out", type=Path, default=None)
-    args = ap.parse_args()
+def compute_s_top10_stats(
+    cases: Dict[str, List[Optional[float]]],
+    *,
+    thresh: float = DEFAULT_THRESH,
+    n_boot: int = DEFAULT_BOOTSTRAPS,
+    seed: int = 20170715,
+) -> dict:
+    """Unit-testable end-to-end: cases → S_top10 bootstrap stats."""
+    ordered = sorted(cases.items(), key=lambda kv: kv[0])
+    success = [s_top10(v, thresh) for _, v in ordered]
+    stats = bootstrap_median(success, n_boot, seed)
+    stats["metric"] = "S_top10"
+    stats["thresh_A"] = thresh
+    stats["thresh_op"] = "<="
+    stats["n_pdbs_loaded"] = len(cases)
+    stats["pdb_ids"] = [k for k, _ in ordered]
+    stats["per_case_success"] = {
+        k: bool(s_top10(v, thresh)) for k, v in ordered
+    }
+    return stats
 
-    cases: Dict[str, List[float]] = {}
-    if args.cases:
-        cases = load_cases_json(args.cases)
-    elif args.rank_table:
-        cases = load_rank_table(args.rank_table)
-    elif args.arm_dir:
-        cases = load_arm_dir(args.arm_dir)
-    else:
-        print("Provide --cases, --rank-table, or --arm-dir", file=sys.stderr)
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--cases", type=Path, help="JSON cases file")
+    src.add_argument("--rank-table", type=Path, help="CSV/TSV pdb_id,rank,rmsd")
+    src.add_argument(
+        "--arm-dir",
+        type=Path,
+        help="Campaign arm directory with per-target result.csv (mode_rmsd_*)",
+    )
+    ap.add_argument(
+        "--bootstraps",
+        type=int,
+        default=DEFAULT_BOOTSTRAPS,
+        help=f"Bootstrap resamples (default {DEFAULT_BOOTSTRAPS})",
+    )
+    ap.add_argument("--seed", type=int, default=20170715)
+    ap.add_argument(
+        "--thresh",
+        type=float,
+        default=DEFAULT_THRESH,
+        help=f"RMSD success threshold in Å (default {DEFAULT_THRESH}, inclusive ≤)",
+    )
+    ap.add_argument(
+        "--allow-missing-modes",
+        action="store_true",
+        help="Do not fail when mode_rmsd_* missing (still never uses BCR as S_top10)",
+    )
+    ap.add_argument("--json-out", type=Path, default=None)
+    args = ap.parse_args(argv)
+
+    try:
+        if args.cases:
+            cases = load_cases_json(args.cases)
+        elif args.rank_table:
+            cases = load_rank_table(args.rank_table)
+        else:
+            cases = load_arm_dir(
+                args.arm_dir, strict=not args.allow_missing_modes
+            )
+    except (MissingModeRmsdError, FileNotFoundError, OSError, json.JSONDecodeError) as e:
+        print(f"error: {e}", file=sys.stderr)
         return 2
 
-    success = [s_top10(v, args.thresh) for v in cases.values()]
-    stats = bootstrap_median(success, args.bootstraps, args.seed)
-    stats["metric"] = "S_top10"
-    stats["thresh_A"] = args.thresh
-    stats["n_pdbs_loaded"] = len(cases)
-    stats["pdb_ids"] = sorted(cases.keys())
+    if not cases:
+        print("error: no cases loaded", file=sys.stderr)
+        return 2
 
+    stats = compute_s_top10_stats(
+        cases, thresh=args.thresh, n_boot=args.bootstraps, seed=args.seed
+    )
+
+    point = stats["point"]
+    med = stats["median"]
+    p05 = stats["p05"]
+    p95 = stats["p95"]
     print(
-        f"S_top10 point={stats['point']:.4f}  "
-        f"bootstrap_median={stats['median']:.4f}  "
-        f"p05–p95=[{stats['p05']:.4f},{stats['p95']:.4f}]  "
-        f"n={stats['n_cases']} success={stats['n_success']}"
+        f"S_top10 point={point:.4f}  "
+        f"bootstrap_median={med:.4f}  "
+        f"p05–p95=[{p05:.4f},{p95:.4f}]  "
+        f"n={stats['n_cases']} success={stats['n_success']}  "
+        f"thresh=≤{args.thresh} Å  boot={args.bootstraps}"
     )
     if args.json_out:
         args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        # per_case_success is useful; keep JSON serializable
         args.json_out.write_text(json.dumps(stats, indent=2) + "\n")
         print("wrote", args.json_out)
     return 0

--- a/scripts/parse_flexaid_arm_results.py
+++ b/scripts/parse_flexaid_arm_results.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
 """Parse classic FlexAID pilot outputs into a normalized result.csv row.
 
-Reads ``*_r*_0.pdb`` (cluster rank 0) REMARK lines for CF and RMSD when
-RMSDST was set. Elects best CF.app among restart rank-0 poses.
+Reads emitted cluster-head PDBs for CF and RMSD when RMSDST was set.
+
+**S1 / top-1:** elects best CF.app (else CF) among restart rank-0 poses
+(``*_r*_0.pdb`` or ``*_0.pdb``).
+
+**S_top10 / mode_rmsd_0..9:** RMSDs of the top-10 modes in **emitted rank
+order** (crystal-blind). For multi-restart outputs, uses the elected restart's
+rank 0..9 heads. Missing ranks → empty cells (not NaN strings).
 
 Does not claim PoseBusters or thermodynamic ΔG.
+
+Copyright 2026 Le Bonhomme Pharma
+SPDX-License-Identifier: Apache-2.0
 """
 
 from __future__ import annotations
@@ -27,6 +36,32 @@ RMSD_NS_RE = re.compile(
 )
 CF_RE = re.compile(r"REMARK\s+CF=([-+]?\d+\.?\d*)", re.I)
 CF_APP_RE = re.compile(r"REMARK\s+CF\.app=([-+]?\d+\.?\d*)", re.I)
+
+# Success threshold for S1 / S_top10 / BCR (claim contract: ≤ 2.0 Å)
+RMSD_SUCCESS_THRESH = 2.0
+TOP_N_MODES = 10
+
+# Filename patterns (stem without .pdb):
+#   {PDB}_{rank}                  CF/DP emission
+#   {PDB}_{minPts}_{rank}         FO dual-suffix
+#   {PDB}_r{restart}_{rank}       multi-restart CF/DP
+#   {PDB}_r{restart}_{minPts}_{rank}  multi-restart FO
+_RESTART_FO = re.compile(
+    r"^(?P<pdb>[A-Za-z0-9]+)_r(?P<restart>\d+)_(?P<minpts>\d+)_(?P<rank>\d+)$",
+    re.I,
+)
+_RESTART_CF = re.compile(
+    r"^(?P<pdb>[A-Za-z0-9]+)_r(?P<restart>\d+)_(?P<rank>\d+)$",
+    re.I,
+)
+_FO_DUAL = re.compile(
+    r"^(?P<pdb>[A-Za-z0-9]+)_(?P<minpts>\d+)_(?P<rank>\d+)$",
+    re.I,
+)
+_CF_RANK = re.compile(
+    r"^(?P<pdb>[A-Za-z0-9]+)_(?P<rank>\d+)$",
+    re.I,
+)
 
 
 def sha256_file(path: Path) -> str:
@@ -60,16 +95,157 @@ def parse_pose_pdb(path: Path) -> Dict[str, Optional[float]]:
     return out
 
 
-def collect_restart_poses(out_dir: Path, pdb: str) -> List[Tuple[int, Path, Dict]]:
-    rows = []
-    for rdir_pdb in sorted(out_dir.glob(f"{pdb}_r*_0.pdb")):
-        name = rdir_pdb.name
-        try:
-            r = int(name.split("_r")[1].split("_")[0])
-        except (IndexError, ValueError):
-            r = -1
-        rows.append((r, rdir_pdb, parse_pose_pdb(rdir_pdb)))
+def pose_rmsd(meta: Dict[str, Optional[float]]) -> Optional[float]:
+    if meta.get("rmsd_sym") is not None:
+        return meta["rmsd_sym"]
+    return meta.get("rmsd_nosym")
+
+
+def pose_score(meta: Dict[str, Optional[float]]) -> Optional[float]:
+    """Crystal-blind score for election: CF.app preferred, else CF (lower better)."""
+    if meta.get("cf_app") is not None:
+        return meta["cf_app"]
+    return meta.get("cf")
+
+
+def parse_pose_filename(
+    path: Path, pdb: str
+) -> Optional[Tuple[Optional[int], int]]:
+    """Return (restart_or_None, emitted_rank) or None if not a cluster head.
+
+    Rank is the engine-emitted rank index (0 = top), never derived from RMSD.
+    """
+    stem = path.stem
+    if stem.upper().endswith("_INI") or stem.upper() == f"{pdb.upper()}_INI":
+        return None
+    if not stem.upper().startswith(pdb.upper()):
+        return None
+
+    m = _RESTART_FO.match(stem)
+    if m and m.group("pdb").upper() == pdb.upper():
+        return int(m.group("restart")), int(m.group("rank"))
+
+    m = _RESTART_CF.match(stem)
+    if m and m.group("pdb").upper() == pdb.upper():
+        return int(m.group("restart")), int(m.group("rank"))
+
+    m = _FO_DUAL.match(stem)
+    if m and m.group("pdb").upper() == pdb.upper():
+        # FO dual-suffix: middle token is minPts (not a restart index)
+        return None, int(m.group("rank"))
+
+    m = _CF_RANK.match(stem)
+    if m and m.group("pdb").upper() == pdb.upper():
+        return None, int(m.group("rank"))
+
+    return None
+
+
+def collect_all_heads(
+    out_dir: Path, pdb: str
+) -> List[Tuple[Optional[int], int, Path, Dict[str, Optional[float]]]]:
+    """All cluster-head PDBs: (restart, rank, path, meta)."""
+    rows: List[Tuple[Optional[int], int, Path, Dict[str, Optional[float]]]] = []
+    for path in sorted(out_dir.glob(f"{pdb}*.pdb")):
+        parsed = parse_pose_filename(path, pdb)
+        if parsed is None:
+            continue
+        restart, rank = parsed
+        rows.append((restart, rank, path, parse_pose_pdb(path)))
     return rows
+
+
+def collect_restart_poses(
+    out_dir: Path, pdb: str
+) -> List[Tuple[int, Path, Dict[str, Optional[float]]]]:
+    """Rank-0 heads per restart (legacy helper; restart index from filename)."""
+    rows: List[Tuple[int, Path, Dict[str, Optional[float]]]] = []
+    for restart, rank, path, meta in collect_all_heads(out_dir, pdb):
+        if rank != 0:
+            continue
+        r = 0 if restart is None else restart
+        rows.append((r, path, meta))
+    # Prefer restart-style globs if nothing matched via collect_all_heads
+    if not rows:
+        for rdir_pdb in sorted(out_dir.glob(f"{pdb}_r*_0.pdb")):
+            name = rdir_pdb.name
+            try:
+                r = int(name.split("_r")[1].split("_")[0])
+            except (IndexError, ValueError):
+                r = -1
+            rows.append((r, rdir_pdb, parse_pose_pdb(rdir_pdb)))
+    return rows
+
+
+def elect_best_rank0(
+    heads: List[Tuple[Optional[int], int, Path, Dict[str, Optional[float]]]]
+) -> Optional[Tuple[float, Optional[int], Path, Dict[str, Optional[float]]]]:
+    """Elect best CF.app/CF among rank-0 heads. Returns (score, restart, path, meta)."""
+    best: Optional[Tuple[float, Optional[int], Path, Dict[str, Optional[float]]]] = None
+    for restart, rank, path, meta in heads:
+        if rank != 0:
+            continue
+        cf = pose_score(meta)
+        if cf is None:
+            continue
+        if best is None or cf < best[0]:
+            best = (cf, restart, path, meta)
+    return best
+
+
+def mode_rmsds_emitted_order(
+    heads: List[Tuple[Optional[int], int, Path, Dict[str, Optional[float]]]],
+    elected_restart: Optional[int],
+    n: int = TOP_N_MODES,
+) -> List[Optional[float]]:
+    """mode_rmsd_0..n-1 in **emitted rank order** (not RMSD-sorted).
+
+    - Single-emission (no restart token): ranks 0..n-1 from that emission.
+    - Multi-restart: ranks 0..n-1 from the **elected** restart only.
+    - If a rank is missing → None (empty CSV cell).
+    - If multiple heads share a rank (e.g. FO dual minPts), keep lowest score.
+    """
+    # Filter to the emission group we rank within
+    restarts_present = {r for r, _, _, _ in heads if r is not None}
+    if restarts_present:
+        # Multi-restart: stick to elected restart; if None, fall back to first
+        # available restart that has rank-0
+        target = elected_restart
+        if target is None:
+            # Prefer restart with best rank-0 score already encoded as elected;
+            # if still None, take the minimum restart id that has any head
+            target = min(restarts_present)
+        group = [(rank, path, meta) for r, rank, path, meta in heads if r == target]
+    else:
+        group = [(rank, path, meta) for r, rank, path, meta in heads if r is None]
+
+    # Per-rank: keep best score when duplicates (FO multi minPts should not
+    # happen under single-MinPts protocol, but be safe)
+    by_rank: Dict[int, Tuple[Optional[float], Optional[float]]] = {}
+    # value: (score_for_tiebreak, rmsd)
+    for rank, _path, meta in group:
+        if rank < 0 or rank >= n:
+            continue
+        sc = pose_score(meta)
+        rmsd = pose_rmsd(meta)
+        if rank not in by_rank:
+            by_rank[rank] = (sc, rmsd)
+        else:
+            prev_sc, _ = by_rank[rank]
+            if sc is not None and (prev_sc is None or sc < prev_sc):
+                by_rank[rank] = (sc, rmsd)
+
+    return [by_rank[i][1] if i in by_rank else None for i in range(n)]
+
+
+def success_s_top10(
+    mode_rmsds: List[Optional[float]], thresh: float = RMSD_SUCCESS_THRESH
+) -> int:
+    """1 if any finite mode_rmsd_i ≤ thresh."""
+    for v in mode_rmsds:
+        if v is not None and v == v and v >= 0.0 and v <= thresh:  # v==v → not NaN
+            return 1
+    return 0
 
 
 def main() -> int:
@@ -83,49 +259,53 @@ def main() -> int:
     args = ap.parse_args()
 
     pdb = args.pdb.upper()
-    poses = collect_restart_poses(args.out_dir, pdb)
-    if not poses:
+    heads = collect_all_heads(args.out_dir, pdb)
+    if not heads:
+        # Fallback: any *_0.pdb rank-0 style
         for p in sorted(args.out_dir.glob("*_0.pdb")):
-            poses.append((0, p, parse_pose_pdb(p)))
+            meta = parse_pose_pdb(p)
+            heads.append((0, 0, p, meta))
 
-    best = None
-    for r, path, meta in poses:
-        cf = meta.get("cf_app") if meta.get("cf_app") is not None else meta.get("cf")
-        if cf is None:
-            continue
-        if best is None or cf < best[0]:
-            best = (cf, r, path, meta)
+    best = elect_best_rank0(heads)
 
-    rmsd_top1 = None
-    score_top1 = None
+    rmsd_top1: Optional[float] = None
+    score_top1: Optional[float] = None
     elected_path = ""
-    restarts_finished = len(poses)
-    rmsd_bcr = None
+    elected_restart: Optional[int] = None
     if best:
         score_top1 = best[0]
+        elected_restart = best[1]
         elected_path = str(best[2])
-        m = best[3]
-        rmsd_top1 = m.get("rmsd_sym") if m.get("rmsd_sym") is not None else m.get("rmsd_nosym")
+        rmsd_top1 = pose_rmsd(best[3])
 
-    all_rmsds = []
-    for p in args.out_dir.glob(f"{pdb}_r*_*.pdb"):
-        if p.name.endswith("_INI.pdb"):
-            continue
-        meta = parse_pose_pdb(p)
-        v = meta.get("rmsd_sym") if meta.get("rmsd_sym") is not None else meta.get("rmsd_nosym")
+    mode_rmsds = mode_rmsds_emitted_order(heads, elected_restart, TOP_N_MODES)
+    # Keep S1 aligned with elected rank-0 (mode_rmsd_0 when elected emission used)
+    if mode_rmsds and mode_rmsds[0] is not None and rmsd_top1 is None:
+        rmsd_top1 = mode_rmsds[0]
+    # Prefer elected rmsd_top1 as mode_rmsd_0 when both exist (same pose)
+    if rmsd_top1 is not None:
+        mode_rmsds[0] = rmsd_top1
+
+    all_rmsds: List[float] = []
+    for _r, _rank, _path, meta in heads:
+        v = pose_rmsd(meta)
         if v is not None:
             all_rmsds.append(v)
-    if all_rmsds:
-        rmsd_bcr = min(all_rmsds)
+    rmsd_bcr = min(all_rmsds) if all_rmsds else None
 
-    success_s1 = int(rmsd_top1 is not None and rmsd_top1 <= 2.0)
-    success_s3 = int(rmsd_bcr is not None and rmsd_bcr <= 2.0)
+    restarts_finished = len({r for r, rank, _, _ in heads if rank == 0})
+    if restarts_finished == 0:
+        restarts_finished = len(heads)
+
+    success_s1 = int(rmsd_top1 is not None and rmsd_top1 <= RMSD_SUCCESS_THRESH)
+    success_s3 = int(rmsd_bcr is not None and rmsd_bcr <= RMSD_SUCCESS_THRESH)
+    s_top10 = success_s_top10(mode_rmsds, RMSD_SUCCESS_THRESH)
 
     bin_sha = ""
     if args.binary and args.binary.is_file():
         bin_sha = sha256_file(args.binary.resolve())
 
-    row = {
+    row: Dict[str, object] = {
         "arm": args.arm,
         "engine_sha": bin_sha,
         "matrix_md5": args.matrix_md5,
@@ -135,9 +315,10 @@ def main() -> int:
         "success_s1": success_s1,
         "success_s2": "",
         "success_s3": success_s3,
+        "success_s_top10": s_top10,
         "rank_native_mode": "",
-        "n_poses": restarts_finished,
-        "n_modes": restarts_finished,
+        "n_poses": len(heads),
+        "n_modes": sum(1 for v in mode_rmsds if v is not None),
         "score_top1": "" if score_top1 is None else f"{score_top1:.5f}",
         "H": "",
         "TS": "",
@@ -154,13 +335,52 @@ def main() -> int:
         "elected_path": elected_path,
         "parsed_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
+    for i, v in enumerate(mode_rmsds):
+        row[f"mode_rmsd_{i}"] = "" if v is None else f"{v:.4f}"
+
+    # Stable column order: identity → top1/BCR → mode_rmsd_* → flags
+    fieldnames = [
+        "arm",
+        "engine_sha",
+        "matrix_md5",
+        "pdb_id",
+        "rmsd_top1",
+        "rmsd_bcr",
+        *[f"mode_rmsd_{i}" for i in range(TOP_N_MODES)],
+        "success_s1",
+        "success_s2",
+        "success_s3",
+        "success_s_top10",
+        "rank_native_mode",
+        "n_poses",
+        "n_modes",
+        "score_top1",
+        "H",
+        "TS",
+        "F",
+        "pb_pass",
+        "tencom_status",
+        "seed_echo",
+        "native_pose_seeded",
+        "protocol_claim_eligible",
+        "wall_s",
+        "restarts_finished",
+        "evals_actual",
+        "budget_class",
+        "elected_path",
+        "parsed_utc",
+    ]
 
     out_csv = args.out_dir / "result.csv"
     with out_csv.open("w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=list(row.keys()))
+        w = csv.DictWriter(f, fieldnames=fieldnames)
         w.writeheader()
         w.writerow(row)
-    print(f"wrote {out_csv} s1={success_s1} rmsd_top1={row['rmsd_top1']} bcr={row['rmsd_bcr']}")
+    print(
+        f"wrote {out_csv} s1={success_s1} s_top10={s_top10} "
+        f"rmsd_top1={row['rmsd_top1']} bcr={row['rmsd_bcr']} "
+        f"modes={[row[f'mode_rmsd_{i}'] for i in range(TOP_N_MODES)]}"
+    )
     return 0
 
 

--- a/scripts/run_C0_claim_clean.sh
+++ b/scripts/run_C0_claim_clean.sh
@@ -94,7 +94,8 @@ export FLEXAIDDS_BUDGET_SCALE=1
 export FLEXAIDDS_NATIVE_SEED_FRAC=0
 export FLEXAIDDS_SEED_ELITISM=0
 export FLEXAIDDS_POSEBUSTERS_BIN="${FLEXAIDDS_POSEBUSTERS_BIN:-$ROOT/.venv-posebusters/bin/bust}"
-# 3Dsig Shannon ranking path (G̃=H̃−T·S̃) — ON by default; LEGACY_ZH=1 rolls back
+# 3Dsig Shannon ranking path (G̃=H̃−T·S̃) — engine default is OFF until Astex pilot;
+# this claim launch explicitly opts in. LEGACY_ZH=1 rolls back to legacy ZH / min-CF.
 export FLEXAIDDS_ELECTION_SHANNON_F="${FLEXAIDDS_ELECTION_SHANNON_F:-1}"
 export FLEXAIDDS_ELECTION_SOFT_T="${FLEXAIDDS_ELECTION_SOFT_T:-298}"
 unset FLEXAIDDS_FORCE_SEED 2>/dev/null || true

--- a/tests/test_binding_mode_advanced.cpp
+++ b/tests/test_binding_mode_advanced.cpp
@@ -7,7 +7,11 @@
 #include "../LIB/BindingMode.h"
 #include "../LIB/statmech.h"
 #include <cmath>
+#include <cstdio>
 #include <cstring>
+#include <limits>
+#include <string>
+#include <unistd.h>
 #include <vector>
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -273,6 +277,64 @@ TEST_F(BindingModeAdvancedTest, GlobalEnsembleAggregatesModes) {
     // Global ensemble should have aggregated poses
     auto global = population->get_global_ensemble();
     EXPECT_GT(global.size(), 0u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// FO .mcf sidecar (member CFs for DatasetRunner Shannon G̃)
+// ═══════════════════════════════════════════════════════════════════════
+
+TEST_F(BindingModeAdvancedTest, WriteMcfSidecar_HeadFirstFiniteOnly) {
+    // Matches cluster.cpp format: one app_evalue per line; head first.
+    // Non-finite values must be skipped so DatasetRunner parse_pose stays clean.
+    char tmpl[] = "/tmp/flexaidds_fo_mcf_XXXXXX";
+    int fd = mkstemp(tmpl);
+    ASSERT_GE(fd, 0);
+    close(fd);
+    std::string pdb_path = std::string(tmpl) + ".pdb";
+    // mkstemp created empty file at tmpl; rename conceptually to .pdb basename
+    std::remove(tmpl);
+    {
+        FILE* pf = std::fopen(pdb_path.c_str(), "w");
+        ASSERT_NE(pf, nullptr);
+        std::fputs("REMARK dummy FO head\n", pf);
+        std::fclose(pf);
+    }
+
+    std::vector<double> vals = {
+        -12.345678,  // head
+        -10.0,
+        std::numeric_limits<double>::quiet_NaN(),  // skip
+        -8.5,
+        std::numeric_limits<double>::infinity(),   // skip
+        -7.0
+    };
+    ASSERT_TRUE(write_mcf_sidecar(pdb_path.c_str(), vals));
+
+    std::string mcf_path = pdb_path.substr(0, pdb_path.size() - 4) + ".mcf";
+    FILE* mf = std::fopen(mcf_path.c_str(), "r");
+    ASSERT_NE(mf, nullptr);
+    std::vector<double> read_vals;
+    char line[128];
+    while (std::fgets(line, sizeof(line), mf)) {
+        read_vals.push_back(std::strtod(line, nullptr));
+    }
+    std::fclose(mf);
+
+    ASSERT_EQ(read_vals.size(), 4u);
+    EXPECT_NEAR(read_vals[0], -12.345678, 1e-6);  // head first, %.6f
+    EXPECT_NEAR(read_vals[1], -10.0, 1e-6);
+    EXPECT_NEAR(read_vals[2], -8.5, 1e-6);
+    EXPECT_NEAR(read_vals[3], -7.0, 1e-6);
+
+    // First line formatting: six decimal places like cluster.cpp
+    mf = std::fopen(mcf_path.c_str(), "r");
+    ASSERT_NE(mf, nullptr);
+    ASSERT_NE(std::fgets(line, sizeof(line), mf), nullptr);
+    std::fclose(mf);
+    EXPECT_STREQ(line, "-12.345678\n");
+
+    std::remove(pdb_path.c_str());
+    std::remove(mcf_path.c_str());
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_bootstrap_3dsig_s_top10.py
+++ b/tests/test_bootstrap_3dsig_s_top10.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Unit tests for S_top10 bootstrap + FlexAID arm mode_rmsd emission.
+
+Covers:
+  - scripts/bootstrap_3dsig_s_top10.py (≤2.0, fail-closed, 10k-capable helpers)
+  - scripts/parse_flexaid_arm_results.py (mode_rmsd_0..9 in emitted rank order)
+
+Copyright 2026 Le Bonhomme Pharma
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOT = ROOT / "scripts" / "bootstrap_3dsig_s_top10.py"
+PARSE = ROOT / "scripts" / "parse_flexaid_arm_results.py"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_pose(
+    path: Path,
+    *,
+    rmsd: float,
+    cf: float,
+    cf_app: float | None = None,
+    sym: bool = True,
+) -> None:
+    lines = [
+        "REMARK   FlexAID test pose",
+        f"REMARK   CF={cf:.4f}",
+    ]
+    if cf_app is not None:
+        lines.append(f"REMARK   CF.app={cf_app:.4f}")
+    if sym:
+        lines.append(
+            f"REMARK   {rmsd:.4f} RMSD to ref. structure (symmetry corrected)"
+        )
+    else:
+        lines.append(
+            f"REMARK   {rmsd:.4f} RMSD to ref. structure (no symmetry correction)"
+        )
+    lines.append("END")
+    path.write_text("\n".join(lines) + "\n")
+
+
+# ── bootstrap helpers ────────────────────────────────────────────────────────
+
+
+def test_s_top10_inclusive_threshold():
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    # Exactly 2.0 must count as success (≤ 2.0 claim contract)
+    assert mod.s_top10([2.0], thresh=2.0) is True
+    assert mod.s_top10([2.0001], thresh=2.0) is False
+    assert mod.s_top10([1.9, 3.0], thresh=2.0) is True
+    assert mod.s_top10([3.0, 4.0], thresh=2.0) is False
+    assert mod.s_top10([None, None], thresh=2.0) is False
+    assert mod.s_top10([], thresh=2.0) is False
+    # Only first 10 matter
+    vals = [3.0] * 10 + [0.5]
+    assert mod.s_top10(vals, thresh=2.0) is False
+
+
+def test_extract_mode_rmsds_prefer_mode_rmsd_keys():
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    row = {f"mode_rmsd_{i}": str(i * 0.5) for i in range(10)}
+    row["rmsd_top1"] = "9.9"
+    row["rmsd_bcr"] = "0.1"
+    got = mod.extract_mode_rmsds_from_row(row)
+    assert got[0] == 0.0
+    assert got[4] == 2.0
+    assert got[9] == 4.5
+
+
+def test_extract_mode_rmsds_fail_closed_without_mode_cols():
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    row = {
+        "pdb_id": "1ABC",
+        "rmsd_top1": "1.2",
+        "rmsd_bcr": "0.8",
+        "success_s1": "1",
+        "success_s3": "1",
+    }
+    with pytest.raises(mod.MissingModeRmsdError):
+        mod.extract_mode_rmsds_from_row(row, require_mode_columns=True)
+
+
+def test_load_arm_dir_fail_closed(tmp_path: Path):
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    d = tmp_path / "arm" / "1ABC"
+    d.mkdir(parents=True)
+    with (d / "result.csv").open("w", newline="") as f:
+        w = csv.DictWriter(
+            f, fieldnames=["pdb_id", "rmsd_top1", "rmsd_bcr", "success_s1"]
+        )
+        w.writeheader()
+        w.writerow(
+            {
+                "pdb_id": "1ABC",
+                "rmsd_top1": "1.1",
+                "rmsd_bcr": "0.5",
+                "success_s1": "1",
+            }
+        )
+    with pytest.raises(mod.MissingModeRmsdError):
+        mod.load_arm_dir(tmp_path / "arm", strict=True)
+
+
+def test_load_arm_dir_reads_mode_rmsd(tmp_path: Path):
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    d = tmp_path / "arm" / "1ABC"
+    d.mkdir(parents=True)
+    fields = ["pdb_id"] + [f"mode_rmsd_{i}" for i in range(10)]
+    row = {"pdb_id": "1ABC"}
+    # mode 0 bad, mode 3 good → S_top10 success without S1
+    rmsds = [3.0, 4.0, 5.0, 1.5, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0]
+    for i, v in enumerate(rmsds):
+        row[f"mode_rmsd_{i}"] = f"{v:.4f}"
+    with (d / "result.csv").open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        w.writerow(row)
+    cases = mod.load_arm_dir(tmp_path / "arm", strict=True)
+    assert "1ABC" in cases
+    assert cases["1ABC"][3] == pytest.approx(1.5)
+    assert mod.s_top10(cases["1ABC"]) is True
+    # S1 would fail (mode 0 = 3.0)
+    assert cases["1ABC"][0] == pytest.approx(3.0)
+
+
+def test_bootstrap_median_deterministic():
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    # 2/4 success → point 0.5
+    success = [True, True, False, False]
+    a = mod.bootstrap_median(success, n_boot=1000, seed=42)
+    b = mod.bootstrap_median(success, n_boot=1000, seed=42)
+    assert a == b
+    assert a["point"] == pytest.approx(0.5)
+    assert a["n_cases"] == 4
+    assert a["n_success"] == 2
+    assert a["median"] is not None
+    assert 0.0 <= a["p05"] <= a["median"] <= a["p95"] <= 1.0
+
+
+def test_compute_s_top10_stats_json_roundtrip(tmp_path: Path):
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    cases = {
+        "AAAA": [1.0] + [3.0] * 9,  # success
+        "BBBB": [3.0] * 10,  # fail
+        "CCCC": [None, None, 1.9] + [None] * 7,  # success via rank 2
+    }
+    stats = mod.compute_s_top10_stats(cases, n_boot=500, seed=1, thresh=2.0)
+    assert stats["n_cases"] == 3
+    assert stats["n_success"] == 2
+    assert stats["point"] == pytest.approx(2 / 3)
+    assert stats["thresh_op"] == "<="
+    assert stats["per_case_success"]["AAAA"] is True
+    assert stats["per_case_success"]["BBBB"] is False
+    assert stats["per_case_success"]["CCCC"] is True
+    out = tmp_path / "stats.json"
+    out.write_text(json.dumps(stats))
+    loaded = json.loads(out.read_text())
+    assert loaded["metric"] == "S_top10"
+
+
+def test_cli_arm_dir_fail_closed(tmp_path: Path):
+    d = tmp_path / "arm" / "1ABC"
+    d.mkdir(parents=True)
+    with (d / "result.csv").open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["pdb_id", "rmsd_top1", "rmsd_bcr"])
+        w.writeheader()
+        w.writerow({"pdb_id": "1ABC", "rmsd_top1": "0.5", "rmsd_bcr": "0.4"})
+    proc = subprocess.run(
+        [sys.executable, str(BOOT), "--arm-dir", str(tmp_path / "arm")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+    assert "mode_rmsd" in proc.stderr.lower() or "fail-closed" in proc.stderr.lower()
+
+
+def test_cli_json_cases_success(tmp_path: Path):
+    cases_path = tmp_path / "cases.json"
+    cases_path.write_text(
+        json.dumps(
+            {
+                "cases": {
+                    "1ABC": [0.5, 3.0, 4.0],
+                    "2DEF": [3.0, 3.0, 3.0],
+                }
+            }
+        )
+    )
+    out = tmp_path / "out.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(BOOT),
+            "--cases",
+            str(cases_path),
+            "--bootstraps",
+            "200",
+            "--json-out",
+            str(out),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "S_top10" in proc.stdout
+    data = json.loads(out.read_text())
+    assert data["n_cases"] == 2
+    assert data["n_success"] == 1
+    assert data["thresh_A"] == 2.0
+
+
+def test_rank_table_emitted_order_not_rmsd_sorted(tmp_path: Path):
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    table = tmp_path / "ranks.csv"
+    # rank 0 has high RMSD, rank 1 has low — order must follow rank, not RMSD
+    table.write_text(
+        "pdb_id,rank,rmsd\n"
+        "1ABC,1,0.5\n"
+        "1ABC,0,5.0\n"
+        "1ABC,2,4.0\n"
+    )
+    cases = mod.load_rank_table(table)
+    assert cases["1ABC"][0] == pytest.approx(5.0)
+    assert cases["1ABC"][1] == pytest.approx(0.5)
+    assert mod.s_top10(cases["1ABC"]) is True  # via rank 1
+
+
+# ── parse_flexaid_arm_results ────────────────────────────────────────────────
+
+
+def test_parse_filename_cf_and_restart():
+    mod = _load("parse_flexaid_arm_results", PARSE)
+    p = Path("1HNN_0.pdb")
+    assert mod.parse_pose_filename(p, "1HNN") == (None, 0)
+    p = Path("1HNN_3.pdb")
+    assert mod.parse_pose_filename(p, "1HNN") == (None, 3)
+    p = Path("1HNN_r2_0.pdb")
+    assert mod.parse_pose_filename(p, "1HNN") == (2, 0)
+    p = Path("1HNN_r2_7.pdb")
+    assert mod.parse_pose_filename(p, "1HNN") == (2, 7)
+    p = Path("1HNN_10_0.pdb")  # FO dual-suffix minPts=10 rank=0
+    assert mod.parse_pose_filename(p, "1HNN") == (None, 0)
+    p = Path("1HNN_r1_10_3.pdb")  # restart FO dual
+    assert mod.parse_pose_filename(p, "1HNN") == (1, 3)
+    assert mod.parse_pose_filename(Path("1HNN_INI.pdb"), "1HNN") is None
+
+
+def test_mode_rmsds_emitted_order_single_emission():
+    mod = _load("parse_flexaid_arm_results", PARSE)
+    # Simulate heads list: ranks 0,1,2 with rmsds; not sorted by RMSD
+    heads = []
+    for rank, rmsd, cf in [(0, 5.0, -10.0), (1, 1.0, -9.0), (2, 3.0, -8.0)]:
+        meta = {
+            "rmsd_sym": rmsd,
+            "rmsd_nosym": None,
+            "cf": cf,
+            "cf_app": None,
+        }
+        heads.append((None, rank, Path(f"X_{rank}.pdb"), meta))
+    got = mod.mode_rmsds_emitted_order(heads, elected_restart=None, n=10)
+    assert got[0] == 5.0
+    assert got[1] == 1.0
+    assert got[2] == 3.0
+    assert got[3] is None
+    assert mod.success_s_top10(got) == 1
+    # S1 fails (mode 0 = 5.0)
+    assert not (got[0] is not None and got[0] <= 2.0)
+
+
+def test_mode_rmsds_multi_restart_uses_elected():
+    mod = _load("parse_flexaid_arm_results", PARSE)
+    heads = []
+    # restart 0: rank0 CF=-5, rmsd=4.0; rank1 rmsd=0.5
+    heads.append(
+        (
+            0,
+            0,
+            Path("X_r0_0.pdb"),
+            {"rmsd_sym": 4.0, "rmsd_nosym": None, "cf": -5.0, "cf_app": None},
+        )
+    )
+    heads.append(
+        (
+            0,
+            1,
+            Path("X_r0_1.pdb"),
+            {"rmsd_sym": 0.5, "rmsd_nosym": None, "cf": -4.0, "cf_app": None},
+        )
+    )
+    # restart 1: rank0 CF=-20 (better), rmsd=3.0; rank1 rmsd=2.5
+    heads.append(
+        (
+            1,
+            0,
+            Path("X_r1_0.pdb"),
+            {"rmsd_sym": 3.0, "rmsd_nosym": None, "cf": -20.0, "cf_app": None},
+        )
+    )
+    heads.append(
+        (
+            1,
+            1,
+            Path("X_r1_1.pdb"),
+            {"rmsd_sym": 2.5, "rmsd_nosym": None, "cf": -19.0, "cf_app": None},
+        )
+    )
+    best = mod.elect_best_rank0(heads)
+    assert best is not None
+    assert best[1] == 1  # restart 1
+    got = mod.mode_rmsds_emitted_order(heads, elected_restart=1, n=10)
+    assert got[0] == 3.0
+    assert got[1] == 2.5
+    # Must not pick restart 0's rank1 (0.5) — that would be cross-restart mix
+    assert 0.5 not in [v for v in got if v is not None]
+
+
+def test_parse_cli_writes_mode_rmsd_columns(tmp_path: Path):
+    out = tmp_path / "1HNN"
+    out.mkdir()
+    # ranks 0..2 single emission; rank 1 is native-like
+    _write_pose(out / "1HNN_0.pdb", rmsd=4.5, cf=-100.0, cf_app=-99.0)
+    _write_pose(out / "1HNN_1.pdb", rmsd=1.2, cf=-90.0, cf_app=-89.0)
+    _write_pose(out / "1HNN_2.pdb", rmsd=3.0, cf=-80.0, cf_app=-79.0)
+    # noise file ignored
+    _write_pose(out / "1HNN_INI.pdb", rmsd=0.0, cf=0.0)
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(PARSE),
+            "--arm",
+            "A",
+            "--pdb",
+            "1HNN",
+            "--out-dir",
+            str(out),
+            "--matrix-md5",
+            "72d7c7396702331d96ff12d18f831796",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    rows = list(csv.DictReader((out / "result.csv").open()))
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["pdb_id"] == "1HNN"
+    assert "mode_rmsd_0" in row
+    assert float(row["mode_rmsd_0"]) == pytest.approx(4.5)
+    assert float(row["mode_rmsd_1"]) == pytest.approx(1.2)
+    assert float(row["mode_rmsd_2"]) == pytest.approx(3.0)
+    assert row["mode_rmsd_3"] == ""
+    assert row["success_s1"] == "0"  # top1 = 4.5
+    assert row["success_s_top10"] == "1"  # mode 1 = 1.2
+    assert float(row["rmsd_top1"]) == pytest.approx(4.5)
+    assert float(row["rmsd_bcr"]) == pytest.approx(1.2)
+
+    # Bootstrap must accept this arm dir
+    boot = _load("bootstrap_3dsig_s_top10", BOOT)
+    cases = boot.load_arm_dir(tmp_path, strict=True)
+    assert "1HNN" in cases
+    assert boot.s_top10(cases["1HNN"]) is True
+
+
+def test_parse_multi_restart_cli(tmp_path: Path):
+    out = tmp_path / "2GBP"
+    out.mkdir()
+    # r0 rank0 worse score, good rmsd on rank1 — must not leak into elected modes
+    _write_pose(out / "2GBP_r0_0.pdb", rmsd=5.0, cf=-50.0)
+    _write_pose(out / "2GBP_r0_1.pdb", rmsd=0.8, cf=-40.0)
+    # r1 elected by better CF
+    _write_pose(out / "2GBP_r1_0.pdb", rmsd=1.5, cf=-200.0)
+    _write_pose(out / "2GBP_r1_1.pdb", rmsd=2.5, cf=-180.0)
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(PARSE),
+            "--arm",
+            "B",
+            "--pdb",
+            "2GBP",
+            "--out-dir",
+            str(out),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    row = list(csv.DictReader((out / "result.csv").open()))[0]
+    assert float(row["mode_rmsd_0"]) == pytest.approx(1.5)
+    assert float(row["mode_rmsd_1"]) == pytest.approx(2.5)
+    assert row["success_s1"] == "1"
+    assert row["success_s_top10"] == "1"
+    # BCR can still see 0.8 from other restart
+    assert float(row["rmsd_bcr"]) == pytest.approx(0.8)

--- a/tests/test_classic_entropy_ranking.cpp
+++ b/tests/test_classic_entropy_ranking.cpp
@@ -1,5 +1,5 @@
 // tests/test_classic_entropy_ranking.cpp
-// Classic FlexAID entropy ranking (soft-β, global Z, ACF elects rank-0).
+// Classic FlexAID entropy ranking (soft-β SoftBeta G̃ ≡ ACF elects rank-0).
 // Rollback: FA->force_cf_rank_emission = true (P3b CF emission / physical F).
 // Apache-2.0 © 2026 Le Bonhomme Pharma
 
@@ -7,10 +7,12 @@
 #include "../LIB/BindingMode.h"
 #include "../LIB/statmech.h"
 #include "../LIB/gaboom.h"
+#include "../LIB/SoftBetaFreeEnergy.h"
 #include <cmath>
 #include <cstring>
 #include <vector>
 #include <algorithm>
+#include <limits>
 
 namespace {
 
@@ -237,4 +239,82 @@ TEST_F(ClassicEntropyRankingTest, ClassicRankingIncludesVibCorrectionTerm) {
     // No modes → vib = 0; ranking F must match classic conf free energy.
     EXPECT_NEAR(F, F_conf, EPS);
     EXPECT_GT(S, 0.0);
+}
+
+// ─── SoftBeta free-energy identity (shared ranking objective) ───────────────
+// G̃ = H̃ − T·S̃ ≡ E_min − T ln Z  (cluster ACF form). Used by cluster.cpp,
+// BindingMode classic ranking, and DatasetRunner S1 election.
+
+TEST(SoftBetaIdentity, EmptyIsInf) {
+    auto fe = flexaids::soft_beta::free_energy({}, 300.0);
+    EXPECT_TRUE(std::isinf(fe.G));
+}
+
+TEST(SoftBetaIdentity, SingletonEqualsEnergy) {
+    auto fe = flexaids::soft_beta::free_energy({-42.5}, 300.0);
+    EXPECT_NEAR(fe.G, -42.5, 1e-12);
+    EXPECT_NEAR(fe.H, -42.5, 1e-12);
+    EXPECT_NEAR(fe.S, 0.0, 1e-12);
+    EXPECT_EQ(fe.n, 1);
+}
+
+TEST(SoftBetaIdentity, GEqualsHminusTS) {
+    const std::vector<double> energies = {-100.0, -98.0, -95.0, -90.0, -88.0};
+    const double T = 300.0;
+    auto fe = flexaids::soft_beta::free_energy(energies, T);
+    EXPECT_NEAR(fe.G, fe.H - T * fe.S, 1e-9);
+}
+
+TEST(SoftBetaIdentity, GEqualsEminMinusTlnZ) {
+    const std::vector<double> energies = {-100.0, -98.0, -95.0, -90.0, -88.0};
+    const double T = 300.0;
+    auto fe = flexaids::soft_beta::free_energy(energies, T);
+    const double acf_form = fe.Emin - T * std::log(fe.Z);
+    EXPECT_NEAR(fe.G, acf_form, 1e-9);
+    EXPECT_NEAR(flexaids::soft_beta::acf(energies, T), fe.G, 1e-12);
+}
+
+TEST(SoftBetaIdentity, DenseBasinBeatsDeepSingleton) {
+    // 1HNN-class: dense middling basin vs sparse deep false minimum
+    std::vector<double> dense(29, -72.0);
+    for (int i = 0; i < 29; ++i)
+        dense[static_cast<size_t>(i)] = -72.0 - 0.05 * (i % 7);
+    const std::vector<double> deep = {-189.9};
+    const double T = 300.0;
+    const double G_dense = flexaids::soft_beta::free_energy_G(dense, T);
+    const double G_deep  = flexaids::soft_beta::free_energy_G(deep, T);
+    EXPECT_LT(G_dense, G_deep);  // elect lowest G → dense wins
+}
+
+TEST(SoftBetaIdentity, OffsetInvariance) {
+    // Adding constant Δ to all CF must shift G by Δ (soft-β property)
+    const std::vector<double> energies = {-50.0, -48.0, -45.0};
+    const double T = 250.0;
+    const double delta = 12.3;
+    std::vector<double> energies2 = energies;
+    for (double& e : energies2) e += delta;
+    auto a = flexaids::soft_beta::free_energy(energies, T);
+    auto b = flexaids::soft_beta::free_energy(energies2, T);
+    EXPECT_NEAR(b.G, a.G + delta, 1e-9);
+    EXPECT_NEAR(b.S, a.S, 1e-9);
+}
+
+TEST_F(ClassicEntropyRankingTest, BindingModeMatchesSoftBetaLocal) {
+    ASSERT_FALSE(mock_fa->force_cf_rank_emission);
+    BindingMode mode(pop);
+    std::vector<double> cfs;
+    for (int i = 0; i < 8; ++i) {
+        const double cf = -80.0 - 0.5 * i;
+        cfs.push_back(cf);
+        Pose p = make_pose(cf, i);
+        mode.add_Pose(p);
+    }
+    pop->add_BindingMode(mode);
+    const BindingMode& ranked = pop->get_binding_mode(0);
+    const double T = 300.0;
+    auto fe = flexaids::soft_beta::free_energy(cfs, T);
+    EXPECT_NEAR(ranked.compute_enthalpy(), fe.H, 1e-9);
+    EXPECT_NEAR(ranked.compute_entropy(), fe.S, 1e-9);
+    // vib=0, nat=0 → ranking energy == SoftBeta G
+    EXPECT_NEAR(ranked.compute_energy(), fe.G, 1e-9);
 }

--- a/tests/test_dataset_runner.cpp
+++ b/tests/test_dataset_runner.cpp
@@ -28,6 +28,7 @@
 #include <filesystem>
 #include <fstream>
 #include <numeric>
+#include <set>
 #include <sstream>
 #include <vector>
 
@@ -1523,4 +1524,127 @@ TEST(SAMPL7Data, EntryCount) {
     }
 
     fs::remove_all("/tmp/flexaidds_test_sampl7");
+}
+
+
+// =============================================================================
+// FO dual-suffix / CF single-suffix cluster-head enumeration
+// =============================================================================
+
+TEST(EmittedClusterHeads, SingleSuffixCfDpOnly) {
+    const fs::path dir = fs::temp_directory_path() / "flexaidds_enum_single";
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+    const std::string prefix = (dir / "1G9V").string();
+
+    // CF/DP emission: prefix_rank.pdb
+    for (int i : {0, 1, 3}) {
+        std::ofstream((dir / ("1G9V_" + std::to_string(i) + ".pdb")).string())
+            << "REMARK CF=-12.3\n";
+    }
+    // Noise that must NOT be enumerated as heads
+    std::ofstream((dir / "1G9V_INI.pdb").string()) << "REMARK CF=0\n";
+    std::ofstream((dir / "1G9V_0_member0.pdb").string()) << "REMARK CF=-1\n";
+    std::ofstream((dir / "1G9V_notes.txt").string()) << "nope\n";
+
+    auto heads = enumerate_emitted_cluster_heads(prefix);
+    ASSERT_EQ(heads.size(), 3u);
+    EXPECT_TRUE(has_emitted_cluster_heads(prefix));
+
+    std::set<int> ranks;
+    for (const auto& h : heads) {
+        EXPECT_EQ(h.min_pts, -1);
+        ranks.insert(h.rank);
+        EXPECT_TRUE(fs::exists(h.path));
+        EXPECT_NE(h.path.find("1G9V_"), std::string::npos);
+        // Must not pick dual-suffix or members
+        EXPECT_EQ(h.path.find("_member"), std::string::npos);
+    }
+    EXPECT_EQ(ranks, (std::set<int>{0, 1, 3}));
+
+    fs::remove_all(dir);
+}
+
+TEST(EmittedClusterHeads, DualSuffixFoOnly) {
+    const fs::path dir = fs::temp_directory_path() / "flexaidds_enum_dual";
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+    const std::string prefix = (dir / "1G9V").string();
+
+    // FO emission: prefix_minPts_rank.pdb (BindingMode.cpp)
+    std::ofstream((dir / "1G9V_15_0.pdb").string()) << "REMARK CF=-10.0\nFrequency: 12\n";
+    std::ofstream((dir / "1G9V_15_1.pdb").string()) << "REMARK CF=-8.5\nFrequency: 4\n";
+    std::ofstream((dir / "1G9V_12_0.pdb").string()) << "REMARK CF=-9.0\nFrequency: 3\n";
+    // Noise
+    std::ofstream((dir / "1G9V_15_0_member0.pdb").string()) << "REMARK CF=-1\n";
+    std::ofstream((dir / "1G9V_15_MODEL_0.pdb").string()) << "REMARK CF=-1\n";
+    std::ofstream((dir / "other_15_0.pdb").string()) << "REMARK CF=-1\n";
+
+    auto heads = enumerate_emitted_cluster_heads(prefix);
+    ASSERT_EQ(heads.size(), 3u) << "FO dual-suffix heads must be discovered without single-suffix files";
+    EXPECT_TRUE(has_emitted_cluster_heads(prefix));
+
+    // All dual-suffix; ranks/minPts parsed
+    std::set<std::pair<int,int>> keys;
+    for (const auto& h : heads) {
+        EXPECT_GE(h.min_pts, 0);
+        EXPECT_GE(h.rank, 0);
+        keys.insert({h.min_pts, h.rank});
+        // path ends with .pdb and contains minPts_rank
+        EXPECT_TRUE(h.path.size() > 4 && h.path.substr(h.path.size() - 4) == ".pdb");
+        EXPECT_EQ(h.path.find("_member"), std::string::npos);
+        EXPECT_EQ(h.path.find("MODEL"), std::string::npos);
+    }
+    EXPECT_EQ(keys, (std::set<std::pair<int,int>>{{15, 0}, {15, 1}, {12, 0}}));
+
+    fs::remove_all(dir);
+}
+
+TEST(EmittedClusterHeads, MixedSingleAndDualSuffix) {
+    const fs::path dir = fs::temp_directory_path() / "flexaidds_enum_mixed";
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+    const std::string prefix = (dir / "1Z95").string();
+
+    std::ofstream((dir / "1Z95_0.pdb").string()) << "REMARK CF=-5\n";
+    std::ofstream((dir / "1Z95_1.pdb").string()) << "REMARK CF=-4\n";
+    std::ofstream((dir / "1Z95_10_0.pdb").string()) << "REMARK CF=-6\n";
+    std::ofstream((dir / "1Z95_10_2.pdb").string()) << "REMARK CF=-3\n";
+
+    auto heads = enumerate_emitted_cluster_heads(prefix);
+    ASSERT_EQ(heads.size(), 4u);
+
+    int n_single = 0, n_dual = 0;
+    for (const auto& h : heads) {
+        if (h.min_pts < 0) ++n_single;
+        else ++n_dual;
+    }
+    EXPECT_EQ(n_single, 2);
+    EXPECT_EQ(n_dual, 2);
+
+    // Empty prefix yields no heads
+    EXPECT_FALSE(has_emitted_cluster_heads((dir / "MISSING").string()));
+    EXPECT_TRUE(enumerate_emitted_cluster_heads((dir / "MISSING").string()).empty());
+
+    fs::remove_all(dir);
+}
+
+TEST(EmittedClusterHeads, RejectsNonDigitSuffixes) {
+    const fs::path dir = fs::temp_directory_path() / "flexaidds_enum_reject";
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+    const std::string prefix = (dir / "2BM2").string();
+
+    std::ofstream((dir / "2BM2_foo_0.pdb").string()) << "x\n";
+    std::ofstream((dir / "2BM2_10_bar.pdb").string()) << "x\n";
+    std::ofstream((dir / "2BM2_10_0_extra.pdb").string()) << "x\n";  // extra non-digit mid
+    // valid FO head for contrast
+    std::ofstream((dir / "2BM2_10_0.pdb").string()) << "REMARK CF=-1\n";
+
+    auto heads = enumerate_emitted_cluster_heads(prefix);
+    ASSERT_EQ(heads.size(), 1u);
+    EXPECT_EQ(heads[0].min_pts, 10);
+    EXPECT_EQ(heads[0].rank, 0);
+
+    fs::remove_all(dir);
 }

--- a/tests/test_protocol_config.cpp
+++ b/tests/test_protocol_config.cpp
@@ -287,6 +287,40 @@ TEST(ProtocolConfig, ElectionV135TauOverride) {
     EXPECT_FALSE(cfg.election_include_singletons);
 }
 
+// FLEXAIDDS_ELECTION_SOFT_T=0 (unset) means "resolve at election": dock TEMPER
+// first, then 298 fallback. The env knob itself stays 0 in ProtocolConfig.
+// Positive values override dock T in select_pose_freq_gated_pooled (source=env).
+TEST(ProtocolConfig, ElectionSoftTFromEnv) {
+    ClearProtocolEnv clear;
+    {
+        const auto unset = flexaids::ProtocolConfig::from_env();
+        EXPECT_DOUBLE_EQ(unset.election_soft_T, 0.0);
+        EXPECT_TRUE(unset.election_shannon_free_energy);  // 3Dsig default ON
+    }
+    {
+        ScopedEnv soft("FLEXAIDDS_ELECTION_SOFT_T", "21.0");
+        const auto cfg = flexaids::ProtocolConfig::from_env();
+        EXPECT_DOUBLE_EQ(cfg.election_soft_T, 21.0);
+        EXPECT_TRUE(cfg.election_shannon_free_energy);
+    }
+    {
+        ScopedEnv soft("FLEXAIDDS_ELECTION_SOFT_T", "298.15");
+        const auto cfg = flexaids::ProtocolConfig::from_env();
+        EXPECT_DOUBLE_EQ(cfg.election_soft_T, 298.15);
+    }
+}
+
+TEST(ProtocolConfig, ElectionSoftTJsonRoundTrip) {
+    ClearProtocolEnv clear;
+    ScopedEnv soft("FLEXAIDDS_ELECTION_SOFT_T", "21.0");
+    const auto a = flexaids::ProtocolConfig::from_env();
+    EXPECT_DOUBLE_EQ(a.election_soft_T, 21.0);
+    const std::string json = a.to_json();
+    EXPECT_NE(json.find("\"election_soft_T\":"), std::string::npos);
+    const auto b = flexaids::ProtocolConfig::from_json(json);
+    EXPECT_DOUBLE_EQ(b.election_soft_T, 21.0);
+}
+
 TEST(ProtocolConfig, JsonRoundTrip) {
     ClearProtocolEnv clear;
     ScopedEnv seed("FLEXAIDDS_SEED_BASE", "99");

--- a/tests/test_protocol_config.cpp
+++ b/tests/test_protocol_config.cpp
@@ -107,7 +107,13 @@ struct ClearProtocolEnv {
         , force_cf("FLEXAIDDS_FORCE_CF_RANK_EMISSION", nullptr)
         , classic("FLEXAIDDS_CLASSIC_ENTROPY_RANKING", nullptr)
         , ent_w("FLEXAIDDS_ENTROPY_WEIGHT", nullptr)
-        , div_m("FLEXAIDDS_DIVERSITY_MONITORING", nullptr) {}
+        , div_m("FLEXAIDDS_DIVERSITY_MONITORING", nullptr)
+        , elect_shannon("FLEXAIDDS_ELECTION_SHANNON_F", nullptr)
+        , elect_legacy_zh("FLEXAIDDS_ELECTION_LEGACY_ZH", nullptr)
+        , elect_soft_t("FLEXAIDDS_ELECTION_SOFT_T", nullptr)
+        , elect_v135("FLEXAIDDS_ELECTION_V135", nullptr)
+        , elect_tau("FLEXAIDDS_ELECTION_SCORE_TAU", nullptr)
+        , elect_sing("FLEXAIDDS_ELECTION_INCLUDE_SINGLETONS", nullptr) {}
 
     ScopedEnv seed_base, restarts, parallel, vct_r0, vct_norm, vct_ew,
               sharing, boom, n_elite, shannon, thermo, t_eff, tencom,
@@ -115,7 +121,9 @@ struct ClearProtocolEnv {
               seed_elit, seed_delta, freqsel, freq_a, freq_r, consensus,
               hvib, ring, eval_scale, budget, fine, multi, cognate, score_n,
               native_o, use_dp, ignore, thermo_csv, hbond, no_sec, bench,
-              t_hot, instream, chain, smfree, force_cf, classic, ent_w, div_m;
+              t_hot, instream, chain, smfree, force_cf, classic, ent_w, div_m,
+              elect_shannon, elect_legacy_zh, elect_soft_t, elect_v135,
+              elect_tau, elect_sing;
 };
 
 }  // namespace
@@ -153,7 +161,7 @@ TEST(ProtocolConfig, DefaultsMatchHistoricalFallbacks) {
     EXPECT_FALSE(e.election_v135);
     EXPECT_DOUBLE_EQ(e.election_score_tau, 0.0);
     EXPECT_FALSE(e.election_include_singletons);
-    EXPECT_TRUE(e.election_shannon_free_energy);  // 3Dsig default ON
+    EXPECT_FALSE(e.election_shannon_free_energy);  // OFF until Astex pilot
     EXPECT_DOUBLE_EQ(e.election_soft_T, 0.0);
     EXPECT_TRUE(e.hvib_enabled);
     EXPECT_FALSE(e.ring_flex);
@@ -285,6 +293,43 @@ TEST(ProtocolConfig, ElectionV135TauOverride) {
     EXPECT_TRUE(cfg.election_v135);
     EXPECT_DOUBLE_EQ(cfg.election_score_tau, 40.0);
     EXPECT_FALSE(cfg.election_include_singletons);
+}
+
+// Shannon S1 election default OFF; opt-in via FLEXAIDDS_ELECTION_SHANNON_F=1;
+// FLEXAIDDS_ELECTION_LEGACY_ZH=1 forces legacy ZH (false path).
+TEST(ProtocolConfig, ElectionShannonDefaultOffOptInAndLegacyZh) {
+    {
+        ClearProtocolEnv clear;
+        const auto cfg = flexaids::ProtocolConfig::from_env();
+        EXPECT_FALSE(cfg.election_shannon_free_energy);
+        EXPECT_FALSE(cfg.election_include_singletons);  // not forced when Shannon OFF
+    }
+    {
+        ClearProtocolEnv clear;
+        ScopedEnv sh("FLEXAIDDS_ELECTION_SHANNON_F", "1");
+        const auto cfg = flexaids::ProtocolConfig::from_env();
+        EXPECT_TRUE(cfg.election_shannon_free_energy);
+    }
+    {
+        ClearProtocolEnv clear;
+        ScopedEnv sh("FLEXAIDDS_ELECTION_SHANNON_F", "1");
+        ScopedEnv zh("FLEXAIDDS_ELECTION_LEGACY_ZH", "1");
+        const auto cfg = flexaids::ProtocolConfig::from_env();
+        EXPECT_FALSE(cfg.election_shannon_free_energy);  // LEGACY_ZH wins
+    }
+    {
+        ClearProtocolEnv clear;
+        // Missing JSON key must keep default OFF (not coerce to true).
+        const auto cfg = flexaids::ProtocolConfig::from_json("{}");
+        EXPECT_FALSE(cfg.election_shannon_free_energy);
+    }
+    {
+        ClearProtocolEnv clear;
+        const auto cfg =
+            flexaids::ProtocolConfig::from_json(
+                "{\"election_shannon_free_energy\":true}");
+        EXPECT_TRUE(cfg.election_shannon_free_energy);
+    }
 }
 
 TEST(ProtocolConfig, JsonRoundTrip) {


### PR DESCRIPTION
## Summary

Lands all six P0 science fixes from the 26h audit as one stack:

1. **soft_T ← dock TEMPER** — DatasetRunner S1 uses CONFIG TEMPER (log `source=dock|env|fallback`)
2. **FO `.mcf` emission** — BindingMode writes member CFs so Shannon S is non-vacuous on FO
3. **SoftBeta local Z** — `LIB/SoftBetaFreeEnergy.h` shared by cluster ACF, BindingMode classic F, DatasetRunner
4. **FO dual-suffix** — `enumerate_emitted_cluster_heads()` for election + BCR + consensus + Hvib
5. **Shannon S1 default OFF** — opt-in via `FLEXAIDDS_ELECTION_SHANNON_F=1` (C0 claim still exports it)
6. **S_top10** — `mode_rmsd_0..9` in pilot parse + fail-closed 10k bootstrap (≤ 2.0 Å)

## Tests

- ProtocolConfigTests PASS
- ClassicEntropyRankingTests PASS (SoftBeta identity)
- BindingModeAdvancedTests PASS (.mcf sidecar)
- DatasetRunnerTests PASS (dual-suffix enumeration)
- pytest tests/test_bootstrap_3dsig_s_top10.py — 15 passed

## Science notes

- Soft-β is β=1/T on CF scoring proxy (not k_B T / experimental ΔG).
- Engine and DatasetRunner share dock T and local SoftBeta G when Shannon is enabled.
- Default ranking path stays legacy until explicit opt-in (safe for non-claim runs).

## Test plan

- [x] ctest ProtocolConfig + ClassicEntropyRanking + BindingModeAdvanced + DatasetRunner
- [x] pytest S_top10 bootstrap
- [ ] After merge: rebuild claim binary; smoke one FO target with TEMPER 21 and confirm `[3DSIG-RANK] … source=dock` + `.mcf` beside FO heads


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cluster and pose selection across standard and FastOPTICS output formats.
  * Added soft-β free-energy ranking for more consistent thermodynamic scoring.
  * Added `.mcf` sidecar files containing finite per-member energy values.
  * Added per-mode RMSD reporting and S_top10 success metrics to result processing.

* **Bug Fixes**
  * Fixed cases where valid FastOPTICS outputs produced empty election or scoring pools.
  * Improved temperature selection and runtime diagnostics.

* **Documentation**
  * Clarified ranking behavior, configuration defaults, output naming, and inclusive RMSD thresholds.

* **Configuration**
  * Shannon free-energy election is now opt-in and disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->