### PR TITLE
Fix: CF competitiveness prep (SOFTWA, matrix 9dc9, sphere prune, R=10)

### DIFF
--- a/LIB/read_input.cpp
+++ b/LIB/read_input.cpp
@@ -202,6 +202,9 @@ void read_input(FA_Global* FA,atom** atoms, resid** residue,rot** rotamer,gridpo
 		if(strcmp(field,"VINDEX") == 0){FA->vindex=1;}
 		if(strcmp(field,"HTPMOD") == 0){FA->htpmode=true;}
 		if(strcmp(field,"PERMEA") == 0){sscanf(buffer,"%s %f",field,&FA->permeability);}
+		// SOFTWA <Å>: soft-core wall cutoff for CF.wal (6-char classic keyword).
+		// 0 = legacy capped r^-12; >0 = v43 Hermite soft-core (default 0.40).
+		if(strcmp(field,"SOFTWA") == 0){sscanf(buffer,"%s %f",field,&FA->soft_wall_cutoff);}
 		if(strcmp(field,"INTRAF") == 0){sscanf(buffer,"%s %f",field,&FA->intrafraction);}
 		if(strcmp(field,"VARDIS") == 0){sscanf(buffer,"%s %lf",field,&FA->delta_angstron);}
 		if(strcmp(field,"VARANG") == 0){sscanf(buffer,"%s %lf",field,&FA->delta_angle);}

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -508,6 +508,10 @@ int main(int argc, char **argv){
 
 	FA->force_interaction=0;
 	FA->interaction_factor=5.0;
+	// Classic CONFIG path never set soft_wall_cutoff (stayed 0 → hard r^-12 only).
+	// Default matches JSON/DatasetRunner (0.40 Å) so CF.wal competes with CF.com;
+	// override with SOFTWA 0.0 in CONFIG.inp for pure legacy hard wall.
+	FA->soft_wall_cutoff = 0.40f;
 	FA->atm_cnt=0;
 	FA->atm_cnt_real=0;
 	FA->res_cnt=0;

--- a/docs/implementation/3dsig_red_pair_protocol.md
+++ b/docs/implementation/3dsig_red_pair_protocol.md
@@ -16,7 +16,7 @@
 | Budget / sim | **2 000 000** energy evaluations (`pop × gen = 1000 × 2000`) |
 | Headline | **Median** success rate over **10 000** bootstrap resamples of N cases |
 | Seed | **Off** for claim-style fair redock (no native pose seed) |
-| Matrix | `MC_st0r5.2_6.dat` MD5 **`72d7c7396702331d96ff12d18f831796`** |
+| Matrix | `MC_st0r5.2_6.dat` MD5 **`9dc93717dfed0698006d88dd6a9627bc`** (repo/baseline-validated; not the 72d7 packing fork) |
 | Primary N | Astex Diverse **85** (pilot gate: pilot8 first) |
 
 **Do not report as 3Dsig success:** S1 alone, BCR, S2/PoseBusters, CF=10000 packaging, RMSD −1 sentinels.

--- a/scripts/aggregate_claim_metrics.py
+++ b/scripts/aggregate_claim_metrics.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 # Production matrix pin used by three-engine / C0 full85 (see RUN_RECEIPT).
-DEFAULT_MATRIX_MD5 = "72d7c7396702331d96ff12d18f831796"
+DEFAULT_MATRIX_MD5 = "9dc93717dfed0698006d88dd6a9627bc"
 RMSD_SUCCESS_A = 2.0
 C0_FULL85_REL = "campaigns/C0_full85_defined_cleft_nativeseed_forbidden"
 

--- a/scripts/clean_target_apo.py
+++ b/scripts/clean_target_apo.py
@@ -20,16 +20,19 @@ Usage:
 Env:
   FLEXAIDDS_KEEP_HOH=1      keep waters
   FLEXAIDDS_KEEP_METALS=1   keep metal ions
+  FLEXAIDDS_KEEP_METALS_NEAR_LIGAND=<Å>  keep metals within this distance of
+      any ligand heavy atom (default 4.0 when ligand coords provided; 0=off)
 """
 
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Iterable, List, Optional, Sequence, Set
+from typing import Iterable, List, Optional, Sequence, Set, Tuple
 
 WATER_RES = frozenset({"HOH", "WAT", "H2O", "DOD", "SOL", "TIP", "TIP3", "WAT2"})
 
@@ -100,11 +103,13 @@ class CleanReport:
     atoms_out: int = 0
     waters_removed: int = 0
     metals_removed: int = 0
+    metals_kept_near_ligand: int = 0
     other_removed: int = 0
     conect_removed: int = 0
     conect_rewritten: int = 0
     keep_hoh: bool = False
     keep_metals: bool = False
+    metal_near_ligand_a: float = 0.0
     removed_resnames: List[str] = field(default_factory=list)
     messages: List[str] = field(default_factory=list)
 
@@ -144,12 +149,52 @@ def _element(line: str) -> str:
     return ""
 
 
+def _xyz(line: str) -> Optional[Tuple[float, float, float]]:
+    if len(line) < 54:
+        return None
+    try:
+        return (float(line[30:38]), float(line[38:46]), float(line[46:54]))
+    except ValueError:
+        return None
+
+
+def load_ligand_heavy_xyz(ligand_path: Path) -> List[Tuple[float, float, float]]:
+    """Heavy-atom coords from LIG_ref / ligand PDB (or SDF-like PDB columns)."""
+    out: List[Tuple[float, float, float]] = []
+    if not ligand_path.is_file():
+        return out
+    for line in ligand_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not (line.startswith("ATOM  ") or line.startswith("HETATM")):
+            continue
+        elem = _element(line)
+        if elem in {"H", "D"}:
+            continue
+        xyz = _xyz(line)
+        if xyz:
+            out.append(xyz)
+    return out
+
+
+def _min_dist_to_ligand(
+    line: str, lig_xyz: Sequence[Tuple[float, float, float]]
+) -> Optional[float]:
+    xyz = _xyz(line)
+    if xyz is None or not lig_xyz:
+        return None
+    return min(
+        math.sqrt((xyz[0] - lx) ** 2 + (xyz[1] - ly) ** 2 + (xyz[2] - lz) ** 2)
+        for lx, ly, lz in lig_xyz
+    )
+
+
 def should_strip_atom(
     line: str,
     *,
     keep_hoh: bool,
     keep_metals: bool,
     extra_strip_res: Optional[Set[str]] = None,
+    lig_xyz: Optional[Sequence[Tuple[float, float, float]]] = None,
+    metal_near_ligand_a: float = 0.0,
 ) -> str:
     """Return reason code if atom should be stripped, else empty string."""
     if not (line.startswith("ATOM  ") or line.startswith("HETATM")):
@@ -168,6 +213,11 @@ def should_strip_atom(
     if res in METAL_RES or (elem in METAL_RES and res in METAL_RES):
         if keep_metals:
             return ""
+        # Keep catalytic / structural metals that coordinate the crystal ligand.
+        if metal_near_ligand_a > 0.0 and lig_xyz:
+            d = _min_dist_to_ligand(line, lig_xyz)
+            if d is not None and d <= metal_near_ligand_a:
+                return ""
         return "metal"
 
     if res in extra:
@@ -215,12 +265,28 @@ def rewrite_conect(line: str, kept_serials: Set[int]) -> Optional[str]:
     return out + "\n" if line.endswith("\n") else out
 
 
+def resolve_metal_near_ligand_a(explicit: Optional[float] = None) -> float:
+    """Å cutoff for keeping metals near ligand; 0 disables. Default 4.0 via env/default."""
+    if explicit is not None:
+        return float(explicit)
+    env = os.environ.get("FLEXAIDDS_KEEP_METALS_NEAR_LIGAND", "").strip()
+    if env:
+        try:
+            return float(env)
+        except ValueError:
+            return 0.0
+    # Default ON at 4.0 Å when ligand coords are supplied by callers.
+    return 4.0
+
+
 def clean_apo_pdb(
     text: str,
     *,
     keep_hoh: bool = False,
     keep_metals: bool = False,
     extra_strip_res: Optional[Iterable[str]] = None,
+    lig_xyz: Optional[Sequence[Tuple[float, float, float]]] = None,
+    metal_near_ligand_a: float = 0.0,
 ) -> tuple[str, CleanReport]:
     """Clean PDB text; return (new_text, report)."""
     extra = {r.strip().upper() for r in (extra_strip_res or []) if r.strip()}
@@ -229,6 +295,7 @@ def clean_apo_pdb(
         output_path="",
         keep_hoh=keep_hoh,
         keep_metals=keep_metals,
+        metal_near_ligand_a=float(metal_near_ligand_a or 0.0),
     )
     lines = text.splitlines(keepends=True)
     kept_lines: List[str] = []
@@ -249,6 +316,8 @@ def clean_apo_pdb(
                 keep_hoh=keep_hoh,
                 keep_metals=keep_metals,
                 extra_strip_res=extra,
+                lig_xyz=lig_xyz,
+                metal_near_ligand_a=metal_near_ligand_a,
             )
             if reason:
                 res = _resname(line)
@@ -260,6 +329,18 @@ def clean_apo_pdb(
                 else:
                     report.other_removed += 1
                 continue
+            # Count metals kept only because they are ligand-proximal
+            res = _resname(line)
+            elem = _element(line)
+            if (
+                not keep_metals
+                and metal_near_ligand_a > 0
+                and lig_xyz
+                and (res in METAL_RES or elem in METAL_RES)
+            ):
+                d = _min_dist_to_ligand(line, lig_xyz)
+                if d is not None and d <= metal_near_ligand_a:
+                    report.metals_kept_near_ligand += 1
             ser = _serial(line)
             if ser is not None:
                 kept_serials.add(ser)
@@ -296,6 +377,7 @@ def clean_apo_pdb(
     report.removed_resnames = sorted(removed_res)
     report.messages.append(
         f"stripped waters={report.waters_removed} metals={report.metals_removed} "
+        f"metals_kept_near_lig={report.metals_kept_near_ligand} "
         f"other={report.other_removed}; atoms {atom_in}->{atom_out}; "
         f"conect_removed={report.conect_removed}"
     )
@@ -309,13 +391,22 @@ def clean_apo_file(
     keep_hoh: bool = False,
     keep_metals: bool = False,
     extra_strip_res: Optional[Iterable[str]] = None,
+    ligand_ref: Optional[Path] = None,
+    metal_near_ligand_a: Optional[float] = None,
 ) -> CleanReport:
     text = src.read_text(encoding="utf-8", errors="replace")
+    lig_xyz: List[Tuple[float, float, float]] = []
+    near_a = 0.0
+    if ligand_ref is not None and Path(ligand_ref).is_file():
+        lig_xyz = load_ligand_heavy_xyz(Path(ligand_ref))
+        near_a = resolve_metal_near_ligand_a(metal_near_ligand_a)
     out, report = clean_apo_pdb(
         text,
         keep_hoh=keep_hoh,
         keep_metals=keep_metals,
         extra_strip_res=extra_strip_res,
+        lig_xyz=lig_xyz or None,
+        metal_near_ligand_a=near_a,
     )
     report.input_path = str(src)
     report.output_path = str(dst)

--- a/scripts/generate_flexaid_inp.py
+++ b/scripts/generate_flexaid_inp.py
@@ -49,7 +49,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 # Local script imports (same directory) for P0 canary prep gates.
 _SCRIPTS_DIR = Path(__file__).resolve().parent
@@ -75,7 +75,8 @@ DEFAULT_GEN = 2000  # claim freeze 2026-07-15 (was 6000)
 DEFAULT_RESTARTS = 5
 DEFAULT_MAXRES = 50  # match FlexAIDdS cluster emit ceiling for fair S3/BCR
 MATRIX_NAME = "MC_st0r5.2_6.dat"
-MATRIX_MD5_PIN = "72d7c7396702331d96ff12d18f831796"
+# Repo / baseline-validated JCIM matrix (NOT the 72d7 campaign fork that sweetens 2–4 packing).
+MATRIX_MD5_PIN = "9dc93717dfed0698006d88dd6a9627bc"
 LIGAND_RESNUM = 9999
 ATOM_INDEX = 90000
 
@@ -102,19 +103,35 @@ PILOT8 = ["1G9V", "1GPK", "1MEH", "1P62", "1Q4G", "1R9O", "1T40", "2BYS"]
 # Engine chooses MinPts once in FastOPTICS_cluster.cpp — no multi-scale ladder in CONFIG.
 # See docs/implementation/fo_minpts_literature.md and 3dsig_red_pair_protocol.md §2.1.
 ARM_SPEC = {
-    "A": {"bin_arm": "A", "temper": 0, "clusta": "CF", "label": "FlexAID-2015 JCIM CF"},
+    "A": {
+        "bin_arm": "A",
+        "temper": 0,
+        "clusta": "CF",
+        "label": "FlexAID historical pin TEMPER0 CLUSTA CF (must differ SHA from master B)",
+    },
     "B0": {
         "bin_arm": "B",
         "temper": 0,
         "clusta": "CF",
-        "label": "FlexAID-master TEMPER 0 / CF (deferred)",
+        # Twin of A when bin A==B SHA — not an independent control. Prefer arm B for master.
+        "label": "master TEMPER0 CLUSTA CF (twin of A if same binary; not claim control)",
+        "science_control": False,
     },
     "B": {
         "bin_arm": "B",
         "temper": 21,
         "clusta": "FO",
         "fo_minpts_policy": "single_literature",
-        "label": "FlexAID-master TEMPER 21 / FO single-literature-MinPts entropy",
+        "label": "master TEMPER21 CLUSTA FO single-literature-MinPts",
+    },
+    # Arm C: FO @ 298K — only after panel native CF oracle PASS (claim gate).
+    "C": {
+        "bin_arm": "B",
+        "temper": 298,
+        "clusta": "FO",
+        "fo_minpts_policy": "single_literature",
+        "label": "master TEMPER298 CLUSTA FO (requires native CF oracle PASS)",
+        "requires_oracle_pass": True,
     },
 }
 
@@ -257,9 +274,98 @@ def convert_spheres_to_atom(src: Path, dst: Path) -> int:
     return n
 
 
+def _pdb_xyz(line: str) -> Optional[Tuple[float, float, float]]:
+    if len(line) < 54:
+        return None
+    try:
+        return (float(line[30:38]), float(line[38:46]), float(line[46:54]))
+    except ValueError:
+        return None
+
+
+def prune_spheres_near_ligand(
+    spheres_pdb: Path,
+    ligand_ref: Path,
+    *,
+    max_dist: float = 8.0,
+    max_spheres: int = 2500,
+) -> Dict[str, Any]:
+    """Keep LOCCLF spheres near LIG_ref; cap count for GA budget.
+
+    Oversized native-occupied GetCleft clouds (10k–25k spheres) dilute search
+    under R=1 budgets. Prune by distance to any LIG_ref heavy atom, then
+    nearest-first cap to ``max_spheres``.
+    """
+    import math
+
+    lig_xyz: List[Tuple[float, float, float]] = []
+    if ligand_ref.is_file():
+        for line in ligand_ref.read_text(errors="replace").splitlines():
+            if line.startswith(("ATOM  ", "HETATM")):
+                xyz = _pdb_xyz(line)
+                if xyz:
+                    lig_xyz.append(xyz)
+    if not lig_xyz:
+        return {"pruned": False, "reason": "no_ligand_coords", "n_in": 0, "n_out": 0}
+
+    header: List[str] = []
+    spheres: List[Tuple[float, str]] = []  # (min_dist, line)
+    n_in = 0
+    for line in spheres_pdb.read_text(errors="replace").splitlines():
+        if line.startswith(("ATOM  ", "HETATM")):
+            n_in += 1
+            xyz = _pdb_xyz(line)
+            if xyz is None:
+                continue
+            dmin = min(
+                math.sqrt(
+                    (xyz[0] - lx) ** 2 + (xyz[1] - ly) ** 2 + (xyz[2] - lz) ** 2
+                )
+                for lx, ly, lz in lig_xyz
+            )
+            if dmin <= max_dist:
+                # normalize to ATOM record for classic FlexAID
+                atom_line = ("ATOM  " + line[6:]) if line.startswith("HETATM") else line
+                spheres.append((dmin, atom_line))
+        else:
+            header.append(line)
+
+    spheres.sort(key=lambda t: t[0])
+    kept = spheres[: max(1, int(max_spheres))]
+    lines_out = header + [ln for _, ln in kept]
+    if not kept:
+        return {"pruned": False, "reason": "empty_after_prune", "n_in": n_in, "n_out": 0}
+    spheres_pdb.write_text("\n".join(lines_out) + "\n")
+    return {
+        "pruned": True,
+        "n_in": n_in,
+        "n_out": len(kept),
+        "max_dist": max_dist,
+        "max_spheres": max_spheres,
+        "max_kept_dist": kept[-1][0] if kept else None,
+    }
+
+
 def parse_fledih_count(ligand_inp: Path) -> int:
     text = ligand_inp.read_text(errors="replace")
     return sum(1 for line in text.splitlines() if line.startswith("FLEDIH"))
+
+
+def resolve_soft_wall_cutoff(explicit: Optional[float] = None) -> float:
+    """Soft-core wall cutoff (Å) for classic CONFIG SOFTWA.
+
+    Default 0.40 matches DatasetRunner / top.cpp. Set FLEXAIDDS_SOFT_WALL=0 for
+    legacy hard r^-12 (not recommended — CF.com overpacking pathology).
+    """
+    if explicit is not None:
+        return float(explicit)
+    env = os.environ.get("FLEXAIDDS_SOFT_WALL", "").strip()
+    if env:
+        try:
+            return float(env)
+        except ValueError:
+            pass
+    return 0.40
 
 
 def write_config(
@@ -276,7 +382,9 @@ def write_config(
     temper: int,
     n_flex: int,
     maxres: int = DEFAULT_MAXRES,
+    soft_wall_cutoff: Optional[float] = None,
 ) -> None:
+    soft_wa = resolve_soft_wall_cutoff(soft_wall_cutoff)
     lines: List[str] = [
         "# generated by scripts/generate_flexaid_inp.py",
         f"PDBNAM {target_pdb}",
@@ -296,6 +404,8 @@ def write_config(
         [
             f"IMATRX {matrix_path}",
             "PERMEA 0.9",
+            # SOFTWA: 6-char classic keyword → FA->soft_wall_cutoff (Å)
+            f"SOFTWA {soft_wa:.2f}",
             "VARANG 5.0",
             "VARDIH 5.0",
             "VARFLX 10.0",
@@ -424,6 +534,8 @@ def prepare_target(
     skip_clean_apo: bool = False,
     skip_ligand_gate: bool = False,
     max_bond: float = 3.0,
+    sphere_max: int = 0,
+    sphere_max_dist: float = 8.0,
 ) -> Path:
     if arm not in ARM_SPEC:
         raise ValueError(f"unknown arm {arm}; expected one of {list(ARM_SPEC)}")
@@ -528,6 +640,7 @@ def prepare_target(
                 apo_work,
                 keep_hoh=use_hoh,
                 keep_metals=use_metals,
+                ligand_ref=ligand_ref if ligand_ref.is_file() else None,
             )
             (work / "clean_apo_report.json").write_text(
                 json.dumps(clean_report.as_dict(), indent=2) + "\n",
@@ -536,6 +649,7 @@ def prepare_target(
             print(
                 f"  clean_apo {pdb}: waters={clean_report.waters_removed} "
                 f"metals={clean_report.metals_removed} "
+                f"metals_near_lig={getattr(clean_report, 'metals_kept_near_ligand', 0)} "
                 f"atoms {clean_report.atoms_in}->{clean_report.atoms_out} "
                 f"(keep_hoh={use_hoh} keep_metals={use_metals})"
             )
@@ -549,7 +663,11 @@ def prepare_target(
                 if not apo_raw.is_file():
                     shutil.copy2(apo, apo_raw)
                 clean_apo_file(
-                    apo_raw, apo_work, keep_hoh=use_hoh, keep_metals=use_metals
+                    apo_raw,
+                    apo_work,
+                    keep_hoh=use_hoh,
+                    keep_metals=use_metals,
+                    ligand_ref=ligand_ref if ligand_ref.is_file() else None,
                 )
             else:
                 shutil.copy2(apo, apo_work)
@@ -581,6 +699,33 @@ def prepare_target(
         convert_spheres_to_atom(sph_src, sph_dst)
         (work / "sphere_source.txt").write_text(str(sph_src) + "\n")
 
+    # Optional LOCCLF prune (arg or env): oversized native-occupied clouds dilute GA
+    sph_max = int(sphere_max or 0)
+    if sph_max <= 0:
+        sph_max = int(os.environ.get("FLEXAIDDS_SPHERE_MAX", "0") or "0")
+    sph_dist = float(sphere_max_dist)
+    env_dist = os.environ.get("FLEXAIDDS_SPHERE_MAX_DIST", "").strip()
+    if env_dist:
+        try:
+            sph_dist = float(env_dist)
+        except ValueError:
+            pass
+    if sph_max > 0 and ligand_ref.is_file():
+        prune_info = prune_spheres_near_ligand(
+            sph_dst,
+            ligand_ref,
+            max_dist=sph_dist,
+            max_spheres=sph_max,
+        )
+        (work / "sphere_prune.json").write_text(
+            json.dumps(prune_info, indent=2) + "\n"
+        )
+        if prune_info.get("pruned"):
+            print(
+                f"  sphere prune {pdb}: {prune_info['n_in']} → {prune_info['n_out']} "
+                f"(d≤{sph_dist}Å max={sph_max})"
+            )
+
     n_flex = parse_fledih_count(ligand_inp)
     temper = int(spec["temper"]) if temper_override is None else int(temper_override)
 
@@ -601,6 +746,7 @@ def prepare_target(
         rmsd_ref=ligand_ref.resolve() if ligand_ref.is_file() else None,
         temper=temper,
         n_flex=n_flex,
+        soft_wall_cutoff=resolve_soft_wall_cutoff(),
     )
 
     sharealf, sharepek, sharescl = resolve_pshare_knobs()
@@ -633,6 +779,7 @@ def prepare_target(
             rmsd_ref=ligand_ref.resolve() if ligand_ref.is_file() else None,
             temper=temper,
             n_flex=n_flex,
+            soft_wall_cutoff=resolve_soft_wall_cutoff(),
         )
         (rdir / "seed.txt").write_text(f"{seed}\n")
 
@@ -669,6 +816,11 @@ def prepare_target(
         ),
         "clean_apo": not skip_clean_apo,
         "ligand_integrity_gate": not skip_ligand_gate,
+        "soft_wall_cutoff": resolve_soft_wall_cutoff(),
+        "sphere_max": sph_max if sph_max > 0 else None,
+        "sphere_max_dist": sph_dist if sph_max > 0 else None,
+        "science_control": bool(spec.get("science_control", True)),
+        "requires_oracle_pass": bool(spec.get("requires_oracle_pass", False)),
         "post_ini_preflight": (
             "python3 scripts/validate_ligand_integrity.py "
             f"--work {work.resolve()} --require-ini"
@@ -761,6 +913,18 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         default=3.0,
         help="Max CONECT bond (Å) for ligand integrity gate (default 3.0)",
     )
+    ap.add_argument(
+        "--sphere-max",
+        type=int,
+        default=int(os.environ.get("FLEXAIDDS_SPHERE_MAX", "0") or "0"),
+        help="Prune LOCCLF to this many spheres near LIG_ref (0=off; env FLEXAIDDS_SPHERE_MAX)",
+    )
+    ap.add_argument(
+        "--sphere-max-dist",
+        type=float,
+        default=float(os.environ.get("FLEXAIDDS_SPHERE_MAX_DIST", "8.0") or "8.0"),
+        help="Max distance (Å) from LIG_ref for sphere keep (default 8; env FLEXAIDDS_SPHERE_MAX_DIST)",
+    )
     args = ap.parse_args(argv)
 
     if not args.queue_root:
@@ -821,6 +985,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     skip_clean_apo=args.skip_clean_apo,
                     skip_ligand_gate=args.skip_ligand_gate,
                     max_bond=args.max_bond,
+                    sphere_max=args.sphere_max,
+                    sphere_max_dist=args.sphere_max_dist,
                 )
                 print(f"OK {arm}/{pdb} → {w}")
                 n_ok += 1

--- a/scripts/run_3dsig_red_pair_full85.sh
+++ b/scripts/run_3dsig_red_pair_full85.sh
@@ -6,11 +6,12 @@
 #
 # Deck knobs (same as pilot8 3dsig_r10):
 #   pop=1000 gen=2000 (2e6 evals) restarts=10
-#   matrix MD5 72d7c7396702331d96ff12d18f831796
-#   CLI: FlexAID --legacy
-#   Arm order: A (CF) -> B0 (master CF) -> B (TEMPER 21 + single FO MinPts)
-# Live OUT namespace (separate from pilot8):
-#   $FLEXAIDDS_LOCAL_ROOT/campaigns/three_engine/{A,B0,B}/3dsig_full85_r10/
+#   matrix MD5 9dc93717dfed0698006d88dd6a9627bc (repo/baseline-validated)
+#   CLI: FlexAID --legacy + SOFTWA 0.40 + sphere prune + metal-near-ligand
+#   Arm order (default): A → B  (B0 skip unless FLEXAID_INCLUDE_B0=1)
+#   Arm C FO@298K only after native CF oracle PASS
+# Live OUT namespace:
+#   $FLEXAIDDS_LOCAL_ROOT/campaigns/three_engine/{A,B0,B,C}/$CAMPAIGN/
 #
 # Usage:
 #   bash scripts/run_3dsig_red_pair_full85.sh --dry-run   # plan only (safe while pilot8 live)
@@ -47,17 +48,80 @@ done
 
 export FLEXAID_POP="${FLEXAID_POP:-1000}"
 export FLEXAID_GEN="${FLEXAID_GEN:-2000}"
-export FLEXAID_RESTARTS="${FLEXAID_RESTARTS:-1}"  # first pass R=1; raise later to resume multi-restart
+# Claim-comparable default: R=10. Diagnostic R=1 only if FLEXAID_DIAGNOSTIC=1.
+# FLEXAID_CLAIM_MODE=1 adds hard gates (oracle PASS + A≠B binary split).
+CLAIM_MODE="${FLEXAID_CLAIM_MODE:-0}"
+DIAGNOSTIC="${FLEXAID_DIAGNOSTIC:-0}"
+if [[ "$DIAGNOSTIC" == "1" ]]; then
+  export FLEXAID_RESTARTS="${FLEXAID_RESTARTS:-1}"
+else
+  # Recovery / claim path: multi-restart
+  export FLEXAID_RESTARTS="${FLEXAID_RESTARTS:-10}"
+fi
 export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
 export FLEXAIDDS_PARALLEL_RESTARTS="${FLEXAIDDS_PARALLEL_RESTARTS:-0}"
+# Softβ always OFF unless operator explicitly overrides after oracle PASS
+export FLEXAIDDS_SOFTBETA_ELECTION="${FLEXAIDDS_SOFTBETA_ELECTION:-0}"
+# Soft-core wall on classic path (SOFTWA in CONFIG.inp)
+export FLEXAIDDS_SOFT_WALL="${FLEXAIDDS_SOFT_WALL:-0.40}"
+# Sphere prune default for new preps (oversized LOCCLF); 0 disables
+export FLEXAIDDS_SPHERE_MAX="${FLEXAIDDS_SPHERE_MAX:-2500}"
+export FLEXAIDDS_SPHERE_MAX_DIST="${FLEXAIDDS_SPHERE_MAX_DIST:-8.0}"
+# Keep catalytic metals within 4 Å of crystal ligand
+export FLEXAIDDS_KEEP_METALS_NEAR_LIGAND="${FLEXAIDDS_KEEP_METALS_NEAR_LIGAND:-4.0}"
 
-CAMPAIGN="${FLEXAID_CAMPAIGN:-3dsig_full85_r1}"
-MATRIX_PIN="72d7c7396702331d96ff12d18f831796"
+CAMPAIGN="${FLEXAID_CAMPAIGN:-3dsig_full85_r10_cf_fix}"
+MATRIX_PIN="9dc93717dfed0698006d88dd6a9627bc"
 MAT="$FLEXAIDDS_QUEUE_ROOT/data/MC_st0r5.2_6.dat"
 [[ -f "$MAT" ]] || MAT="$FLEXAIDDS_LOCAL_ROOT/three_engine_entropy_q1/data/MC_st0r5.2_6.dat"
 GOT=$(md5 -q "$MAT" 2>/dev/null || true)
 [[ "$GOT" == "$MATRIX_PIN" ]] || { echo "FAIL: matrix MD5 '$GOT' != $MATRIX_PIN" >&2; exit 90; }
 echo "OK: matrix md5=$GOT path=$MAT"
+
+# --- Claim / science gates (serial only; no dual-launch) ---------------------
+# B0 is NOT a scientific control when bin/A SHA == bin/B SHA (deterministic twin).
+BIN_ROOT="${FLEXAIDDS_LOCAL_ROOT}/three_engine_entropy_q1/bin"
+if [[ "$CLAIM_MODE" == "1" ]]; then
+  if (( FLEXAID_RESTARTS < 10 )); then
+    echo "FAIL: FLEXAID_CLAIM_MODE=1 requires FLEXAID_RESTARTS>=10 (got $FLEXAID_RESTARTS)" >&2
+    exit 93
+  fi
+  if ! python3 "$ROOT/scripts/stage_three_engine_bins.py" --check-claim-split --dest "$BIN_ROOT"; then
+    echo "FAIL: claim mode needs distinct historical A vs master B binaries" >&2
+    exit 94
+  fi
+  ORACLE_STATUS="${FLEXAID_ORACLE_STATUS:-$FLEXAIDDS_LOCAL_ROOT/campaigns/three_engine/${CAMPAIGN}_oracle_status.json}"
+  if [[ ! -f "$ORACLE_STATUS" ]]; then
+    echo "FAIL: claim mode needs native CF oracle status at $ORACLE_STATUS" >&2
+    echo "  Run: python3 scripts/run_panel_native_cf_oracle.py --out-dir ... --status-out $ORACLE_STATUS" >&2
+    exit 95
+  fi
+  if ! python3 -c 'import json,sys; s=json.load(open(sys.argv[1])); sys.exit(0 if s.get("ranking_allowed") else 1)' "$ORACLE_STATUS"; then
+    echo "FAIL: native CF oracle ranking_allowed=false — Softβ/arm-C/claim ranking FORBIDDEN" >&2
+    exit 96
+  fi
+  echo "OK: claim mode gates (R>=10, binary split, oracle PASS)"
+else
+  if [[ "$DIAGNOSTIC" == "1" ]]; then
+    echo "OK: diagnostic mode (R=$FLEXAID_RESTARTS) — not 3Dsig-claimable"
+  else
+    echo "OK: recovery path R=$FLEXAID_RESTARTS Softβ=OFF — set FLEXAID_CLAIM_MODE=1 after oracle PASS for claim gates"
+  fi
+  # Warn if A==B (B0 twin)
+  if [[ -x "$BIN_ROOT/A/FlexAID" && -x "$BIN_ROOT/B/FlexAID" ]]; then
+    if ! python3 "$ROOT/scripts/stage_three_engine_bins.py" --check-claim-split --dest "$BIN_ROOT" 2>/dev/null; then
+      echo "WARN: bin A SHA == bin B SHA → B0 is a deterministic twin of A (not science control)" >&2
+    fi
+  fi
+fi
+# Refuse Softβ unless oracle allows
+if [[ "${FLEXAIDDS_SOFTBETA_ELECTION}" != "0" && "${FLEXAIDDS_SOFTBETA_ELECTION}" != "false" ]]; then
+  ORACLE_STATUS="${FLEXAID_ORACLE_STATUS:-$FLEXAIDDS_LOCAL_ROOT/campaigns/three_engine/${CAMPAIGN}_oracle_status.json}"
+  if [[ ! -f "$ORACLE_STATUS" ]] || ! python3 -c 'import json,sys; s=json.load(open(sys.argv[1])); sys.exit(0 if s.get("softbeta_allowed") else 1)' "$ORACLE_STATUS" 2>/dev/null; then
+    echo "FAIL: Softβ election requested but oracle softbeta_allowed is false/missing" >&2
+    exit 97
+  fi
+fi
 
 # --- Input coverage (Astex Diverse N=85) via python (bash 3.2 safe) ----------
 INP_DIR="$FLEXAIDDS_QUEUE_ROOT/inputs/astex_diverse"
@@ -269,17 +333,49 @@ run_arm() {
   NOHUP=0 bash "$ROOT/scripts/run_flexaid_arm_pilot8.sh" "$arm" "${extra[@]}"
 }
 
-ARMS=(A B0 B)
-if [[ -n "$ONLY" ]]; then
+# Science chain (serial, no dual-launch):
+#   default: A (historical pin) → B (master TEMPER21 FO)
+#   B0: optional only — NOT a claim control when A≡B binary; set FLEXAID_INCLUDE_B0=1
+#   C: FO@298K only after native CF oracle PASS; set FLEXAID_INCLUDE_ARM_C=1
+#   FLEXAID_ARMS="A,B0,B,C" overrides (still enforces C oracle gate)
+INCLUDE_B0="${FLEXAID_INCLUDE_B0:-0}"
+INCLUDE_C="${FLEXAID_INCLUDE_ARM_C:-0}"
+ORACLE_STATUS="${FLEXAID_ORACLE_STATUS:-$FLEXAIDDS_LOCAL_ROOT/campaigns/three_engine/${CAMPAIGN}_oracle_status.json}"
+
+oracle_allows_c() {
+  [[ -f "$ORACLE_STATUS" ]] && python3 -c 'import json,sys; s=json.load(open(sys.argv[1])); sys.exit(0 if s.get("arm_c_fo298_allowed") else 1)' "$ORACLE_STATUS" 2>/dev/null
+}
+
+if [[ -n "${FLEXAID_ARMS:-}" ]]; then
+  IFS=',' read -r -a ARMS <<< "$FLEXAID_ARMS"
+elif [[ -n "$ONLY" ]]; then
   ARMS=("$ONLY")
 else
   case "$FROM" in
-    A) ARMS=(A B0 B) ;;
-    B0) ARMS=(B0 B) ;;
-    B) ARMS=(B) ;;
+    A)
+      ARMS=(A)
+      if [[ "$INCLUDE_B0" == "1" ]]; then ARMS+=(B0); fi
+      ARMS+=(B)
+      if [[ "$INCLUDE_C" == "1" ]]; then ARMS+=(C); fi
+      ;;
+    B0) ARMS=(B0 B); [[ "$INCLUDE_C" == "1" ]] && ARMS+=(C) ;;
+    B) ARMS=(B); [[ "$INCLUDE_C" == "1" ]] && ARMS+=(C) ;;
+    C) ARMS=(C) ;;
     *) echo "bad --from $FROM" >&2; exit 2 ;;
   esac
 fi
+
+# Enforce arm-C oracle gate whenever C is in the chain
+for _a in "${ARMS[@]}"; do
+  if [[ "$_a" == "C" ]]; then
+    if [[ "${FLEXAIDDS_ALLOW_ARM_C:-0}" != "1" ]] && ! oracle_allows_c; then
+      echo "FAIL: arm C requires oracle arm_c_fo298_allowed=true in $ORACLE_STATUS" >&2
+      echo "  (or FLEXAIDDS_ALLOW_ARM_C=1 diagnostic-only). Softβ/FO@298K blocked." >&2
+      exit 98
+    fi
+  fi
+done
+echo "OK: arm order ${ARMS[*]} (INCLUDE_B0=$INCLUDE_B0 INCLUDE_C=$INCLUDE_C CLAIM_MODE=$CLAIM_MODE R=$FLEXAID_RESTARTS SOFT_WALL=$FLEXAIDDS_SOFT_WALL)"
 
 CHAIN_LOG="$LOGDIR/run_3dsig_red_pair_full85.log"
 CHAIN_PID="$LOGDIR/run_3dsig_red_pair_full85.pid"

--- a/scripts/run_3dsig_red_pair_serial.sh
+++ b/scripts/run_3dsig_red_pair_serial.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Serial 3Dsig red-pair: A → B0 → B  (LOCAL-FIRST; sync iCloud later)
 #
-# Deck knobs: pop=1000 gen=2000 (2e6) restarts=10 · matrix 72d7
+# Deck knobs: pop=1000 gen=2000 (2e6) restarts=10 · matrix 9dc93717…
 # Live I/O: ~/flexaidds_results (APFS). No CloudDocs during prepare/dock.
 # Later: bash scripts/sync_three_engine_local_to_icloud.sh
 #
@@ -36,7 +36,7 @@ export FLEXAID_RESTARTS="${FLEXAID_RESTARTS:-10}"
 export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
 export FLEXAIDDS_PARALLEL_RESTARTS="${FLEXAIDDS_PARALLEL_RESTARTS:-0}"
 
-MATRIX_PIN="72d7c7396702331d96ff12d18f831796"
+MATRIX_PIN="9dc93717dfed0698006d88dd6a9627bc"
 MAT="$FLEXAIDDS_QUEUE_ROOT/data/MC_st0r5.2_6.dat"
 [[ -f "$MAT" ]] || MAT="$FLEXAIDDS_LOCAL_ROOT/three_engine_entropy_q1/data/MC_st0r5.2_6.dat"
 GOT=$(md5 -q "$MAT" 2>/dev/null || true)

--- a/scripts/run_flexaid_arm_pilot8.sh
+++ b/scripts/run_flexaid_arm_pilot8.sh
@@ -37,7 +37,7 @@ export FLEXAIDDS_QUEUE_ROOT="$Q"
 
 ARM="${1:-}"
 if [[ -z "$ARM" || "$ARM" == -* ]]; then
-  echo "Usage: $0 <A|B0|B> [--dry-run|--smoke|--full85|--pdb ID|--force|--no-prepare]" >&2
+  echo "Usage: $0 <A|B0|B|C> [--dry-run|--smoke|--full85|--pdb ID|--force|--no-prepare]" >&2
   exit 2
 fi
 shift || true
@@ -66,15 +66,32 @@ if (( SMOKE && FULL85 )); then
 fi
 
 case "$ARM" in
-  A|B0|B) ;;
-  *) echo "ERROR: arm must be A, B0, or B (got $ARM)" >&2; exit 2 ;;
+  A|B0|B|C) ;;
+  *) echo "ERROR: arm must be A, B0, B, or C (got $ARM)" >&2; exit 2 ;;
 esac
+
+# C (FO@298K) requires native CF oracle PASS unless diagnostic override
+if [[ "$ARM" == "C" && "${FLEXAIDDS_ALLOW_ARM_C:-0}" != "1" ]]; then
+  _orc="${FLEXAID_ORACLE_STATUS:-${FLEXAIDDS_LOCAL_ROOT:-$HOME/flexaidds_results}/campaigns/three_engine/${FLEXAID_CAMPAIGN:-3dsig_full85_r1}_oracle_status.json}"
+  if [[ ! -f "$_orc" ]] || ! python3 -c 'import json,sys; s=json.load(open(sys.argv[1])); sys.exit(0 if s.get("arm_c_fo298_allowed") else 1)' "$_orc" 2>/dev/null; then
+    echo "ERROR: arm C blocked until oracle arm_c_fo298_allowed=true ($_orc)" >&2
+    echo "  Or set FLEXAIDDS_ALLOW_ARM_C=1 for diagnostic-only runs." >&2
+    exit 98
+  fi
+fi
 
 BIN_ARM="B"
 [[ "$ARM" == "A" ]] && BIN_ARM="A"
+[[ "$ARM" == "C" ]] && BIN_ARM="C"
+# Fall back to B binary if C not staged
 BINARY="$Q/bin/$BIN_ARM/FlexAID"
+if [[ "$ARM" == "C" && ! -x "$BINARY" ]]; then
+  BIN_ARM="B"
+  BINARY="$Q/bin/B/FlexAID"
+fi
 MATRIX="$Q/data/MC_st0r5.2_6.dat"
-MATRIX_PIN="72d7c7396702331d96ff12d18f831796"
+# Repo/baseline-validated JCIM matrix (not the 72d7 packing-sweetened fork)
+MATRIX_PIN="9dc93717dfed0698006d88dd6a9627bc"
 
 REPO="${FLEXAIDDS_ROOT:-}"
 if [[ -z "$REPO" ]]; then

--- a/scripts/run_panel_native_cf_oracle.py
+++ b/scripts/run_panel_native_cf_oracle.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Panel-wide native CF oracle gate for a classic-arm campaign OUT tree.
+
+Scans one-level ``*/result.csv`` (CloudDocs-safe), pairs each target with work
+and/or OUT poses, runs the same logic as ``native_cf_oracle_gate.py``.
+
+Claim policy (full85 / Softβ / arm C):
+  ranking and Softβ experiments are **forbidden** until this gate PASSes on
+  a canary set (or full panel). See ``docs/implementation/softbeta_election_policy.md``.
+
+Usage:
+  python3 scripts/run_panel_native_cf_oracle.py \\
+    --out-dir ~/flexaidds_results/campaigns/three_engine/A/3dsig_full85_scratch_3b2fa57cc \\
+    --work-root ~/flexaidds_results/three_engine_entropy_q1/work_scratch_3b2fa57cc/A \\
+    --json-out oracle_panel.json --status-out oracle_status.json
+
+Exit:
+  0  all evaluated targets PASS (or --min-pass rate met)
+  1  any pathology FAIL
+  2  usage
+  3  no evaluable targets / all missing native CF
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from native_cf_oracle_gate import (  # noqa: E402
+    EXIT_FAIL_PATHOLOGY,
+    EXIT_MISSING_NATIVE,
+    EXIT_PASS,
+    EXIT_USAGE,
+    run_gate,
+)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--out-dir",
+        type=Path,
+        required=True,
+        help="Campaign OUT with <PDB>/result.csv",
+    )
+    ap.add_argument(
+        "--work-root",
+        type=Path,
+        default=None,
+        help="Optional work tree root with <PDB>/ subdirs",
+    )
+    ap.add_argument("--tolerance", type=float, default=0.0)
+    ap.add_argument(
+        "--min-pass-rate",
+        type=float,
+        default=1.0,
+        help="Fraction of evaluable targets that must PASS (default 1.0)",
+    )
+    ap.add_argument("--json-out", type=Path, default=None)
+    ap.add_argument(
+        "--status-out",
+        type=Path,
+        default=None,
+        help="Compact status JSON for claim-mode launchers (oracle_status.json)",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Max targets to evaluate (0 = all)",
+    )
+    args = ap.parse_args(argv)
+
+    out_dir = args.out_dir.expanduser().resolve()
+    if not out_dir.is_dir():
+        print(f"ERROR: out-dir missing: {out_dir}", file=sys.stderr)
+        return EXIT_USAGE
+
+    csvs = sorted(
+        p
+        for p in out_dir.glob("*/result.csv")
+        if "incomplete" not in p.parent.name
+    )
+    if args.limit and args.limit > 0:
+        csvs = csvs[: args.limit]
+    if not csvs:
+        print(f"ERROR: no result.csv under {out_dir}", file=sys.stderr)
+        return EXIT_MISSING_NATIVE
+
+    rows: List[Dict[str, Any]] = []
+    n_pass = n_fail = n_missing = 0
+    for rc in csvs:
+        pdb = rc.parent.name
+        work = None
+        if args.work_root is not None:
+            cand = args.work_root.expanduser().resolve() / pdb
+            if cand.is_dir():
+                work = cand
+        res = run_gate(
+            work=work,
+            results=rc.parent,
+            poses_dir=rc.parent,
+            pdb_id=pdb,
+            tolerance=args.tolerance,
+            require_poses=True,
+        )
+        d = res.as_dict()
+        d["pdb_id"] = pdb
+        rows.append(d)
+        if res.exit_code == EXIT_PASS:
+            n_pass += 1
+        elif res.exit_code == EXIT_FAIL_PATHOLOGY:
+            n_fail += 1
+        else:
+            n_missing += 1
+        tag = "PASS" if res.ok else ("PATHOL" if res.exit_code == 1 else "MISS")
+        print(
+            f"{pdb:6s} {tag:6s} native={res.cf_native} best_ga={res.best_ga_cf} "
+            f"gap={res.gap}  {res.source_native} / {res.source_ga}"
+        )
+
+    n_eval = n_pass + n_fail
+    rate = (n_pass / n_eval) if n_eval else 0.0
+    ranking_ok = n_eval > 0 and rate + 1e-12 >= args.min_pass_rate and n_fail == 0
+    # Allow min-pass-rate soft mode: if min_pass_rate < 1, allow some fails
+    if args.min_pass_rate < 1.0 - 1e-12:
+        ranking_ok = n_eval > 0 and rate + 1e-12 >= args.min_pass_rate
+
+    summary = {
+        "out_dir": str(out_dir),
+        "work_root": str(args.work_root) if args.work_root else None,
+        "n_targets": len(rows),
+        "n_pass": n_pass,
+        "n_fail_pathology": n_fail,
+        "n_missing_native": n_missing,
+        "pass_rate": round(rate, 4),
+        "min_pass_rate": args.min_pass_rate,
+        "tolerance": args.tolerance,
+        "ranking_allowed": bool(ranking_ok),
+        "softbeta_allowed": bool(ranking_ok),
+        "arm_c_fo298_allowed": bool(ranking_ok),
+        "claim_eligible": False,  # claim also needs R=10 + binary split
+        "message": (
+            "PASS: native CF competitive — Softβ/arm-C may proceed when other gates OK"
+            if ranking_ok
+            else "FAIL: native CF not competitive — Softβ/arm-C/ranking FORBIDDEN"
+        ),
+    }
+    payload = {"summary": summary, "targets": rows}
+
+    if args.json_out:
+        args.json_out.expanduser().parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.expanduser().write_text(
+            json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+        )
+        print(f"wrote {args.json_out}", file=sys.stderr)
+    if args.status_out:
+        args.status_out.expanduser().parent.mkdir(parents=True, exist_ok=True)
+        args.status_out.expanduser().write_text(
+            json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+        )
+        print(f"wrote {args.status_out}", file=sys.stderr)
+
+    print(
+        f"\n# panel: pass={n_pass} pathol={n_fail} missing={n_missing} "
+        f"rate={rate:.2%} ranking_allowed={ranking_ok}"
+    )
+    if n_eval == 0:
+        return EXIT_MISSING_NATIVE
+    if ranking_ok:
+        return EXIT_PASS
+    return EXIT_FAIL_PATHOLOGY
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/stage_three_engine_bins.py
+++ b/scripts/stage_three_engine_bins.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Stage FlexAID / FlexAIDdS binaries for three-engine red-pair with claim checks.
+
+Claim science requires a **true** A vs master split:
+  - bin/A/FlexAID  = historical FlexAID pin (JCIM-era lineage)
+  - bin/B/FlexAID  = current master rebuild
+  - bin/C/FlexAID + FlexAIDdS = master (arm C FO@298K only after oracle PASS)
+
+If A and B are the same SHA256, B0 is a **deterministic twin** of A (same STRTSEED
++ same code) and is **not** a scientific control.
+
+Usage:
+  # Stage master build into B and C; leave A untouched
+  python3 scripts/stage_three_engine_bins.py --master-bin build/FlexAID \\
+    --flexaidds-bin build/FlexAIDdS --dest ~/flexaidds_results/three_engine_entropy_q1/bin
+
+  # Claim-mode check (exit 1 if A==B)
+  python3 scripts/stage_three_engine_bins.py --check-claim-split \\
+    --dest ~/flexaidds_results/three_engine_entropy_q1/bin
+
+  # Force-stage same binary to A and B (diagnostic only; refuse with --claim)
+  python3 scripts/stage_three_engine_bins.py --master-bin build/FlexAID --also-a
+
+Copyright 2026 Le Bonhomme Pharma
+SPDX-License-Identifier: Apache-2.0
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def git_sha(repo: Path) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def write_pin(arm_dir: Path, *, binary: Path, git: str, note: str) -> str:
+    arm_dir.mkdir(parents=True, exist_ok=True)
+    dest = arm_dir / "FlexAID"
+    shutil.copy2(binary, dest)
+    dest.chmod(0o755)
+    digest = sha256_file(dest)
+    (arm_dir / "SHA256").write_text(digest + "\n")
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    (arm_dir / "BUILD_PIN.md").write_text(
+        f"# FlexAID pin (arm {arm_dir.name})\n"
+        f"- built/staged: {ts}\n"
+        f"- git: {git}\n"
+        f"- sha256: {digest}\n"
+        f"- source: {binary.resolve()}\n"
+        f"- note: {note}\n"
+    )
+    return digest
+
+
+def main(argv: Optional[list] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--dest",
+        type=Path,
+        default=Path(
+            os.environ.get(
+                "FLEXAIDDS_LOCAL_QUEUE",
+                str(Path.home() / "flexaidds_results/three_engine_entropy_q1"),
+            )
+        )
+        / "bin",
+    )
+    ap.add_argument("--master-bin", type=Path, default=None, help="Master FlexAID binary")
+    ap.add_argument(
+        "--historical-a-bin",
+        type=Path,
+        default=None,
+        help="Historical FlexAID for arm A (required for claim split)",
+    )
+    ap.add_argument("--flexaidds-bin", type=Path, default=None)
+    ap.add_argument(
+        "--also-a",
+        action="store_true",
+        help="Also copy master into A (diagnostic only — breaks claim split)",
+    )
+    ap.add_argument(
+        "--check-claim-split",
+        action="store_true",
+        help="Exit 0 only if A and B FlexAID SHAs differ",
+    )
+    ap.add_argument(
+        "--claim",
+        action="store_true",
+        help="Refuse staging if A and B would be identical",
+    )
+    ap.add_argument(
+        "--repo",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+    )
+    args = ap.parse_args(argv)
+    dest: Path = args.dest.expanduser().resolve()
+    dest.mkdir(parents=True, exist_ok=True)
+    git = git_sha(args.repo.expanduser())
+
+    if args.check_claim_split:
+        a = dest / "A" / "FlexAID"
+        b = dest / "B" / "FlexAID"
+        if not a.is_file() or not b.is_file():
+            print("FAIL: missing bin/A or bin/B FlexAID", file=sys.stderr)
+            return 1
+        sa, sb = sha256_file(a), sha256_file(b)
+        print(f"A={sa}")
+        print(f"B={sb}")
+        if sa == sb:
+            print(
+                "FAIL: A and B are the same binary — B0 is a deterministic twin of A; "
+                "not a claim control. Stage a historical A pin with --historical-a-bin.",
+                file=sys.stderr,
+            )
+            return 1
+        print("OK: claim binary split (A ≠ B)")
+        return 0
+
+    if args.master_bin is None and args.historical_a_bin is None:
+        print("ERROR: provide --master-bin and/or --historical-a-bin", file=sys.stderr)
+        return 2
+
+    digests = {}
+    if args.historical_a_bin:
+        p = args.historical_a_bin.expanduser()
+        if not p.is_file():
+            print(f"ERROR: missing {p}", file=sys.stderr)
+            return 2
+        digests["A"] = write_pin(
+            dest / "A",
+            binary=p,
+            git=git,
+            note="historical FlexAID pin for arm A (TEMPER0 CF)",
+        )
+        print(f"staged A {digests['A']}")
+
+    if args.master_bin:
+        p = args.master_bin.expanduser()
+        if not p.is_file():
+            print(f"ERROR: missing {p}", file=sys.stderr)
+            return 2
+        digests["B"] = write_pin(
+            dest / "B",
+            binary=p,
+            git=git,
+            note="master FlexAID for B0/B (TEMPER0 CF / TEMPER21 FO)",
+        )
+        print(f"staged B {digests['B']}")
+        digests["C"] = write_pin(
+            dest / "C",
+            binary=p,
+            git=git,
+            note="master FlexAID for arm C FO@298K (oracle gate required)",
+        )
+        print(f"staged C FlexAID {digests['C']}")
+        if args.also_a:
+            digests["A"] = write_pin(
+                dest / "A",
+                binary=p,
+                git=git,
+                note="DIAGNOSTIC: master copied to A (NOT claim split)",
+            )
+            print(f"staged A (also-a) {digests['A']}")
+
+    if args.flexaidds_bin:
+        fb = args.flexaidds_bin.expanduser()
+        if not fb.is_file():
+            print(f"ERROR: missing {fb}", file=sys.stderr)
+            return 2
+        cdir = dest / "C"
+        cdir.mkdir(parents=True, exist_ok=True)
+        out = cdir / "FlexAIDdS"
+        shutil.copy2(fb, out)
+        out.chmod(0o755)
+        print(f"staged C FlexAIDdS {sha256_file(out)}")
+
+    a_path, b_path = dest / "A" / "FlexAID", dest / "B" / "FlexAID"
+    if a_path.is_file() and b_path.is_file():
+        sa, sb = sha256_file(a_path), sha256_file(b_path)
+        status = {
+            "A": sa,
+            "B": sb,
+            "identical": sa == sb,
+            "claim_binary_split_ok": sa != sb,
+            "git": git,
+            "ts_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+        (dest / "BINARY_SPLIT.json").write_text(json.dumps(status, indent=2) + "\n")
+        if sa == sb:
+            print(
+                "WARN: A and B SHAs identical — B0 is not an independent control",
+                file=sys.stderr,
+            )
+            if args.claim:
+                print("FAIL: --claim refuses identical A/B", file=sys.stderr)
+                return 1
+        else:
+            print("OK: A ≠ B claim binary split")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_clean_target_apo.py
+++ b/tests/test_clean_target_apo.py
@@ -79,6 +79,23 @@ def test_keep_metals(cta):
     assert rep.waters_removed == 2
 
 
+def test_keep_metals_near_ligand(cta):
+    """Catalytic metals within 4 Å of ligand are kept; far metals still stripped."""
+    # Ligand heavy at (5.5, 5.0, 5.0) — near MG at (5,5,5), far from FE ion at (8,8,8)
+    lig = [(5.5, 5.0, 5.0)]
+    out, rep = cta.clean_apo_pdb(
+        TINY_PDB,
+        keep_hoh=False,
+        keep_metals=False,
+        lig_xyz=lig,
+        metal_near_ligand_a=4.0,
+    )
+    assert "MG" in out  # ~0.5 Å from lig
+    assert "FE A 404" not in out and "FE    FE" not in out  # far ion stripped
+    assert rep.metals_kept_near_ligand >= 1
+    assert rep.waters_removed == 2
+
+
 def test_file_roundtrip(cta, tmp_path: Path):
     src = tmp_path / "in.pdb"
     dst = tmp_path / "out.pdb"

--- a/tests/test_sphere_prune_and_softwa.py
+++ b/tests/test_sphere_prune_and_softwa.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for LOCCLF sphere prune + classic SOFTWA emission (CF competitiveness prep)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPTS = REPO / "scripts"
+
+
+def _load_gen():
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    path = SCRIPTS / "generate_flexaid_inp.py"
+    spec = importlib.util.spec_from_file_location("generate_flexaid_inp", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["generate_flexaid_inp"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def gen():
+    return _load_gen()
+
+
+def test_matrix_pin_is_repo_validated(gen):
+    assert gen.MATRIX_MD5_PIN == "9dc93717dfed0698006d88dd6a9627bc"
+
+
+def test_soft_wall_default_and_config_keyword(gen, tmp_path, monkeypatch):
+    monkeypatch.delenv("FLEXAIDDS_SOFT_WALL", raising=False)
+    assert abs(gen.resolve_soft_wall_cutoff() - 0.40) < 1e-9
+    monkeypatch.setenv("FLEXAIDDS_SOFT_WALL", "0.0")
+    assert gen.resolve_soft_wall_cutoff() == 0.0
+    monkeypatch.delenv("FLEXAIDDS_SOFT_WALL", raising=False)
+
+    cfg = tmp_path / "CONFIG.inp"
+    gen.write_config(
+        cfg,
+        target_pdb=tmp_path / "t.pdb",
+        ligand_inp=tmp_path / "l.inp",
+        spheres_pdb=tmp_path / "s.pdb",
+        matrix_path=tmp_path / "m.dat",
+        depspa=tmp_path,
+        statep=tmp_path / "state",
+        tempop=tmp_path / "tmp",
+        rmsd_ref=None,
+        temper=0,
+        n_flex=0,
+        soft_wall_cutoff=0.40,
+    )
+    text = cfg.read_text()
+    assert "SOFTWA 0.40" in text
+    assert "TEMPER 0" in text
+    assert "CLUSTA CF" in text
+
+
+def test_prune_spheres_near_ligand(gen, tmp_path):
+    lig = tmp_path / "LIG_ref.pdb"
+    lig.write_text(
+        "HETATM    1  C   LIG A   1       0.000   0.000   0.000  1.00  0.00           C\n"
+        "HETATM    2  O   LIG A   1       1.200   0.000   0.000  1.00  0.00           O\n"
+    )
+    sph = tmp_path / "sph.pdb"
+    # near (kept), mid (kept if max large), far (pruned by distance)
+    lines = ["REMARK spheres\n"]
+    for i, (x, y, z) in enumerate(
+        [
+            (0.1, 0.0, 0.0),
+            (2.0, 0.0, 0.0),
+            (3.0, 0.0, 0.0),
+            (20.0, 0.0, 0.0),
+            (30.0, 0.0, 0.0),
+        ],
+        start=1,
+    ):
+        lines.append(
+            f"ATOM  {i:5d}  SPH SURF    1    {x:8.3f}{y:8.3f}{z:8.3f}  1.00  1.50           S\n"
+        )
+    sph.write_text("".join(lines))
+    info = gen.prune_spheres_near_ligand(
+        sph, lig, max_dist=5.0, max_spheres=2
+    )
+    assert info["pruned"] is True
+    assert info["n_in"] == 5
+    assert info["n_out"] == 2
+    out_lines = [
+        ln for ln in sph.read_text().splitlines() if ln.startswith("ATOM")
+    ]
+    assert len(out_lines) == 2
+    # nearest-first: 0.1 and 2.0 kept
+    assert "0.100" in out_lines[0] or "  0.100" in out_lines[0]
+
+
+def test_arm_c_requires_oracle_flag(gen):
+    assert gen.ARM_SPEC["C"]["requires_oracle_pass"] is True
+    assert gen.ARM_SPEC["B0"].get("science_control") is False


### PR DESCRIPTION
## Summary
Implements the post-scratch full85 failure priority stack (serial / no dual-launch):

1. **B0 not science** — skip unless `FLEXAID_INCLUDE_B0=1`
2. **Native CF competitiveness prep**
   - `SOFTWA` classic keyword + default `soft_wall_cutoff=0.40`
   - Matrix pin **9dc93717…** (drop 72d7 packing-sweetened fork)
   - Sphere prune near LIG_ref (max 2500 @ 8 Å)
   - Keep metals within 4 Å of ligand in clean apo
3. **R=10** recovery default (`FLEXAID_DIAGNOSTIC=1` → R=1)
4. **Binary staging** helper `stage_three_engine_bins.py` (claim A≠B check)
5. **Arm C / Softβ** gated on panel `native_cf_oracle` PASS
6. Panel oracle helper `run_panel_native_cf_oracle.py`

## Tests
- `pytest tests/test_clean_target_apo.py tests/test_sphere_prune_and_softwa.py` — 11 passed
- `./build/test_soft_wall` — 6 passed
- Fresh Release build FlexAID/FlexAIDdS linked

## Note
Oracle PASS still requires a new GA panel after re-prep; Softβ/arm-C stay blocked until then.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable soft-wall behavior, including a default cutoff and legacy hard-wall override.
  - Added optional ligand-aware sphere pruning with configurable distance and count limits.
  - Added support for retaining metals near ligands during structure cleanup.
  - Introduced three-engine staging and panel-level native oracle evaluation.
  - Added support for the new C processing arm with validation safeguards.

- **Documentation**
  - Updated validated matrix references and associated verification records.

- **Tests**
  - Added coverage for soft-wall configuration, sphere pruning, ligand-near metals, and C-arm eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->