### PR TITLE
Fix: Hungarian RMSD OOB after clustering (cad_only_no_pose_pdb)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2389,6 +2389,17 @@ flexaids_add_unit_test(test_protocol_config
         TEST_NAME BufferSafetyTests
     )
 
+    # test_hungarian_rmsd_bounds — post-cluster RMSDST Hungarian SEGV regression
+    # (cad_only_no_pose_pdb: atoms[k+l] walked past ligand into NULL coor_ref)
+    flexaids_add_unit_test(test_hungarian_rmsd_bounds
+        SOURCES
+            tests/test_hungarian_rmsd_bounds.cpp
+            tests/hungarian_rmsd_stubs.cpp
+            LIB/calc_rmsd.cpp
+            LIB/geometry.cpp
+        TEST_NAME HungarianRmsdBoundsTests
+    )
+
     # test_shell_exec — path-safe shell quoting / argv exec helpers
     flexaids_add_unit_test(test_shell_exec
         SOURCES tests/test_shell_exec.cpp

--- a/LIB/calc_rmsd.cpp
+++ b/LIB/calc_rmsd.cpp
@@ -99,7 +99,11 @@ float calc_rmsd(FA_Global* FA,atom* atoms,resid* residue, gridpoint* cleftgrid,i
                 }
             }
         }
