### PR TITLE
Docs: audit merge 8071a5582 (PR #254 github-script v7→v9)

### DIFF
--- a/docs/audit/26h-swarm/8071a5582.md
+++ b/docs/audit/26h-swarm/8071a5582.md
@@ -1,0 +1,181 @@
+# Audit: 8071a5582 — Merge PR #254 actions/github-script-9
+
+| Field | Value |
+|-------|--------|
+| **Commit** | `8071a5582235795e6145e4f8d1ff8d3927f6dd00` |
+| **Short** | `8071a5582` |
+| **Subject** | Merge pull request #254 from LeBonhommePharma/dependabot/github_actions/actions/github-script-9 |
+| **PR** | [#254](https://github.com/LeBonhommePharma/FlexAIDdS/pull/254) — `Build(deps): Bump actions/github-script from 7 to 9` |
+| **Merge parents** | `e55c2eecf` (first-parent / prior main tip) · `bd74015fe` (Dependabot leaf) |
+| **Author / Committer** | Louis-Philippe Morency (merge via GitHub) · Dependabot authored leaf `bd74015fe` (2026-07-13) |
+| **AuthorDate (merge)** | 2026-07-14 20:20:38 -0400 |
+| **Files** | `.github/workflows/coverage.yml` only (**+1 / −1**) |
+| **Scope** | GitHub Actions CI hygiene — **no** `LIB/`, Python science, scoring, GA, or benchmark storage |
+| **Audit focus** | Major-version action jump · v7→v9 breaking API · pin/supply-chain · PR-comment permissions · ranking/repro science impact |
+| **Verdict** | **ACCEPT** for science and runtime docking. Residual **CI hygiene** (mutable tag, missing `permissions`, pre-existing coverage pipeline red) is **not introduced as new science risk** by this one-line bump. |
+
+---
+
+## Summary (2–4 sentences)
+
+Merge `8071a5582` lands Dependabot PR #254: a **single-line** version pin change of `actions/github-script` from **`@v7` → `@v9`** in the Code Coverage workflow’s “Comment PR with coverage” step. The inlined script uses only the standard injected `github` / `context` / `process.env` surface (`github.rest.issues.createComment`) and does **not** call `require('@actions/github')` or redeclare `getOctokit`, so it is **API-compatible with v9 breaking changes**. Runtime evidence from the PR #254 coverage job shows **v9 loaded and executed under Node 24** (user-agent includes orchestration ID); the step then failed with a **pre-existing 403** (`Resource not accessible by integration`) because the job token lacks `issues`/`pull-requests` write — not because of a v9 script regression. **No docking, ranking, CF scoring, StatMech, or reproducibility artifact path is touched.**
+
+## Severity: LOW
+
+(Science / ranking / repro: **none**. CI residual hygiene: **LOW–MEDIUM**, largely pre-existing relative to the version pin.)
+
+---
+
+## Change inventory (exact merge delta)
+
+```diff
+--- a/.github/workflows/coverage.yml
++++ b/.github/workflows/coverage.yml
+@@ -108,7 +108,7 @@ jobs:
+       - name: Comment PR with coverage
+         if: github.event_name == 'pull_request' && always()
+-        uses: actions/github-script@v7
++        uses: actions/github-script@v9
+         with:
+           script: |
+             const coverage = process.env.COVERAGE;
+```
+
+- **Leaf commit:** `bd74015fed554d71c49f7cd928f5dbbce41a2ea5` — Dependabot `version-update:semver-major` for `actions/github-script` 7 → 9.
+- **Only consumer in tree:** `rg` shows **one** `github-script` use repo-wide (this step).
+- **Script body (unchanged):** reads `process.env.COVERAGE`, builds a markdown status block (PASS if `Number(coverage) >= 50`), posts via `github.rest.issues.createComment({ issue_number, owner, repo, body })`.
+- **At merge tip content:** workflow still targeted branches `[ master ]` (retarget to `main` landed later in `d9bee5a38`). Comment step only runs on `pull_request`.
+
+---
+
+## Findings
+
+### F1. Script is compatible with github-script v9 breaking changes (INFO / positive)
+
+- **Evidence:** Upstream v9 notes (actions/github-script releases + README):
+  - `require('@actions/github')` no longer works (ESM-only `@actions/github` v9).
+  - `getOctokit` is now an **injected** context function; `const`/`let getOctokit = …` redeclares and throws `SyntaxError`.
+  - v8+ runs scripts on **Node 24** (min runner **v2.327.1**); v9 adds orchestration ID in user-agent and injects `getOctokit` factory.
+- **This repo’s script:** no `require`, no `getOctokit` binding, only `github.rest.*` + `context` + `process.env` — the stable documented surface across v7–v9.
+- **Why it matters:** A naïve major bump can break PR commenting; this particular script is the happy path for v9.
+- **Fix recommendation:** None required for API compatibility. Optionally add a one-line comment in YAML noting “v9-safe: no require('@actions/github')”.
+
+### F2. Runtime proof: v9 executed on PR #254; failure is token permissions, not script syntax (MEDIUM — pre-existing CI defect)
+
+- **Evidence:** Actions run [29231601039](https://github.com/LeBonhommePharma/FlexAIDdS/actions/runs/29231601039) (PR #254 coverage job):
+  - Step **Comment PR with coverage** → `failure`.
+  - Log: `POST /repos/LeBonhommePharma/FlexAIDdS/issues/254/comments - 403`
+  - `RequestError [HttpError]: Resource not accessible by integration`
+  - Response header: `x-accepted-github-permissions: issues=write; pull_requests=write`
+  - User-agent: `actions/github-script actions_orchestration_id/…coverage.__default octokit-core.js/7.0.6 Node.js/24` → confirms **v9** + Node 24 + orchestration ID feature.
+  - Job token permissions logged: **Contents: read, Metadata: read** only (Dependabot secret source on that PR).
+- **Why it matters:** The bump **did not** introduce a SyntaxError / missing API. PR coverage comments were already non-functional without an explicit `permissions:` block (contrast `benchmark-tier1.yml`, which sets `pull-requests: write` for sticky comments). Dependabot PRs further restrict tokens.
+- **Fix recommendation (follow-up, not this commit’s duty):**
+  ```yaml
+  jobs:
+    coverage:
+      permissions:
+        contents: read
+        pull-requests: write   # createComment via issues API
+        # issues: write        # optional explicit; createComment accepts either
+  ```
+  Prefer sticky update (list + update existing bot comment) over unbounded `createComment` spam. Catch API errors so comment failure does not mark the job red when coverage itself already failed.
+
+### F3. Mutable major tag `@v9` vs SHA-pin discipline used elsewhere (MEDIUM — supply chain hygiene)
+
+- **Evidence:** Same file pins other third-party actions by **full commit SHA + version comment**:
+  - `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6` (HEAD; at Dependabot PR time was `de0fac2e…`)
+  - `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7`
+  - Repo pattern across `ci.yml`, `codeql.yml`, `pypi-release.yml`, etc.
+  - **Only** `actions/github-script@v9` remains a **floating major tag** in `coverage.yml` after this merge (and was already floating as `@v7` before).
+- **Resolved v9 tip (audit-time):**
+  - Tag `v9` / `v9.0.0` peel to commit **`3a2844b7e9c422d3c10d287c895573f7108da1b3`** (PR #700 merge: getOctokit + `@actions/github` v9).
+- **Why it matters:** Floating tags are retargetable; GitHub/immutable action packages mitigate but do not match the repo’s stronger SHA-pin contract for other official actions. Dependabot major bumps often leave tags mutable unless configured for SHA.
+- **Fix recommendation:**
+  ```yaml
+  uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+  ```
+  Configure Dependabot `github-actions` to prefer commit SHAs if not already.
+
+### F4. `if: always()` + missing COVERAGE produces “undefined%” comments (LOW — pre-existing)
+
+- **Evidence:** Same PR #254 job step table:
+  1. Generate coverage report → **failure** (exit 255; no `build/coverage/html`)
+  2. Calculate coverage percentage → **skipped**
+  3. Upload artifacts → success (warning: no files)
+  4. Comment PR → runs under `always()`, body included **`Core coverage: undefined%` / Status: FAIL**
+- **Why it matters:** Even if permissions were fixed, failure-mode comments would be misleading noise. Not caused by v7→v9; preserved by the unchanged script + `always()` guard.
+- **Fix recommendation:** Gate comment on `steps.calc.outcome == 'success'` (name the calculate step) and/or `env.COVERAGE != ''`. Prefer step summary (already written when calc succeeds) over PR comments for red pipelines.
+
+### F5. Coverage workflow red is chronic and orthogonal to this merge (INFO)
+
+- **Evidence:** Recent `coverage.yml` runs on `main` (post-merge window) repeatedly conclude **failure** (threshold / lcov pipeline — not github-script on push, since the comment step is PR-only). Historical fixes on this file (`51254e060`, `e9251a286`, clang/llvm-gcov paths) show the **report generation** path is the fragile axis, not the comment action version.
+- **Why it matters:** Do not attribute main-branch coverage red to PR #254. Attribute comment-step red on PRs primarily to **F2** (permissions) after report failure (F4/F5).
+- **Fix recommendation:** Track coverage pipeline health separately from action bumps; keep Dependabot action PRs from being blocked solely by unrelated lcov failures if desired (path filters / required-check policy).
+
+### F6. No ranking, scoring, thermodynamics, or DoF-budget impact (INFO)
+
+- **Evidence:** Diff is workflow YAML only. No `LIB/**`, `python/flexaidds/**`, dataset YAML, claim scripts, or GA flags. AGENTS.md scientific guardrails (CF vs true ΔG, pop-not-gen budget, ranking preservation) are **out of scope**.
+- **Fix recommendation:** N/A.
+
+### F7. Licensing / repo hygiene (INFO)
+
+- **Evidence:** Official GitHub-published action under Actions terms; no new GPL dependency; no secrets, `.env`, or machine-absolute paths introduced. Dependabot commit is signed-off by dependabot[bot].
+- **Fix recommendation:** N/A for this merge. SHA pin (F3) is the remaining supply-chain hygiene item.
+
+### F8. Merge graph / branch context (INFO)
+
+- **Evidence:** First-parent before merge: `e55c2eecf` (sticky-pull-request-comment Dependabot). Cluster of Dependabot GA bumps: #251 pypi-publish, #252 cache-6, #253 sticky-comment, **#254 github-script**, #255 checkout. Default-branch rename `master`→`main` for this workflow is **later** (`d9bee5a38`), not part of #254.
+- **Why it matters:** Auditors correlating “coverage on main” should not expect this merge alone to retarget triggers.
+- **Fix recommendation:** N/A.
+
+---
+
+## Ranking/scoring impact: **NO**
+
+Zero changes to CF/contact-function scoring, VoronoiCF, GA selection/crossover, BindingMode clustering order, StatMech, Shannon/tENCoM, or claim election. Comment markdown is operator-facing CI only.
+
+## Reproducibility impact: **NO** (science) / **minimal** (CI)
+
+- Docking runs, OUT trees, RUN_RECEIPT, result.csv, and binary pins: **unaffected**.
+- CI reproducibility of the **comment step** improves only insofar as v9 is a maintained Node 24 runtime; floating `@v9` (F3) is slightly worse for bit-identical CI provenance than a SHA pin — same class of issue as prior `@v7`.
+
+## Tests adequate: **N/A → weak for comment path**
+
+- No unit test suite covers workflow YAML or the inlined JS.
+- PR #254 CI exercised the real action: **v9 ran**; failures were coverage-report + 403, not assertion of script correctness.
+- Adequacy for **science**: N/A. Adequacy for **“PR coverage comments work”**: **NO** until F2 permissions are fixed and a green PR path is observed.
+
+## Security notes
+
+| Topic | Assessment |
+|-------|------------|
+| Action trust | Official `actions/*` publisher; major jump still trusted origin |
+| Pin strength | **Weaker** than sibling pins in same file (mutable `@v9`) |
+| Token scope | Default/job token **too narrow** for intended comment (403); fail-closed is good, silent success would be worse |
+| Script injection | Coverage string interpolated into markdown body only; not shell-eval’d. If `COVERAGE` were attacker-controlled it could inject markdown into PR comments — source is `lcov --summary` on self-built artifacts (low risk) |
+| Node 24 | Matches GitHub’s forward runtime; runner used on PR job was `2.335.1` (> 2.327.1) |
+
+---
+
+## Verdict: **ACCEPT**
+
+**Safe to keep.** This merge is a routine Dependabot major bump of a single CI helper with a **compatible** inlined script and **zero** scientific surface. Do **not** reverse it for ranking/repro reasons.
+
+**Recommended follow-ups (separate PR; not blockers for accepting this history):**
+
+1. **SHA-pin** `actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9` (F3).
+2. Add **`permissions: pull-requests: write`** (and minimal `contents: read`) on the coverage job so legitimate non-Dependabot PRs can receive comments (F2).
+3. Stop commenting when coverage was never computed; avoid `undefined%` under `always()` (F4).
+4. Keep coverage-report / lcov reliability work on its own track (F5).
+
+---
+
+## Audit metadata
+
+| Item | Value |
+|------|--------|
+| Method | `git show` / first-parent merge diff · full `coverage.yml` read · repo-wide `github-script` grep · PR #254 `gh pr view` + checks · failed-job logs (403, user-agent, step table) · upstream action.yml (`runs.using: node24`) · tag peel to `3a2844b…` · comparison to SHA-pin pattern in other workflows |
+| Science kernel inspected | Confirmed **absent** from diff |
+| Source edits by auditor | **None** (documentation only) |
+| Related swarm entries | Dependabot cluster: `e55c2eecf` (#253 sticky-comment), `214113cbb` (#252 cache), `b041397ff` (#251 pypi-publish), `155ebbb7b` (#255 checkout) |


### PR DESCRIPTION
Deep CI-only audit for Dependabot bump of actions/github-script in coverage.yml: v9 API compatibility, mutable-tag vs SHA pins, and pre-existing 403 on PR comments. No source changes.

## Summary

What changed and why.

## Scope

- [ ] Core 1.0 supported surface
- [ ] Experimental surface only
- [ ] Documentation only
- [ ] CI / release engineering
- [ ] Security hardening
- [ ] Benchmark / reproducibility

## Release impact

- [ ] affects CLI behavior
- [ ] affects Python package behavior
- [ ] affects configuration schema or defaults
- [ ] affects benchmark or metric reporting
- [ ] affects installation instructions
- [ ] no user-facing release impact

## Validation

Describe how this was validated.

- [ ] unit tests
- [ ] integration tests
- [ ] smoke benchmark
- [ ] documentation review
- [ ] manual validation

## Security and safety

- [ ] no new third-party dependency
- [ ] third-party dependency added and documented
- [ ] no known security-sensitive parsing change
- [ ] security-sensitive parsing change reviewed

## Reproducibility

- [ ] no benchmark claim involved
- [ ] benchmark claim updated with reproducibility artifact
- [ ] benchmark language remains preliminary

## Notes

Anything reviewers should pay attention to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an audit record documenting the workflow action update and its validation.
  * Recorded CI observations, including token permission requirements and coverage comment behavior.
  * Confirmed no changes to scientific results, rankings, or reproducibility artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->