### PR TITLE
Docs: audit merge 6774dcb (master into dependabot pypi-publish)

### DIFF
--- a/docs/audit/26h-swarm/6774dcb7d.md
+++ b/docs/audit/26h-swarm/6774dcb7d.md
@@ -1,0 +1,108 @@
+# Audit: 6774dcb7d — Merge master into dependabot pypi-publish
+
+## Summary (2-4 sentences)
+Merge commit `6774dcb7d70fd07d722f0ce33fa00114ebdcb73e` refreshes Dependabot branch `dependabot/github_actions/pypa/gh-action-pypi-publish-1.14.0` with then-current `master` so PR #251 can land. The merge is a **clean recursive auto-merge** (`git merge-tree --write-tree` tree SHA equals the merge commit tree `50e38742…`); there are **no conflict resolutions** and **no science/engine blobs rewritten**. Net unique content vs second parent (master `83f7a8584`) is **only** a two-line pin of `pypa/gh-action-pypi-publish` from `76f52bc…` (v1.12.4) → `cef2210…` (v1.14.0) in `.github/workflows/pypi-release.yml`, with a pre-existing stale trailing comment still saying `# v1.10.3`.
+
+## Severity: LOW
+
+## Merge topology
+
+| Role | SHA | Subject |
+|------|-----|---------|
+| Merge | `6774dcb7d` | Merge branch 'master' into dependabot/…/pypi-publish-1.14.0 |
+| Parent1 (ours / dependabot tip) | `b50beef7d` | Build(deps): Bump pypa/gh-action-pypi-publish 1.12.4 → 1.14.0 |
+| Parent2 (theirs / master) | `83f7a8584` | Add: PB extract hygiene + optional BindingMode clash promotion |
+| Merge-base | `439534790` | (ancestor before ~20 master commits of PoseBust / Astex stack) |
+
+**Conflict resolution intent:** none required — disjoint paths (workflow pin vs master science/CI bulk).
+
+**What each side owned**
+
+| Artifact | Parent1 | Parent2 | Merge result |
+|----------|---------|---------|--------------|
+| `.github/workflows/pypi-release.yml` action pin | `cef2210…` (1.14.0) | `76f52bc…` (1.12.4) | **P1 pin kept** |
+| `LIB/**`, PoseBust, DatasetRunner, CMake, tests, Astex assets | pre-base | full master tip | **identical to P2** (blob SHAs match for core files) |
+| Rest of tree | pre-base | master | **identical to P2** except workflow |
+
+**Downstream land:** PR #251 merge commit `b041397ff` = merge of `83f7a8584` + `6774dcb7d` into master; diff vs pre-PR master is the same 4-line workflow change only. State: **MERGED**.
+
+**Integrity checks performed this session**
+- `git merge-tree --write-tree b50beef7d 83f7a8584` → `50e387421a06fa47d78143fbcee975b1e10c14f3` == `6774dcb7d^{tree}`
+- `git diff --name-only 83f7a8584 6774dcb7d` → only `.github/workflows/pypi-release.yml`
+- Blob parity: `CMakeLists.txt`, `LIB/gaboom.cpp`, `LIB/DatasetRunner.cpp`, `LIB/BindingMode.cpp` SHAs identical on master vs merge
+- No `<<<<<<<` / `>>>>>>>` conflict markers in the merge tree (false positives are comment separators `====`)
+- Merge authored by `LeBonhommePharma`, committed by GitHub (web merge), GPG-signed with GitHub’s key
+
+**Scope discipline:** The ~12k-line `--stat` vs parent1 is **master content being pulled into the Dependabot branch**, not new work invented by this merge. PoseBust, cognate docking, DatasetRunner PB gates, Astex repro scripts, etc. belong to parent2 commits already listed in the swarm (`83f7a8584`, `7e79352e3`, `dea70ea88`, …). This report audits **merge integrity + the only non-master delta**.
+
+## Findings
+
+### F1. Clean merge; no engine/ranking code lost or rewritten (INFO — good)
+- Evidence: merge-tree tree matches commit tree; zero path conflicts; master blob identity for docking cores preserved. Dependabot side only ever touched the two `uses:` lines in `pypi-release.yml`.
+- Why it matters: “Merge master into dependabot” merges are high-risk for silent master reverts if someone resolves conflicts by preferring the branch tip. Here there was nothing to resolve; master science stack is intact on the branch tip.
+- Fix recommendation: None for this merge. Prefer the same check (`merge-tree` tree == commit tree; `git diff master` = expected pin only) before landing other Dependabot PRs that sat while master moved.
+
+### F2. Action pin is correct for v1.14.0 (INFO — good)
+- Evidence:
+  - Dependabot message: 1.12.4 → 1.14.0, commits `76f52bc884231f62b9a034ebfe128415bbaabdfc`…`cef221092ed1bacb1cc03d23a2d87d1d172e277b`
+  - Upstream release pages: [v1.12.4](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.4) = `76f52bc…`; [v1.14.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.0) = `cef2210…` (tag signed by maintainers)
+  - Full SHA pin (not floating `@v1`) remains — good supply-chain hygiene relative to unpinned `@release/v1` guidance
+- Why it matters: Wrong pin would break or silently change PyPI publish behavior for `flexaidds`.
+- Fix recommendation: Keep full-commit pins. Optionally add Dependabot `commit-message` / comment rewrite so trailing `# vX.Y.Z` tracks the real tag (see F3).
+
+### F3. Trailing version comment stays `# v1.10.3` while SHA is v1.14.0 (LOW)
+- Evidence: both publish steps after the merge:
+  ```yaml
+  uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.10.3
+  ```
+  Dependabot correctly rewrote the SHA but **did not** update the human comment. The comment was already wrong on master (`76f52bc…` is v1.12.4, still labeled `# v1.10.3` from the original workflow add `7e22073d8`).
+- Why it matters: Operators and auditors grepping for “which action version?” will report the wrong version in incident response. Does not change runtime (GitHub Actions resolves the SHA, not the comment).
+- Fix recommendation: One-line follow-up (can be a tiny chore PR):
+  ```yaml
+  uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+  ```
+  on both PyPI and TestPyPI steps. Prefer tooling that rewrites comments with SHA pins, or drop the trailing comment and rely on the full SHA + Dependabot PR title.
+
+### F4. Security: bump closes GHSA-vxmw-7h4f-hqxh (≤1.12.4) (INFO — positive)
+- Evidence: Advisory [GHSA-vxmw-7h4f-hqxh](https://github.com/pypa/gh-action-pypi-publish/security/advisories/GHSA-vxmw-7h4f-hqxh) — “Injectable expression expansions in action steps”; affected `<= v1.12.4`; patched `> v1.12.4` (landed in **v1.13.0**). Severity **Low** upstream; impact requires attacker-controlled `github.ref_name` when `ACTION_REF` / PR ref fall through.
+- This repo’s workflow triggers: `release: types: [published]` and `workflow_dispatch` only — **not** `pull_request` from untrusted forks. Upstream notes many configs (including **release** events) are not practically vulnerable.
+- Why it matters: Still correct to leave 1.12.4; 1.14.0 includes 1.13.0’s fix + later diagnostics. Residual risk for this exact workflow shape is low.
+- Fix recommendation: None beyond keeping ≥1.13. Do not reintroduce 1.12.x pins.
+
+### F5. Behavioral deltas 1.12.4 → 1.14.0 are ops/logging, not science (LOW–INFO)
+- Evidence from upstream release notes:
+  - **v1.14.0:** `verbose` and `print-hash` default to **true** (were false/off before). CI logs will be noisier and print dist hashes — generally good for release forensics.
+  - **v1.13.0:** GHSA fix; Trusted Publishing diagnostics (environment claim print, reusable-workflow warnings); internal Python/runtime bumps.
+  - **v1.11.0 path already behind 1.12.4:** PEP 740 attestations default **on** for Trusted Publishing (unchanged relative to pre-bump master for that feature family).
+- Workflow still sets: `permissions: contents: read` + `id-token: write`; `skip-existing: true`; `password: ${{ secrets.PYPI_API_TOKEN }}` / `TEST_PYPI_API_TOKEN` with comments that empty password → OIDC. Action `action.yml` at `cef2210` still has `password` optional and `attestations` default `true`.
+- Why it matters: First publish after the bump may log more and still attempt attestations under OIDC. Token-only path remains supported when secrets are set. No docking/CF/ranking path is in this workflow.
+- Fix recommendation: After next TestPyPI `workflow_dispatch`, skim job logs for attestation warnings if using token auth; optional explicit `verbose: true` / `print-hash: true` for clarity (redundant with new defaults). No science gate required.
+
+### F6. Workflow contract otherwise unchanged (INFO)
+- Evidence: `git diff 83f7a8584 6774dcb7d -- .github/workflows/pypi-release.yml` is exactly two `uses:` line replacements. Unchanged:
+  - Build matrix: sdist + pure `py3-none-any` wheel with `FLEXAIDDS_SKIP_CORE=1`
+  - Environments `pypi` / `testpypi` and trusted-publisher checklist comments (`LeBonhommePharma` / `FlexAIDdS` / `pypi-release.yml`)
+  - Artifact download `merge-multiple: true` into `dist/` (matches action default `packages-dir: dist`)
+  - No secrets committed; no machine-absolute paths
+- Fix recommendation: None.
+
+### F7. Large `--stat` vs P1 can mislead swarm triage (INFO — process)
+- Evidence: `git show 6774dcb7d --stat` lists 99 files / +12k lines (PoseBust, Astex sites, DatasetRunner, …). That is **`master` not in the Dependabot tip**, not “this merge rewrote docking.” Unique vs master = 1 file / 4 lines.
+- Why it matters: Per-commit auditors who only read `--stat` against first parent may over-scope severity or re-litigate master science in the wrong report.
+- Fix recommendation: For two-parent merges, always report **both** `git diff P1..M --stat` and `git diff P2..M --stat`. Swarm INDEX already lists sibling commits for the master bulk.
+
+## Ranking/scoring impact: NO
+
+No `LIB/`, GA, CF/contact-function, BindingMode ranking, clustering, DatasetRunner election, or budget code is unique to this merge vs master. Pin change is release workflow only.
+
+## Reproducibility impact: NO (science) / YES (release tooling)
+
+Docking campaigns and claim CSVs are unaffected. PyPI publish jobs will run action **v1.14.0** (hash-pinned), with louder logs and post-1.12.4 security/runtime stack — better release reproducibility of *what was published*, not of docking RMSD/ensemble thermo.
+
+## Tests adequate: N/A for this merge’s unique delta
+
+No C++/Python tests apply to a GitHub Actions SHA pin. Adequacy of PoseBust/etc. tests is owned by parent2 commits. Recommended smoke (ops, not blocking this audit): after land, `workflow_dispatch` → TestPyPI once and confirm upload + OIDC/token path.
+
+## Verdict: MERGE_OK
+
+Safe and correctly formed. Prefer keeping the 1.14.0 pin (security + maintainability). Optional non-blocking hygiene: fix `# v1.10.3` → `# v1.14.0` on both publish steps (F3). Do not treat the large first-parent `--stat` as new science risk from this commit.

--- a/docs/audit/26h-swarm/8c42517bd.md
+++ b/docs/audit/26h-swarm/8c42517bd.md
@@ -1,0 +1,202 @@
+# Audit: 8c42517bd — Fix: Harden self-hosted Metal gate + exact release language
+
+## Summary (2–4 sentences)
+
+Commit `8c42517bd2ffc7b32c622b375eb1049339a5b3f5` hardens the **self-hosted Metal full gate** (`.github/workflows/metal-self-hosted.yml`) and expands `docs/CI_RELEASE_GATES.md` with exact allowed/forbidden release language plus an LP release-manager checklist. It requires building **both** `FlexAID` and `FlexAIDdS` under `FLEXAIDS_USE_METAL=ON`, adds fail-closed CMakeCache checks, and adds an optional `nm` symbol smoke (`metal_eval_*` / `metal_rmsd`). **No engine/source ranking code changes.** Twin commit `e752df7aa` (identical `git patch-id`) was applied ~19s earlier on a different parent and **reverted ~2s after this commit by `4d51e413e`**; this SHA was **not** reverted and landed on `main` via **PR #271** (`125f76cc8`, 2026-07-15 00:55:33 −0400). Net on current `main`: the hardened workflow/docs content is **present**.
+
+## Severity: HIGH
+
+(Operational: the default `nm_symbol_smoke` path is broken for `FlexAIDdS` LTO; policy docs are otherwise strong.)
+
+## Commit identity
+
+| Field | Value |
+|:--|:--|
+| Full SHA | `8c42517bd2ffc7b32c622b375eb1049339a5b3f5` |
+| Short | `8c42517bd` |
+| Author / date | LP `<lp@thebonhomme.com>` / 2026-07-15 00:42:44 −0400 (author); commit 00:43:03 −0400 |
+| Parent | `342d6650de100537a69907d36a9d3468af132efc` (Merge PR #268 formula sha) |
+| Files | `.github/workflows/metal-self-hosted.yml` (+79/−lines net), `docs/CI_RELEASE_GATES.md` (+131/−lines net) |
+| Stats | 2 files, +192 / −18 |
+| Patch-id | `335eafef8fbc7c5f3fad02b10c6cd1e2e40e3254` (identical to twin `e752df7aa`) |
+| Landed | PR #271 `fix/science-macos-metal-release-gates` → merge `125f76cc8` |
+
+## Twin commit / subsequent revert (required note)
+
+| SHA | Role | Parent | Notes |
+|:--|:--|:--|:--|
+| `e752df7aa` | Twin of this patch | `80f6ba783` (INSTALLATION Metal Homebrew docs) | Same subject/body, **same patch-id**, different tree (extra INSTALLATION delta vs `8c42517bd`) |
+| **`4d51e413e`** | **Revert of `e752df7aa` only** | `e752df7aa` | Message: *Revert "Fix: Harden self-hosted Metal gate…"* / *This reverts commit e752df7aa…*. Timestamp **00:43:05** (−0400), ~2s after `8c42517bd`. Tree equals `e752^` (clean reverse of twin). **Does not revert `8c42517bd`.** |
+| `8c42517bd` | This audit subject | `342d6650d` | Re-application of same patch on mainline tip after PR #268 |
+| `125f76cc8` | Merge PR #271 | `af2ab1348` + `8c42517bd` | Puts this hardening on `main` |
+
+**Graph (simplified):**
+
+```text
+342d6650d (mainline after v2.0.3 formula sha)
+├── 8c42517bd  ← this commit (harden Metal gate)
+│     └── … → PR #271 merge 125f76cc8 → main
+└── 80f6ba783 (INSTALLATION align)
+      └── e752df7aa  ← twin (same patch-id)
+            └── 4d51e413e  ← REVERT twin only
+```
+
+**Implication for auditors:** Do not treat `4d51e413e` as undoing Metal-gate hardening on `main`. It only undoes the `e752` tip on the INSTALLATION-docs side-branch; the surviving path is `8c42517bd` via PR #271. Current `main` workflow blob matches `8c42517bd:.github/workflows/metal-self-hosted.yml` (tree hash `ae0cfe38d…`).
+
+## What changed (Metal gate)
+
+### Workflow `.github/workflows/metal-self-hosted.yml`
+
+Relative to parent (`ffa7499cd` baseline already had fail-closed Metal toolchain preflight + `workflow_dispatch` + `self-hosted`/`self-hosted-m3`):
+
+1. **Header note** — do not claim an M3 runner exists unless `gh api …/actions/runners` lists `self-hosted-m3`.
+2. **New input** `nm_symbol_smoke` (choice true/false, **default true**).
+3. **Configure** — `set -euo pipefail` comment; add `-DBUILD_FLEXAIDDS_FAST=ON`; after `cmake`, fail if no Metal-related CMakeCache lines **or** if `FLEXAIDS_USE_METAL:BOOL=OFF`.
+4. **Build** — `cmake --build … --target FlexAID FlexAIDdS` (was FlexAID only); `ls` both binaries.
+5. **nm symbol smoke** (if input true) — require substring matches on both binaries for:
+   - `metal_eval_get_capabilities`
+   - `metal_eval_init`
+   - `metal_eval_batch`
+   - `metal_eval_shutdown`
+   - `metal_eval_runtime_available`
+   - `metal_rmsd`
+6. **Summarize** — list both binaries + dispatch reminder.
+
+### Docs `docs/CI_RELEASE_GATES.md`
+
+- Soft-skip of hosted `macos_metal_compile_smoke` explicitly **not** a Metal release claim.
+- Dual-binary + nm smoke + fail-closed configure documented.
+- Runner registration snippet with `gh api repos/LeBonhommePharma/FlexAIDdS/actions/runners`.
+- **Allowed / forbidden / allowed-with-green** claim tables (release notes, Homebrew, README, papers).
+- Expanded **LP release managers** checklist (always / macOS CPU / Metal / non-claims including PoseBusters + no true-ΔG).
+- Local repro builds both targets + optional `nm | grep`.
+
+## Findings
+
+### F1. Default nm smoke fails on `FlexAIDdS` under LTO — required symbol never referenced (HIGH)
+
+- **Evidence (this session, local `build_metal_fix` with `FLEXAIDS_USE_METAL:BOOL=ON`):**
+  - `build_metal_fix/FlexAID`: all six patterns **OK**.
+  - `build_metal_fix/FlexAIDdS`: **`metal_eval_runtime_available` MISSING**; other five OK.
+- Root cause: `metal_eval_runtime_available()` is defined in `LIB/metal_eval.mm` / declared in `LIB/metal_eval.h` but **has zero call sites** outside those files (`rg` only hits the definition/declaration). `FlexAIDdS` is built with `-flto` + `INTERPROCEDURAL_OPTIMIZATION ON` (`CMakeLists.txt` ~681–699); dead-code elimination drops the unreferenced symbol. `FlexAID` is not built with the same LTO flags, so the symbol survives there.
+- Why it matters: With defaults (`nm_symbol_smoke=true`, `BUILD_FLEXAIDDS_FAST=ON`), a correctly Metal-linked Apple Silicon build **fails the full gate** on the dual-binary check. Operators may then (a) disable nm smoke and over-claim from a partial green run, or (b) never achieve a green Metal release gate. PR #271 body already notes **no `self-hosted-m3` runner registered**, so this was not exercised on Actions in that session.
+- **Fix recommendation:** Drop `metal_eval_runtime_available` from the required list **or** call it from a live path (`detect_hardware()` / `UnifiedHardwareDispatch`) so LTO cannot strip it; re-run nm on both LTO binaries in CI. Prefer calling it from `hardware_detect` so the probe is real, not just a keep-alive.
+
+### F2. CMakeCache “fail-closed” checks are incomplete vs non-CACHE soft-disable (MEDIUM)
+
+- **Evidence:**
+  - Workflow greps `FLEXAIDS_USE_METAL|Metal` (very loose — any Metal *toolchain path* line passes) then rejects only `^FLEXAIDS_USE_METAL:BOOL=OFF`.
+  - `cmake/FlexAIDDependencies.cmake` (~187–189): if `FLEXAIDS_USE_METAL` is on but `_HAS_OBJCXX` is false, it does `set(FLEXAIDS_USE_METAL OFF)` as a **normal variable**, **not** `CACHE … FORCE`. Cache can still show `FLEXAIDS_USE_METAL:BOOL=ON` while Metal bridges are not attached.
+  - Root `CMakeLists.txt` does `FATAL_ERROR` when Metal compiler missing **only** under `if(APPLE AND FLEXAIDS_USE_METAL)` after options — good when the variable stays ON; the Dependencies soft-off path is the hole.
+- Why it matters: On a misconfigured self-hosted runner, configure can “succeed” with cache ON while building CPU-only objects; first-line cache checks pass; **nm smoke (F1) is the real backstop** — and F1 currently breaks for other reasons.
+- **Fix recommendation:** After configure, assert stronger signals, e.g. `grep -E '^FLEXAIDS_USE_METAL:BOOL=ON$'` **and** require `METAL_LIBRARY:FILEPATH=` non-empty / log line `Metal acceleration enabled`. Better: make Dependencies use `FATAL_ERROR` when `-DFLEXAIDS_USE_METAL=ON` was requested and OBJCXX is missing (fail-closed at CMake, not soft OFF).
+
+### F3. Gate proves link/symbols, not Metal GA scoring parity or GPU docking (MEDIUM — scientific)
+
+- **Evidence:** `LIB/metal_eval.mm` file header (current tree): *“Experimental approximate Metal chromosome evaluation… does not currently reproduce the full CPU ic2cf/vcfunction scoring path… UnifiedHardwareDispatch therefore keeps production GA fitness on CPU/OpenMP until parity is implemented.”* Workflow never runs a GPU fitness smoke, metallib load test, or CF parity suite. Docs correctly forbid “Metal-accelerated docking is CI-proven” without full gate, but **allowed-with-green** language (“Metal OBJCXX bridges **link**…”, “expose … symbols”) is easy to inflate verbally into “Metal docking validated.”
+- Why it matters: AGENTS.md scientific guardrails — scoring proxy vs thermodynamics; inspect-first. A green self-hosted gate still does **not** authorize claims that production GA used Metal CF kernels or that Metal CF matches CPU.
+- **Fix recommendation:** Keep release tables as-is (already careful). Add one explicit row: *“Production GA fitness still CPU unless UnifiedHardwareDispatch routes Metal (parity not done).”* Optional future step: microbench / known-system CF parity job behind a third input, not conflated with link smoke.
+
+### F4. No registered `self-hosted-m3` runner ⇒ full gate cannot go green (MEDIUM — process)
+
+- **Evidence:** PR #271 verification text: `gh api …/actions/runners` listed **no** `self-hosted-m3`. Workflow is `workflow_dispatch` only with `runs-on: [self-hosted, self-hosted-m3]`; without a runner, jobs stay **queued** until cancelled (never soft-pass — correct). Commit header comment + docs reinforce this.
+- Why it matters: Hardening is process-ready but **not operationally enforceable** for release tags until a machine is registered. Risk of “docs say gate exists” being treated as “Metal is gated in CI.”
+- **Fix recommendation:** Register labeled M3 runner; pin Actions run URL in every release that claims Metal link. Until then, default public language must stay **experimental** (docs already allow this).
+
+### F5. Hosted soft-skip language is correctly hardened; still human-enforced (LOW–MEDIUM)
+
+- **Evidence:** Docs state soft-skip ≠ Metal release claim; forbidden table includes soft-skip misuse and false “M3 runner online.” No automated check that release notes avoid forbidden phrases.
+- Why it matters: Social process only — good checklist, no CI bot.
+- **Fix recommendation:** Optional release-script grep over notes against forbidden patterns; not required for this commit’s intent.
+
+### F6. `BUILD_FLEXAIDDS_FAST=ON` is redundant with default but couples gate to LTO (LOW)
+
+- **Evidence:** `option(BUILD_FLEXAIDDS_FAST … ON)` already defaults ON; workflow forces ON explicitly (good for cache contamination). That same path enables LTO on `FlexAIDdS`, which triggers F1.
+- Fix recommendation: Keep explicit ON; fix F1 symbol list/call graph.
+
+### F7. nm matching is substring-based on mangled C++ names (LOW / INFO)
+
+- **Evidence:** `metal_eval_*` are C++ (not `extern "C"`); local `nm -gU` shows mangled forms like `__Z27metal_eval_get_capabilitiesP17MetalCapabilities`. Substring `grep -E` matches. `metal_rmsd` is a namespace; mangled forms contain `metal_rmsd`. Comment in workflow is accurate.
+- Residual risk: unanchored patterns could theoretically match unrelated symbols; names are specific enough in practice.
+- Fix recommendation: Optional `nm -gU --demangle` for readability; not required for correctness.
+
+### F8. Binary path assumptions (LOW)
+
+- **Evidence:** Workflow assumes Ninja single-config outputs at `build-metal/FlexAID` and `build-metal/FlexAIDdS`. Matches project conventions; multi-config generators are not used here (`-G Ninja`).
+- Fix recommendation: Prefer `$<TARGET_FILE:…>` via `cmake --build … --target` + `cmake -E true` already ok; optional `cmake --find-package` not needed.
+
+### F9. Docs checklist aligns with AGENTS.md scientific guardrails (INFO / positive)
+
+- **Evidence:** Explicit non-claims: no RMSD-only success without PoseBusters; no “true ΔG” for CF-only scoring. Hosted vs self-hosted separation matches SUPPORT_MATRIX / CONTRIBUTING. Parent work `ffa7499cd` / PR #261 blocking `macos_cpu_tests` correctly preserved as prerequisite.
+- No fix needed for language tables beyond F3 one-liner.
+
+### F10. Security / hygiene (INFO)
+
+- CI YAML + docs only; no secrets, no machine-absolute user paths in the commit. `LeBonhommePharma` in `gh api` examples matches AGENTS.md identity rule.
+- N/A.
+
+### F11. Twin-commit thrash / history noise (INFO)
+
+- **Evidence:** `e752` → `4d51` revert ~21s later on side parent; same patch reapplied as `8c42517bd` on mainline; PR merge ~12 min later. Audit swarm lists all three SHAs separately (`INDEX.md` #41–43).
+- Why it matters: Auditors reading only `4d51` may wrongly conclude Metal hardening was backed out of the product.
+- Fix recommendation: Cross-link these three audits; prefer single linear landing next time (no twin+revert).
+
+## Ranking/scoring impact: NO
+
+Diff touches only GHA workflow + release-gate documentation. No changes to GA selection, CF/Voronoi scoring, BindingMode clustering, StatMech, or campaign YAML. Production GA Metal routing remains as before (CPU per `metal_eval.mm` header).
+
+## Reproducibility impact: YES (process)
+
+**Positive:** Dual-binary Metal link intent, nm smoke design, fail-closed configure intent, exact claim language, runner existence API check, LP checklist.  
+**Negative:** Default nm list broken under FlexAIDdS LTO (F1); cache checks incomplete (F2); no runner ⇒ gate never green (F4); no GPU/runtime parity proof (F3).
+
+## Tests adequate: NO
+
+- No CI exercise of `metal-self-hosted.yml` on this commit (dispatch-only + no runner).
+- No unit test that the required `nm` symbol set matches symbols retained under LTO for both targets.
+- Hosted `macos_metal_compile_smoke` / `macos_cpu_tests` are out of this commit’s file set (parent PR #261).
+
+## Verdict: MERGE_WITH_FIX
+
+**Already merged** via PR #271; content should stay on `main`. Before treating any tag as “Metal full gate green,” fix **F1** (symbol list or live call to `metal_eval_runtime_available`), tighten **F2** configure assertions, and register a real **`self-hosted-m3`** runner (**F4**). Until then, public Metal language must remain **experimental / best-effort** per the commit’s own tables.
+
+**Do not interpret subsequent `4d51e413e` as reverting this SHA** — it only reverts twin `e752df7aa` on a different parent; `8c42517bd` survived and is the lineage that shipped.
+
+## Evidence appendix
+
+### Patch scope
+
+```text
+.github/workflows/metal-self-hosted.yml | 79 ++++++++++++++++++-
+docs/CI_RELEASE_GATES.md                | 131 ++++++++++++++++++++++++++++----
+2 files changed, 192 insertions(+), 18 deletions(-)
+```
+
+### Local nm smoke (audit session)
+
+| Binary | metal_eval_get_capabilities | metal_eval_init | metal_eval_batch | metal_eval_shutdown | metal_eval_runtime_available | metal_rmsd |
+|:--|:--|:--|:--|:--|:--|:--|
+| `build_metal_fix/FlexAID` | OK | OK | OK | OK | OK | OK |
+| `build_metal_fix/FlexAIDdS` | OK | OK | OK | OK | **MISSING** | OK |
+
+### Related commits
+
+| SHA | Subject |
+|:--|:--|
+| `ffa7499cd` | Introduced `metal-self-hosted.yml` + first `CI_RELEASE_GATES.md` + blocking macOS CPU |
+| `e752df7aa` | Twin harden (same patch-id) |
+| **`4d51e413e`** | **Revert twin `e752df7aa` only** |
+| `8c42517bd` | This commit |
+| `125f76cc8` | Merge PR #271 onto main |
+| `3e059594b` / `5a3b95430` | Homebrew Metal link via `flexaid_core` (prerequisite for dual-binary Metal link) |
+
+### What this gate still does **not** cover
+
+| Claim | Covered by this commit? |
+|:--|:--|
+| Metal shader compile on hosted GHA | No (hosted job; parent) |
+| Metal OBJCXX **link** both production binaries | Intended yes (when runner exists + F1 fixed) |
+| GPU runtime / device acquire | No |
+| CF numerical parity vs CPU | No (`metal_eval` experimental) |
+| Campaign / Astex docking on Metal | No |
+| Blocking PR status check for Metal | No (`workflow_dispatch` only) |

--- a/docs/audit/26h-swarm/b041397ff.md
+++ b/docs/audit/26h-swarm/b041397ff.md
@@ -1,0 +1,258 @@
+# Audit: `b041397ff` — Merge PR #251 pypa/gh-action-pypi-publish 1.14.0
+
+| Field | Value |
+|-------|--------|
+| **Commit** | `b041397ffaa8ce610bb1fa84ccef9a1566f840dc` |
+| **Short** | `b041397ff` |
+| **Subject** | Merge pull request #251 from LeBonhommePharma/dependabot/github_actions/pypa/gh-action-pypi-publish-1.14.0 |
+| **Type** | GitHub merge of Dependabot minor bump (supply-chain / CI only) |
+| **Parents** | `83f7a8584` (master tip: PB extract hygiene) · `6774dcb7d` (branch merge of Dependabot into master) |
+| **Leaf change** | `b50beef7d` — `Build(deps): Bump pypa/gh-action-pypi-publish from 1.12.4 to 1.14.0` |
+| **AuthorDate** | 2026-07-14 20:19:18 -0400 (merge via GitHub) |
+| **Files (merge vs first parent)** | `.github/workflows/pypi-release.yml` only (+2 / −2) |
+| **Scope** | **No source edits.** Zero `LIB/`, `python/`, tests, science kernels, ranking, CF, or StatMech. |
+| **Audit focus** | PyPI publish security · pin integrity · GHSA coverage · trusted publishing · residual workflow risks |
+| **Verdict** | **PASS** as a correct SHA-pinned security-relevant action upgrade (includes GHSA-vxmw-7h4f-hqxh via 1.13.0). **Hygiene FAIL (low)** for stale `# v1.10.3` comments that do not match either the old or new pin. |
+
+---
+
+## 1. Executive summary
+
+This merge lands Dependabot PR #251: pin `pypa/gh-action-pypi-publish` from **SHA of v1.12.4** to **SHA of v1.14.0** in both PyPI and TestPyPI publish steps. Runtime behavior of FlexAIDdS docking/science is untouched.
+
+**What is correct**
+
+- Full commit SHAs are used (not floating major tags alone) — good pin hygiene for Actions supply chain.
+- Dependabot’s declared range `1.12.4 → 1.14.0` matches peeled tag commits on `pypa/gh-action-pypi-publish`:
+  - `76f52bc884231f62b9a034ebfe128415bbaabdfc` = **v1.12.4**
+  - `cef221092ed1bacb1cc03d23a2d87d1d172e277b` = **v1.14.0**
+- Path includes **v1.13.0**, which ships the fix for **[GHSA-vxmw-7h4f-hqxh](https://github.com/pypa/gh-action-pypi-publish/security/advisories/GHSA-vxmw-7h4f-hqxh)** (*Injectable expression expansions in action steps*; severity **low**; vulnerable `<= v1.12.4`).
+- v1.14.0 turns **`verbose` and `print-hash` on by default** — improves release-log transparency (hashes of uploaded artifacts).
+- Workflow already uses least-privilege workflow permissions (`contents: read`, `id-token: write`), GitHub Environments (`pypi` / `testpypi`), build→artifact→publish separation, and OIDC trusted publishing with optional token fallback.
+
+**What is wrong / residual**
+
+- YAML comments still say `# v1.10.3` on **both** before and after the bump. The old pin was **never** v1.10.3 (true v1.10.3 peel is `f760068…`); it was always v1.12.4 SHA with a stale label from the original workflow introduction (`7e22073d8`). Dependabot correctly updated the SHA but **did not rewrite the comment**, so humans reading the workflow still see a false version.
+- Optional long-lived `PYPI_API_TOKEN` / `TEST_PYPI_API_TOKEN` paths remain (pre-existing). If either secret is non-empty, the action prefers token auth over OIDC trusted publishing — larger blast radius if the secret leaks.
+- This commit does **not** add environment protection reviews, attestations knobs, or zizmor CI for the consumer workflow; those are residual hardens, not regressions.
+
+**Science / claim impact:** none.
+
+---
+
+## 2. Change inventory (exact merge)
+
+### Diff (first-parent / PR net)
+
+```diff
+# .github/workflows/pypi-release.yml — publish + publish-testpypi steps only
+- uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.10.3
++ uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.10.3
+```
+
+Applied twice (prod PyPI job + TestPyPI job). Inputs unchanged:
+
+| Input | Value | Notes |
+|-------|-------|--------|
+| `skip-existing` | `true` | Idempotent re-publish of same filenames |
+| `password` | `${{ secrets.PYPI_API_TOKEN }}` / `TEST_PYPI_API_TOKEN` | Empty secret → OIDC trusted publishing |
+| `repository-url` | TestPyPI only | `https://test.pypi.org/legacy/` |
+
+### Merge graph
+
+```
+83f7a8584 (master) ──┐
+                     ├─ b041397ff  Merge PR #251
+6774dcb7d ───────────┘
+   └─ b50beef7d  Dependabot leaf (pin only)
+```
+
+`git diff 83f7a8584 b041397ff --name-only` → only `pypi-release.yml`. Confirms subject claim: **no source edits**.
+
+---
+
+## 3. Pin integrity — **PASS** (with comment hygiene defect)
+
+### 3.1 Tag ↔ SHA verification (upstream)
+
+| Tag | Peeled commit | Present in workflow? |
+|-----|---------------|----------------------|
+| v1.10.3 | `f7600683efdcb7656dec5b29656edb7bc586e597` | **Never** (comment only) |
+| v1.12.4 | `76f52bc884231f62b9a034ebfe128415bbaabdfc` | Pre-merge pin |
+| v1.13.0 | `ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e` | Intermediate (not pinned; contained in range) |
+| v1.14.0 | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` | Post-merge pin |
+
+Dependabot commit message cites the exact compare URL:
+
+`https://github.com/pypa/gh-action-pypi-publish/compare/76f52bc…cef2210`
+
+GitHub compare reports **status: ahead**, **53 commits**, **behind_by: 0** — clean fast-forward range, not a forced or divergent pin.
+
+### 3.2 Finding H1 — Stale version comments (LOW hygiene)
+
+| Location (post-merge) | Comment | Reality |
+|-----------------------|---------|---------|
+| Publish to PyPI `uses:` | `# v1.10.3` | **v1.14.0** |
+| Publish to TestPyPI `uses:` | `# v1.10.3` | **v1.14.0** |
+
+- **Runtime risk:** none (Actions resolves by full SHA, not the trailing comment).
+- **Audit / ops risk:** humans and semi-automated scanners that trust comments over SHAs will mis-report the fleet as “still on 1.10.3” and may miss GHSA remediation status.
+- **Root cause:** original workflow (`7e22073d8`) already pinned `76f52bc…` (v1.12.4) while labeling it `v1.10.3`. Dependabot preserves comments when rewriting `uses:` lines.
+- **Fix (not applied here):** rewrite both comments to `# v1.14.0` (or `# v1.14.0 (GHSA-vxmw-7h4f-hqxh fixed in 1.13.0)`).
+
+### 3.3 Floating-tag risk
+
+Not introduced. Repo continues full-SHA pins for this action (and other Actions in the same file). Prefer this over `@release/v1` or `@v1` for reproducible release jobs.
+
+---
+
+## 4. Security delta of 1.12.4 → 1.14.0 — **PASS (net positive)**
+
+### 4.1 GHSA-vxmw-7h4f-hqxh (primary security reason to bump past 1.12.4)
+
+| Field | Value |
+|-------|--------|
+| Advisory | GHSA-vxmw-7h4f-hqxh |
+| Summary | Injectable expression expansions in action steps |
+| Severity | **Low** (upstream) |
+| Vulnerable | `pypa/gh-action-pypi-publish` **≤ v1.12.4** |
+| Fixed | **v1.13.0** (included on path to 1.14.0) |
+| Mechanism | Composite step `set-repo-and-ref` interpolated `github.ref_name` (and related contexts) via `${{ … }}` inside a shell `run:` script, enabling template-injection / shell metacharacter breakout if attacker-controlled ref names were evaluated when `ACTION_REF` / `PR_REF` were empty |
+
+**Exposure for FlexAIDdS `pypi-release.yml` at this merge**
+
+Triggers are only:
+
+1. `release: types: [published]`
+2. `workflow_dispatch` (manual; default target `testpypi`)
+
+Upstream advisory states impact is **very low** in intended operation (`github.action_ref` normally wins) and that many popular configs (`release`, `pull_request`, tag push) are not practically vulnerable. FlexAIDdS does **not** invoke this action on `pull_request` from forks. Residual theoretical surface is mainly odd runner/`action_ref` empty edge cases under `workflow_dispatch` / custom ref names — still low severity, but **staying on ≤1.12.4 was unnecessary risk** once 1.13.0 existed.
+
+**Verdict:** Merge correctly moves the project **out of the vulnerable range**. Good Dependabot merge for supply-chain hygiene even if residual exploitability for this exact workflow was low.
+
+### 4.2 Other notable upstream changes in the range (non-exhaustive)
+
+| Release | Security / supply-chain notes |
+|---------|-------------------------------|
+| **v1.13.0** | GHSA fix; Zizmor integrated upstream; `actions/setup-python` SHA-pinned inside the action; runtime → Python 3.13; dependency tree refresh |
+| **v1.14.0** | Defaults: `verbose=true`, `print-hash=true` (artifact hashes in logs); `sigstore` / `pypi-attestations` lockfile bumps; PEP 740 language no longer marked experimental in docs |
+
+No evidence of intentionally weakening auth, broadening default permissions, or removing trusted-publishing support.
+
+### 4.3 Behavioral change operators should expect
+
+After this pin, publish logs are **noisier by default** (verbose + hashes). That is desirable for release forensics. No FlexAIDdS workflow `with:` keys need changing for basic OIDC + `skip-existing` operation.
+
+---
+
+## 5. Workflow security surface (unchanged by this merge) — residual review
+
+The merge only moves the pin. The surrounding control plane is pre-existing; audit it as context so the “PyPI publish security” goal is complete.
+
+### 5.1 Positive controls (do not regress)
+
+| Control | Evidence at `b041397ff` tree |
+|---------|------------------------------|
+| Minimal permissions | Top-level `permissions: contents: read` + `id-token: write` (OIDC only) |
+| No write to contents/packages from default | No `contents: write` / `packages: write` for publish |
+| Environment isolation | `environment: pypi` / `testpypi` with project URLs |
+| Trigger gating | Prod publish only on `release.published` **or** manual `workflow_dispatch` with `target=pypi` |
+| TestPyPI isolation | Separate job + environment + optional `TEST_PYPI_API_TOKEN` |
+| Build attestation of packages | `twine check` + venv install smoke before artifact upload |
+| Pure-Python ship path | `FLEXAIDDS_SKIP_CORE=1`; no untrusted C++ toolchain in publish job |
+| Artifact handoff | `upload-artifact` → `download-artifact` with `merge-multiple: true`; publish job does not rebuild from unpinned sources after approval gate |
+| Trusted publisher checklist | Echoed Owner / Repo / workflow filename / environment for OIDC claim match |
+| SHA pins on other steps | checkout / setup-python / upload-artifact / download-artifact also SHA-pinned at this tip |
+
+### 5.2 Residual risks (not introduced by PR #251)
+
+| ID | Finding | Severity | Notes |
+|----|---------|----------|-------|
+| R1 | Optional API tokens prefer long-lived secret auth when set | **Medium** (ops) | Comment says empty password → OIDC. Prefer **unset** `PYPI_API_TOKEN` in production and rely on Trusted Publisher + env protection. Rotate/delete tokens if OIDC is green. |
+| R2 | `workflow_dispatch` can publish to **real PyPI** | **Medium** (process) | Depends on GitHub Environment protection (required reviewers, wait timer, restricted branches). Confirm `pypi` env is not “open to all writers.” |
+| R3 | Stale `# v1.10.3` labels | **Low** | See §3.2 |
+| R4 | No explicit `attestations:` input in workflow | **Low** | Upstream defaults evolved; if PEP 740 attestations are desired as a hard requirement, set them explicitly and verify on TestPyPI first. |
+| R5 | `skip-existing: true` | **Info** | Prevents re-upload failure; also means a **compromised same-version rebuild cannot overwrite** already-published files on PyPI (immutable name+version) — generally good. Version-bump discipline remains the real integrity gate. |
+| R6 | Dependabot weekly `github-actions` ecosystem | **Info** | Configured in `.github/dependabot.yml`. Good. Review still required for action major bumps that change trust boundaries. |
+| R7 | Publish job has no second human checksum gate beyond env rules | **Info** | Artifact list step is local to the job; reviewers should use env deployment protection + release tag immutability. |
+
+### 5.3 What this merge does **not** change (and must not be claimed as fixed)
+
+- Does not validate that Trusted Publisher is correctly registered on pypi.org / test.pypi.org for `LeBonhommePharma/FlexAIDdS` / `pypi-release.yml` / env names.
+- Does not prove `PYPI_API_TOKEN` is absent from repo secrets.
+- Does not touch Homebrew formula, wheel attestation of accelerated builds (cibuildwheel path was already deferred), or package contents of `flexaidds` sdist/wheel.
+- Does not alter scientific claim pipelines, PoseBusters gates, or CF vs ΔG language.
+
+---
+
+## 6. Science / ranking / licensing — **N/A clean**
+
+| Dimension | Result |
+|-----------|--------|
+| Pose ranking / BindingMode / GA | Untouched |
+| CF scoring proxy vs thermodynamics | Untouched |
+| PoseBusters / admission metrics | Untouched |
+| Apache-2.0 / GPL isolation | No new deps in product code; Action is PyPA-maintained CI tooling |
+| Benchmark / iCloud policy | Untouched |
+
+---
+
+## 7. Test / verification performed in this audit
+
+| Check | Result |
+|-------|--------|
+| `git show b041397ff -m --first-parent` | Only pin lines in `pypi-release.yml` |
+| `git show b50beef7d` | Dependabot leaf confirms 1.12.4→1.14.0 + SHA compare |
+| GitHub tag peel API | SHA↔tag mapping verified for 1.10.3 / 1.12.4 / 1.13.0 / 1.14.0 |
+| Compare API `76f52bc…cef2210` | Ahead 53, behind 0 |
+| GHSA-vxmw-7h4f-hqxh body | Confirmed vulnerable ≤1.12.4; fixed in 1.13.0 release notes |
+| Current tip still on `cef2210` | Yes (later commits did not re-pin this action) |
+| Live PyPI publish dry-run | **Not executed** (would require secrets / release; out of scope for doc audit) |
+
+No `ctest` / pytest required: no product source change.
+
+---
+
+## 8. Recommended follow-ups (report only; **not applied**)
+
+1. **P1 hygiene:** Fix both trailing comments to `# v1.14.0` (or `# v1.14.0 — was 1.12.4; GHSA-vxmw-7h4f-hqxh fixed in 1.13.0`).
+2. **P1 secrets:** Confirm production relies on OIDC only; remove unused `PYPI_API_TOKEN` / `TEST_PYPI_API_TOKEN` if present.
+3. **P1 env protection:** Ensure GitHub Environments `pypi` (and ideally `testpypi`) require reviewer approval and restrict deployment branches to release tags / `main`.
+4. **P2:** Optionally set `attestations: true` explicitly once TestPyPI proves the path; keep `print-hash` / verbose defaults.
+5. **P2:** Add consumer-side `zizmor` (or similar) on `.github/workflows/*.yml` in CI so template-injection class issues are caught locally too.
+6. **P3:** Document in release runbook: pin SHA + comment must be updated together when Dependabot PRs land.
+
+---
+
+## 9. Final matrix
+
+| Dimension | Grade | Notes |
+|-----------|-------|--------|
+| Diff scope (no source) | **A** | Workflow pin only |
+| SHA pin correctness | **A** | Matches v1.12.4 → v1.14.0 peels |
+| GHSA / security delta | **A** | Leaves ≤1.12.4 vulnerable range |
+| Comment / label hygiene | **D** | Still claims `# v1.10.3` |
+| Trusted publishing design (pre-existing) | **B+** | OIDC + envs good; token fallback residual |
+| Science contamination | **N/A / A** | None |
+| Overall for intended merge | **PASS** | Merge was the right security maintenance action |
+
+**Overall:** Accept PR #251 / `b041397ff` as a legitimate PyPI-publish supply-chain upgrade. Do not treat the trailing `# v1.10.3` as authoritative version metadata. No science rollback risk. Residual work is comment fix + secret/environment operational verification, not a revert of this pin.
+
+---
+
+## 10. Evidence anchors
+
+| Anchor | Detail |
+|--------|--------|
+| Merge | `b041397ffaa8ce610bb1fa84ccef9a1566f840dc` |
+| Dependabot leaf | `b50beef7d1c9d8210fc24acc39fae484028d1dfc` |
+| Pre pin | `pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc` (= v1.12.4) |
+| Post pin | `pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b` (= v1.14.0) |
+| GHSA | https://github.com/pypa/gh-action-pypi-publish/security/advisories/GHSA-vxmw-7h4f-hqxh |
+| v1.13.0 notes | GHSA fix + Zizmor |
+| v1.14.0 notes | verbose/print-hash defaults; `cef2210` tag target |
+| Workflow | `.github/workflows/pypi-release.yml` publish jobs only |
+
+---
+
+*Audit mode: report only. No source edits. Inspected via `git show` / Dependabot leaf / upstream tag peels / GHSA advisory text. Current date context: 2026-07-15.*


### PR DESCRIPTION
Deep code audit for 26h swarm: clean merge-tree, pin 1.12.4→1.14.0 only,
stale # v1.10.3 comment, GHSA-vxmw-7h4f-hqxh closed, MERGE_OK.## Summary

What changed and why.

## Scope

- [ ] Core 1.0 supported surface
- [ ] Experimental surface only
- [ ] Documentation only
- [ ] CI / release engineering
- [ ] Security hardening
- [ ] Benchmark / reproducibility

## Release impact

- [ ] affects CLI behavior
- [ ] affects Python package behavior
- [ ] affects configuration schema or defaults
- [ ] affects benchmark or metric reporting
- [ ] affects installation instructions
- [ ] no user-facing release impact

## Validation

Describe how this was validated.

- [ ] unit tests
- [ ] integration tests
- [ ] smoke benchmark
- [ ] documentation review
- [ ] manual validation

## Security and safety

- [ ] no new third-party dependency
- [ ] third-party dependency added and documented
- [ ] no known security-sensitive parsing change
- [ ] security-sensitive parsing change reviewed

## Reproducibility

- [ ] no benchmark claim involved
- [ ] benchmark claim updated with reproducibility artifact
- [ ] benchmark language remains preliminary

## Notes

Anything reviewers should pay attention to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added audit reports covering publishing workflow updates, CI release-gate hardening, and associated security reviews.
  - Documented validation of action version updates, security advisory status, and release workflow behavior.
  - Added findings and follow-up recommendations for symbol checks, runner availability, configuration validation, stale version comments, and release-environment verification.
  - Recorded reproducibility evidence, merge assessments, and operational considerations for future maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->