-        rmsd = sqrtf(rmsd/((float)l));
+        if (l > 0) {
+            rmsd = sqrtf(rmsd/((float)l));
+        } else {
+            rmsd = 0.0f;
+        }
     }
     else if(Hungarian == true)
     {
@@ -120,7 +124,12 @@ float calc_Hungarian_RMSD(FA_Global* FA, atom* atoms, resid* residue, gridpoint*
     int nTypes = 0;
     int nUniqueTypes = 0;
     bool unique_flag = true;
-    
+    int atoms_in_assignment = 0;
+
+    if (FA == NULL || atoms == NULL || residue == NULL || FA->num_het_atm <= 0) {
+        return 0.0f;
+    }
+
     // Counting the number of unique atom types
     // Declaration and Memory Allocation for (int*)unique_atom_type[]
     int *unique_atom_type;
@@ -139,8 +148,14 @@ float calc_Hungarian_RMSD(FA_Global* FA, atom* atoms, resid* residue, gridpoint*
         {
             if(j == FA->het_res[i])
             {
+                const int fatm = residue[j].fatm[0];
+                const int latm = residue[j].latm[0];
+                if (fatm <= 0 || latm < fatm) {
+                    continue;
+                }
+
                 // The 'for loop' below iterates through all the atoms of the ligand
-                for(k=residue[j].fatm[0]; k<=residue[j].latm[0]; k++)
+                for(k=fatm; k<=latm; k++)
                 {
                     for(int jj=0; jj < nUniqueTypes+1; jj++)
                     {
@@ -152,18 +167,42 @@ float calc_Hungarian_RMSD(FA_Global* FA, atom* atoms, resid* residue, gridpoint*
                     }
                     if(unique_flag)
                     {
+                        if (nUniqueTypes >= FA->num_het_atm) {
+                            break;
+                        }
                         unique_atom_type[nUniqueTypes] = atoms[k].type;
                         nUniqueTypes++;
                     }
                     unique_flag = true;
                 }
-                // Counting the number of unique atom types
+                // Per-type symmetric RMSD via Hungarian assignment among same-type atoms.
+                // CRITICAL: only index atoms inside [fatm, latm]. The historical
+                // atoms[k+l] walk (l = 0..num_het_atm-1) read past the ligand into
+                // protein/unmapped memory and dereferenced NULL coor_ref → SIGSEGV
+                // right after CF clustering wrote *.cad but before ranked *_N.pdb.
                 for(int z = 0; z < nUniqueTypes; z++)
                 {
+                    if (unique_atom_type[z] <= 0) {
+                        continue;
+                    }
+
+                    // Collect ligand atoms of this type that have a reference pose.
+                    int *type_atoms = (int*) malloc(sizeof(int) * (size_t)(latm - fatm + 1));
+                    if (type_atoms == NULL) {
+                        fprintf(stderr,"ERROR: memory allocation error for hungarian algorithm.\n");
+                        free(unique_atom_type);
+                        Terminate(2);
+                    }
                     nTypes = 0;
-                    for(k=residue[j].fatm[0]; k<=residue[j].latm[0]; k++)
+                    for(k=fatm; k<=latm; k++)
                     {
-                        if(atoms[k].type > 0 && atoms[k].type == unique_atom_type[z]) nTypes++;
+                        if(atoms[k].type == unique_atom_type[z] && atoms[k].coor_ref != NULL) {
+                            type_atoms[nTypes++] = k;
+                        }
+                    }
+                    if (nTypes <= 0) {
+                        free(type_atoms);
+                        continue;
                     }
                     
                     // Declaration, Memory Allocation and Initialization of the Hungarian algorihm arrays
@@ -178,6 +217,8 @@ float calc_Hungarian_RMSD(FA_Global* FA, atom* atoms, resid* residue, gridpoint*
                     {
                         printf("ERROR: memory allocation error for hungarian algorithm.\n");
                         fprintf(stderr,"ERROR: memory allocation error for hungarian algorithm.\n");
+                        free(type_atoms);
+                        free(unique_atom_type);
                         Terminate(2);
                     }
                     for(k = 0; k < nTypes; k++)
@@ -189,6 +230,8 @@ float calc_Hungarian_RMSD(FA_Global* FA, atom* atoms, resid* residue, gridpoint*
                         {
                             printf("ERROR: memory allocation error for hungarian algorithm.\n");
                             fprintf(stderr,"ERROR: memory allocation error for hungarian algorithm.\n");
+                            free(type_atoms);
+                            free(unique_atom_type);
                             Terminate(2);
                         }
                     }
@@ -200,6 +243,8 @@ float calc_Hungarian_RMSD(FA_Global* FA, atom* atoms, resid* residue, gridpoint*
                     if(row_count == NULL || column_count == NULL || column_assigned == NULL || row_assigned == NULL || matrix_match == NULL)
                     {
                         fprintf(stderr,"ERROR: memory allocation error for hungarian algorithm.\n");
+                        free(type_atoms);
+                        free(unique_atom_type);
                         Terminate(2);
                     }
                     // ~initialize() arrays
@@ -209,40 +254,20 @@ float calc_Hungarian_RMSD(FA_Global* FA, atom* atoms, resid* residue, gridpoint*
                     memset( row_assigned, 0, nTypes * sizeof(row_assigned[0]) );
                     memset( column_assigned, 0, nTypes * sizeof(column_assigned[0]) );
                     memset( matrix_match, 0, nTypes * sizeof(matrix_match[0]) );
-                    // 2D array init for floats arrays (matrix[][] && matrix_original[][]) and int array (matrix_case[][])
-                    for(k = 0; k < nTypes; k++)
+                    // 2D cost matrix: row = docked atom, col = reference atom of same type
+                    for(int ii = 0; ii < nTypes; ii++)
                     {
-                        for(int kk = 0; kk < nTypes; kk++)
+                        const int ai = type_atoms[ii];
+                        for(int jj = 0; jj < nTypes; jj++)
                         {
-                            matrix[k][kk] = 0.0f;
-                            matrix_original[k][kk] = 0.0f;
-                            matrix_case[k][kk] = 0; 
+                            const int aj = type_atoms[jj];
+                            // coor_ref non-NULL guaranteed by type_atoms filter above
+                            matrix[ii][jj] = sqrdist(atoms[ai].coor, atoms[aj].coor_ref);
+                            matrix_original[ii][jj] = matrix[ii][jj];
+                            matrix_case[ii][jj] = 0;
                         }
                     }
 
-                    // Init
-                    int count_i = -1;
-                    int count_j = -1;
-                    
-                    // Filling the matrix
-                    for(k=residue[j].fatm[0]; k<=residue[j].latm[0]; k++) // Foreach Atom in Lig
-                    {
-                        if(atoms[k].type == unique_atom_type[z])
-                        {
-                            count_i++;
-                            count_j = -1;
-
-                            for(int l = 0; l < FA->num_het_atm; l++)
-                            {
-                                if(atoms[k+l].type == unique_atom_type[z])
-                                {
-                                    count_j++;
-                                    matrix[count_i][count_j] = sqrdist(atoms[k].coor,atoms[k+l].coor_ref);
-                                }
-                            }
-                        }
-                    }
-                    
                     // run the Hungarian assignment algorithm. matrix[][], matrix_case[][], matrix_match[], row_count[]. column_count[], row_assigned[] && column_assigned[] memory adresses will
                     Hungarian(matrix, matrix_original, matrix_case, unique_atom_type, row_count, column_count, row_assigned, column_assigned, matrix_match, nTypes, FA->num_het_atm);
                     
@@ -250,8 +275,15 @@ float calc_Hungarian_RMSD(FA_Global* FA, atom* atoms, resid* residue, gridpoint*
                     float assignment = 0.0f;
                     for(int ii = 0; ii < nTypes; ii++)
                     {
-                        assignment += matrix_original[ii][matrix_match[ii]];
-                        // printf("(%d:%d)=%f (total=%f)\n",ii, matrix_match[ii], matrix_original[ii][matrix_match[ii]], assignment);
+                        const int mj = matrix_match[ii];
+                        if (mj < 0 || mj >= nTypes) {
+                            fprintf(stderr,
+                                    "WARNING: Hungarian match out of range for type %d (row=%d match=%d nTypes=%d); skipping atom\n",
+                                    unique_atom_type[z], ii, mj, nTypes);
+                            continue;
+                        }
+                        assignment += matrix_original[ii][mj];
+                        atoms_in_assignment++;
                     }
                     total_assignment += assignment;
                     
@@ -276,20 +308,26 @@ float calc_Hungarian_RMSD(FA_Global* FA, atom* atoms, resid* residue, gridpoint*
                     if(row_assigned != NULL) {free(row_assigned);}
                     if(column_assigned != NULL) {free(column_assigned);}
                     if(matrix_match != NULL) {free(matrix_match);}
+                    free(type_atoms);
                 }
                 
                 // Freeing the unique_atom_type[] dynamically allocated memory (check if it could be placed elsewhere)
                 if(unique_atom_type != NULL) {free(unique_atom_type);}
-                
-                // Return symetry corrected RMSD
-//                rmsd = sqrt(total_assignment/FA->num_het_atm);
-//                return(rmsd);
+                unique_atom_type = NULL;
             }
         }
     }
-    // Return symetry corrected RMSD
-     rmsd = sqrt(total_assignment/(float)FA->num_het_atm);
-     return(rmsd);
+    if (unique_atom_type != NULL) {free(unique_atom_type);}
+
+    // Return symmetry-corrected RMSD (guard empty assignment / zero denom)
+    if (atoms_in_assignment > 0) {
+        rmsd = sqrtf(total_assignment / (float)atoms_in_assignment);
+    } else if (FA->num_het_atm > 0) {
+        rmsd = sqrtf(total_assignment / (float)FA->num_het_atm);
+    } else {
+        rmsd = 0.0f;
+    }
+    return(rmsd);
 }
 
 void Hungarian(float** matrix, float** matrix_original, int** matrix_case, int* unique_atom_type, int* row_count, int* column_count, int* row_assigned, int* column_assigned, int* matrix_match, int nTypes, int num_het_atoms)

--- a/LIB/cluster.cpp
+++ b/LIB/cluster.cpp
@@ -274,12 +274,16 @@ void cluster(FA_Global* FA, GB_Global* GB, VC_Global* VC, chromosome* chrom, gen
         //num_of_results=1;
       
 	printf("num_of_clusters=%d num_of_results=%d\n",num_of_clusters,num_of_results);
+	fflush(stdout);
 	
         // output results, 10% of the number of chromosomes or 
         // the number of clusters, the smallest.
       
 	for(j=0;j<num_of_results;++j)
 	{
+		printf("emitting ranked pose %d/%d (TOP chrom=%d)...\n",
+		       j + 1, num_of_results, Clus_TOP[j]);
+		fflush(stdout);
 		// get parameters of fittest individual in population
 		// after optimization -> best docking candidate
     

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -2689,6 +2689,7 @@ int main(int argc, char **argv){
 			fflush(stdout);
 
 			printf("n_chrom_snapshot=%d\n", n_chrom_snapshot);
+			fflush(stdout);
 
 			if( strcmp(FA->clustering_algorithm,"FO") == 0 )
 			{

--- a/tests/hungarian_rmsd_stubs.cpp
+++ b/tests/hungarian_rmsd_stubs.cpp
@@ -1,0 +1,16 @@
+// Slim stubs for test_hungarian_rmsd_bounds.
+// Links the real LIB/calc_rmsd.cpp; only stub symbols that calc_rmsd.cpp
+// references outside the Hungarian path under test.
+
+#include "flexaid.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+void alter_mode(atom*, resid*, float*, int, int) {}
+void buildcc(FA_Global*, atom*, int, int[]) {}
+
+void Terminate(int status) {
+    std::fprintf(stderr, "Terminate(%d) called from hungarian_rmsd test\n", status);
+    std::exit(status == 0 ? 1 : status);
+}

--- a/tests/test_hungarian_rmsd_bounds.cpp
+++ b/tests/test_hungarian_rmsd_bounds.cpp
@@ -1,0 +1,107 @@
+// Regression: calc_Hungarian_RMSD must not walk past ligand atom bounds.
+//
+// Historical bug (cad_only_no_pose_pdb): after CF clustering wrote *.cad, pose
+// emission called calc_rmsd(..., Hungarian=true). The old cost-matrix fill used
+// atoms[k + l] for l in [0, num_het_atm), reading protein/unmapped memory and
+// often NULL coor_ref → SIGSEGV before any ranked *_N.pdb was written.
+//
+// This unit test builds a minimal FA/atom/residue layout that would have
+// crashed the old walker (ligand followed by protein atoms without coor_ref)
+// and asserts the fixed Hungarian path returns a finite RMSD.
+
+#include <gtest/gtest.h>
+
+// flexaid.h defines E (Euler) as a macro — must come after gtest headers.
+#include "flexaid.h"
+
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+// Defined in LIB/calc_rmsd.cpp
+float calc_Hungarian_RMSD(FA_Global* FA, atom* atoms, resid* residue,
+                          gridpoint* cleftgrid, int npar, const double* icv);
+
+namespace {
+
+struct MiniSystem {
+    FA_Global FA{};
+    std::vector<atom> atoms;
+    std::vector<resid> residue;
+    // fatm/latm are pointers in resid — own storage here.
+    int prot_fatm[1]{1};
+    int prot_latm[1]{4};
+    int lig_fatm[1]{5};
+    int lig_latm[1]{8};
+    float ref_store[4][3]{};
+
+    MiniSystem() {
+        // indices: 0 unused (1-based FlexAID convention), 1..4 protein, 5..8 ligand
+        atoms.assign(9, atom{});
+        residue.assign(3, resid{});  // 0 unused, 1 protein, 2 ligand
+
+        std::memset(static_cast<void*>(&FA), 0, sizeof(FA));
+        FA.num_het = 1;
+        FA.num_het_atm = 4;
+        FA.res_cnt = 2;
+        FA.het_res[1] = 2;
+
+        // Protein residue (no coor_ref) — old k+l walker would enter here.
+        residue[1].fatm = prot_fatm;
+        residue[1].latm = prot_latm;
+        residue[1].type = 0;
+        for (int i = 1; i <= 4; ++i) {
+            atoms[i].type = 4;  // same type as ligand carbons → would match
+            atoms[i].coor[0] = 100.0f + static_cast<float>(i);
+            atoms[i].coor[1] = 0.0f;
+            atoms[i].coor[2] = 0.0f;
+            atoms[i].coor_ref = nullptr;
+        }
+
+        // Ligand residue with reference coords
+        residue[2].fatm = lig_fatm;
+        residue[2].latm = lig_latm;
+        residue[2].type = 1;
+        for (int i = 0; i < 4; ++i) {
+            const int ai = 5 + i;
+            atoms[ai].type = 4;
+            atoms[ai].coor[0] = static_cast<float>(i);
+            atoms[ai].coor[1] = 0.0f;
+            atoms[ai].coor[2] = 0.0f;
+            ref_store[i][0] = static_cast<float>(i) + 0.1f;
+            ref_store[i][1] = 0.0f;
+            ref_store[i][2] = 0.0f;
+            atoms[ai].coor_ref = ref_store[i];
+        }
+    }
+};
+
+}  // namespace
+
+TEST(HungarianRmsdBounds, DoesNotSegfaultWhenProteinFollowsLigand) {
+    MiniSystem sys;
+    const float rmsd = calc_Hungarian_RMSD(&sys.FA, sys.atoms.data(),
+                                           sys.residue.data(), nullptr, 0,
+                                           nullptr);
+    EXPECT_TRUE(std::isfinite(rmsd));
+    EXPECT_GE(rmsd, 0.0f);
+}
+
+TEST(HungarianRmsdBounds, NullRefAtomsSkipped) {
+    MiniSystem sys;
+    // Drop coor_ref on one ligand atom — must not crash.
+    sys.atoms[6].coor_ref = nullptr;
+    const float rmsd = calc_Hungarian_RMSD(&sys.FA, sys.atoms.data(),
+                                           sys.residue.data(), nullptr, 0,
+                                           nullptr);
+    EXPECT_TRUE(std::isfinite(rmsd));
+    EXPECT_GE(rmsd, 0.0f);
+}
+
+TEST(HungarianRmsdBounds, EmptySystemSafe) {
+    FA_Global FA{};
+    FA.num_het_atm = 0;
+    const float rmsd = calc_Hungarian_RMSD(&FA, nullptr, nullptr, nullptr, 0,
+                                           nullptr);
+    EXPECT_FLOAT_EQ(rmsd, 0.0f);
+}


### PR DESCRIPTION
Root cause: calc_Hungarian_RMSD filled the symmetry cost matrix with atoms[k+l] (l=0..num_het_atm-1), walking past the ligand into protein/ unmapped memory and often NULL coor_ref. After CF clustering wrote *.cad, ranked pose emission hit SIGSEGV before any *_N.pdb.

- Bound matrix fill to [fatm, latm] with non-null coor_ref only
- Guard raw RMSD division by zero
- Progress flushes in cluster emission / top.cpp for diagnosis
- Unit test test_hungarian_rmsd_bounds + tiny/medium legacy smokes

Stage fixed binary at three_engine_entropy_q1/bin/A/FlexAID.fixed (do not overwrite live FlexAID mid-restart).

## Summary

What changed and why.

## Scope

- [ ] Core 1.0 supported surface
- [ ] Experimental surface only
- [ ] Documentation only
- [ ] CI / release engineering
- [ ] Security hardening
- [ ] Benchmark / reproducibility

## Release impact

- [ ] affects CLI behavior
- [ ] affects Python package behavior
- [ ] affects configuration schema or defaults
- [ ] affects benchmark or metric reporting
- [ ] affects installation instructions
- [ ] no user-facing release impact

## Validation

Describe how this was validated.

- [ ] unit tests
- [ ] integration tests
- [ ] smoke benchmark
- [ ] documentation review
- [ ] manual validation

## Security and safety

- [ ] no new third-party dependency
- [ ] third-party dependency added and documented
- [ ] no known security-sensitive parsing change
- [ ] security-sensitive parsing change reviewed

## Reproducibility

- [ ] no benchmark claim involved
- [ ] benchmark claim updated with reproducibility artifact
- [ ] benchmark language remains preliminary

## Notes

Anything reviewers should pay attention to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RMSD calculations for empty, invalid, or incomplete atom data.
  * Prevented crashes and out-of-bounds access during symmetry-corrected RMSD matching.
  * Improved handling of missing reference coordinates and invalid atom ranges.
  * Added clearer progress output while generating and clustering poses.

* **Tests**
  * Added regression coverage for Hungarian RMSD boundary conditions and degenerate inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->