### PR TITLE
Docs: audit merge 8eaf043 PR #257 fleet DatasetRunner stubs

### DIFF
--- a/docs/audit/26h-swarm/292a0ce6a.md
+++ b/docs/audit/26h-swarm/292a0ce6a.md
@@ -1,0 +1,129 @@
+# Audit: 292a0ce6a — Merge: origin/master into main — align main with master tip
+
+## Summary (2–4 sentences)
+Commit `292a0ce6a2a77e6c2a4a2ffde003b73b5dca0caa` is a **local (non-GitHub) merge** of `origin/master` (`964bec0a2`, PR #258 tip) into `main` (`8eaf043ae`, PR #257 tip) to recover from dual-default-branch drift. The **only conflicted path** was `CMakeLists.txt`; resolution correctly took master’s real **2948-line** build file over main’s **17-line non-functional fleet stub** from PR #257. The merge message claims “align main with master tip,” but the resulting **tree is not master**: first-parent diff is only CMake, so main’s PR #257 placeholder wipe of `LIB/DatasetRunner.h` (595 → 1 pseudo-line) and six other fleet stub files remain. That is **partial merge cleanliness** and the core dual-branch debt artifact of this hour-scale `main`/`master` split.
+
+## Severity: HIGH
+
+## Topology
+
+| Role | SHA | Subject / note |
+|------|-----|----------------|
+| Merge | `292a0ce6a` | `Merge: origin/master into main — align main with master tip` (2026-07-14 21:07:49 −0400, author LP) |
+| Parent 1 (main) | `8eaf043ae` | Merge PR **#257** `feature/bonhomme-fleet-dataset-runner-v1` → **main** |
+| Parent 2 (master) | `964bec0a2` | Merge PR **#258** `feature/bonhomme-fleet-dataset-runner` → **master** |
+| Primary merge-base | `155ebbb7b` | Dependabot checkout-7.0.0 on the shared trunk |
+| Secondary merge-base | `4beb3b36d` | “CMake: entropy collapse…” stub CMake commit (criss-cross history) |
+
+`git merge-tree --write-tree 8eaf043ae 964bec0a2` reports a **single** content conflict:
+
+```text
+Auto-merging CMakeLists.txt
+CONFLICT (content): Merge conflict in CMakeLists.txt
+```
+
+No conflict markers remain in `292a0ce6a`’s tree. First-parent `git show --stat` matches the commit body: only `CMakeLists.txt` (+2942 / −11).
+
+Tree identity:
+
+| Comparison | Result |
+|------------|--------|
+| `292a0ce6a` tree vs `8eaf043ae` (main) | **Differs only in `CMakeLists.txt`** (master’s full file) |
+| `292a0ce6a` tree vs `964bec0a2` (master) | **Differs in 8 fleet-stub paths** (main kept) |
+| `CMakeLists.txt` vs master parent | **Byte-identical** (2948 lines) |
+| `CMakeLists.txt` vs main parent | Main was a 17-line fragment (no `project()`, fake `CoreLib` / `Metal::Metal` / `flexaidds` targets) |
+
+## Dual-branch debt (root cause)
+
+For a window around 2026-07-14 ~20:37–21:07 −0400 the repo effectively had **two live integration branches**:
+
+1. **PR #257 → `main`** (`8eaf043ae`, merged 20:38:30): claimed “full Bonhomme Fleet integration” but landed **placeholder text** as source:
+   - `69aa0fab6` replaced real `LIB/DatasetRunner.h` (**595 → 1** line of comment prose with `struct FleetConfig { ... }`) and added 1–2 line “implementations” (`FleetRunner.cpp`, `fleet_dataset_runner.py`, `FLEET_BENCHMARKS.md`, `cli.py`, tests, viz, microbench).
+   - `2fc7189d8` replaced real `CMakeLists.txt` (**2948 → 17** line stub fragment).
+2. **PR #258 → `master`** (`964bec0a2`, merged 20:37:31): titled/carried “CMake: entropy collapse…” via feature history including `4beb3b36d`, but after `Merge branch 'master' into feature/…` (`a4e13fc9b`) the **master tip kept the production `CMakeLists.txt` and untouched 595-line `DatasetRunner.h`**.
+
+Near-simultaneous GitHub merges onto **different base refs** (`main` vs `master`) guaranteed divergence. `292a0ce6a` is the manual heal on `main`. Downstream, dual-branch was reduced further by:
+
+- `d9bee5a38` — CI triggers `master` → `main`
+- `d280a8fc5` — Homebrew HEAD pin **main only**
+- Remote default: **`main` only** (`origin/master` absent; `origin/HEAD → origin/main`)
+
+So **branch topology debt was largely retired after this merge**; **content debt from PR #257 stubs was only partially healed here**.
+
+## Findings
+
+### F1. “Align with master tip” is false for the tree (HIGH)
+- Evidence: `git rev-parse 292a0ce6a^{tree}` ≠ `964bec0a2^{tree}`. Diff master→merge retains main’s stubs (`DatasetRunner.h`, `FleetRunner.cpp`, six support files). Diff main→merge is **only** `CMakeLists.txt`.
+- Why it matters: Operators reading the subject line may assume `main@292a0ce6a ≡ master@964bec0a2`. Build file yes; DatasetRunner/public fleet surface **no**. AGENTS.md “inspect first, claim never.”
+- Fix recommendation: Prefer precise subjects (`Restore CMakeLists from master; retain main fleet stubs`) or finish with a second commit that either drops stubs or re-imports master’s headers. For history rewrites: do not force-reset; document in audit (done here).
+
+### F2. Automatic 3-way merge kept main’s destruction of `DatasetRunner.h` (HIGH)
+- Evidence: Master did **not** touch `LIB/DatasetRunner.h` vs merge-base `155ebbb7b` (still 595-line production header). Main alone replaced it with a non-compilable one-liner. 3-way merge therefore took **main** without a conflict. Merge result: 8010-line `DatasetRunner.cpp` still includes `"DatasetRunner.h"` expecting full `dataset::` API → **header/implementation mismatch** until later restore.
+- Why it matters for science/repro: Any configure+build of DatasetRunner targets between `292a0ce6a` and header restore would fail or (worse) compile against wrong declarations. Claim/orchestration code depending on the real header is silently absent from the public include.
+- Fix recommendation (historical): At merge time, take **master (or merge-base) `DatasetRunner.h`** explicitly, not only CMake. Actual later fix: `033eeb889` (“Clarify CF scoring proxy…”) re-expanded the header to 613 lines (~2.5 h after this merge) — correct content restore, but **unrelated commit subject** hides the recovery.
+
+### F3. CMake conflict resolution was correct and necessary (INFO → positive)
+- Evidence: Main’s 17-line file:
+
+  ```cmake
+  add_library(FleetRunner LIB/FleetRunner.cpp)
+  target_link_libraries(FleetRunner PUBLIC CoreLib Metal::Metal)
+  target_sources(flexaidds PRIVATE tools/metal_microbench.cpp)
+  ```
+
+  No `cmake_minimum_required`, no `project()`, no real target graph — **cannot configure**. Master file is the modular production CMake (OBJCXX fallback, provenance, DatasetRunner sources at known lines ~1065+). Post-merge `CMakeLists.txt` **identical** to master parent.
+- Why it matters: Without this resolution `main` was build-dead at the root CMake entrypoint. This is the legitimate reason for the merge.
+- Fix recommendation: None for the CMake choice. Add CI gate: fail if `CMakeLists.txt` line count / `project(FlexAID` missing (guard against future stub overwrites).
+
+### F4. PR #257 / #258 parallel fleet narrative is dual-branch theater (HIGH)
+- Evidence: Two similarly named features merged ~1 minute apart onto different bases. #257 PR body claims “All new tests green,” “4.2x faster fleet mode,” full FleetRunner — but blob contents are ellipsis comments (`#include ... // complete code snippet`). #258 title is CMake entropy collapse, not a second real Fleet implementation. Criss-cross merge-bases (`155ebbb7b` and `4beb3b36d`) are the fingerprint of **both** stub-CMake (`4beb` / #257 path) and trunk-with-real-CMake (`155` / master path).
+- Why it matters: Dual default-ish branches let a stub PR “win” on `main` while `master` stayed buildable. Merge cleanliness at `292a0ce6a` only fixed the path that **conflicted**.
+- Fix recommendation: Single default branch only (done). Require `cmake --build` + `ctest` green on the **target base** before merge. Reject PRs whose “implementation” files are under a minimum byte/line threshold without `NOT_IMPLEMENTED` markers. Prefer one Fleet PR series (later real work: `d842e3247` production FleetRunner ~285 lines, etc.).
+
+### F5. Placeholder fleet files survive the “align” merge (MEDIUM)
+- Evidence: At `292a0ce6a`, retained from main: `LIB/FleetRunner.cpp` (2 lines), `benchmarks/m3pro/fleet_dataset_runner.py` (2), `docs/FLEET_BENCHMARKS.md` (2), `python/flexaidds/cli.py` (1), `tests/test_fleet_benchmark.py` (2), `tools/metal_microbench_enhanced.cpp` (1), `visualizer/ligand_fleet_pose_viz.py` (1). As of current `origin/main`, several paths still exist with empty/near-empty bodies (e.g. empty `metal_microbench_enhanced.cpp` / `ligand_fleet_pose_viz.py`, 1-line `fleet_dataset_runner.py`) while `FleetRunner.cpp` and `FLEET_BENCHMARKS.md` were later filled by real work.
+- Why it matters: Dead paths and hollow modules pollute the tree, confuse “is fleet integrated?” audits, and can break naive `add_executable` wiring if CMake ever lists them.
+- Fix recommendation: Delete residual hollow files or replace with real modules; add hygiene check for empty tracked sources under `LIB/`, `tools/`, `visualizer/`.
+
+### F6. Criss-cross merge-base complicates future `git merge-base` reasoning (MEDIUM)
+- Evidence: `git merge-base --all 8eaf043ae 964bec0a2` returns **two** bases (`155ebbb7b`, `4beb3b36d`). Tools that pick one base may mis-attribute “ours/theirs” blame for CMake history (`4beb` wiped CMake to a one-line comment; master path re-anchored full file).
+- Why it matters: Bisect and automated conflict replay can disagree with human expectation of “main vs master.”
+- Fix recommendation: Prefer first-parent history for release notes; when dual-branch debt is closed, avoid reintroducing long-lived parallel integration branches.
+
+### F7. Ranking / scoring / thermodynamics path (INFO)
+- Evidence: Merge diff does not touch `gaboom.cpp`, Voronoi CF, StatMech, BindingMode election, soft-β, or GA budget env. Only build entry + retained stubs.
+- Why it matters: No direct change to pose ranking or CF/contact-function proxy. Indirect risk: a broken DatasetRunner **build** can block benchmark packaging, not alter scores of already-built binaries.
+- Fix recommendation: None for ranking identity. Do not cite this merge as a science change.
+
+### F8. Security (INFO)
+- Evidence: No secrets, `.env`, or absolute user paths introduced by the merge resolution. CMake restoration is pure build metadata.
+- Fix recommendation: N/A.
+
+### F9. Verification discipline of the merge itself (MEDIUM)
+- Evidence: Commit message documents the CMake choice (good) but does not record `cmake -B` / `ctest` proof, nor acknowledge the retained header stub. Message overclaims “align … with master tip.”
+- Why it matters: Violates spirit of AGENTS.md verify-before-done for a build-critical merge.
+- Fix recommendation: Future heal merges should attach configure+build log summary and a `git diff --stat <master-tip>` table in the body.
+
+## Ranking/scoring impact: NO
+
+No GA, CF, clustering, or thermodynamic-ledger code in the resolved merge surface. Residual risk is **build/availability** of DatasetRunner, not rank order of poses.
+
+## Reproducibility impact: YES
+
+**Positive:** Restores a configure-capable root `CMakeLists.txt` on `main`, prerequisite for reproducible builds and Homebrew/CI.  
+**Negative:** Preserves PR #257 placeholder narrative files and a non-real `DatasetRunner.h` until `033eeb889`; dual-branch window made “which tip do I build?” ambiguous until master was retired.
+
+## Tests adequate: NO (for the merge window)
+
+No test gate attached to `292a0ce6a`. PR #257’s claimed pytest green is **not credible** against 1–2 line stub sources. Header restore later hitchhiked on a CF-naming commit rather than a dedicated “restore DatasetRunner.h from master” test-backed fix.
+
+## Verdict: MERGE_WITH_FIX
+
+**Keep** the CMake resolution (mandatory; master file is correct). Treat the commit as a **partial dual-branch heal**, not a full alignment with master.
+
+**Required follow-through (status as of later history):**
+1. ~~Restore production `LIB/DatasetRunner.h`~~ — done in `033eeb889` (subject mismatch; content OK).
+2. ~~Collapse default branch to `main` only; retarget CI/Homebrew~~ — done (`d9bee5a38`, `d280a8fc5`, remote HEAD).
+3. **Still open-ish:** purge or complete residual hollow fleet paths; add CI guard against CMake/header stub overwrites; never re-open long-lived `master` integration parallel to `main`.
+
+**Do not** rewrite `292a0ce6a`; document and move forward (this audit).

--- a/docs/audit/26h-swarm/8eaf043ae.md
+++ b/docs/audit/26h-swarm/8eaf043ae.md
@@ -1,0 +1,156 @@
+# Audit: 8eaf043ae — Merge pull request #257 bonhomme-fleet-dataset-runner-v1
+
+## Summary (2–4 sentences)
+Merge commit `8eaf043ae7160e2517dabda5aba34c9e69480d1d` lands PR #257 (`feature/bonhomme-fleet-dataset-runner-v1` → `main`) with a PR title/body that claims **full Bonhomme Fleet integration** in DatasetRunner, green tests, and a **4.2× fleet speedup**. The two commits that uniquely deliver that “feat” (`69aa0fab6`, `2fc7189d8`) are **placeholder stubs**: they replace the real `LIB/DatasetRunner.h` API (~530–595 lines) with a 2-line comment, replace `CMakeLists.txt` with a 16–17 line non-buildable sketch referencing nonexistent targets (`CoreLib`, `Metal::Metal`), and add comment-only “implementations” for FleetRunner, tests, CLI, viz, and docs. The second parent also carries a large legitimate science stack (native PoseBust, DoF **population** eval-scaling, CF-based SMFREE stagnation, soft-β ranking restore, DirectLigandIC, success_pb contract, etc.), but at merge tip the tree is **compile-broken** on DatasetRunner consumers; all C++/Python CI jobs on the PR **failed**. Real Fleet control-plane code arrived later the same evening in `d842e3247`, not in this PR’s named feature commits.
+
+## Severity: CRITICAL
+
+## Merge topology
+
+| Field | Value |
+|-------|--------|
+| Full SHA | `8eaf043ae7160e2517dabda5aba34c9e69480d1d` |
+| Short | `8eaf043ae` |
+| Parents | `4beb3b36d` (main: already-gutted modular CMake placeholder) · `711b83cc9` (feature tip after merge-of-main) |
+| First-parent unique | merge commit only |
+| Second-parent span | ~190 commits, ~3828 paths vs first parent |
+| Named “fleet” commits | `69aa0fab6` (feat stubs) · `2fc7189d8` (CMake stub) · `711b83cc9` (merge main into feature) |
+| PR | [#257](https://github.com/LeBonhommePharma/FlexAIDdS/pull/257) merged 2026-07-15T00:38:31Z |
+| Claimed delta | +115842 / −36074, 3832 files |
+| Reviews | Codex bot left P1 comments (header gutting, unwired sources); CodeRabbit skipped; no human APPROVE gate visible |
+| CI on PR | **All C++ matrix jobs fail**; pure Python + bindings fail; license-scan / hygiene / skill-package pass only |
+
+## Findings
+
+### F1. Named “Fleet integration” is comment theater, not code (CRITICAL)
+- Evidence: At merge tip:
+  - `LIB/DatasetRunner.h` (full content):
+    ```text
+    // Updated with Fleet support
+    struct FleetConfig { ... }; // full header with classes
+    ```
+  - `LIB/FleetRunner.cpp`:
+    ```text
+    // Full implementation of FleetRunner as detailed earlier
+    #include ... // complete code snippet for sharding, dispatch, aggregation
+    ```
+  - `tests/test_fleet_benchmark.py`: “# Pytest for FleetRunner… Tests pass: mocked workers…”
+  - `benchmarks/m3pro/fleet_dataset_runner.py`, `docs/FLEET_BENCHMARKS.md`, `visualizer/ligand_fleet_pose_viz.py`, `tools/metal_microbench_enhanced.cpp`, `python/flexaidds/cli.py`: single-line or outline comments only.
+  - `git show 8eaf043ae:LIB/DatasetRunner.cpp | rg -i fleet` → **no matches**. Fleet is not wired into DatasetRunner.cpp.
+- PR body claims: “intelligent sharding, dispatch… aggregation… All new tests green… End-to-end: Astex subset benchmark completes 4.2x faster with fleet mode.” None of that is implementable from the stubs.
+- Why it matters: Violates AGENTS.md **verify with actual execution** and **inspect first, claim never**. Merging marketing prose as a feature pollutes `main`, poisons provenance, and breaks any consumer of `DatasetRunner.h`.
+- Fix recommendation: Treat `69aa0fab6`/`2fc7189d8` as **non-features**. Never cite PR #257 as the Fleet delivery; cite `d842e3247` (real FleetRunner serialization + tests + docs) and later production fleet work. Add a CI gate that fails if any `LIB/**/*.{h,cpp}` file is under a minimum non-comment token count or contains `{ ... }` placeholder class bodies.
+
+### F2. DatasetRunner.h API deleted while .cpp and tests still include it (CRITICAL — build break)
+- Evidence:
+  - First parent `4beb3b36d:LIB/DatasetRunner.h` ≈ **530 lines** with real `enum class BenchmarkSet`, `struct DockingResult`, `class DatasetRunner`, etc.
+  - Pre-gut on feature branch `dea70ea88:LIB/DatasetRunner.h` ≈ **595 lines**.
+  - Merge tip: **2 lines**, invalid C++ (`struct FleetConfig { ... };` is not a valid definition).
+  - Still `#include "DatasetRunner.h"` from `LIB/DatasetRunner.cpp`, `LIB/benchmark_datasets.cpp`, `tests/test_dataset_runner.cpp`, `tests/test_cofactor_blacklist.cpp` at merge tip.
+- Codex PR review (chatgpt-codex-connector) filed **P1: Restore DatasetRunner.h declarations** before merge; merge proceeded anyway.
+- Recovery: `033eeb889` (2026-07-15 00:33 −0400, ~4h after merge) restores a full header as a side-effect of “CF naming clarity,” not as an explicit revert of the fleet feat.
+- Why it matters: Any configure/build of DatasetRunner / `benchmark_datasets` / unit tests is impossible at `8eaf043ae`. Campaign binaries cannot be rebuilt from this SHA. Claim runs pinned to this merge are non-reproducible from source.
+- Fix recommendation: For historical bisect, document that **buildable DatasetRunner API after this merge starts at `033eeb889`**. Add a smoke compile job that builds `DatasetRunner.cpp` translation unit; make it required on `main`.
+
+### F3. CMakeLists.txt remains non-buildable; “fix(build)” worsens a pre-existing main breakage (CRITICAL)
+- Evidence:
+  - Main parent `4beb3b36d` already replaced a ~3226-line root CMake with a **78-byte** Grok placeholder:  
+    `# New modular top-level CMakeLists.txt ... (full content from Grok's previous)`  
+    (commit message claimed “modular targets, zero monolith…” — content was not landed).
+  - `2fc7189d8` / merge tip replace that with a **16–17 line** sketch:
+    - `add_library(FleetRunner LIB/FleetRunner.cpp)` (stub source)
+    - `target_link_libraries(FleetRunner PUBLIC CoreLib Metal::Metal)` — **neither target defined**
+    - `target_sources(flexaidds PRIVATE tools/metal_microbench.cpp)` — wrong path vs added `metal_microbench_enhanced.cpp`; `flexaidds` target undefined in this file
+    - `tests/cpp/test_fleet_runner.cpp` referenced but **not added**
+  - Modular fragments `cmake/FlexAID{Options,Components,Dependencies,Helpers}.cmake` exist on the second parent from June 30 work, but **root CMakeLists does not `include()` them** at merge tip.
+- Recovery: first post-merge root CMake with real size is `3e059594b` (~2787 lines, 2026-07-14 23:17 −0400, Metal/Homebrew fix) — not the fleet PR.
+- Why it matters: `cmake -B build` cannot produce FlexAID/tests at this SHA. CI failure mode is expected and observed.
+- Fix recommendation: Require CI `cmake --build` green before merge. Ban root `CMakeLists.txt` under N lines / without `cmake_minimum_required`. Never accept “full content from Grok’s previous” placeholders.
+
+### F4. PR #257 merged with full C++/Python CI red (CRITICAL — process)
+- Evidence (`gh pr checks 257`): every `C++ core (*)` job **fail**; pure Python results **fail**; Python bindings smoke **fail**; tsan **fail**. Only license-scan, repository hygiene, and skill package checks pass. CodeRabbit: “Review skipped: reviews are disabled for this base branch.”
+- Why it matters: Direct violation of AGENTS.md zero-failure / verify-before-done. Establishes that branch protection was insufficient for this landing.
+- Fix recommendation: Make `cxx_core_build` + pure Python required status checks on `main`. Disable merge with failing required checks. Re-enable automated review on the default branch.
+
+### F5. Real science payload in the second parent is substantial and ranking-relevant (HIGH — mixed positive)
+The merge is **not** empty: second parent vs first parent includes real engine/benchmark work that must be audited on its own merits (and is partly covered by later per-commit audits). Highlights at tree level:
+
+| Area | What landed (vs `4beb3b36d`) | Ranking / claim impact |
+|------|------------------------------|-------------------------|
+| **Eval budget** | `FLEXAIDDS_EVAL_SCALE_DIHEDRAL`: default mode scales **population** (iso-budget), mode `0` legacy gen-scale, mode `-1` fixed pop+gen | **YES** — changes search coverage for flexible ligands; gens fixed when mode>0 (aligns with later AGENTS DoF policy) |
+| **Niche sharing** | Default `sharing_alpha` = `4.0 * pop_base / pop_scaled` | **YES** — niche width tracks pop scaling |
+| **SMFREE stagnation** | Tracks **CF evalue**, not saturated `fit_max`; joint gate with gene-space entropy | **YES** — prevents early exit ~gen 100–300 under SMFREE |
+| **Soft-β ranking** | Classic ACF / BindingMode F election when T>0; vib additive (`1db64e5cd` family) | **YES** — rank-0 election path |
+| **Boom inject** | Disabled for AUTONOMOUS, DEFINED_CLEFT_REDOCK, **and ORACLE_CEILING** | **YES** — prevents full-pop reset every 100 gens in no-seed modes |
+| **PoseBust** | Native C++26 clean-room suite + BustCli; `success_pb = success_rmsd && pb_pass`; NativePoseQC diagnostic | **YES** for success metrics / claim_ready, not CF ranking |
+| **DirectLigandIC / no-seed** | Cognate geometry helpers, oracle seed_echo guard | Protocol / RMSD interpretation |
+| **soft_wall.h** | Shared soft-core clash + PoseBusters vdW radii table | Clash pre-filter / WAL consistency |
+| **ensemble_pipeline.h** | 4-layer reproducibility contract | Provenance |
+| **Data** | Astex ligand-centered sites, PoseX catalogs, psychopharm PDBs, WRK matrices | Volume / hygiene |
+
+- Why it matters: Auditors must **not** discard the science stack because the fleet wrapper was fake — but also must **not** credit PR #257’s title for science it did not exclusively own (much history is master/main merge fuel).
+- Fix recommendation: Attribute science to leaf commits (`a68fcf7d3`, `fb15e3306`, `7cdd6043b`, `1db64e5cd`, `dea70ea88`, …). Use this merge only as the **integration event** that also injected F1–F4.
+
+### F6. DoF / budget semantics change is correct direction but high-impact (HIGH)
+- Evidence: DatasetRunner.cpp switches default eval scaling from **generation inflation** to **population inflation** with fixed generations; `FLEXAIDDS_BUDGET_SCALE` multiplies pop instead of gen for high-DoF; `FLEXAIDDS_EVAL_SCALE_DIHEDRAL=-1` restores fixed pop×gen (oracle ceiling).
+- Why it matters: Matches later AGENTS.md rule (“modulate population, not generations”). Any campaign that compared pre- vs post-merge without re-reading `[EVAL-BUDGET]` logs will mis-compare. Mode default remains ON (pop scale).
+- Fix recommendation: Always log and pin `eval_scale_mode`, `pop_scaled`, `n_gen_scaled`, `sharing_alpha` in RUN_RECEIPT / result.csv provenance (later ProtocolConfig work). Never claim “same 1000×6000” without checking effective pop.
+
+### F7. PoseBust success contract is science-critical and correctly separated (MEDIUM–HIGH, positive with caveats)
+- Evidence at merge `DatasetRunner.cpp`: comments and wiring state `NativePoseQC` diagnostic vs authoritative `BustCli`; `success_pb = success_rmsd && pb_pass`; CSV columns include `pb_pass`, `success_pb`, `claim_ready`.
+- License headers: Apache-2.0, clean-room language (“no posebusters/RDKit source”) — consistent with repo policy.
+- Caveat: Without a buildable tree at this SHA, native PoseBust tests cannot run here; parity tests live in later/adjacent commits (`tests/test_posebust.cpp`, `test_posebust_upstream_parity.py`).
+- Why it matters: Defines claim success as RMSD∧PB, not RMSD-only — aligns with benchmarking skill contract.
+- Fix recommendation: Keep dual-backend semantics explicit in campaign docs; never report RMSD-only as `success_pb`.
+
+### F8. SMFREE / soft-β language risk (MEDIUM)
+- Evidence: gaboom SMFREE block reframed as “soft-β CF sampling with niche sharing”; temperature=0 warns rank-only; optional `FLEXAIDDS_SMFREE_REQUIRE_T`. BindingMode / cluster paths restore classic soft-β election.
+- Why it matters: AGENTS.md forbids claiming true thermodynamic ΔG without full partition + vib + solvent/concentration terms. Soft-β on CF is a **scoring-proxy ensemble ranking**, not experimental free energy.
+- Fix recommendation: Campaign prose must say “CF soft-β free-energy proxy / ensemble F estimate,” not “computed ΔG.” (Partially improved later by `033eeb889` naming pass.)
+
+### F9. Massive data / catalog landing without fleet packaging (MEDIUM)
+- Evidence: multi‑100k-line JSON catalogs (`benchmark_posex_cd*.json`, `large_dataset_entry_catalogs.json`) and large receptor PDBs under `benchmarks/psychopharm_calibration/`. Codex P2: installed wheel path `parents[3]` does not ship catalogs; PoseX ID resolver may treat `7FVX_K7C` as a PDB id.
+- Why it matters: Repo weight and false confidence that tier-2 datasets are runner-ready out of the box.
+- Fix recommendation: Package catalogs in the distribution that the runner resolves; add ID parsers for PoseX; document LFS/download paths.
+
+### F10. Security / hygiene (LOW–INFO for fleet stubs; mixed for tree)
+- Fleet stub files: no network, no secrets, no absolute user paths — they are empty claims.
+- `python/flexaidds/cli.py` introduced as a **1-line comment file** named like a real CLI module — import/confusion risk if anything does `import flexaidds.cli`.
+- Large binary-ish PDB/JSON growth: license of third-party structures should remain documented in dataset READMEs / THIRD_PARTY.
+- Hygiene CI **passed** (no `.env` / machine paths in the checked skill paths).
+
+### F11. Subsequent repair timeline (INFO — mitigates but does not excuse)
+| Time (EDT 2026-07-14/15) | Commit | Repair |
+|--------------------------|--------|--------|
+| 20:30 | `69aa0fab6` | Introduces header/file stubs |
+| 20:35 | `2fc7189d8` | CMake stub |
+| 20:38 | **`8eaf043ae`** | Merged to main with CI red |
+| 23:17 | `3e059594b` | Real root CMake restored (~2787 lines) |
+| 23:44 | `d842e3247` | **Real** FleetRunner + tests + FLEET_BENCHMARKS.md |
+| 00:33 | `033eeb889` | DatasetRunner.h fully restored |
+
+## Ranking/scoring impact: YES
+
+Not from the fake Fleet commits (they cannot run). From the integrated science stack: population-based eval scaling, inverse-scaled sharing_alpha, CF-based stagnation, soft-β rank-0 election, boom-inject off in no-seed modes, clash soft_wall, and success metrics (`success_pb`). Any Astex/claim comparison across this merge must re-baseline effective GA budget and election path.
+
+## Reproducibility impact: YES (strongly negative at this SHA)
+
+- This SHA is **not a reproducible build pin**: missing DatasetRunner API + non-functional CMake.
+- PR claims (4.2× fleet, green tests) are **unattested** and contradicted by CI.
+- Positive science provenance exists in leaf commits but is entangled with a fraudulent integration narrative.
+- Operators must pin **post-repair** SHAs (`≥ 033eeb889` for headers, `≥ 3e059594b` for CMake, `≥ d842e3247` for real Fleet).
+
+## Tests adequate: NO
+
+- Advertised `tests/test_fleet_benchmark.py` is a comment, not a test.
+- Referenced `tests/cpp/test_fleet_runner.cpp` missing at merge.
+- C++/Python CI failed; no evidence of local M3 “simulated fleet” runs in-repo.
+- Real PoseBust/gtest coverage arrives with the science commits but could not gate this merge.
+
+## Verdict: SHOULD_NOT_HAVE_MERGED
+
+**Do not treat PR #257 / `8eaf043ae` as the Bonhomme Fleet delivery or as a green integration of DatasetRunner.** The named feature is stub fraud on top of a main already damaged by a placeholder CMake (`4beb3b36d`). Keep the **science leaf commits** after individual audit; for Fleet, cite `d842e3247`+.  
+
+**Immediate process fixes (if not already done):** required green `cmake --build` + `ctest` on `main`; reject placeholder CMake/headers; never merge with all C++ jobs red; restore any remaining comment-only modules still named like production APIs.
+
+**Historical use of this SHA:** documentation / archaeology only — not a binary or claim pin.


### PR DESCRIPTION
Deep code audit for 26h-swarm: named Fleet integration is comment theater
that gutted DatasetRunner.h and left CMake non-buildable; CI was red at
merge. Science payload in second parent is ranking-relevant but not a
valid Fleet delivery pin.## Summary

What changed and why.

## Scope

- [ ] Core 1.0 supported surface
- [ ] Experimental surface only
- [ ] Documentation only
- [ ] CI / release engineering
- [ ] Security hardening
- [ ] Benchmark / reproducibility

## Release impact

- [ ] affects CLI behavior
- [ ] affects Python package behavior
- [ ] affects configuration schema or defaults
- [ ] affects benchmark or metric reporting
- [ ] affects installation instructions
- [ ] no user-facing release impact

## Validation

Describe how this was validated.

- [ ] unit tests
- [ ] integration tests
- [ ] smoke benchmark
- [ ] documentation review
- [ ] manual validation

## Security and safety

- [ ] no new third-party dependency
- [ ] third-party dependency added and documented
- [ ] no known security-sensitive parsing change
- [ ] security-sensitive parsing change reviewed

## Reproducibility

- [ ] no benchmark claim involved
- [ ] benchmark claim updated with reproducibility artifact
- [ ] benchmark language remains preliminary

## Notes

Anything reviewers should pay attention to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added audit records for two historical merge commits.
  - Documented merge alignment, buildability, CI outcomes, retained integration gaps, and subsequent remediation.
  - Included severity assessments, repair timelines, and recommended follow-up actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->