### PR TITLE
chore: land audit records, paired-election analyzer, and hygiene fixes (no headline-accuracy changes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,10 @@ benchmarks/astex_repro/*.pid
 benchmarks/astex_repro/*.log
 benchmarks/astex_repro/**/*.bak
 benchmarks/astex_repro/spheres/
+
+# CTest run artifacts (regenerable build output — never source)
+Testing/
+
+# Compiled test binaries accidentally captured under validation evidence
+validation_evidence/**/test_cmaes_search_clang
+validation_evidence/**/*.o

--- a/.grok/skills/flexaidds/scripts/resolve_build.py
+++ b/.grok/skills/flexaidds/scripts/resolve_build.py
@@ -352,7 +352,9 @@ def sync_flexaidds_env(resolution: BuildResolution) -> Path:
         f"export FLEXAIDDS_ENGINE_SHA256={_shell_quote(resolution.engine_sha256)}",
         f"export FLEXAIDDS_RUNNER_SHA256={_shell_quote(resolution.runner_sha256)}",
         f"export FLEXAIDDS_RESULTS={_shell_quote(results)}",
-        f"export PATH={_shell_quote(resolution.build_dir + ':$PATH')}",
+        # Quote only the build dir; leave :$PATH unquoted so the shell expands PATH.
+        # Quoting '…:$PATH' freezes the literal string and wipes /usr/bin from PATH.
+        f"export PATH={_shell_quote(resolution.build_dir)}:$PATH",
         "",
         "# Re-resolve after rebuilds: python3 .grok/skills/flexaidds/scripts/resolve_build.py --sync-env",
     ]

--- a/docs/ATOM_TYPES.md
+++ b/docs/ATOM_TYPES.md
@@ -1,0 +1,211 @@
+# Atom Types in FlexAID∆S: The 40-Type NRGDock System
+
+FlexAID∆S uses a 40-type atom classification system derived from the SYBYL forcefield types. Each heavy atom in a receptor or ligand is assigned one of these 40 types, and that type is used as the row and column index into the 40×40 NRGDock energy matrix (`MC_st0r5.2_6.dat`). Getting the type right is essential: a mis-typed atom scores against the wrong row of the matrix and contributes either noise or the wrong sign to CF.
+
+This document describes all 40 types, explains the biological and chemical rationale for each, and documents the four type assignments that were incorrect in the original FlexAID and have been fixed in FlexAID∆S.
+
+---
+
+## The 40 Canonical Types
+
+The types are numbered 1–40. This numbering is the canonical index used internally in all source files. The table below gives the type number, the SYBYL/chemical name as used in FlexAID∆S, a brief chemical description, and representative examples.
+
+| # | Name | Chemical description | Examples |
+|:--|:-----|:---------------------|:---------|
+| 1 | C.1 | sp carbon | ≡C– (alkyne terminal), ·C≡N (nitrile carbon) |
+| 2 | C.2 | sp2 carbon | Alkene =CH₂, carbonyl C=O, conjugated C |
+| 3 | C.3 | sp3 carbon | Aliphatic CH₃, CH₂, CH, C |
+| 4 | C.AR | Aromatic carbon | Benzene ring C, pyridine C |
+| 5 | C.CAT | Carbocation / guanidinium C | Guanidinium resonance; rare in drug-like ligands |
+| 6 | N.1 | sp nitrogen | Nitrile N (≡N), isocyanate N |
+| 7 | N.2 | sp2 imine nitrogen | Imine =N– (pyridine-exo, Schiff base, not aromatic) |
+| 8 | N.3 | Aliphatic amine (sp3) | –NH₂, –NHR, –NR₂ (non-protonated, non-amide) |
+| 9 | N.4 | Quaternary ammonium N | –N⁺R₄ (fully substituted, positive charge) |
+| 10 | N.AR | Aromatic nitrogen | Pyridine N, pyrimidine N, imidazole ring N |
+| 11 | N.AM | Amide nitrogen | –NH–C=O, –NR–C=O; peptide bond N |
+| 12 | N.PL3 | Planar sp2 amine | Aniline (resonance delocalized), guanidine terminal N |
+| 13 | O.2 | sp2 oxygen | Carbonyl O (C=O in ketone, ester, amide) |
+| 14 | O.3 | sp3 oxygen | Alcohol –OH, ether –O–, phosphate O |
+| 15 | O.CO2 | Carboxylate oxygen | –COO⁻ in ionized carboxylic acid |
+| 16 | O.AR | Aromatic oxygen | Furan ring O |
+| 17 | S.2 | sp2 sulfur | Thioketone >C=S, dithioester |
+| 18 | S.3 | sp3 sulfur | Thiol –SH, thioether –S–, disulfide |
+| 19 | S.O | Sulfoxide S | R₂S=O |
+| 20 | S.O2 | Sulfone S | R₂SO₂ |
+| 21 | S.AR | Aromatic sulfur | Thiophene ring S |
+| 22 | P.3 | sp3 phosphorus | Phosphate –PO₄²⁻, phosphonate –PO₃H, phosphine |
+| 23 | F | Fluorine | –F (organofluorine) |
+| 24 | CL | Chlorine | –Cl (organochlorine) |
+| 25 | BR | Bromine | –Br (organobromine); **also used for I in FlexAID∆S** |
+| 26 | I | Iodine | –I; sparse in PDB training set — remapped to BR in FlexAID∆S |
+| 27 | SE | Selenium | Selenomethionine Se, selenocysteine Se |
+| 28 | MG | Magnesium | Mg²⁺ cofactor |
+| 29 | SR | Strontium | Sr²⁺ (uncommon; crystallographic artifact in some structures) |
+| 30 | CU | Copper | Cu²⁺ / Cu⁺ in metalloenzymes |
+| 31 | MN | Manganese | Mn²⁺ cofactor |
+| 32 | HG | Mercury | Hg²⁺ (organomercury, heavy-atom derivatives) |
+| 33 | CD | Cadmium | Cd²⁺ (heavy-atom derivative) |
+| 34 | NI | Nickel | Ni²⁺ in Ni-dependent enzymes |
+| 35 | ZN | Zinc | Zn²⁺ (very common: zinc-finger, carbonic anhydrase, HDAC) |
+| 36 | CA | Calcium | Ca²⁺ cofactor (kinases, EF-hand proteins) |
+| 37 | FE | Iron | Fe²⁺/Fe³⁺ (heme, iron-sulfur clusters) |
+| 38 | CO.OH | Cobalt / hydroxo metal | Co²⁺ or hydroxo-bridged metal centers |
+| 39 | DUMMY | Hydrogen + unknown | H (not scored); anything not matching types 1–38 |
+| 40 | SOLVENT | Solvent / water | Structural water O; not scored against ligand in CF.com |
+
+---
+
+## Source of Types: MOL2 vs. SDF vs. Internal Perception
+
+The type assigned to each ligand atom depends on the input format:
+
+**MOL2 files** carry explicit SYBYL type strings (`C.3`, `N.ar`, `O.2`, etc.) in the `@<TRIPOS>ATOM` block. `Mol2Reader.cpp` reads these strings and maps them to canonical VCT indices via `sybyl_to_flexaid_type()`. Because MOL2 carries hybridization information, this is the most accurate path.
+
+**SDF/MOL files** carry only element symbols (from the atoms block) and bond-order information. `SdfReader.cpp` maps element symbols to VCT types via `element_to_flexaid_type()`. Because hybridization is not explicit in SDF format, element fallbacks are used: carbon → C.3 (type 3), nitrogen → N.am (type 11), oxygen → O.3 (type 14), sulfur → S.3 (type 18). When more detailed perception is needed, the `ProcessLigand/BonMol` pipeline perceives full hybridization and aromaticity from the connectivity, then maps the perceived SYBYL type to the canonical VCT index via `sybyl_name_to_canonical_vct()` in `top.cpp`. This is the Tier 2 typing path and is used when BonMol is active.
+
+**Receptor atoms** (from PDB files) are typed by `assign_radii_types.cpp`, which uses the PDB residue name and atom name to assign SYBYL-equivalent types. The same canonical type numbering applies.
+
+All three paths must produce the same canonical integer for a given chemical environment — this is a shared source-of-truth invariant enforced by the identical mapping tables in `Mol2Reader.cpp`, `SdfReader.cpp`, and `top.cpp`.
+
+---
+
+## The Four Type Fixes in FlexAID∆S
+
+Four atom-type assignments were incorrect in the original FlexAID code. Each fix corrects a specific mismatch between the chemical nature of the atom and the matrix row it was scored against. The fixes are applied identically in `Mol2Reader.cpp`, `SdfReader.cpp`, and `top.cpp` to ensure consistency across all input paths.
+
+---
+
+### Fix 1: N.2 → N.AR (type 7 → type 10)
+
+**SYBYL name**: `N.2` (sp2 imine nitrogen, as in pyridine-exocyclic imines, Schiff bases, oximes, hydrazones)
+
+**Old mapping**: → N.am (type 11, amide nitrogen)
+
+**New mapping**: → N.AR (type 10, aromatic/sp2 nitrogen)
+
+**Why this was wrong**: N.am (type 11) is an H-bond *donor* — the nitrogen donates its NH to a receptor carbonyl or charged group. The N.2 imine nitrogen is an H-bond *acceptor* — its lone pair accepts an H-bond from a protein backbone NH or Lys/Arg side chain. These two roles have opposite effects on CF: when a donor type is scored against a receptor H-bond acceptor, the contact appears favorable in the matrix (donor–acceptor = stabilizing). When an acceptor type is scored against the same receptor site, the contact also appears favorable. But if the **wrong** type is used, the calculation scores the interaction against the wrong partner type's statistics. For N.2 → N.am, the acceptor nitrogen was scored as a donor, which reverses the H-bond sign and maps contacts to the wrong quadrant of the energy matrix.
+
+**Why N.AR is the right fix**: The vast majority of sp2 imine nitrogens in PDB drug–receptor complexes are chemically analogous to aromatic nitrogens (they are π-delocalized, acceptors, and geometrically similar to pyridine N). N.ar (type 10) has a well-populated matrix row reflecting exactly these contacts. Using N.ar for N.2 aligns the statistical potential with the correct physical chemistry.
+
+**Chemical examples affected**: Pyridine-exo imines in kinase inhibitors (e.g., imatinib C=N–Ar); hydrazone linkers; oximes; many heterocyclic nitrogen atoms that SDF readers perceive as N.2 when not in a fully aromatic ring.
+
+---
+
+### Fix 2: N.3 → N.AM (type 8 → type 11)
+
+**SYBYL name**: `N.3` (aliphatic sp3 amine: –NH₂, –NHR, –NR₂)
+
+**Old mapping**: → N.3 (type 8)
+
+**New mapping**: → N.AM (type 11)
+
+**Why this was wrong**: Type 8 (N.3) has a dead matrix row — all or nearly all entries are zero or near-zero because the PDB training set classified most aliphatic amine contacts under N.am (type 11, amide/generic amine) rather than the strict N.3 category. The practical consequence is that any ligand nitrogen typed as N.3 contributed nothing to CF.com — it was invisible to the scoring function. This is particularly damaging for amine-containing pharmacophores, where the amine often makes a key hydrogen-bond or ionic interaction with the receptor that should dominate CF for that contact.
+
+**Why N.AM is the right fix**: N.am (type 11) is the "generic nitrogen" in the NRGDock system — amide, amine, and other sp3-like nitrogens all end up in this row in the PDB training set. It has a rich, well-populated set of matrix entries. Mapping N.3 → N.am makes the amine contribute realistically to CF.
+
+**Chemical examples affected**: Primary and secondary amines in drug scaffolds (amfetamines, propranolol, metoprolol); basic nitrogens in piperidines and morpholines when read from MOL2 as N.3; any ligand with an unprotonated sp3 amine.
+
+---
+
+### Fix 3: C.1 → C.2 (type 1 → type 2)
+
+**SYBYL name**: `C.1` (sp carbon: alkyne –C≡C–, allene =C=, nitrile C≡N)
+
+**Old mapping**: → C.1 (type 1)
+
+**New mapping**: → C.2 (type 2, sp2 carbon)
+
+**Why this was wrong**: Type 1 (C.1) has only 10 live matrix entries because sp carbons (alkynes, nitriles) are rare in PDB binding sites — the training set simply did not have enough contact statistics to populate the row. While C.1 is not a dead row in the same way as N.3, its sparse population means CF.com contributions from sp carbons are noisy and unreliable.
+
+**Why C.2 is the right fix**: sp carbon is geometrically and electronically similar to sp2 carbon: both are linear or near-planar, both are relatively non-polar, and both pack in binding sites similarly. C.2 (type 2) has a far richer training set derived from the abundant aromatic, vinyl, and carbonyl carbons in drug-like molecules. The fallback to type 2 improves signal strength without introducing a chemical mismatch.
+
+**Note**: This fix applies specifically when the MOL2 SYBYL string is `C.1`. Nitrile carbons in SDF input are typed as `C` (element fallback → C.3, type 3), so SDF input is unaffected by this particular fix.
+
+---
+
+### Fix 4: I → BR (type 26 → type 25)
+
+**Element**: Iodine (I)
+
+**Old mapping**: → I (type 26)
+
+**New mapping**: → BR (type 25, bromine)
+
+**Why this was wrong**: Type 26 (I) has only 3 live matrix entries — the iodine row in MC_st0r5.2_6.dat is almost entirely empty because iodine is extremely rare in PDB drug–receptor co-crystals in the training set era. The few iodinated compounds in the PDB at training time were mostly heavy-atom derivatives for phasing, not true ligands. As a result, an iodinated ligand scored against the type-26 row would appear to make essentially no contacts — its iodine atoms would be phantom atoms contributing nothing to CF.
+
+**Why BR is the right fix**: Bromine (type 25) is electronically and sterically very similar to iodine — both are large, polarizable halogens in Group 17, both commonly engage in halogen bonding with carbonyl oxygens and aromatic rings, and both have similar van der Waals radii relative to the pocket atoms they contact. The bromine row is well-populated because brominated drug scaffolds are common in PDB binding sites. Using type 25 for iodine gives a physically reasonable score where type 26 gives noise.
+
+**Limitation**: This is an approximation. Iodine is ~25% larger than bromine (vdW radii: Br = 1.85 Å, I = 1.98 Å) and forms stronger halogen bonds due to its larger, more polarizable electron cloud. A future version of the energy matrix trained on the current PDB (which contains substantially more iodinated ligands, particularly iodinated kinase inhibitors) would populate type 26 correctly. Until then, type 25 is the best available approximation.
+
+---
+
+## Verifying Atom Types for a New Ligand
+
+Before docking a ligand with unusual chemistry, it is worth checking that its atom types will be assigned correctly.
+
+### From MOL2 input
+
+The SYBYL type strings in the MOL2 `@<TRIPOS>ATOM` block are used directly. Check that:
+
+1. Aromatic nitrogens in heterocycles are typed `N.ar` (not `N.3` or `N.2`).
+2. Imine nitrogens (non-aromatic =N–) are typed `N.2` (which maps to N.ar/type 10 in FlexAID∆S).
+3. Amide nitrogens are typed `N.am` (which maps to N.am/type 11 directly).
+4. Iodine atoms are typed `I` (which maps to BR/type 25 in FlexAID∆S).
+
+A quick check with OpenBabel or RDKit:
+
+```python
+from rdkit import Chem
+mol = Chem.MolFromMolFile("ligand.sdf")
+for atom in mol.GetAtoms():
+    print(atom.GetIdx(), atom.GetSymbol(), atom.GetHybridization())
+```
+
+Or to convert to MOL2 with SYBYL types:
+
+```bash
+obabel ligand.sdf -O ligand.mol2 --gen3D
+```
+
+Then inspect the `@<TRIPOS>ATOM` block — each line's 6th field is the SYBYL type.
+
+### From SDF input
+
+SDF input uses element-level fallbacks. The type mapping is:
+
+| Element | FlexAID∆S type | Notes |
+|:--------|:--------------:|:------|
+| C | C.3 (type 3) | Generic sp3; perception upgrades to C.2/C.ar if BonMol active |
+| N | N.am (type 11) | Generic amine/amide |
+| O | O.3 (type 14) | Generic sp3 oxygen |
+| S | S.3 (type 18) | Generic thioether/thiol |
+| P | P.3 (type 22) | Phosphate/phosphonate |
+| F | F (type 23) | |
+| Cl | CL (type 24) | |
+| Br | BR (type 25) | |
+| I | BR (type 25) | Remapped; iodine row too sparse |
+| Se | SE (type 27) | |
+| H | DUMMY (type 39) | Not scored |
+| Other | DUMMY (type 39) | Not scored |
+
+For SDF ligands with aromatic rings or sp2 centers, the BonMol Tier-2 perception path (`ProcessLigand`) is strongly recommended — it perceives full hybridization/aromaticity and assigns the correct C.ar, N.ar, O.2, etc. types. Without it, all carbons default to type 3 (C.3), which underestimates aromatic packing contributions in CF.com.
+
+### Diagnostic Output
+
+FlexAID∆S logs the typed atom count per type when `FLEXAIDDS_BENCHMARK=1` is set. The `[EVAL-BUDGET]` and `[ATOM_TYPES]` output lines report the histogram of type assignments for the current ligand. This is useful for confirming that expected types (e.g., C.ar for a phenyl ring) are actually assigned.
+
+---
+
+## Type Completeness and the Energy Matrix
+
+Not all 40 types are equally well-represented in the energy matrix. The rough tiers are:
+
+**Well-populated (high signal, reliable)**: C.2, C.3, C.AR, N.AR, N.AM, O.2, O.3, S.3, CL, BR, ZN, FE, CA, MG
+
+**Moderately populated (usable)**: C.1 (after fix → C.2), N.1, N.4, N.PL3, O.CO2, O.AR, S.2, S.O, S.O2, S.AR, P.3, F, SE, CU, MN, NI, CO.OH
+
+**Sparse / near-dead (use with caution)**: N.3 (type 8, fixed → N.AM in FlexAID∆S), I (type 26, fixed → BR in FlexAID∆S), SR, HG, CD
+
+**DUMMY / not scored**: H, any unrecognized element, SOLVENT
+
+For any ligand containing atom types in the sparse tier, the CF.com score for those atoms should be interpreted cautiously — the low matrix entries mean the statistical potential provides little discriminatory power for those contacts, and the overall CF may underestimate binding contributions from those functional groups.

--- a/docs/COMPARATIVE_BENCHMARK_METHODOLOGY.md
+++ b/docs/COMPARATIVE_BENCHMARK_METHODOLOGY.md
@@ -1,0 +1,197 @@
+# Fair Comparative Benchmarking Methodology — FlexAIDdS vs FlexAID-2015 vs FlexAID-first-entropy
+
+**Goal.** Compare, fairly and objectively, three points on the FlexAID lineage on the Astex Diverse 85 redocking benchmark, isolating the effect of the entropy concept and of the FlexAIDdS extensions.
+
+**Status.** Draft protocol (2026-07-24). Version pins finalized below; execution pending.
+
+---
+
+## 1. The three engines (pinned to the FlexAID lineage)
+
+Reference repo: `LeBonhommePharma/FlexAID` (mirror of `NRGlab/FlexAID`), local clone at `../flexaid` / `../FlexAID`. 377 commits, 2012–2020, branches `master` and `entropy` (originally `entropize`).
+
+| Engine | Definition | Ref | Notes |
+|---|---|---|---|
+| **V1 — FlexAID 2015 (JCIM baseline)** | Published CF + GA + FastOPTICS methodology, **no entropy scoring** | `master` branch, paper-era commit (mid-2015) | The Gaudreault & Najmanovich 2015 methodology (doi:10.1021/acs.jcim.5b00078). C code. |
+| **V2 — FlexAID first-entropy** | First working `BindingPopulation::Entropize()` + `SolvatedPartitionFunction` | `entropy` branch, first stable-entropy commit (~2016) | The direct conceptual ancestor of FlexAIDdS's Shannon/partition-function pose entropy. C/C++. |
+| **V3 — FlexAIDdS** | Current entropy-driven fork | `9dc9-production` (PR #300, clean 9dc9 matrix + validated fixes) | C++26. Adds ΔG_eff, ΔS_vib (tENCoM), Shannon pose entropy, PoseBusters QC. |
+
+> **Pin discipline.** Each engine is built once from an immutable commit SHA recorded in the run receipt. V1 must be the *published* state — before entropy was wired into scoring — so exact commit selection is verified by confirming `Entropize()` is NOT in the CF/selection path (it may exist as dead scaffolding on `master`, which is acceptable only if unused).
+
+---
+
+## 2. Fairness controls (the crux of objectivity)
+
+A comparison is only meaningful if every difference in the *result* is attributable to the *engine*, not to prep, protocol, scoring, or compute noise. Controls:
+
+1. **Identical dataset + preparation.** ONE canonical Astex-85 input set (same apo receptors, same ligand SDFs, same defined binding-site definition) fed to all three engines. This is non-negotiable: the session already showed prep confounds (un-stripped HEM on 1G9V/1Q4G) can dominate. All engines dock the *same* atoms.
+2. **Identical search protocol.** Blind redock, defined-cleft (no native-pose seeding, `seed=OFF`), identical search budget (population, generations, restarts) mapped to each engine's equivalent parameters. Document any parameter that cannot be matched 1:1.
+3. **N random seeds (≥3, ideally 5).** Docking GAs are stochastic; a single seed is not a measurement. Report mean ± dispersion across seeds; this is what makes the comparison a *measurement* rather than an anecdote.
+4. **Uniform EXTERNAL scoring.** Success is computed by ONE external RMSD scorer (symmetry-corrected, e.g. `spyrmsd`/Hungarian) applied identically to every engine's emitted rank-0 pose vs the crystal ligand. **Never** trust an engine's self-reported success column (the session showed FlexAIDdS's `success`/`claim_ready` are QC-gated and not comparable). Denominator frozen at 85 (a target that crashes or emits nothing = failure, never removed).
+5. **Matrix control — TWO arms.** The interaction matrix differs across versions and is a confound:
+   - **Arm A (as-published):** each engine uses its OWN native/validated matrix. Answers "which released engine docks best."
+   - **Arm B (matrix-held-constant):** all engines use the SAME matrix (9dc9). Isolates the *algorithm/entropy* changes from the *matrix* changes.
+   Report both; their difference quantifies how much of any gap is matrix vs algorithm.
+6. **Serialized compute (no contention).** Runs execute ONE engine at a time on the same hardware, pinned threads, determinism flags where available. Box contention was the single largest confound this session — it must be eliminated, not managed.
+7. **Genuine-blind enforcement.** All engines verified to run without native-pose seeding / seed-echo (rmsd≈0 with best_score≈native = disqualified). The metric is genuine top-1, not seed-inflated.
+
+---
+
+## 3. Primary metric & statistics
+
+- **Primary:** genuine top-1 sub-2Å success rate = (# targets whose rank-0 elected pose has symmetry-corrected RMSD < 2.0 Å) / 85, with **binomial 95% CI** (Wilson).
+- **Paired analysis:** per-target win/loss matrix across engines; **McNemar's test** for each pairwise comparison (V1↔V2, V2↔V3, V1↔V3) — the correct test for paired binary outcomes on the same targets.
+- **Averaging seeds:** per target, success = majority (or mean sub-2Å fraction) across the N seeds; report both the pooled rate and the per-seed spread.
+- **Secondary/diagnostic:** full RMSD distribution (not just the 2 Å threshold — report 1/2/2.5/3 Å bins), near-native sampling frequency, wall-clock per target, and pose validity (PoseBusters) as a *separate* axis (not folded into the success metric).
+
+---
+
+## 3b. Shared-search design for V1↔V2 (paired; do NOT search twice)
+
+**Finding (verified against the code, 2026-07-24).** Between `master` (V1) and `entropy` (V2):
+- `Entropize()` is invoked from `FOPTICS.cpp` (clustering) — the entropy is a **post-GA re-ranking of the converged population**, never a search-time fitness.
+- `gaboom.c` differs by +418 added lines, but those are **new standalone functions** (`generate_genetic_variants`, `generate_single_gene_mutants`, `generate_multiple_genes_mutants`, `generate_true_positive_cluster`, `generate_true_negatives_clusters`) — clustering *validation scaffolding*, not the search loop. Only **1** added line mentions entropy/BindingMode. Core operators are untouched (`mutate`/`boom`/`populate` diffs are `genlim*` → `const genlim*` signature propagation).
+- V1 elects via `cluster.c` (CF-ordered); V2 adds `entropy_cluster.c` (+134 lines) and reorders clusters "after considering entropy" (`505d764`).
+
+**⇒ Consequence: run the GA ONCE, score it TWICE.** Because the search is common and the entropy acts only at election, running two independent GAs would make part of any V1↔V2 difference pure stochastic noise. Instead:
+
+1. Run the search **once** per (target, seed) using the V2 binary.
+2. Emit the **full final population** with per-pose coordinates and per-pose CF (FlexAID already writes ranked results; ensure the whole population, not just rank-0, is dumped).
+3. Apply **both election rules to that same population, offline in the analysis layer**:
+   - **E_CF** (V1-style): elect lowest-CF cluster head.
+   - **E_S** (V2-style): entropy-weighted cluster election (`Entropize()` semantics).
+4. Score both elected poses with the same external RMSD scorer.
+
+**Why this is better, not just cheaper:** it is a **paired** design — identical search, identical population, identical prep, identical scorer. The *only* difference is the election rule, so the measured Δ is attributable to the entropy concept alone. It also halves compute and removes GA-seed variance from the most important comparison. Applying the election rules offline (rather than in-engine) keeps both rules transparent, auditable, and identically implemented.
+
+**Scope limits (stated honestly):**
+- This arm answers **"does the entropy concept improve pose election?"** — the core scientific question.
+- It does **not** reproduce "V1 exactly as published" (V2's binary still carries the const-correctness/scaffolding deltas). The as-published engine comparison remains a separate, lower-priority arm requiring V1's own binary.
+- **V3 (FlexAIDdS) cannot share this search** — it is an independent C++26 engine with its own GA (coarse-init, elitism, restarts) and its own entropy that *does* enter fitness (SMFREE/ACF sharing). V3 must run its own search and be compared unpaired (hence §2.3 N seeds + §3 CIs).
+
+**Risk de-scoped:** because the entropy question no longer depends on a working V1 binary, the hardest feasibility risk (building 2015-era C on macOS/arm64) is removed from the critical path.
+
+## 3c. VERIFIED build + output facts (2026-07-24) — engines are executable on darwin/arm64
+
+**⚠ LANDMINE — never build from the clones' working trees.** Both `../flexaid` and `../FlexAID` have **33 uncommitted modified files** (a prior session's WIP) that **comment out the entropy dispatch in `top.c` and strip ~455 lines from `gaboom.c`**. A build from the dirty tree silently produces an entropy-less binary (283 KB, zero `Entropize` symbols). **Always build from the pinned SHA via `git worktree add`.**
+
+| | V1 (2015 baseline) | V2 (first-entropy) |
+|---|---|---|
+| Pinned SHA | **`b555e0e`** (Makefile portability fix; master HEAD `9aa7995` is byte-identical apart from a README) | **`1a6ae0b`** (entropy HEAD) — methodology first functional at **`312f0c9`** (2017-02-23, "reranked according to CFdS instead of CF in entropy_cluster()"), built at HEAD only because the 2017 commits predate the Makefile portability fixes |
+| Entropy present? | **No** — `BindingMode.cpp/h` exist in-tree but are *not compiled or linked*; `top.c` calls classic `cluster()` only. Binary: **0** `Entropize` symbols | **Yes** — links `BindingMode/FOPTICS/ColonyEnergy/entropy_cluster`. Binary: **1** `Entropize` symbol |
+| Built / docks | yes / yes (283 KB) | yes / yes (467 KB) |
+
+**Build (both, ~10 s, warnings only):**
+```bash
+git worktree add /tmp/flexaid_v2_pristine 1a6ae0b     # or b555e0e for V1
+cd /tmp/flexaid_v2_pristine/BIN
+make -f Makefile.Linux64 CXX=g++ BOOST_INCLUDES=/opt/homebrew/include -j4
+```
+**Only macOS adaptation** (CLI override, no source edits): `BOOST_INCLUDES` → `/opt/homebrew/include` (Apple-Silicon homebrew; Boost is header-only here, so no link libs). Apple clang aliases `g++` and targets arm64 natively.
+Staged binaries: `~/flexaid_ref_binaries/FlexAID_V{1_master,2_entropy}`.
+
+**Full-population output (enables the offline paired election).** Run V2 with `TEMPER 0 / CLUSTA CF` to get the raw un-elected population from a single search:
+- **`<out>.rrd`** — every GA survivor (`NUMCHROM` lines): `idx  clusterID  clusterRMSD  RMSD_ref  CF  [genes]`. Requires `RMSDST` set.
+- **`<out>.cad`** — per cluster: `TOP=<idx> TCF=<lowest CF> ACF=<avg CF> freq=<size>` (TCF order **is** the E_CF election order).
+- **`<out>_N.pdb`** — Cartesian representative (lowest-CF member) per cluster + CF breakdown (`CF.app/com/sas/wal/con`).
+- Config: **⚠ `MAXRES 0` writes ZERO results, not "all"** — empirically verified on identical inputs (`MAXRES 0` → `num_of_results=0`, only `_INI.pdb`; `MAXRES 500` → 500 results/PDBs). **Use `MAXRES = NUMCHROM`.** `NUMCHROM` = population size; `TEMPER 0`→CF election, `TEMPER>0`→entropy; `CLUSTA CF|FO`. Also set `OUTGENER 50` (at `OUTGENER 1` logs are ~35% of the disk footprint). Invocation: `FlexAID CONFIG.inp ga.inp <out_prefix>`.
+- *Caveat:* `_N.pdb` holds only the per-cluster representative; all-pose Cartesians require `.rrd` (internal coords) or enabling `output_dynamic_BindingMode()` (`BindingMode.cpp:50`).
+
+### The two election rules (reference semantics, to be reimplemented offline)
+From `BindingMode.cpp`, per pose *i* with `CF_i = chrom->app_evalue` and `T = TEMPER` (integer):
+
+```
+w_i = exp(−(1/T)·CF_i)          # β = 1/T  — NOT 1/(k_B·T)
+Z   = Σ_{i ∈ whole population} w_i
+per binding mode (cluster) m:
+  H_m = Σ_{i∈m} (w_i/Z)·CF_i
+  S_m = −Σ_{i∈m} (w_i/Z)·ln(w_i/Z)        # Shannon, no reference state
+  G_m = H_m − T·S_m                        # compute_energy()
+```
+- **E_S (V2-style):** `Entropize()` sorts modes **ascending by `G_m`**; `mode[0]` wins. Written structure = the mode's lowest-CF member (`elect_Representative(false)`).
+- **E_CF (V1-style):** rank modes by raw CF, lowest wins (= `.cad` TCF order).
+
+> **Note the normalization:** `w_i/Z` is normalized over the **whole population**, so within-mode probabilities do not sum to 1 — this must be reproduced exactly. **β = 1/T (no k_B)** matches FlexAIDdS's convention (adding k_B collapses the weights → S≡0), and the reference's `TEMPER 21` is the same calibration as FlexAIDdS's "ISMB 2017 T=21".
+
+## 3d. Integration with the existing harness (`scripts/generate_flexaid_inp.py`)
+
+A mature generator already exists and defines the classic-FlexAID arms. **Reuse it**; do not rebuild.
+
+| Arm | Binary | TEMPER | CLUSTA | Meaning |
+|---|---|---|---|---|
+| **A** | 2015 pin (`b555e0e`) | 0 | CF | FlexAID 2015 as published |
+| **B0** | master/entropy build | 0 | CF | entropy build with entropy OFF |
+| **B** | entropy (`1a6ae0b`) | 21 | FO | entropy ON (as shipped) |
+| **C** | entropy | 298 | FO | high-T variant (gated) |
+| **C0** | FlexAIDdS | — | — | separate runner (not this generator) |
+
+It already encodes good fairness practice: `DEFAULT_MAXRES = 50` deliberately matches the FlexAIDdS cluster-emit ceiling, one canonical prep per target, and clean-apo/ligand-integrity gates.
+
+**Two issues resolved / flagged:**
+
+1. **The "A == B twin" hazard is now resolved.** The generator warns that B0 is *"twin of A when bin A==B SHA — not an independent control"*. The build audit settles it: `b555e0e` (master) links **no** entropy — `BindingMode.cpp/h` are present but never compiled, `top.c` calls classic `cluster()` only, binary has **0** `Entropize` symbols (283 KB) — while `1a6ae0b` (entropy) has **1** (467 KB). Pinning A→`b555e0e`, B→`1a6ae0b` gives a genuine, verifiable binary difference.
+
+2. **⚠ Arm B changes TWO variables at once.** B differs from A/B0 in *both* `TEMPER` (0→21, entropy ranking) **and** `CLUSTA` (CF→FO, Fast-OPTICS density clustering). A B-vs-A difference therefore cannot be attributed to entropy alone. Hence the two complementary readouts:
+   - **Q1 — "the entropy concept" (isolated):** the §3b paired offline election — ONE search, fixed CF clustering, `E_CF` vs `E_S` on the same population (`scripts/elect_paired.py`). Only the election rule varies.
+   - **Q2 — "the entropy pipeline as shipped":** arm **B** vs arm **A/B0** — entropy ranking *plus* FO clustering, i.e. the engine as released. Legitimate, but reported as a pipeline effect, not an entropy effect.
+
+   Both are reported; their difference measures how much of B's effect is FO clustering rather than entropy.
+
+3. **Seeding caveat (affects replicate design).** The generator notes the staged Mach-O binaries **seed from `time(0)` and may ignore `STRTSEED`**. Consequence: runs are *not* bit-reproducible, but independent invocations are genuinely independent replicates — so N-seed replication works by simply re-invoking, while exact reproduction requires archiving outputs (record this in the receipt).
+
+**Validation status of the election layer:** `scripts/elect_paired.py` was checked against real engine output (1GPK smoke, 100 poses → 21 modes): its `E_CF` winner reproduces the engine's own `.cad` rank-0 (`Cluster 0 TOP=0 TCF=-30.09`) exactly, and log-sum-exp weighting absorbs the clash-sentinel poses (CF ≈ 10⁴, visible as `ACF=19608`) without underflow.
+
+## 3e. PILOT RESULTS + blockers (2026-07-24, 8 targets × 3 seeds, V2 @ 500 chrom × 500 gen)
+
+**Sizing (measured):** median **30 s/run** single-threaded (min 18, max 42; n=32). Per arm: 85×3 seeds ≈ 2.1 CPU-h (~42 min wall @3 concurrent); 85×5 seeds ≈ 3.5 CPU-h (~70 min). Full matrix (3 arms × 85 × 5) ≈ **5 CPU-h, <2 h wall, ~8 GB disk**. **Disk is the binding constraint, not CPU** (~19 MB/run; 12 GB free — free ≥8 GB before launching).
+
+**Early signal (pooled 24 obs):** `E_CF` 3/24, `E_S` 3/24. The elected pose **differs on 12/24 (50%)** — the entropy rule is genuinely active, *not* a no-op — but discordant outcomes are 1 vs 1, **McNemar exact p = 1.00**. ⇒ *At this n, entropy election changes the pose but not the outcome.*
+
+**Two facts that constrain any conclusion:**
+- **Seed noise dominates.** Per-target E_CF RMSD spread across 3 seeds reaches **7.84 Å** (1P62), 6.66 (1SJ0), 3.93 (1GPK). A single seed is uninterpretable → **N=5 seeds is mandatory**, and the V1-vs-V2 engine table at n=1 carries **no information** (do not quote it).
+- **Sampling ceiling:** a sub-2 Å pose exists in the population for only **3–4 of 8** targets. Studying election rules on populations where the answer is absent ~60% of the time has little headroom — **raise `NUMCHROM` before drawing election conclusions** (cheap at 30 s/run).
+
+**Blindness re-verified:** `POPINIMT RANDOM`, "generated 500 randomized individuals", and **zero poses < 0.05 Å across all 32 runs** — no seed echo. Binary pins re-verified by `nm -a`: **5** `entrop*` symbols in V2, **0** in V1.
+
+### ⛔ P0 blockers — the entropy claim is NOT yet defensible
+1. **Population mismatch (fidelity gap).** The `.rrd` exposes only the final `NUMCHROM` chromosomes, but `Entropize()` elects over the **whole GA snapshot**: `.cad` cluster frequencies are 139–25,172 vs 500 `.rrd` rows (1GPK cluster 0: **209 members in-engine, 4 in the `.rrd`**). Since `S_m` depends on mode membership, the offline `E_S` is reconstructed from **~2%** of the poses the reference actually uses ⇒ **the §3b paired election is currently a PROXY, not a reproduction.** *Fix:* enable the reference's own `output_dynamic_BindingMode()` (`BindingMode.cpp:50`, one-line uncomment — instrumentation only, writes each Pose as a MODEL with its CF), rebuild V2, and re-derive `E_S` from the full snapshot.
+2. **Internal RMSD is not symmetry-corrected.** V1's Hungarian column quantifies the cost: 1MEH 3.99→**2.01**, 1L7F 4.78→**2.94**, 1OWE 9.83→**5.90**. Internal RMSD systematically overstates error and would flip success calls. **§2.4's external symmetry-corrected scorer (spyrmsd) on the emitted `_N.pdb` is mandatory — never use the `.rrd` column.**
+
+### Fixed in this round
+- `elect_paired.py` is now **column-layout aware** (V1 writes 6 numeric cols with CF **last** and a Hungarian RMSD at col 4; V2 writes 5 with CF at col 4 — the previous hardcoded `cf=parts[4]` silently read V1's *RMSD* as its CF), and it **drops `cluster < 0`** poses (MAXRES-overflow poses were fabricating one spurious mega-mode of up to 376/500 poses).
+- `MAXRES 0` corrected above; `OUTGENER 50` recommended.
+- `SOFTWA 0.40` in the canonical prep is **inert for both classic binaries** (token absent from both) — harmless for V1↔V2 fairness, but a documented non-1:1 vs FlexAIDdS.
+
+## 4. Execution plan
+
+1. **Build** V1 (`master`, C, Makefile adapted for this platform), V2 (`entropy`, C/C++), V3 (FlexAIDdS, CMake C++26). Record each build's compiler, flags, and commit SHA.
+2. **Freeze inputs**: one canonical Astex-85 prep (receptors/ligands/sites), checksummed, shared read-only by all engines.
+3. **Run**: each engine × 85 targets × N seeds, blind, serialized. Isolated output dirs, local storage.
+4. **Score**: uniform external RMSD scorer over every rank-0 pose. Build the 3 × 85 × N outcome table.
+5. **Analyze**: success ± CI per engine (Arms A & B), McNemar pairwise, RMSD distributions, per-target win/loss heatmap.
+6. **Report**: a single results table + significance + the "how much is matrix vs algorithm vs entropy" decomposition.
+
+---
+
+## 5. Threats to validity (and their controls)
+
+| Threat | Control |
+|---|---|
+| Prep differences (HEM, protonation, site) | §2.1 one canonical prep |
+| Matrix differences | §2.5 two arms (native vs constant) |
+| Seed-echo inflation | §2.7 blind enforcement + §2.4 external scoring |
+| Stochastic single-seed noise | §2.3 N seeds + §3 CI |
+| Box contention / CPU starvation | §2.6 serialized runs |
+| Self-reported-metric incomparability | §2.4 uniform external scorer |
+| Old-C vs C++26 numerical drift | document compiler/flags; the metric is geometric (RMSD), not score-value, so scale differences don't bias it |
+| Parameter non-equivalence across engines | §2.2 document every non-1:1 mapping |
+
+---
+
+## 6. Open decisions (require sign-off before execution)
+
+1. **V1 exact commit** — the paper-era `master` SHA (verify entropy not in scoring path).
+2. **V2 exact commit** — the first *stable* `Entropize()` state to pin.
+3. **N seeds** — 3 (faster) vs 5 (tighter CI).
+4. **Which arm first** — Arm A (as-published) is the headline; Arm B (matrix-constant) is the mechanistic decomposition. Recommend both, Arm A first.
+5. **RMSD scorer** — spyrmsd (symmetry-correct) recommended over the engines' internal RMSD.

--- a/docs/audit/AUDIT_2026-07-23.md
+++ b/docs/audit/AUDIT_2026-07-23.md
@@ -1,0 +1,515 @@
+# FlexAIDdS — Deep Code Review & Science Audit
+
+**Branch:** `feat/smart-water-retention` (7 commits ahead of `main`, HEAD `cf428ab28`)
+**Date:** 2026-07-23
+**Scope:** C++ core engine (`LIB/`), Python dataset runner and results parser (`python/flexaidds/`)
+**Mode:** Read-only. No source files were modified.
+
+## Scope limits and honesty notes
+
+Three caveats on coverage, stated up front so no finding is read as stronger than its evidence:
+
+1. **Red-flag files.** The repository carries a standing order against touching `Vcontacts.cpp/.h`, `gaboom.cpp`, `ic2cf.cpp`, and `buildlist.cpp`. I honored it: these were inspected only through their *interfaces* (declarations, call sites, and the surrounding comments) via grep, not read in full. Threading findings that would require reading the GA loop body are therefore marked **unverified** below, with the experiment that would settle them.
+2. **No execution.** This audit is static. Nothing here was confirmed by a build or a docking run. Every finding that would change a number is paired with a concrete experiment.
+3. **Where I am uncertain, I say so.** Several findings hinge on which code path a given atom actually takes at runtime; those are flagged as conditional.
+
+---
+
+# 1. Code quality and correctness
+
+## 1.1 — CRITICAL: benchmark RMSD is silently computed on truncated, unmatched atom arrays
+
+**Location:** `python/flexaidds/dataset_runner/runner.py:1993-2012` (`_pose_rmsd_vs_reference`)
+
+```python
+if pred.shape != ref_coords.shape:
+    n = min(len(pred), len(ref_coords))
+    if n < 3:
+        return -1.0
+    pred = pred[:n]
+    ref = ref_coords[:n]
+```
+
+When the docked pose and the crystal reference have different heavy-atom counts, the function **truncates both arrays to their first `n` atoms in file order** and computes an RMSD on that prefix. There is no warning, no log line, and no flag on the returned value. The number then flows into `PoseScore.rmsd`, into `docking_power()`, and into the headline success rate.
+
+This is wrong in two independent ways. First, prefix truncation assumes the two files list atoms in the same order — nothing enforces that, and the pose PDB is written by the engine while the reference comes from the benchmark dataset. Second, even with matched counts, `compute_rmsd(pred, ref)` is a straight index-wise RMSD with no atom-name matching and no molecular-symmetry correction, so a phenyl-ring flip or a swapped carboxylate oxygen pair registers as a large RMSD on a pose that is chemically identical to the crystal.
+
+The count mismatch is not hypothetical: hydrogens, alternate conformations, and the extracted-ligand SDF path all plausibly produce it, and the repository's own history records ligand-extraction problems of exactly this kind.
+
+**Impact.** Any target hitting the truncation branch reports a meaningless RMSD that is nonetheless counted as a real success or failure. The symmetry gap biases the reported rate *downward* on symmetric ligands; the truncation branch biases it in an unpredictable direction.
+
+**Recommended fix.** Return `-1.0` (or raise) on any shape mismatch rather than truncating, and log the target and the two counts. Separately, add graph-isomorphism symmetry correction — the codebase already distinguishes `rmsd_raw` from `rmsd_sym` in `io.py:parse_pose_result`, so the concept exists but this path does not use it.
+
+**Experiment.** Instrument the mismatch branch with a counter and re-run the v127 Astex-85 campaign. If the counter is zero, this is latent and drops to *major*; if it is non-zero, every affected target's RMSD must be recomputed before the 91.8% figure can be quoted.
+
+---
+
+## 1.2 — CRITICAL: failed targets are dropped from the success-rate denominator
+
+**Location:** `python/flexaidds/dataset_runner/metrics.py:325-334` (`docking_power`)
+
+```python
+valid = [p for p in target_poses if p.rmsd >= 0]
+if not valid:
+    continue          # <-- target vanishes entirely
+n_valid += 1
+...
+return n_success / n_valid if n_valid > 0 else 0.0
+```
+
+A target whose poses all carry `rmsd < 0` — which is exactly what `_pose_rmsd_vs_reference` returns when extraction fails, when fewer than three atoms match, or when `compute_rmsd` raises — is skipped by `continue` and never increments `n_valid`. It is removed from the denominator rather than counted as a failure.
+
+This means the reported success rate is *conditional on the target having produced a parseable pose*, not a rate over the 85-target set. A run that produces zero poses for six targets and succeeds on all 79 others reports 100%, not 92.9%.
+
+**Impact.** The headline figure (91.8%, v127) may be over an N smaller than 85. This compounds with finding 1.1: the same failure modes that trigger truncation can also trigger `-1.0`.
+
+**Recommended fix.** Report `n_success / n_targets_attempted` as the primary number and `n_valid` separately, or at minimum emit both `N_evaluated` and `N_total` alongside every rate. Treat a target with no parseable pose as a failure — that is what it is.
+
+**Experiment.** Print `n_valid` next to the success rate for the archived v127 run. If `n_valid < 85`, the ceiling figure needs restating.
+
+---
+
+## 1.3 — MAJOR: `ensemble_mean` silently switches estimators on clash-dominated populations
+
+**Location:** `LIB/ThermodynamicEngine.cpp:43-70`
+
+The function computes two means — one over finite non-clash values (`|x| < 1e5`), one over all finite values — and returns the first if any non-clash pose exists, otherwise the second. Neither the count of discarded poses nor which branch was taken is recorded in `ThermoResult`.
+
+The comment at lines 62-66 is candid about the motive (avoiding a NaN that would "silently drop the target from selection"), but the cure has the same shape as the disease: a target whose population is 99% clashes yields a mean over the surviving 1%, reported identically to a clean run. The two numbers can differ by orders of magnitude.
+
+**Recommended fix.** Add `n_valid` and `n_clash` fields to `ThermoResult` and propagate them to the report. Any downstream consumer can then discount a mean computed from a handful of poses.
+
+---
+
+## 1.4 — MAJOR: `is_hydrogen_atom` misclassifies mercury (and helium) as hydrogen
+
+**Location:** `LIB/hbond_potential.h:182-186`
+
+```cpp
+inline bool is_hydrogen_atom(const atom_struct& atom) {
+    return atom.element[0] == 'H' ||
+           (atom.element[0] == ' ' && atom.element[1] == 'H') ||
+           atom.name[0] == 'H';
+}
+```
+
+`element[0] == 'H'` is true for `"HG"` (mercury) and `"HE"` (helium). Mercury is not exotic in crystallography — it appears in heavy-atom derivative structures and as a genuine ligand-site metal. A mercury atom classified as hydrogen is excluded from `heavy_neighbor_count`, excluded from the virtual-H neighbor collection, and counted by `bonded_hydrogen_count` as an explicit H — which then causes `assign_virtual_h_geometry` to return early at line 215 (`if (explicit_h > 0) return;`), leaving the neighboring donor with `VHG_NONE` and no angular term at all.
+
+The third clause (`name[0] == 'H'`) has the mirror problem in the other direction: PDB hydrogen names are frequently `1HB`, `2HG1`, etc., where `name[0]` is a digit, so genuine hydrogens are missed.
+
+**Recommended fix.** Compare the full trimmed element field against `"H"` and `"D"` exactly, and for the name fallback strip leading digits before testing. The engine already has an element table (`pb_vdw_radius` / `get_element`); route through it rather than re-deriving.
+
+---
+
+## 1.5 — MAJOR (conditional): protonated tertiary amines get a planar or misplaced virtual H
+
+**Location:** `LIB/hbond_potential.h:217-224`, `:237-239`
+
+The heavy-neighbor collection loop stops at two:
+
+```cpp
+for (int b=1; b<=a.bond[0] && b<=6 && nheavy<2; ++b) { ... hidx[nheavy++] = nb; }
+```
+
+and `atom_struct::vH_nbr` holds exactly two slots. For an sp3 nitrogen with **three** heavy neighbors and a positive charge — a protonated piperidine, morpholine, or N-methylpiperazine, i.e. the single most common basic center in CNS drugs — the code reaches line 237 (`heavy_bonds>=2 && nheavy>=2`) and applies `VHG_SP3_2NBR`, whose derivation (documented at line 134) explicitly assumes the nitrogen has *two* heavy bonds. The resulting H direction is `normalize(-0.5*(d0+d1) + 0.8165*(d0×d1))`, which for a three-substituted nitrogen points approximately at the third substituent.
+
+The correct direction for three heavy neighbors is `-(d0+d1+d2)`, which requires a third neighbor slot.
+
+Given that FlexAIDdS explicitly targets psychopharmacology, this is the wrong atom class to get wrong. Nearly every monoamine-transporter and GPCR ligand has a protonated amine making the key salt bridge to a conserved aspartate.
+
+**Uncertainty.** Whether this fires depends on whether these nitrogens reach `case 8` at all — see finding 3.1, which argues they are remapped to type 11 and take the amide path instead. Either way the geometry is wrong; the two findings identify different wrong paths for the same atoms.
+
+**Recommended fix.** Extend `vH_nbr` to three slots and add a `VHG_SP3_3NBR` case placing the H at `-(d0+d1+d2)`.
+
+**Experiment.** Run with `FLEXAIDS_VH_DEBUG=1` on a target with a protonated tertiary amine and inspect the `[vH]` dump for the amine nitrogen's assigned `vH_kind`.
+
+---
+
+## 1.6 — MINOR: hydroxyl and primary-amine virtual H are placed at an arbitrary, frame-dependent torsion
+
+**Location:** `LIB/hbond_potential.h:80-86` (`perp3`), used by `VHG_HYDROXYL` (:165-177) and `VHG_SP3_1NBR` (:147-164)
+
+Both cases place the H using `perp3`, which manufactures a perpendicular from a hard-coded reference axis chosen by `if (std::fabs(v[0]) < 0.9) ref[0]=1.0; else ref[2]=1.0;`. The resulting azimuth around the donor axis is a function of the *global coordinate frame*, not of chemistry.
+
+But the O–H torsion of a serine, threonine, or tyrosine hydroxyl is a free rotor, as is the NH2 rotation of a primary amine. The physically meaningful quantity is the *best achievable* D–H···A angle over that rotation, not the angle at one arbitrary azimuth. As written, a hydroxyl donor perfectly positioned to donate to an acceptor may score an angle term near zero purely because `perp3` happened to point the H the other way — and rotating the entire complex in space changes the score.
+
+This is scored through `donor_angle_term`, so it directly perturbs `cfs->hbond`.
+
+**Recommended fix — and this is one of the cleanest quick wins in the codebase.** For a rotor donor the optimal H lies in the plane containing the donor axis and the acceptor, so the best-case D–H···A angle is available in closed form: project the D→A vector onto the cone of allowed H directions (half-angle 104.5° for hydroxyl, 109.5° for the amine) and take the angle at that projection. No search required, a dozen lines, and it removes a frame-dependence that is currently injecting noise into every hydroxyl H-bond.
+
+**Experiment.** Rotate an entire receptor-ligand complex by an arbitrary rigid rotation and re-score. Any change in `CF.hbond` is this bug (a rigid rotation must leave every scoring term invariant). This is also a good permanent regression test.
+
+---
+
+## 1.7 — MINOR: salt bridges are silently attenuated to 30% of their weight
+
+**Location:** `LIB/hbond_potential.h:366-390`
+
+```cpp
+const bool salt_bridge = is_charge_supported_salt_bridge(a, b);
+if (!a_to_b && !b_to_a && !salt_bridge) return 0.0;
+...
+if (best_angle_term == 0.0) best_angle_term = 0.3;
+double w = salt_bridge ? salt_bridge_weight : weight;
+double energy = w * E_dist * best_angle_term;
+```
+
+The header comment at line 345 states: *"Salt bridge: ionic pairs bypass the angular gate and use salt_bridge_weight."* They do not bypass it. When a pair qualifies as a salt bridge but neither direction passes the donor/acceptor gate (`a_to_b` and `b_to_a` both false — the exact case the `|| salt_bridge` clause exists to admit), `best_angle_term` stays 0.0, hits the 0.3 fallback, and the salt bridge is scored at **30% of `salt_bridge_weight`** (default −5.0 → effective −1.5).
+
+Whether that is desirable is a modeling choice, but the code and its documentation disagree, and the 0.3 is a fallback constant intended for "donor with underdetermined geometry", not a deliberate ionic-interaction scale factor.
+
+**Recommended fix.** Make the intent explicit: either apply `best_angle_term = 1.0` on the pure-salt-bridge path, or introduce a named `SALT_BRIDGE_ANGLE_FACTOR` constant. Do not leave a scoring decision resting on a fallback value.
+
+---
+
+## 1.8 — MINOR: the COM_FLOOR documentation block no longer describes the code
+
+**Location:** `LIB/vcfunction.cpp:869-871` (comment) vs `:889-897` (code)
+
+The comment still documents the pre-`3df9d7659` formula:
+
+```
+softfloor(x) = −F + F·softplus((x + F)/F)
+```
+
+while the code now implements `softfloor(x) = −F + softplus(x + F)` — the unscaled variant. These are different functions: the old one has a transition region of width ~F, the new one a fixed width of ~1 CF unit. Both are monotone, bounded below by −F, and asymptotically identity, so the fix in `4805de1d8` is sound and the overflow guard is correct. But a reader working from the comment will predict wrong numbers, and for large F the new form is effectively a hard hinge rather than the soft floor the comment describes.
+
+The `NOTE (reconstruction)` at lines 878-883 also still asks the reader to "confirm F and the exact squashing against the original work order" — that reconciliation appears not to have happened.
+
+**Recommended fix.** Update the comment to the implemented formula and record the deliberate choice to make the softness scale-independent.
+
+---
+
+## 1.9 — Threading: no data race found in the reviewed paths (unverified for the GA loop body)
+
+`FA->contributions` is a shared mutable accumulator: it is `memset` at `vcfunction.cpp:171` and incremented at `:714-716` and `:821-822` on every contact. Called concurrently on a shared `FA`, this would be a textbook race — and it would corrupt the Shannon entropy penalty at `:908-931`, which reads the whole array.
+
+That does not happen: `gaboom.cpp:2601` and `:3285` install per-thread `FA` shadows with per-thread `contributions` buffers (`tl_fa[t].contributions = tl_contrib[t].data();`, `p_fa[t].contributions = p_contrib[t].data();`), and the comment at `gaboom.cpp:2480` documents the scratch set being thread-localized. The four `#pragma omp parallel for` sites at `gaboom.cpp:2635, 2732, 2799, 3350` all use `default(none)`, which forces every shared variable to be named explicitly — a genuinely good defensive choice that makes accidental sharing a compile error rather than a silent race.
+
+**Unverified.** I did not read the loop bodies (red-flag file), so I cannot confirm that *every* member of the thread-local `FA` that `vcfunction` writes is actually shadowed. `FA->optres[j].cf` is written throughout `vcfunction` and is reached through a pointer inside `FA`; if the shadow copies the `FA` struct but leaves `optres` pointing at the shared array, the `cf` accumulators race.
+
+**Experiment.** This is exactly what ThreadSanitizer is for. Build with `-fsanitize=thread`, `OMP_NUM_THREADS=4`, and run one small target (1LPZ). The repository already has a documented determinism protocol (`--omp-threads 1` + `FLEXAIDDS_PARALLEL_RESTARTS=0` + fixed seed produces bit-identical output) — the fact that multi-thread runs show a ~2 Å run-to-run RMSD spread while single-thread runs are bit-identical is *consistent with* benign scheduling nondeterminism, but it is also consistent with a race. TSan distinguishes them. Given that the spread is currently attributed to threading and treated as noise, I would rank this the highest-value unresolved question in the correctness section.
+
+---
+
+## 1.10 — Dead code assessment
+
+| Location | Status | Recommendation |
+|---|---|---|
+| `vcfunction.cpp:620-630` | Deliberate no-op; the v51/v52 H-bond angular-correction block, retained as a comment documenting a failed approach and why | **Keep.** This is institutional memory about a regression that cost real benchmark points. |
+| `hbond_potential.h:394-414` | Debug path behind `FLEXAIDS_VH_DEBUG`, guarded by a function-local static | **Keep.** Zero cost when unset, and it is the diagnostic several experiments in this report depend on. |
+| `hbond_potential.h:226-231` (`case 7`, N.2) | Likely unreachable for ligands — see 3.1 | **Investigate, do not delete.** If it is unreachable that is a *bug in the remap*, not dead code. |
+| `hbond_potential.h:232-244` (`case 8`, N.3) | Same | Same |
+| `spfunction.cpp` | Genuinely dead — no callers, not linked into the binary; `vcfunction.cpp` is the live scorer | **Remove**, or add a one-line header stating it is superseded. It has already caused at least one misdirected fix. |
+| `ThermodynamicEngine.cpp:82` `n_heavy` | Computed, used only for `H_vct`, which per the comment at :118-119 is "a diagnostic only" and no longer enters `G_bind` | Keep as reported diagnostic; the comment is accurate. |
+
+---
+
+# 2. Scoring function science
+
+## 2.1 — MAJOR: `vct_normalize_contacts` creates a structural false minimum independent of CF.com overflow
+
+**Location:** `LIB/vcfunction.cpp:854-861`
+
+```cpp
+constexpr double VCT_NREF = 100.0;
+if(vct_ncon[j] > 0) FA->optres[j].cf.com *= VCT_NREF / (double)vct_ncon[j];
+```
+
+This converts `CF.com` from extensive to intensive by dividing by the contact count and rescaling by 100. The stated motive (line 848-853) is sound: the raw sum rewards sheer burial, so a ligand jammed into a groove out-scores the native H-bond-driven pose.
+
+But the fix is applied to `com` **only**. `cf.wal`, `cf.sas`, `cf.hbond`, `cf.elec`, and `cf.metal_coord` all remain extensive sums over contacts. The consequence is a new pathology in the opposite direction: a pose making very few contacts gets its complementarity multiplied by a large factor while its clash penalty is untouched. A ligand with 5 contacts has `com` amplified 20×; with 100 contacts, 1×.
+
+The optimizer will therefore find it profitable to make *fewer, better* contacts — i.e. to partially withdraw from the pocket, keeping only the most favorable pairs. That is a structural false minimum arising purely from the mixed intensive/extensive arithmetic, entirely separate from the CF.com overflow that `COM_FLOOR` addresses. It is precisely the failure mode the audit question asks about.
+
+**Mitigating fact.** `vct_normalize_contacts` defaults to `false` (`config_defaults.h:28`), so this is not live in the default protocol. It is a runner knob, and the concern is that it looks like a safe "make com intensive" improvement while carrying a hidden cost.
+
+**Recommended fix.** If `com` is normalized, normalize the whole CF consistently (all channels by the same `N`), or normalize by a *pose-independent* quantity — ligand heavy-atom count is the natural choice and is already available as `n_heavy_atoms`. Dividing by ligand size is intensive without being pose-dependent, so it cannot be gamed by withdrawing from the pocket.
+
+**Experiment.** With `vct_normalize_contacts=1`, plot `vct_ncon` against RMSD across the elected poses of an Astex-85 run. If normalization is inducing withdrawal, near-native poses will sit at systematically higher contact counts than the elected ones. This is a two-hour analysis on existing archived output if `vct_ncon` is logged (it currently is not — adding it to the per-pose REMARK block alongside the new `CF.com`/`CF.wal` instrumentation from `cf428ab28` would cost almost nothing).
+
+---
+
+## 2.2 — MAJOR: no acceptor-side directionality, and no donor occupancy accounting
+
+**Location:** `LIB/hbond_potential.h:347-417` (`compute_hbond_energy`)
+
+The potential is `w · exp(−½((d−d₀)/σ_d)²) · angle_term`, where `angle_term` constrains only the **D–H···A** angle. Two standard geometric constraints are absent:
+
+**Acceptor lone-pair geometry.** There is no term for the H···A–X angle. A carbonyl oxygen accepts in the sp2 lone-pair directions (roughly ±120° from the C=O axis, in plane); an H approaching along the C=O axis from behind the carbon is geometrically impossible but scores identically here. This admits a class of physically unrealizable poses that the distance term alone cannot reject, and it is the single largest remaining approximation in the H-bond model.
+
+**Donor occupancy.** `donor_angle_term` returns `best` over the donor's virtual hydrogens (line 318-324), correctly avoiding double-counting *within* a pair. But the pair loop in `vcfunction.cpp:663-676` calls `compute_hbond_energy` independently for every contacting pair and accumulates into `cfs->hbond` with no per-donor budget. A single NH2 nitrogen contacting three acceptors scores three full H-bonds — the same two hydrogens donated three times. The `HBOND_PAIR_MIN = -2.0` cap at line 391-392 bounds each *pair*, not each *donor*, so the total is unbounded in the number of neighbors.
+
+This is exactly the bifurcated-H-bond case the audit asks about. Real bifurcation exists but is weaker than two full bonds; here it is scored as stronger.
+
+**Recommended fix.** For occupancy: accumulate H-bond terms into a per-donor and per-acceptor bucket during the contact loop, then apply a saturating function (or simply cap each donor's total at `vH_n × per-bond max`) before adding to `cfs->hbond`. This requires a second pass or a scratch array indexed by atom, but it is bounded work and it closes a real over-counting channel. For acceptor geometry: add a second Gaussian on the H···A–X angle using the acceptor's heavy neighbor, which `atom_struct::bond[]` already provides — the same machinery `build_virtual_H` uses.
+
+**Note on charged donors.** `is_charge_supported_salt_bridge` (line 327-332) thresholds raw partial charge at ±0.30 e. This is a fragile criterion: Gasteiger charges on a neutral amide oxygen routinely reach −0.30, and formal-charge information is not consulted. A neutral amide C=O paired with a neutral amide N–H can therefore be classified as a salt bridge and scored with `salt_bridge_weight` (−5.0) instead of `weight` (−2.5) — a 2× over-reward on the most common interaction in any protein site. **This may be the highest-frequency scoring error in the H-bond module.** Use formal charge or a residue/functional-group whitelist (Asp/Glu carboxylate, Arg guanidinium, Lys ammonium, His imidazolium, ligand carboxylate/amidinium/phosphate) rather than a partial-charge threshold.
+
+**Experiment for the charge threshold.** Instrument `is_charge_supported_salt_bridge` to log every pair it classifies as ionic, with residue names, on a handful of Astex targets. Count how many involve a genuine formal-charge pair. If the false-positive rate is high, this is a large and cheap correction.
+
+---
+
+## 2.3 — MINOR: electrostatics is truncated at the Voronoi contact shell
+
+**Location:** `LIB/vcfunction.cpp:641-659`
+
+The Coulomb term is evaluated only for pairs enumerated by the Vcontacts loop — i.e. Voronoi *surface* neighbors. Coulomb is the longest-ranged interaction in the model, and truncating it at the first contact shell means charge-charge interactions across the pocket (a ligand cation and an aspartate 6 Å away with a water or a side chain between them) contribute nothing.
+
+The distance-dependent dielectric (`E = 332·qₐq_b / (ε·r²)`, line 655) partially masks this by decaying as 1/r², which is the conventional justification for the approximation. But note the same occlusion argument the code makes for the PoseBust clash term at lines 548-555 — *"the Vcontacts loop enumerates only Voronoi SURFACE-contact pairs, so deep interpenetration pairs are geometrically occluded"* — applies with equal force here, and there the team correctly moved to an independent all-pairs cell-list scan. Electrostatics has a stronger claim to that treatment than the clash term does.
+
+**Recommended fix.** If electrostatics proves load-bearing, move it to the same all-pairs cell-list scan used for `pb_clash`, with a 10-12 Å cutoff. Cost is one extra neighbor sweep per evaluation, and the cell list already exists.
+
+**Experiment.** Compare `CF.elec` from the current path against an offline all-pairs computation on the crystal poses of the Astex-85 set. If the correlation is high, the truncation is benign and this drops to a documentation note.
+
+---
+
+## 2.4 — Smart water retention: the criterion is defensible, but it uses crystal-ligand coordinates
+
+**Location:** `LIB/modify_pdb.cpp:43-235`, gated by `DatasetRunner.cpp:5841-5867`
+
+The three criteria — cavity proximity (≤ `radius`, default 4.5 Å from a crystal-ligand heavy atom), a protein H-bond in the 2.4-3.5 Å heavy-atom window, and the pre-existing B-factor cutoff — are a reasonable operational definition of a bridging water, and the implementation is careful in ways worth noting: HOH ordinals are recorded even for unparseable lines so the pre-pass and the streaming pass stay in lockstep (lines 217-223), the B-factor cutoff is mirrored so the logged count matches what reaches the model (line 246-248), and an unreadable ligand falls back to B-factor-only retention with a stderr warning rather than silently stripping everything (lines 289-295). That fallback design is exactly right.
+
+The diagnosis motivating the work is also well-evidenced: `DatasetRunner.cpp:5841-5847` records 1JD0 retaining 156 waters and reaching CF = −4269 against an expected ~−50, via sub-Ångström ligand-O···HOH-O contacts. That is a real pathology and the filter addresses it at the source.
+
+Three concerns:
+
+**(a) MAJOR — the filter consumes the crystal ligand pose.** The water set depends on `FLEXAIDDS_RMSDST` (line 271-274), the crystal reference. The surrounding code goes to deliberate lengths to keep crystal coordinates out of the GA — `DatasetRunner.cpp` leaves `reference_ligand.file` empty specifically so "crystal coordinates must NOT enter the GA as pose seeds." Selecting the receptor's water set from the answer reintroduces crystal information through the receptor rather than the ligand. The waters retained are, by construction, the ones the true pose interacts with.
+
+This does not invalidate the pathology fix, and it is not seed-echo — the GA still has to find the pose. But it means **an Astex-85 number produced with `FLEXAIDDS_SMART_WATER=1` is not blind**, and it cannot be compared against a blind arm or quoted as a prospective docking result. The comment block at `modify_pdb.cpp:264-267` acknowledges the runner "deliberately leaves that empty to keep crystal coordinates out of the GA" and then reaches for `FLEXAIDDS_RMSDST` anyway — the tension was noticed but not resolved.
+
+**Recommended fix.** Select waters by a pose-independent criterion: apex/cavity center from the existing `CavityDetect`/`CleftDetector` output, which is what a prospective run would have. Retain the ligand-based path as an explicitly-labeled oracle arm for ablation, and make the report distinguish the two.
+
+**Experiment.** Run three arms on Astex-85: (A) all low-B waters, (B) smart-water from the crystal ligand, (C) smart-water from the detected cavity center at the same radius. The A→C delta is the real, prospectively-available gain; the B→C delta measures how much of the improvement is oracle leakage. This is the single most informative experiment on this branch, and the three-arm launch infrastructure from `ad0c937ca` already exists to run it.
+
+**(b) MINOR — retained waters are scored as ordinary receptor atoms.** A retained water enters the receptor model with no entropic cost for immobilizing it and no reward for displacing it. Real bridging waters cost roughly 1.5-2 kcal/mol of translational and rotational entropy to order, and a ligand that displaces one recovers that. As modeled, retention is a free win for any pose that contacts the water and a free loss for any pose that would displace it — which structurally biases the GA *against* the water-displacing poses that are often the correct answer in medicinal chemistry. The `GIST` desolvation channel (`vcfunction.cpp:952-965`) is the right place for this and already exists; it appears not to be coupled to the retained-water set.
+
+**(c) MINOR — the H-bond criterion only considers `ATOM` records.** At `modify_pdb.cpp:230-234`, `protein_polar` is populated only when `is_atom` is true. A water bridging the ligand to a `HETATM` cofactor, a metal, or a nucleic acid chain read as HETATM will fail criterion 2 and be stripped. Given the repository's history with cofactors (1HNN, 1N1M), this is a plausible live case.
+
+---
+
+## 2.5 — MAJOR: `dG_eff` and `G_bind` are not thermodynamically consistent, and `G_bind` is dimensionally incoherent
+
+**Location:** `LIB/ThermodynamicEngine.cpp:120-122`, `:140-156`; `LIB/ProtocolConfig.h:57, 65`
+
+This is the direct answer to the audit's question, and it is worth stating plainly.
+
+**`G_bind` is not a free energy.**
+
+```cpp
+r.G_bind = T_eff_ * r.H_vct_raw - r.TdS_shannon + r.TdS_vib;
+```
+
+with `T_eff = 0.596` (`ProtocolConfig.h:57`) — which is *kT at 300 K in kcal/mol*, not a temperature. So the first term is `kT × ΔH`: an energy multiplied by an energy. It has units of kcal²/mol², and it is being added to two terms that are (nominally) energies. Whatever `G_bind` ranks, it is not a free energy, and its numerical value cannot be compared to an experimental ΔG.
+
+The comment at lines 109-119 is unusually honest about how this arose: the formula was chosen because v88 scored 91.7% and v100 scored 9.4%, and the three differences between them were reverted. That is a defensible engineering response to a regression, but it means the expression is **fitted to a benchmark metric, not derived from statistical mechanics**, and it should not be described in a paper as a thermodynamic quantity.
+
+**A missing `ln 2`.** `shannon_entropy` (line 36) accumulates in **bits** (`log2`), while `shannon_entropy_nats` (used for the whiteboard diagnostics at line 135) accumulates in **nats**. `TdS_shannon = T_eff × H_bits` is therefore short by a factor of `ln 2 ≈ 0.693` relative to `kT × H_nats`, the form that would be an energy. Two entropy channels in the same struct use different units.
+
+**`TdS_shannon` measures the optimizer, not the ligand.** `shannon_entropy(final_pop)` is the entropy of the *GA population's gene histogram* at termination. A better-converged run — more generations, stronger elitism, smaller population — yields lower `H`, hence a different `G_bind`, for identical physics. Configurational entropy of the bound ligand is a property of the ligand's accessible conformational volume; population diversity at GA termination is a property of the search. They are not the same quantity, and the repository's own history documents the GA collapsing to a 2-pose population at generation 10 under some settings — which would drive `H → 0` and `TdS_shannon → 0` for reasons having nothing to do with binding.
+
+*(One concern I checked and can dismiss: the histogram at line 30, `clamp(chrom[g]*255, 0, 255)`, assumes genes in [0,1], which would silently collapse the entire negative half of a [−1,1] gene into bin 0. `gaboom.cpp:1158` documents normalizing each gene before this call, so the assumption is upheld. I did not verify that the normalization spans each gene's actual limits — worth a glance, but I found no evidence of a problem.)*
+
+**Consistency with the MC sampling temperature — no.** There are three independent temperature-like scalars with no shared definition: the GA's `FA->beta` (which per the repository's own hard-won result must be `1/T`, *not* `1/(k_B T)`), `T_eff = 0.596` (kT at 300 K in kcal/mol), and `report_T = 21.0` ("kT_ISMB", an ISMB-2017 calibration constant in raw CF units). `boltzmann_probabilities(cf_values, report_T)` at line 133 reweights poses at a pseudo-temperature more than 35× the physical one, chosen so the distribution over CF values is "genuinely broad" (comment, line 144-146) rather than because 21 corresponds to any physical state. The comments are transparent about this. It is a calibration, not a thermostat.
+
+**Should it be wired into selection? No — and it currently isn't, which is correct.** The engine is off by default (`DatasetRunner.cpp:6087`, `FLEXAIDDS_THERMO=1`). Given that `G_bind` is dimensionally incoherent and that `TdS_shannon` depends on GA convergence, wiring it into selection would couple pose ranking to search hyperparameters — a feedback loop that would make every benchmark comparison uninterpretable. **Keep it as post-processing.**
+
+**Recommended path to making it real, in order:**
+1. Fix the units: `G_bind = H_vct_raw − kT·ln2·H_bits + TdS_vib`, all terms in kcal/mol. Re-run the benchmark. If the score degrades, that is informative — it means the current formula's benchmark performance comes from the weighting, not the physics, and that should be known.
+2. Replace population Shannon entropy with a genuine configurational entropy: the entropy of the *converged pose ensemble* in Cartesian or torsional space (quasi-harmonic from the pose covariance matrix), which is a property of the ligand, not of the GA.
+3. Only then consider selection coupling.
+
+**Minor items in the same file.** `compensation` (line 121-122) divides the *intensive* `H_vct` by a sum of extensive-ish entropy terms and returns exactly `0.0f` when the denominator is near zero — indistinguishable from a genuine zero ratio. And the code comment on line 120 states "entropy costs (+TdS), vib gain stabilizes (−)" while the formula has `−TdS_shannon` and `+TdS_vib`, the opposite signs. Given that sign flips in this expression are precisely what caused the v100 regression, this comment is actively dangerous.
+
+---
+
+# 3. Atom typing
+
+## 3.1 — CRITICAL: VCT row substitutions leak into the H-bond and virtual-H model
+
+**Location:** `LIB/top.cpp:71-110` (`sybyl_name_to_canonical_vct`), consumed at `:1591-1604`
+
+Three entries in the SYBYL→VCT table are deliberate *substitutions*, made because the scoring matrix `MC_st0r5.2_6.dat` has sparse or empty rows:
+
+```cpp
+if (!strcmp(s, "N.2"))  return 10;  // N.ar — sp2 imine is an acceptor
+if (!strcmp(s, "N.3"))  return 11;  // N.am — row 8 is all-zero in MC_st0r5.2_6.dat
+if (!strcmp(s, "I"))    return 25;  // BR — iodo near-absent from PDB training
+```
+
+As *matrix row choices* these are pragmatic and the comments justify them. The problem is that `atoms[i].type` is not only a matrix row index — it is also the **chemistry role selector** for the entire H-bond subsystem. At `top.cpp:1591-1604`, the same remapped integer is passed to `encode_from_sybyl` (which sets the type256 donor/acceptor bits), to `conservative_implicit_h_count` (which switches on `a.type`: cases 7, 8, 10, 11, 12, 14, 18), and to `assign_virtual_h_geometry` (`hbond_potential.h:226-293`, switching on the same values).
+
+One integer is doing two incompatible jobs. The consequences are concrete:
+
+**N.3 → 11 (N.am).** Every sp3 amine in every ligand typed through this path takes the **amide** branch. `assign_virtual_h_geometry` `case 11` applies `VHG_AMIDE` — the *planar external bisector* — to a **tetrahedral** nitrogen. The H is placed in the plane of the two heavy neighbors instead of out of plane, an angular error of roughly 55° for a secondary amine. `case 8`'s correct `VHG_SP3_2NBR` and `VHG_SP3_1NBR` geometry is **unreachable** for these atoms. Worse, `conservative_implicit_h_count` `case 11` returns `heavy_bonds <= 2 ? 1 : 0`, so a tertiary amine (3 heavy neighbors) is assigned **zero** hydrogens and loses its donor bit entirely — while `case 8`'s charge-aware `valence = (charge>=0.3) ? 4 : 3` logic, which exists precisely to handle protonated amines, never runs.
+
+For a docking engine aimed at psychopharmacology, silently converting every ligand amine into a planar amide with possibly no donor is a severe defect.
+
+**N.2 → 10 (N.ar).** Every sp2 imine takes the aromatic-nitrogen branch, whose donor/acceptor decision (`top.cpp:1541-1560+`) is a 2-hop BFS looking for a 5-membered ring. A non-cyclic imine has no such ring, so it is classified acceptor-only. A *terminal* imine (`C=NH`, one heavy neighbor) hits `if (heavy_bonds != 2) return 0` and loses its donor bit — whereas `case 7`, the correct branch, returns `heavy_bonds <= 1 ? 1 : 0`, i.e. exactly one H. `case 7` in both `conservative_implicit_h_count` and `assign_virtual_h_geometry` is dead for ligands.
+
+**Scope — and this is where I am uncertain.** This table is the Tier-2 ligand path (`bonmol_atom_to_canonical_vct`, `top.cpp:278-286`). Receptor atoms are typed through `assign_types`/`AMINO.def`, so protein Lys NZ and backbone amides are probably unaffected. I did not confirm that. If receptor typing shares this table, the severity increases substantially — backbone amide geometry would still be correct (N.am → 11 is a true identity there), but Lys/Arg side chains would not.
+
+**Recommended fix.** Decouple the two roles. Keep `atom.type` as the VCT matrix row (substitutions and all) and add a separate `atom.chem_type` holding the *true* SYBYL type, then switch the H-bond and virtual-H code on `chem_type`. This is a mechanical change — the true SYBYL name is already in hand at the call site (`bonmol_atom_to_canonical_vct` receives it as `out_name`) and is simply discarded. It is a day of work and it unlocks the correct code paths that already exist and are currently unreachable.
+
+**Experiment.** `FLEXAIDS_VH_DEBUG=1` on any ligand containing a secondary or tertiary aliphatic amine. If the amine nitrogen reports `vH_kind=VHG_AMIDE` (or `VHG_NONE` for a tertiary amine), this is confirmed. This takes about ten minutes and I would run it before anything else in this report.
+
+---
+
+## 3.2 — Answering the N.2 question directly
+
+The audit asks whether the unconditional N.2 → N.ar remap is scientifically correct. **It is not, as a chemistry statement**, though it is defensible as a matrix-row choice.
+
+The N.2 class in drug-like molecules covers at least four chemically distinct groups:
+
+| Class | Example | Correct role | What the remap gives |
+|---|---|---|---|
+| Cyclic aromatic N (pyridine, pyrimidine) | nicotine, pyrimidine kinase hinge binders | Acceptor only — **N.ar is right** | Correct |
+| Non-cyclic imine / Schiff base `C=N–R` | retinal-lysine, reduced-amine prodrugs | Acceptor only | Correct by accident (BFS finds no 5-ring) |
+| Terminal imine / amidine `C=NH` | amidine and guanidine warheads, benzamidines | **Donor and acceptor** | Donor bit **lost** (`heavy_bonds != 2 → 0`) |
+| Oxime / hydrazone N | oxime reactivators, hydrazone linkers | Acceptor, sometimes donor | Acceptor only |
+
+The remap is correct for the first two and wrong for the third — and the third matters: benzamidine is one of the most-studied fragments in the trypsin/thrombin serine-protease series, and amidines appear in the Astex set.
+
+The right structural answer is the same as 3.1: N.2 should remain type 7 for chemistry purposes and map to row 10 only for the matrix lookup. Then `case 7`'s existing correct logic (`heavy_bonds <= 1 → 1 H`, `VHG_SP2_1NBR`) applies, and terminal amidines keep their donors.
+
+## 3.3 — Other suspicious typing entries
+
+- **`C.1 → 2` (`top.cpp:73`).** sp carbon mapped to sp2. Comment says sp C is "rare in PDB sites" — true, but nitriles are common in medicinal chemistry, and a nitrile carbon has a very different steric profile (linear, small) from an sp2 carbon. Affects the VCT radius via `assign_radii_types`. Minor; worth measuring on a nitrile-containing target.
+- **`N.1 → 6`.** Correct identity, but note the paired nitrile *nitrogen* is a strong, highly directional acceptor and `assign_virtual_h_geometry` has no `case 6`. Nitrile N gets no directional treatment at all.
+- **`I → 25` (Br row).** Documented and defensible given three live entries in the iodine row. But this discards halogen-bond behavior specifically: iodine is the strongest halogen-bond donor (σ-hole) and bromine is substantially weaker. Any iodinated ligand loses its most important interaction. The repository already records that ligand readers type I as 25 while receptor `read_coor` types it 26 — **the two typing sites disagree on iodine**, which means an iodine in the receptor and an iodine in the ligand are scored against different matrix rows. Astex-85 contains no iodine so the benchmark cannot detect this; a thyroid-hormone or iodinated-contrast target would.
+- **`Co.oh` / `Co → 38`.** Cobalt collapsed onto a single row regardless of oxidation state. Acceptable given data sparsity.
+- **`default → FA_TYPE_DUMMY (39)`** for anything unrecognized, including `"H"`. Silent — an unrecognized element becomes a dummy atom with no diagnostic. Add a one-time warning listing unmapped element symbols encountered; a mistyped ligand currently docks without complaint.
+
+---
+
+# 4. Benchmark architecture
+
+## 4.1 — Is Astex Diverse 85 the right benchmark? Partly.
+
+**What it is good for.** Astex Diverse is hand-curated for structure quality (resolution, ligand density, no ambiguous protonation), chemically diverse, and pharmaceutically relevant. As a *self-docking* set for a pose-prediction engine it is a reasonable and widely-recognized choice, and its small size makes iteration fast.
+
+**Known biases, and how they interact with this engine specifically:**
+
+- **It is a self-docking set.** Every receptor is the holo structure co-crystallized with the ligand being docked. The side chains are already in their bound rotamers and the pocket is already open. This rewards rigid-receptor scoring accuracy and says nothing about induced fit — which is precisely the regime where `tENCoM` and the vibrational-entropy machinery are supposed to pay off. **The engine's most distinctive scientific contributions are invisible to this benchmark.**
+- **Holo bias interacts with the water finding (2.4).** Holo structures have crystallographic waters positioned around the bound ligand. Retaining them is more informative than it would be prospectively.
+- **Small N.** At N = 85, the 1σ binomial uncertainty near 90% is about ±3.3 percentage points. A move from 91.8% to 94% is roughly 2 targets and is **not statistically distinguishable from noise**. Combined with the documented multi-thread run-to-run RMSD spread of ~2 Å and roughly six targets sitting within 0.5 Å of the 2.0 Å cutoff, single-run differences of 1-3 targets carry essentially no information. This is the most important practical point in this section: **the current measurement precision is coarser than the improvements being chased.**
+- **Ceiling compression.** At 91.8%, seven targets remain. Any change is evaluated on seven data points. Overfitting to them is nearly unavoidable, and the `G_bind` history in `ThermodynamicEngine.cpp:109-119` is a documented instance of exactly that — a formula selected because it recovered a benchmark number.
+- **No decoys, no affinity.** Astex measures pose prediction only. Nothing about screening power or affinity ranking is being tested, though the thermodynamic engine's stated purpose is affinity.
+
+**Recommendation.** Keep Astex-85 as the fast regression gate, but stop treating it as the headline. Add:
+1. **Repeats.** Every reported number should be a mean over ≥3 seeds with a stated spread. Given the known threading nondeterminism this is not optional — it is the difference between a result and an anecdote. *(Cheapest, highest-value change in this entire report.)*
+2. **A cross-docking / apo set** (Astex Non-native, or the existing crossdock-85 pairing) to exercise receptor flexibility.
+3. **PoseBusters (428 targets)** as the primary pose-quality benchmark — larger N, harder, current field standard, and it directly tests the physical realism the `pb_clash` scan already computes.
+4. **CASF-2016** for scoring/ranking/screening power, which is where the thermodynamic engine would actually be tested.
+
+## 4.2 — The RMSD < 2.0 Å criterion should be supplemented
+
+**Yes, and the infrastructure is already present.** `vcfunction.cpp:960-975` already runs an all-pairs PoseBusters-compatible clash scan, and `LIB/PoseBust/` contains `NativePoseQC`. The pieces exist; they are not in the reported metric.
+
+Recommended reporting tuple, replacing the single rate:
+
+| Metric | Rationale |
+|---|---|
+| RMSD < 2.0 Å | Continuity with the existing record |
+| RMSD < 1.0 Å | Distinguishes "found the site" from "got the pose." At 91.8% on the 2 Å criterion, this is where the remaining signal is — and it will not saturate |
+| **PB-valid ∧ RMSD < 2.0 Å** | The honest number. A pose with correct RMSD but internal clashes or broken stereochemistry is not a solution, and this is the field's direction of travel |
+| Median RMSD | Continuous, no cliff at the threshold, immune to the ±2-target noise that dominates the pass rate |
+| N_evaluated / N_total | Per finding 1.2 — non-negotiable |
+
+Median RMSD deserves emphasis: it uses all 85 targets rather than the seven near the cutoff, so it can detect improvements that the pass rate cannot resolve at this N.
+
+## 4.3 — Correctness issues in DatasetRunner and the results parser
+
+**RMSD.** Findings 1.1 and 1.2 are the substantive ones and are the two most important items in this report after 3.1.
+
+**CF.com / CF.wal (new in `cf428ab28`).** The parsing is correct. `_CF_COM_REMARK_RE` and `_CF_WAL_REMARK_RE` (`data_paths.py:23-28`) are anchored to `REMARK CF.com=` / `REMARK CF.wal=` and applied per-line. One asymmetry: `CF.app` is only assigned `if m and enthalpy_score == 0.0` (`runner.py:1261-1262`), while `cf_com`/`cf_wal` are assigned unconditionally — so with multiple matching REMARK lines, `CF.app` takes the first and the new fields take the last. Harmless today (one line each), but a latent inconsistency; make both take the first.
+
+**Interpretation caveat on the values.** `CF.com` as written to the REMARK is the value *after* the `vct_normalize_contacts` rescale and *after* the `COM_FLOOR` squashing (both applied at `vcfunction.cpp:854-897`, before pose output). When either knob is active, the logged `CF.com` is not the raw sum of contact contributions, and comparing values across arms with different knob settings compares different quantities. Log the knob state per pose, or log the raw value alongside.
+
+**`top_contact_pair` is mislabeled.** `_parse_top_contact` (`io.py:186-203`) extracts the rank-1 entry from the `write_contributions` block. The regex matches the format at `write_pdb.cpp:264` (`"REMARK %3d: %2d-%2d with energy of %.3f"`) correctly, and scoping the search to the text after the POSITIVE-section header is a good precaution. But the two integers `k, l` are **atom-type indices** from the `i, j` loop over `FA->ntypes` (`write_pdb.cpp:236-243`), not atom serial numbers — and they are 0-based, while VCT types are 1-based everywhere else in the codebase. The docstring's `("3-4", -43.404)` reads as a contact between atoms 3 and 4; it is actually the aggregated contribution of the type-3/type-4 *pair channel*. Rename to `top_contact_type_pair` and either add 1 to match VCT numbering or document the offset. As it stands, a reader will draw wrong conclusions about which atoms drive a pose.
+
+One more note: because `contributions[]` accumulates *all* pairs of a given type combination, the "top contact" is the strongest type *channel*, not the strongest individual contact. For a ligand with eight aromatic carbons, C.ar/C.ar will almost always win by sheer multiplicity even when the pose is driven by a single H-bond. As a diagnostic for "what drives this pose," it will be systematically misleading toward abundant carbon types. If per-atom-pair attribution is the goal, that requires tracking individual pairs, not the type matrix.
+
+---
+
+# 5. Enhancements and next steps
+
+## 5.1 — Quick wins (1-3 days each, low regression risk)
+
+Ordered by value per unit of risk.
+
+**W1. Report `N_evaluated` alongside every success rate.** *(hours)* Finding 1.2. Cannot regress anything — it only adds information — and it may immediately change the interpretation of the 91.8% figure. **Do this first.**
+
+**W2. Replace RMSD truncation with an explicit failure.** *(hours)* Finding 1.1. Changes reported numbers only where they were already wrong.
+
+**W3. Run the `FLEXAIDS_VH_DEBUG` check on an amine-containing ligand.** *(minutes)* Confirms or refutes finding 3.1, the highest-severity item in this report, at essentially zero cost. Do it before planning any work on 3.1.
+
+**W4. Add a rigid-rotation invariance test.** *(1 day)* Rotate a complex by an arbitrary rigid transform and assert every CF channel is unchanged to within float tolerance. This catches finding 1.6 today and will catch an entire class of future frame-dependence bugs permanently. There is no legitimate reason for any term to fail it.
+
+**W5. Fix `is_hydrogen_atom`.** *(hours)* Finding 1.4. Affects only structures containing Hg/He, plus PDB hydrogens with leading digits.
+
+**W6. Audit the salt-bridge charge threshold.** *(1 day)* Finding 2.2. Log every pair classified as ionic on ten targets and count genuine formal-charge pairs. If neutral amide pairs are being scored at −5.0 instead of −2.5, this is a large systematic error with a cheap fix, and it is the kind of thing that silently caps a scoring function's accuracy.
+
+**W7. Report median RMSD and RMSD < 1.0 Å.** *(1 day)* Pure additions to the report, and they give a metric with enough resolution to detect the changes being attempted.
+
+**W8. Reconcile the COM_FLOOR comment with the code.** *(minutes)* Finding 1.8.
+
+**W9. Run ThreadSanitizer once.** *(1 day)* Finding 1.9. Either it closes the question or it finds something that has been misattributed to GA noise for a long time. Both outcomes are worth a day.
+
+## 5.2 — Highest-leverage scientific improvements within the current architecture
+
+**S1. Decouple the VCT matrix row from the chemistry type.** *(finding 3.1, ~1 week)* The single highest-value change in this report. Correct virtual-H geometry for all aliphatic amines and correct donor assignment for terminal imines and amidines. The correct code already exists and is unreachable; this makes it reachable. No new science required.
+
+**S2. Add acceptor-side directionality and donor occupancy to the H-bond term.** *(finding 2.2, ~1-2 weeks)* These are the two standard geometric constraints the potential currently lacks, and together they close both an under-constraint (impossible acceptor approach geometries score full) and an over-count (one NH2 donating three times).
+
+**S3. Torsion-optimal virtual H for rotor donors.** *(finding 1.6, ~2 days)* Closed-form, small, and removes a genuine frame-dependence from every hydroxyl and primary-amine H-bond in every pose.
+
+**S4. Make the retained-water set pose-independent, and couple it to desolvation.** *(finding 2.4, ~1-2 weeks)* Removes oracle leakage — a prerequisite for quoting any smart-water benchmark result — and adds the entropic cost of ordering a water, without which the model is structurally biased against water-displacing poses.
+
+**S5. Rebuild the thermodynamic engine on dimensionally consistent footing.** *(finding 2.5, ~1 month)* Fix the units, then replace population Shannon entropy with a real configurational entropy from the pose-ensemble covariance. Keep it as post-processing until it survives a blind test on affinity data — the ITC calibration framework already in the repository is the natural proving ground, and it is a far better validation target for a thermodynamic claim than a pose-prediction benchmark.
+
+## 5.3 — Pushing past the 91.8% ceiling
+
+**Start by establishing whether the ceiling is real.** At N = 85 with documented run-to-run variance and roughly six targets within 0.5 Å of the cutoff, 91.8% ± ~3.3pp means the true value could be anywhere from about 88% to 95%. Three seeded repeats would cost one campaign and would tell you whether you are optimizing against a signal or against noise. **Every other item in this section is contingent on that, and none of them should be attempted first.**
+
+Assuming the ceiling is real, the repository's own diagnostic history is the best guide, and it consistently points away from the scoring function:
+
+- Matrix-magnitude rescaling: **null** (two independent experiments, `FA_matrix_v1` and the r0 lever).
+- VCT geometry / `r0`: **null** — deepening the CF wells 18× moved zero poses.
+- The recorded failure mode is *search*, not scoring: near-native poses are found and then lost to population collapse and selection, and the generation-10 entropy-collapse mechanism is documented.
+
+That evidence says the remaining targets are lost in **pose selection and search diversity**, not in the energy function. Three consequences:
+
+1. **Fix the measurement first (W1, W2).** Some fraction of the missing 8% may be targets silently dropped from the denominator or scored on truncated RMSD arrays. It would be unfortunate to spend a month on physics to recover targets that a reporting bug had already miscounted.
+
+2. **Then fix the typing (S1).** This is the one *scoring-side* change with strong prior evidence of a real defect rather than a tuning opportunity, and the repository's own null results on matrix magnitude support the reading that the problem was never the matrix values — it was that atoms were being scored and geometrized as the wrong chemistry.
+
+3. **Then invest in selection, not scoring.** Finding 2.1 is directly relevant: if `vct_normalize_contacts` is enabled in the current protocol, it is actively creating a false minimum that rewards pose withdrawal. More generally, the cluster-selection path — which elects the lowest-CF representative and is documented as the bottleneck, with near-native poses repeatedly present at rank 2 — is where the recorded headroom is. A selection rule that consults pose-ensemble frequency or physical validity (`PoseBust`) rather than CF alone is the most evidence-supported route to the remaining targets.
+
+**A closing caution.** With seven targets left, the risk is no longer under-fitting the physics — it is over-fitting the benchmark. The `G_bind` formula in `ThermodynamicEngine.cpp:109-119` is a documented case of a scientific expression selected because it recovered a benchmark number, and it is now dimensionally incoherent as a result. The most valuable thing this project could do for the credibility of its 91.8% is to **validate on a set it has never tuned against** — PoseBusters-428 or CASF-2016 — and report that number alongside. If it holds up, the result is real and defensible in review. If it does not, that is much better learned now than after publication.
+
+---
+
+## Summary table
+
+| # | Severity | Location | Finding |
+|---|---|---|---|
+| 3.1 | **Critical** | `top.cpp:71-110`, `:1591-1604` | VCT row substitutions (N.3→N.am, N.2→N.ar) leak into H-bond/virtual-H logic; correct sp3-amine and imine paths unreachable |
+| 1.1 | **Critical** | `runner.py:2001-2006` | Benchmark RMSD silently computed on truncated, unmatched atom arrays |
+| 1.2 | **Critical** | `metrics.py:325-334` | Targets with unparseable RMSD dropped from the success-rate denominator |
+| 2.5 | **Major** | `ThermodynamicEngine.cpp:120` | `G_bind` dimensionally incoherent (kT×ΔH); bits/nats mismatch; `TdS_shannon` measures GA convergence, not ligand entropy |
+| 2.1 | **Major** | `vcfunction.cpp:854-861` | `vct_normalize_contacts` makes only `com` intensive → structural false minimum rewarding pose withdrawal (default OFF) |
+| 2.2 | **Major** | `hbond_potential.h:347-417` | No acceptor lone-pair geometry; no donor occupancy limit; salt-bridge detection by partial charge misfires on neutral amides |
+| 2.4a | **Major** | `modify_pdb.cpp:271-274` | Smart-water selection consumes the crystal ligand pose → benchmark arm is not blind |
+| 1.3 | **Major** | `ThermodynamicEngine.cpp:43-70` | `ensemble_mean` silently switches estimators on clash-dominated populations |
+| 1.4 | **Major** | `hbond_potential.h:182-186` | `is_hydrogen_atom` misclassifies Hg/He as hydrogen; misses `1HB`-style PDB names |
+| 1.5 | **Major** (cond.) | `hbond_potential.h:217-239` | Protonated tertiary amines: 2-neighbor slots force wrong virtual-H geometry |
+| 1.6 | Minor | `hbond_potential.h:80-86` | Rotor donors (hydroxyl, NH2) get a frame-dependent arbitrary H torsion |
+| 1.7 | Minor | `hbond_potential.h:366-390` | Salt bridges silently attenuated to 30% via the 0.3 fallback |
+| 2.3 | Minor | `vcfunction.cpp:641-659` | Electrostatics truncated at the Voronoi contact shell |
+| 2.4b | Minor | `modify_pdb.cpp` | Retained waters carry no ordering entropy cost / displacement reward |
+| 2.4c | Minor | `modify_pdb.cpp:230-234` | Water H-bond criterion ignores HETATM cofactors and metals |
+| 1.8 | Minor | `vcfunction.cpp:869-871` | COM_FLOOR comment documents the superseded formula |
+| 4.3 | Minor | `io.py:186-203` | `top_contact_pair` is a 0-based atom-*type* pair, mislabeled as a contact |
+| 3.3 | Minor | `top.cpp:73, 96` | C.1→C.2; I→Br row, and receptor/ligand typing disagree on iodine |
+| 1.9 | Unverified | `gaboom.cpp` (red-flag) | Thread-local `FA` shadowing looks correct; `optres` aliasing unconfirmed — run TSan |

--- a/docs/audit/AUDIT_scoring.md
+++ b/docs/audit/AUDIT_scoring.md
@@ -1,0 +1,191 @@
+# AUDIT — Theme A: SCORING PHYSICS
+FlexAIDdS main @ d623c45ea · auditor: adversarial code review (scoring physics)
+Patch: theme_A_scoring.patch (8 commits) · verified against live merged tree.
+
+## Bottom line
+**minor_issues.** Every genuine scoring change in this theme is env-gated and
+default-OFF; with no env vars set, the default CF/ranking path is byte-identical
+to before. The DEFAULT-OFF / bit-identity invariant HOLDS across all 8 commits.
+
+The one substantive finding is a **correctness-of-claim defect in the thermo
+impossibility gate (7a44c7035)**: the `+1000` sentinel is advertised (commit
+msg + header comments) as making "downstream clustering never select impossible
+poses rank-0", but **nothing reads it** — `dG_eff` / `thermo_impossible` /
+`n_impossible_poses` are consumed ONLY by `printf` in gaboom.cpp. Ranking is
+`QuickSort(CF)` at gaboom.cpp:1238, which runs BEFORE `compute()` at 1308; and
+`compute()` runs only under `thermo_engine_enabled` (default false). The gate is
+inert w.r.t. pose selection. This is DEFAULT-SAFE (no bit-identity breach) but
+the feature does not do what it claims. Medium.
+
+---
+
+## KEY SCRUTINY answers (as posed in the task)
+
+**Q1: Is the thermo `dG_eff=+1000` sentinel in the DEFAULT scoring path or gated?**
+GATED, three times over, and even when fully enabled it never touches scoring:
+- `compute()` (ThermodynamicEngine) is called from gaboom.cpp:1308 ONLY inside
+  `if (FA->thermo_engine_enabled && FA->thermo_engine != nullptr)` (1241).
+  `thermo_engine_enabled` defaults to **false** (config_parser.cpp:355;
+  flexaid.h:678 "default false; zero cost when off"). Default run never even
+  computes `dG_eff`.
+- The gate body inside compute() is further behind `if
+  (flexaids::thermo_score_enabled())` (ThermodynamicEngine.cpp:164), i.e.
+  `FLEXAIDDS_THERMO_SCORE` truthy (ProtocolConfig.cpp:309, default OFF).
+- **Even with both flags on, the sentinel changes only a printed number.**
+  Repo-wide grep for consumers of `dG_eff`/`thermo_impossible`/`apply_gate`
+  outside the engine internals returns printf lines only. QuickSort(CF) at
+  gaboom.cpp:1238 has already fixed the ranking before compute() runs at 1308.
+  => The commit-message claim "clustering can never rank it 0" is FALSE in the
+  merged code. No selection path reads the gated field.
+
+**Q2: Is the P1 pocket-presence penalty default-on or gated?**
+GATED, default-OFF. `FA->pb_pocket_weight = 0.0` hard-set in top.cpp:539 and
+defaulted to 0.0 in config_parser.cpp; `pb_pocket_enabled(w) = (w>0.0)`
+(ProtocolConfig.h). The penalty block (vcfunction.cpp:1204) is entered only when
+`pb_pocket_enabled` is true. The enclosing PB block (981) is entered only when
+`pb_clash_weight>0 || pb_pocket_weight>0` — both zero by default => whole block
+skipped => bit-identical.
+
+---
+
+## Per-commit
+
+### 7a44c7035 — thermo impossibility gate (dH>0 & dS<0 -> dG_eff=+1000)
+- **What:** adds `thermo_gate::is_impossible/apply_gate` (header-only), a
+  Boltzmann-population `dG_eff = <CF> - T*H` diagnostic, and a gate that forces
+  `dG_eff` to +1000 when `mean_CF>0 & TdS_vib<0`. All under
+  `thermo_engine_enabled` + `FLEXAIDDS_THERMO_SCORE`.
+- **default_behavior_changed:** NO. compute() not called in default (engine off);
+  even when on, only reporting.
+- **correctness:** SUSPECT. The primitive is fine and unit-tested (7/7), and the
+  ΔS-source reasoning (use TdS_vib, not Shannon H≥0, else dead code) is sound.
+  BUT the advertised integration does not exist: (a) no ranking/clustering
+  consumer reads `dG_eff`/`thermo_impossible` — printf-only (gaboom.cpp:1341,
+  1355); (b) selection is QuickSort(CF) at gaboom.cpp:1238, BEFORE compute() at
+  1308. Secondary physics concerns even if it WERE wired in: the per-pose test
+  uses `dH_i = CF_i` (contact-fitness proxy, not a calibrated enthalpy — sign of
+  CF is not sign of ΔH), and a SINGLE complex-level `TdS_vib` is applied to every
+  pose (r.gate_dS_used is one scalar), so "per-pose impossibility" is really
+  "one dS gate broadcast across poses".
+- **severity:** MEDIUM (false capability claim + misleading in-code comments an
+  operator would trust; not high — defaults byte-identical, physics primitive
+  correct).
+- **verdict:** NEEDS_CHANGE. Either wire the gate/dG_eff into an actual
+  selection consumer, or correct the commit message + ThermodynamicEngine.h
+  comments to state "diagnostic only; does NOT affect pose selection."
+
+### d5c33b349 — FLEXAIDDS_COM_FLOOR soft lower clamp on CF.com
+- **What:** softplus soft-floor on `FA->optres[j].cf.com` at -F, applied in
+  vcfunction.cpp:884 after VCT_NORM.
+- **default_behavior_changed:** NO. Pure `getenv("FLEXAIDDS_COM_FLOOR")` guard
+  with inner `if(F>0.0)`; unset/≤0 => block skipped => bit-identical.
+- **correctness:** SOUND (math). Verified the form: softfloor(x)=-F+F*softplus((x+F)/F)
+  with numerically-stable softplus `(z>0?z:0)+log1p(exp(-|z|))`. x»-F -> x
+  (near-identity); x->-inf -> -F (bounded); derivative in (0,1] (monotone in the
+  com channel). Implementation matches. Caveat: monotone in com ONLY, not in the
+  summed CF — it rebalances channels (that is the intended "enabler" effect), and
+  the commit itself flags the functional form as RECONSTRUCTED from a summary
+  ("Confirm F and the exact squashing against the original work order").
+- **severity:** LOW (default-off + author-flagged unverified form).
+- **verdict:** MAKES_SENSE (gated); confirm form vs work order before any canary.
+
+### dd292d6dd — P1 pocket-presence soft penalty
+- **What:** `pb_pocket_weight*(d-radius)^2` on ligand-centroid-to-nearest-heavy-
+  receptor-atom distance, into cf.pb_clash; also fixes config_parser env-override
+  ordering so FLEXAIDDS_PB_CLASH_* aren't clobbered by JSON defaults.
+- **default_behavior_changed:** NO. weight defaults 0.0 (top.cpp:539); gated by
+  pb_pocket_enabled; enclosing PB block skipped when both weights 0. The
+  config_parser env-override addition only overrides when the env var is set.
+- **correctness:** SOUND. Quadratic ramp is zero inside radius (correct sign,
+  dimensionally fine as a CF-unit penalty). Chebyshev-shell nearest-atom search
+  with `(R-1)*cell)^2 >= best_d2` early-out is a correct branch-and-bound over the
+  hoisted cell list; rec_heavy precomputed and rebuilt atomically with the other
+  parallel arrays (vcfunction.cpp:1002-1029). Attribution to first ligand optres
+  matches pb_clash/GIST convention.
+- **severity:** NONE (for defaults).
+- **verdict:** MAKES_SENSE.
+
+### bb8e166e5 — carve out coordinating-metal pairs from pb_clash
+- **What:** skip clash pair when either partner is Zn/Fe/Mg/Ca/Mn/Co/Ni/Cu
+  (Na/K excluded); receptor flags precomputed in cache.
+- **default_behavior_changed:** NO. `pb_metal_carveout` = getenv truthy, default
+  OFF; when off both metal flags are hard-false, skip branch never taken, visited
+  pair set unchanged. Also only reachable inside pb_clash_weight>0 (non-default).
+- **correctness:** SOUND. Physics is right (1.9-2.3 Å coordination bonds sit
+  inside 0.75*(vdw_i+vdw_j) and were being scored as clashes vs the metal_coord
+  Morse reward). Na/K exclusion is defensible (spectator ions).
+- **severity:** NONE.
+- **verdict:** MAKES_SENSE.
+
+### 88df9bf96 — precomputed pb_vdw_radius instead of per-eval lookup
+- **What:** optionally read atoms[].pb_vdw_radius instead of
+  posebusters_vdw_radius(get_element(type)).
+- **default_behavior_changed:** NO. `pb_vdw_cached` getenv, default OFF; both
+  ligand+receptor sides switched together so a pair never mixes sources.
+- **correctness:** SOUND, and honestly gated: authors correctly identified this
+  is NOT a pure perf swap (the two sources diverge for some atoms) and gated it +
+  wrote a parity test rather than shipping it as default. (The commit's *initial*
+  divergence attribution — "type 39/H diverges" — was WRONG, and is corrected in
+  074612fba; the CODE was always correct, only the explanatory comment/test was.)
+- **severity:** NONE (default-off).
+- **verdict:** MAKES_SENSE.
+
+### c856dcdf6 — auto-couple grid-hoist to pb_clash_weight>0 (remove opt-in flag)
+- **What:** removes FLEXAIDDS_PB_CLASH_GRID_HOIST; hoist now unconditional when
+  the PB block runs. `use_cache = pb_cache.valid`.
+- **default_behavior_changed:** NO — THIS IS THE ONE TO SCRUTINIZE, and it is
+  clean. The hoist lives ENTIRELY inside the `pb_clash_weight>0 ||
+  pb_pocket_weight>0` block (vcfunction.cpp:981). With pb_clash OFF (default) the
+  block is never entered, so removing the flag cannot change the pb_clash-OFF
+  path. When pb_clash IS on, the hoist only moves grid *construction* out of the
+  eval loop; CF math is identical (commit shows single-eval bit-identity across
+  legacy/env-hoist/auto-hoist). This is the correct fix for the v134 lesson
+  (loop-invariant receptor grid must not be rebuilt per eval).
+- **correctness:** SOUND. Cache keyed on atm_cnt+ratio, thread_local, invalidated
+  via matches().
+- **severity:** NONE.
+- **verdict:** MAKES_SENSE.
+
+### 83c8f045b — never diverge silently on GPU/accelerated path
+- **What:** warn-once when CUDA/METAL backend + pb_clash_weight>0 (GPU zeroes
+  cf.pb_clash); adds FLEXAIDDS_FORCE_CPU to pin CPU backend.
+- **default_behavior_changed:** NO. pb_clash_weight default 0 and FORCE_CPU unset
+  => neither warning nor backend override fires; select_backend() unchanged.
+- **correctness:** SOUND. This is a correctness *guard* — it surfaces a real
+  physics divergence that was previously silent. Good.
+- **severity:** NONE.
+- **verdict:** MAKES_SENSE.
+
+### 074612fba — correct the pb_vdw divergent set to I/Na/K + posebusters CLI autodetect
+- **What:** rewrites test_pb_vdw_parity.cpp against real reader tables (true
+  divergent set = I, Na, K; H does NOT diverge); adds find_program(POSEBUSTERS_BIN)
+  baked-in fallback.
+- **default_behavior_changed:** NO. FLEXAIDDS_PB_VDW_CACHED stays default-OFF; CLI
+  autodetect only affects the optional bust bridge, gated FLEXAIDDS_POSEBUSTERS_BIN
+  define, native NativePoseQC path unchanged when absent.
+- **correctness:** SOUND. This is a test/comment correction (the earlier
+  "H diverges" reading was wrong); the scoring code is untouched. CLI autodetect
+  is provenance-clean (optional external, no new build dep).
+- **severity:** NONE.
+- **verdict:** MAKES_SENSE.
+
+---
+
+## Cross-cutting notes (not per-commit findings)
+- **Reproducibility (invariant #3):** c856dcdf6 documents that GA end-to-end
+  output is NOT run-to-run reproducible in this build (best_CF -77.1284 vs
+  -77.1467 same binary). This predates the theme, but it is why every bit-identity
+  claim here rests on SINGLE-EVAL comparison, not GA-level. Latent invariant-#3
+  risk for the engine; flag for the reproducibility auditor.
+- **cf.pb_clash overloading:** both pb_clash and pb_pocket accumulate into
+  cf.pb_clash. Correct for attribution, but the [PB_CLASH] name now covers two
+  physically different terms — a reporting-clarity nit, not a bug.
+
+## Highest-severity finding
+7a44c7035 thermo impossibility gate: the `+1000` sentinel and `dG_eff` are
+advertised as deranking thermodynamically-impossible poses in clustering, but no
+selection/clustering path reads them (printf-only), and ranking (QuickSort on CF,
+gaboom.cpp:1238) is finalized before compute() runs (1308). The feature is inert
+w.r.t. pose selection and its in-code comments misdescribe the data flow.
+DEFAULT-SAFE (byte-identical defaults) but functionally a no-op that claims
+otherwise. Medium — needs the wiring done or the claim retracted.

--- a/docs/audit/COMMITTER_ADDENDUM_thermo_gate_N2.md
+++ b/docs/audit/COMMITTER_ADDENDUM_thermo_gate_N2.md
@@ -1,0 +1,94 @@
+# Committer addendum — thermo gate claim + N.2 remap validation
+
+**Date:** 2026-07-22  
+**HEAD baseline reviewed:** `d623c45ea` / later `a5a1a82c3`  
+**Context:** Arm A CF.com blow-up deep-dive + independent source re-verification  
+**Not a code change** — claims to correct, work items to schedule.
+
+---
+
+## 1. Thermo impossibility gate (`7a44c7035`) — claim overreach
+
+### What shipped
+- Header + unit tests for `thermo_gate::is_impossible` / `apply_gate` (`LIB/ThermodynamicEngine.h`).
+- Gate forces `dG_eff → +1000` when `dH>0 ∧ dS<0`, behind `FLEXAIDDS_THERMO_SCORE`.
+- Comments and docs (README, BENCHMARK.md, gaboom.cpp) state that the gate **affects selection** / demotes impossible poses so clustering cannot elect them rank-0.
+
+### What the code actually does (verified)
+| Claim | Reality |
+|---|---|
+| "promotes dG_eff to the ranking criterion" | **False for pose QuickSort.** Ranking is `QuickSort` on CF energy at `gaboom.cpp:705`, `:1147`, `:1238` — finalized **before** `thermo_engine->compute()` at `:1308`. |
+| "clustering never selects impossible poses rank-0" | **Not wired.** Repo consumers of `dG_eff` / `thermo_impossible` outside the engine are **printf only** (`gaboom.cpp:1338–1358`). |
+| Gate runs by default | **No.** Requires `thermo_engine_enabled` (default false) **and** `FLEXAIDDS_THERMO_SCORE` truthy. |
+
+`ProtocolConfig.h` still documents:
+
+> promote ΔG_eff = ⟨CF⟩ − T·H …
+
+`gaboom.cpp:1336–1337` still says:
+
+> Reporting-only unless FLEXAIDDS_THERMO_SCORE=1, which promotes dG_eff to the ranking criterion in place of min(CF).
+
+That promotion path is **not implemented** in the selection pipeline. Arm B (`ops/run_astex85_twoarm.sh`) sets `FLEXAIDDS_THERMO_SCORE=1` and Softβ election — Softβ reorders on CF-derived soft free energy, **not** on the gated `dG_eff` sentinel.
+
+### Required action (pick one)
+**Option A — wire it (feature work):**  
+After `compute()`, if `thermo_score_enabled()`, re-rank / re-elect using `dG_eff` (or attach sentinel to cluster ACF). Add a unit/integration test that a synthetic impossible population loses election.
+
+**Option B — retract the claim (docs-only, preferred if A is out of scope):**  
+- Rewrite commit-message-level language in `ThermodynamicEngine.h`, `ProtocolConfig.h`, `gaboom.cpp` comments, `README.md`, `docs/BENCHMARK.md`.  
+- State clearly: **diagnostic / reporting only; does not change pose or cluster selection.**  
+- Leave unit tests as pure gate-math tests.
+
+**Do not leave the middle ground** — operators will trust the comment and misread Arm B results.
+
+### Secondary physics caveats (if Option A)
+- Gate uses CF as ΔH proxy (`dH_i ≈ CF_i`); sign of CF ≠ calibrated enthalpy.
+- A single complex-level `TdS_vib` is broadcast to all poses — "per-pose impossibility" is really one dS gate across the population.
+
+---
+
+## 2. N.2 → N.ar (`3f56c34b1`) — needs A/B, not settlement
+
+### What shipped (unconditional default path)
+`LIB/top.cpp:78`:
+
+```cpp
+if (!strcmp(s, "N.2"))   return 10;  // N.ar — sp2 imine is an acceptor; N.am (donor) reversed the H-bond sign
+```
+
+Also remaps C.1→C.2, I→Br in the same commit. **Not env-gated.**
+
+### Two live, defensible destinations
+
+| Mapping | Row | Entries (live matrix) | Argument |
+|---|---|---|---|
+| **N.2 → 7** (type-exact) | N.2 | 13 nonzero | Identity: keep imine on its own SYBYL row; auditor preference |
+| **N.2 → 10** (shipped) | N.ar | 20–22 nonzero | Chemistry: sp2 imine is acceptor; prior N.am(11) reversed H-bond donor/acceptor sign |
+
+Both rows are **live** (unlike N.3 row 8, which is all-zero — that fix in `3bdde9932` is **sound** and should stay).
+
+### Required action
+1. **Do not treat N.2→10 as settled** until pose-quality evidence exists.
+2. A/B on a polar / imine-containing subset (or full Astex with typed N.2 ligands):
+   - Arm X: `N.2 → 7` (type-exact)
+   - Arm Y: `N.2 → 10` (current)
+   - Metrics: success@2Å, native CF rank, H-bond REMARK counts on elected poses
+3. Gate experimental remaps behind `FLEXAIDDS_ATOM_REMAP_EXPERIMENTAL=1` if shipping further typing changes without canary.
+
+### Keep
+- **`3bdde9932` N.3 → N.am (11)** — correct; dead row 8 was zeroing live chemistry.
+
+---
+
+## 3. Unrelated one-liner still open
+`BustCli.cpp` mandatory key `no_protein_clashes` vs upstream bust 0.6.5 — 1/79 ctest fail. Independent of Arm A regression; one-line schema pin.
+
+---
+
+## 4. Relation to Arm A CF.com blow-up
+These two items are **not** the primary cause of Arm A CF~−3000 failures. That cause is **raw extensive CF.com with `FLEXAIDDS_VCT_NORM` and `FLEXAIDDS_COM_FLOOR` left off** (see `ops/canary_com_tame.env`).  
+
+This addendum is independent hygiene so future operators do not:
+- believe the thermo gate ranks poses when it only prints, or
+- treat N.2→N.ar as validated chemistry without a canary.

--- a/docs/audit/VALIDATION_2026-07-23.md
+++ b/docs/audit/VALIDATION_2026-07-23.md
@@ -1,0 +1,834 @@
+# Validation of the Claude Science 24 h FlexAIDdS Audit
+
+**Date:** 2026-07-23
+**Branch:** `feat/smart-water-retention` (HEAD `cf428ab28`, 7 commits ahead of `main`)
+**Mode:** read-only — no source files were modified. `ctest` was attempted but no test
+binaries are currently built in any `build*/` directory (see Claim 6).
+
+Every finding below cites the file and line it was derived from.
+
+---
+
+## Summary table
+
+| # | Claim | Verdict |
+|---|---|---|
+| 1 | COM_FLOOR stable-softplus is numerically correct | **Confirmed** (code correct; the doc-comment formula above it is wrong) |
+| 2 | Blow-up is protein-oxygen driven, not water-driven | **Refuted — inverted.** Retained waters are typed as **carbon** (`assign_types.cpp:112`). The "C×O.3" contact is almost certainly water. |
+| 3 | VCT_NORM=1 does not tame the blow-up | **Confirmed, and stronger than stated** — VCT_NORM *amplifies* it whenever contact count < 100 |
+| 4 | Thermo gate is inert for selection | **Confirmed exactly** (and `dG_eff` is a population scalar, so it could never rank poses) |
+| 5 | N.2→N.ar remap is unconditional | **Was true at HEAD; already fixed in the uncommitted working tree** |
+| 6 | PoseBusters schema-pin is the lone ctest failure | **Mechanism confirmed; fix already applied uncommitted and is correct, not masking** |
+| 7 | Smart-water retention is default-OFF and bit-identical | **Confirmed and provable from code.** But it leaks crystal-ligand coordinates into receptor prep. |
+| 8 | The 3-arm campaign is the decisive next gate | **Refuted as designed** — the script cannot execute on this machine, and no arm isolates the one lever that works |
+
+**Two blockers that matter more than any individual claim:**
+
+1. **`assign_types.cpp:112` types every crystallographic water oxygen as VCT row 1 (`C.1`).**
+   Row 1's two most attractive partners are the two most negative entries in the whole
+   scoring matrix. This is the mechanism behind the com blow-up, and it re-frames Claims
+   2, 3, 7 and 8.
+2. **The fixes for Claims 5 and 6 exist only as uncommitted working-tree edits.** They are
+   unbuilt, untested, and one `git checkout` away from being lost.
+
+---
+
+## Claim 1 — COM_FLOOR stable softplus
+
+**Verdict: the code is correct. The comment documenting it is not.**
+
+`LIB/vcfunction.cpp:884–899`:
+
+```cpp
+if(const char* com_floor_env = std::getenv("FLEXAIDDS_COM_FLOOR")){
+    const double F = std::atof(com_floor_env);
+    if(F > 0.0){
+        for(int j=0; j<FA->num_optres; ++j){
+            double& com = FA->optres[j].cf.com;
+            const double z = com + F;
+            com = -F + (z > 0.0 ? z + std::log1p(std::exp(-z))
+                                : std::log1p(std::exp(z)));
+        }
+    }
+}
+```
+
+### (a) Is this the correct stable soft-floor at −F?
+
+Yes. It computes `softfloor(x) = −F + softplus(x + F)` using the standard branch-stable
+softplus. Both branches evaluate `exp` only on a non-positive argument, so the argument is
+in `(0, 1]` and can never overflow. The two properties that matter hold:
+
+- `x → −∞` ⇒ `z → −∞` ⇒ `log1p(exp(z)) → 0` ⇒ `com → −F`. Bounded below.
+- `x ≫ −F` ⇒ `z ≫ 0` ⇒ `log1p(exp(−z)) → 0` ⇒ `com → x`. Near-identity.
+- `softfloor′(x) = σ(z) ∈ (0,1)`. Strictly monotone, so ordering *by com* is preserved.
+
+The near-identity is far tighter than the comment suggests: the residual is
+`log1p(exp(−z))`, which is below `2×10⁻⁹` once `z > 20`, i.e. for any `com > −F + 20`. At
+`F = 500` that means every healthy pose (`com ≈ −130`) is passed through untouched to
+nine decimal places. That is exactly the behaviour you want from an enabler.
+
+### The documentation defect
+
+Line 871 states the implemented form is:
+
+> `softfloor(x) = −F + F·softplus((x + F)/F)`
+
+The code implements `−F + softplus(x + F)` — unit scale, not `F`-scaled. **The code is the
+better of the two**, and the comment should be corrected rather than the code. The
+documented `F`-scaled version would be badly behaved: at `x = 0, F = 500` it returns
+`−500 + 500·softplus(1) = +156`, i.e. it would corrupt every healthy `com` value in the
+population. The unit-scale form is the right choice; only the comment is stale.
+
+The commit message for `4805de1d8` records a smoke test (`−3000→−500, −130→−130, 0→0,
+209→209, 300→300, 1000→1000`) whose outputs are consistent with the unit-scale form and
+inconsistent with the `F`-scaled form — further evidence the code, not the comment, is the
+intended artifact.
+
+### (b) Remaining edge cases
+
+| Input | Result | Assessment |
+|---|---|---|
+| `z = 0` (`com = −F`) | `−F + log1p(1) = −F + 0.693` | Continuous, no branch discontinuity. Both branches agree in the limit. |
+| `F = 0` or negative | Block skipped by `if(F > 0.0)` | Safe. |
+| `com = −1e300` | `exp(−1e300) = 0`, `log1p(0) = 0` → `−F` | Correct, no NaN. |
+| `com = +inf` | Stays `+inf` | Pre-existing pathology, not introduced here. |
+| `com = NaN` | Propagates | Same. |
+| `FLEXAIDDS_COM_FLOOR="abc"` | `atof` → 0.0 → **silently disabled** | Real usability hazard: a typo in the launch script produces a silently un-floored run that looks like a valid arm. |
+
+**Recommendations (all low-risk):**
+
+1. Fix the comment at line 871 to state `−F + softplus(x + F)`.
+2. Reject unparseable `FLEXAIDDS_COM_FLOOR` loudly instead of silently disabling — use
+   `strtod` with endptr checking and `fprintf(stderr, ...)` on failure. Given that the
+   value of the whole campaign depends on this env var being live, silent-off is the
+   single worst failure mode available here.
+3. Emit the effective `F` once per dock in the provenance JSON so a completed run can be
+   audited after the fact.
+
+### (c) One structural caveat on rank preservation
+
+The comment's "monotone ⇒ rank-preserving" claim is true *of the com channel alone*. Total
+CF is `com + sas + wal + elec + hbond + …`, so squashing `com` changes the relative weight
+of every other channel and **does** reorder poses by total CF. That is the intended effect
+— but the code comment should say so, because "rank-preserving" reads as a much stronger
+guarantee than what is delivered.
+
+---
+
+## Claim 2 — "Water blow-up is protein-oxygen driven, not water-driven"
+
+**Verdict: refuted, and the causality is inverted. This is the most consequential finding
+in this review.**
+
+### The matrix is bounded; the area multiplier is not
+
+`LIB/vcfunction.cpp:576–584`:
+
+```cpp
+double contribution = 0.0;
+if(energy_matrix->weight){
+    if(FA->normalize_area){ contribution = yval*area/surfA; }
+    else                  { contribution = yval*area; }
+}
+```
+
+With `energy_matrix->weight` set, `get_yval` (`vcfunction.cpp:1311`) returns the raw matrix
+scalar. I scanned `MC_st0r5.2_6.dat` directly: **the most negative entry in the entire
+matrix is `2-2 = −198.9`.** No pair value exceeds ~199 in magnitude. `FA->normalize_area`
+defaults to `false` (`config_defaults.h:26`, `top.cpp:591`), so the live path is
+`contribution = yval * area` — extensive in the Voronoi facet area.
+
+So a single contact at `−3254` requires an area of about `3254 / 180.8 ≈ 18 Å²`, which is
+a perfectly ordinary Voronoi facet. **Nothing is numerically broken.** The unboundedness
+is not in the potential's *values* — it is in the `value × area × Σcontacts` construction,
+which has no reference state and no per-contact ceiling. Science's phrase "unbounded in
+the NRG matrix" is not right; the matrix is tightly bounded. The correct statement is that
+the *functional form* is unbounded and the matrix units are arbitrary ROC-trained scores,
+not kcal/mol.
+
+### The "C" in "C×O.3" is a water molecule
+
+`LIB/assign_types.cpp:108–114`:
+
+```cpp
+// Set a Hydrophilic type to water molecules
+for(k=1;k<=FA->res_cnt;k++){
+    rot=residue[k].rot;
+    for(i=residue[k].fatm[rot];i<=residue[k].latm[rot];i++){
+        if(strcmp(residue[atoms[i].ofres].name,"HOH") == 0){atoms[i].type = 1;}
+    }
+}
+```
+
+Every retained crystallographic water oxygen is assigned `type = 1`. Under the canonical
+VCT numbering documented at `top.cpp:60–67`, **row 1 is `C.1`** — sp carbon. Row 40
+(`SOLVENT`) exists and is *entirely zero* in `MC_st0r5.2_6.dat`, so waters are not merely
+mistyped, they are typed into a row that was never trained on solvent.
+
+Now look at what row 1 is worth against oxygen:
+
+```
+1-13 (C.1 × O.2)  = −198.3   ← the 2nd most attractive pair in the whole matrix
+1-14 (C.1 × O.3)  = −180.8
+1- 3 (C.1 × C.3)  = −162.9
+```
+
+Science's reported signature is *one dominant `C × O.3` contact at ~−3254*. Under this
+typing, `C.1 × O.3` is precisely the pair you get from **a retained water oxygen touching
+a ligand or protein sp3 oxygen** — and it draws from one of the strongest cells in the
+matrix. The mechanism logger in `ops/run_astex85_twoarm.sh:110` reads the contact *type
+pair* out of the pose REMARKs; if the REMARK reports canonical type indices, a water shows
+up as "C" and is indistinguishable from a genuine carbon. Science read the label and
+concluded "protein carbon"; the label is wrong.
+
+The repository already knows this at the prose level. `LIB/modify_pdb.cpp:49–52`:
+
+> "Without this filter, every low-B-factor water in the structure becomes a receptor atom
+> and the GA can bury the ligand inside the solvent shell, harvesting unbounded
+> complementarity from sub-Ångström ligand-O ⋯ HOH-O contacts."
+
+and `DatasetRunner.cpp:5843–5846` records `1JD0` retaining 156 waters with `CF = −4269`
+against an expected `~−50`. The water hypothesis was the original hypothesis; the typing
+bug is *why* it looks like a carbon problem in the instrumentation.
+
+This is the same class of defect already recorded in project memory as the "ligand
+type-numbering bug" — a reader writing a non-canonical type index that the matrix then
+reads as a different element.
+
+### What this means for the audit
+
+- Science's Type I / Type II split in the campaign header
+  (`ops/run_astex85_twoarm.sh:8–17`) is likely **one mechanism, not two**. Arm C strips
+  all waters; if the blow-up survives Arm C, that is evidence for a genuine protein-oxygen
+  Type II. If it does not, Type II never existed.
+- `1SG0` should be re-examined specifically: dump the residue name of the atom on the
+  dominant contact. If it is `HOH`, Claim 2 is settled.
+
+**Recommendations:**
+
+1. **Highest priority.** Decide what waters should be typed as and make it explicit. Row 40
+   (`SOLVENT`) being all-zero means it cannot be used as-is; the honest options are
+   (a) type water O as `O.3` (row 14) and accept that it is scored as an ordinary sp3
+   oxygen, or (b) keep row 1 but document it as a deliberate hydrophilic proxy and retrain
+   that row. What is not defensible is the current state, where a comment says
+   "hydrophilic" and the matrix says "sp carbon".
+2. Extend the per-pose instrumentation from `cf428ab28` to emit the **residue name and
+   element** of the dominant contact's two atoms, not just the VCT type indices. The whole
+   Type I/Type II confusion is downstream of the logger printing an index whose meaning is
+   wrong.
+3. Add a regression test asserting `assign_types` produces the intended type for an `HOH`
+   oxygen, so this cannot silently drift again.
+
+---
+
+## Claim 3 — VCT_NORM=1 does not tame the blow-up
+
+**Verdict: confirmed, and the canary's 0/5 is fully explained by the code. VCT_NORM does
+not merely fail to bound the sum — it makes the pathological pose worse.**
+
+`LIB/vcfunction.cpp:854–861`:
+
+```cpp
+if(FA->vct_normalize_contacts){
+    constexpr double VCT_NREF = 100.0;
+    for(int j=0; j<FA->num_optres; ++j){
+        if(vct_ncon[j] > 0){
+            FA->optres[j].cf.com *= VCT_NREF / (double)vct_ncon[j];
+        }
+    }
+}
+```
+
+Three independent reasons this cannot work:
+
+**1. The multiplier is greater than 1 for any contact count below 100.** `vct_ncon[j]`
+counts com-contributing Voronoi contacts for one optimizable residue — for a ligand this
+is typically tens. At `N = 20` the multiplier is `×5`: a `com` of `−3254` becomes
+`−16 270`. The rescale that was added to keep the term's magnitude comparable
+(`VCT_NREF`) is precisely what converts a normalizer into an amplifier in the regime that
+matters.
+
+**2. It normalizes by the wrong quantity.** The blow-up is concentrated in *one* contact
+carrying ~95 % of the total (per Science's 1SG0 figure). Dividing a sum by its cardinality
+does nothing to a sum dominated by a single term. Worse, a ligand buried in a solvent
+shell has *fewer, larger* Voronoi facets than a ligand in a normal pocket — so the
+pathological pose gets a *smaller* `N`, hence a *larger* multiplier. The normalization is
+anti-correlated with the pathology.
+
+**3. `com` is extensive in area, not in count.** `contribution = yval * area`. The natural
+extensive variable is buried surface area, so `Σ area` — not `N` — is the only
+denominator that makes the quantity intensive. This mirrors the already-recorded finding
+that ACF is extensive and regressed 1P2Y.
+
+### Normalization schemes that would work
+
+Ranked by risk-adjusted expected value:
+
+**(a) Per-contact energy cap — recommended first move.** Directly mirrors the per-contact
+wall ceiling already in the codebase (`WAL_CONTACT_CAP = 50`, `vcfunction.cpp:543`), which
+is documented as having restored the GA gradient. The com channel has no equivalent:
+
+```cpp
+// at vcfunction.cpp:632, replacing `cfs->com += contribution;`
+cfs->com += (contribution < -COM_CONTACT_CAP) ? -COM_CONTACT_CAP : contribution;
+```
+
+This is strictly better than the global soft floor for the observed failure mode, because
+it removes the *single* runaway contact while leaving the other 40 healthy contacts fully
+expressed. The global `COM_FLOOR` at `−500` cannot distinguish "one absurd contact" from
+"forty good ones", and once a pose saturates the floor its com gradient vanishes entirely.
+The cap keeps a gradient everywhere. Precedent, symmetry with the wall channel, and a
+one-line diff make this the highest-value experiment available.
+
+**(b) Buried-area normalization.** `com / Σ area` gives mean complementarity per Å² of
+contact — genuinely intensive, and immune to the "fewer larger facets" inversion that
+breaks count normalization. Rescale by a reference area (~300 Å² for a drug-like ligand)
+rather than a reference count.
+
+**(c) Per-heavy-atom normalization.** `com / n_heavy`. Crude but ligand-size-invariant, and
+the machinery already exists — `ThermodynamicEngine` computes `H_vct` per heavy atom
+(`gaboom.cpp:1276–1277`, `thermo_result.n_heavy_atoms`).
+
+**(d) Sigmoid saturation per contact.** `−E_max · tanh(|c| / E_max)`. Smooth and
+differentiable, but it distorts every contact rather than only the outliers, and it adds a
+parameter. Prefer (a) unless the GA turns out to be sensitive to the cap's kink.
+
+Whichever is chosen, **VCT_NORM should be retired, not merely defaulted off.** Leaving a
+live env var that silently multiplies com by `100/N` is a trap for the next campaign.
+
+---
+
+## Claim 4 — Thermo gate is inert for selection
+
+**Verdict: confirmed exactly, with an additional reason Science did not give that makes
+the claim even stronger.**
+
+### (a) Ordering of QuickSort vs thermo compute
+
+`LIB/gaboom.cpp`:
+
+- **line 1238** — `QuickSort((*chrom),0,GB->num_chrom-1,true);` — ranking fixed.
+- **line 1241** — `if (FA->thermo_engine_enabled && FA->thermo_engine != nullptr) {` — thermo block *begins*.
+- **line 1308** — `FA->thermo_result = FA->thermo_engine->compute(...)`.
+- **lines 1340–1352** — `printf("[THERMO3] dG_eff=...")`.
+
+The sort strictly precedes the compute. Confirmed.
+
+Note the sort is at line **1238**, not 705 as the campaign script's header comment claims
+(`ops/run_astex85_twoarm.sh:32`). Line 705 is a different, earlier sort inside the
+generation loop. The conclusion is unaffected — every `QuickSort` call site precedes line
+1241 — but the citation in the script header is wrong.
+
+### (b) No selection consumer
+
+`grep -rn "dG_eff" LIB/` returns exactly four files: `ThermodynamicEngine.cpp` (computes
+it), `ThermodynamicEngine.h` (declares it), and `gaboom.cpp` (prints it). There is no read
+of `thermo_result.dG_eff` in any clustering, ranking, or election path. The header states
+this explicitly at `ThermodynamicEngine.h:62`:
+
+> "DIAGNOSTIC ONLY — dG_eff does not affect pose selection, at any flag setting."
+
+`FLEXAIDDS_THERMO_SCORE=1` gates only `apply_gate` (`ThermodynamicEngine.h:35`), which
+overwrites the *reported* `dG_eff` with a `+1000` sentinel. That value is then printed and
+discarded.
+
+### The stronger argument
+
+`ThermoResult::dG_eff` is **a single `float` for the whole population** — `<CF> − T·H`
+where `<CF>` is `mean_CF` and `H` is the Shannon entropy of the population's energy
+histogram (`ThermodynamicEngine.cpp:155`). It is not a per-pose quantity. Even if it were
+wired into `QuickSort` tomorrow, it would add the same constant to every chromosome and
+change nothing. Claim 4 is not "currently unwired" — it is **structurally incapable of
+ranking poses in its present formulation.** This matters because it means "wire dG_eff
+into selection" is not a small change; it requires defining a per-pose thermodynamic
+quantity first.
+
+### (c) Is wiring it in scientifically sound, and where?
+
+Not as it stands, for the reason above. A defensible path, in order:
+
+1. **Define a per-pose ΔG.** The population entropy `H` must be decomposed into a per-pose
+   term. The natural object is a per-*cluster* entropy: for binding mode `m` with member
+   poses `{i}`, `S_m = −Σ p_i ln p_i` over Boltzmann weights within the cluster. This is
+   already close to what `BindingMode.cpp` computes.
+2. **Apply it at cluster election, not at GA selection.** The GA's job is to find minima;
+   entropy is a property of a basin, not of a point, and a single pose has no entropy. The
+   right integration point is where `cluster.cpp` elects the representative of each mode
+   and where modes are ranked against each other — i.e. `G_m = <CF>_m − T·S_m`, ranking
+   *modes*, with the representative still chosen by CF within the mode.
+3. **Never let it touch the GA fitness.** Injecting a population-level entropy into
+   per-chromosome fitness creates a feedback loop: fitness depends on the population's
+   diversity, which selection then changes, which changes fitness. Given the recorded
+   gen-10 energy-Shannon collapse, this codebase is already fragile in exactly that way.
+
+**Regression risk.** Low if confined to mode ranking (the current mode ranking is
+CF-only, so an A/B is clean and cheap). High if placed in the GA loop. Project memory
+already records that near-native poses are consistently *worse* in CF than the elected
+false minimum by −2 to −86 units, and that selection is CF-bound — an entropy term that
+favours broad basins is one of the few principled discriminators that could close that
+gap, which is a real argument for doing (2) properly rather than dismissing the thermo
+stack.
+
+---
+
+## Claim 5 — N.2 → N.ar remap is unconditional
+
+**Verdict: true of committed HEAD; already fixed in the working tree, but uncommitted.**
+
+`git diff LIB/top.cpp` shows an *uncommitted* change:
+
+```diff
+-	if (!strcmp(s, "N.2"))   return 10;  // N.ar — sp2 imine is an acceptor; ...
++	// N.2 keeps its own canonical row 7. It is NOT remapped to N.ar (10):
++	// aromaticity is already perceived upstream — SybylTyper.cpp tests
++	// in_aromatic_ring() first and emits N.ar for any N in an aromatic ring
++	if (!strcmp(s, "N.2"))   return 7;
+```
+
+with a matching uncommitted change in `LIB/Mol2Reader.cpp:43` keeping the two readers in
+sync. So Science's claim was accurate against `HEAD`, and someone has since applied the
+fix locally without committing it.
+
+### (c) Are rows 7 and 10 degenerate? No — the remap materially changed scoring.
+
+I counted non-zero entries directly in `MC_st0r5.2_6.dat`:
+
+| Row | Type | Non-zero entries |
+|---|---|---|
+| 7 | N.2 | **9** |
+| 8 | N.3 | **0** (dead) |
+| 10 | N.ar | **14** |
+
+They are emphatically not degenerate. Comparing the shared partners:
+
+| Partner | Row 7 (N.2) | Row 10 (N.ar) |
+|---|---|---|
+| 11 (N.am) | −195.7 | −157.3 |
+| 12 (N.pl3) | −122.3 | −26.35 |
+| 13 (O.2) | −87.38 | −15.0 |
+| 14 (O.3) | −144.8 | −189.6 |
+| 15 (O.co2) | −197.6 | −125.3 |
+| 18 (S.3) | +28.13 | −190.1 |
+
+The `N × O.2` interaction differs by a factor of **5.8** and the `N × S.3` interaction
+**flips sign** (+28 repulsive vs −190 strongly attractive). Remapping N.2→N.ar was not a
+cosmetic substitution — it rewrote the entire nitrogen interaction profile for every sp2
+imine nitrogen in the benchmark. Amidines, guanidines, imines, azomethines, and
+non-aromatic C=N in fused systems are common in the Astex set; these are exactly the
+groups affected.
+
+The fix's own justification is also sound and I verified the premise: aromaticity is
+perceived upstream, so an atom reaching the `N.2` branch has already been judged
+non-aromatic and an "only when aromatic" guard would be dead code. Row 7 being live (9
+entries) means the dead-row argument that legitimately justifies `N.3 → N.am` does not
+transfer.
+
+### The remaining contested remap
+
+`N.3 → 11 (N.am)` is *still* unconditional, and this one is genuinely contestable. Every
+sp3 amine — including every basic aliphatic amine, the most common protonatable group in
+CNS drugs — is scored with the amide-nitrogen row. The justification (row 8 is all-zero) is
+factually correct and I confirmed it, but the consequence is that FlexAIDdS has **no
+parameters at all for sp3 amine nitrogen**, and silently substitutes a chemically distinct
+type. For a psychopharmacology-targeted engine this is a first-order gap: protonated
+tertiary amines are the defining pharmacophore of most aminergic ligands.
+
+**Recommendations:**
+
+1. **Commit the N.2 fix immediately** and re-run the Astex-85 baseline. It is a scoring
+   change to a live matrix row and invalidates any prior comparison across it.
+2. Treat dead row 8 as a **training-data gap, not a typing problem.** The right fix is to
+   parameterize N.3, not to keep aliasing it. Until then, log a one-time warning per dock
+   listing how many ligand atoms were type-substituted, so downstream results carry the
+   caveat.
+3. Add a unit test asserting `sybyl_name_to_canonical_vct` and
+   `Mol2Reader::sybyl_to_flexaid_type` agree on every SYBYL name. These two tables have now
+   drifted apart at least once, and drift means SDF and MOL2 inputs score the same molecule
+   differently.
+
+---
+
+## Claim 6 — PoseBusters schema-pin is the lone ctest failure
+
+**Verdict: mechanism confirmed by inspection; the fix is already applied uncommitted and is
+correct. It masks nothing.** I could not run `ctest` — see caveat below.
+
+### (a) The code
+
+`git diff LIB/PoseBust/BustCli.cpp` shows an uncommitted removal:
+
+```diff
+         "minimum_distance_to_protein",
+-        "no_protein_clashes",
+         "volume_overlap_with_protein",
+```
+
+### (b) The failure mechanism
+
+`tests/test_posebust.cpp:156–163` defines `synthetic_full_pb_header()`, whose column list
+does **not** contain `no_protein_clashes`. With that name in
+`mandatory_pb_check_columns()`, `TEST(BustCliSchema, PassesWithFullMandatorySet)` at line
+172 must fail with `mandatory_checks_missing` — the schema pin fails closed on a column
+the fixture never provides. That is exactly the failure Science reports, and the removal
+resolves it.
+
+**Caveat on verification:** I ran `ctest` in both `build/` and `build_test/` and every test
+reported `Not Run` — no test binaries are compiled in any `build*/` directory. So I confirm
+the failure *by inspection of the fixture and the pin*, not by execution. The claim that it
+is the **lone** failure is therefore unverified; it needs
+`cmake -DBUILD_TESTING=ON && cmake --build . && ctest --output-on-failure` to stand.
+
+### (c) Is dropping the column correct, or is it masking a real check?
+
+**Correct, and it masks nothing.** I checked the installed PoseBusters package in
+`.venv-posebusters/`. `posebusters/config/redock.yml` defines the protein-clash checks as:
+
+```
+line 160:  no_clashes: "Minimum distance to protein"
+line 231:  no_volume_clash: "Volume overlap with protein"
+```
+
+There is **no `no_protein_clashes` column** anywhere in the redock suite. The name was
+fabricated — a plausible-sounding column that upstream never emits. Both genuine
+protein-clash checks (`minimum_distance_to_protein` and `volume_overlap_with_protein`)
+remain in the mandatory list after the fix, so protein-clash gating is fully intact. The
+pin is *strengthened* by the removal: previously it could never pass against real
+PoseBusters output either, meaning the pin was failing closed on every genuine run.
+
+**Recommendations:**
+
+1. Commit the fix with the `redock.yml` line references as the justification.
+2. Generate the fixture header **from** `mandatory_pb_check_columns()` rather than
+   hand-writing it in the test, so a pin bump cannot desynchronize from its own fixture
+   again.
+3. Add a check that verifies the pin against a real `bust --outfmt csv` header captured
+   from the pinned PoseBusters version, so an upstream rename is caught at test time rather
+   than at campaign time.
+
+---
+
+## Claim 7 — Smart-water retention is default-OFF and bit-identical
+
+**Verdict: confirmed, and provable from code rather than empirically. But the feature has a
+methodological problem Science did not raise.**
+
+### Provable default-off
+
+Three independent gates, all defaulting to disabled:
+
+1. `LIB/config_defaults.h:162` — `{"binding_site_water_radius", V(0.0f)}`.
+2. `LIB/config_parser.cpp:309` — reads with default `0.0f`.
+3. `LIB/DatasetRunner.cpp:5849–5852`:
+   ```cpp
+   const bool smart_water = (smart_water_env != nullptr && std::string(smart_water_env) == "1");
+   double bs_water_radius = smart_water ? 4.5 : 0.0;
+   ```
+
+And the consuming guard, `LIB/modify_pdb.cpp:278–279`:
+
+```cpp
+if(keep_structural_waters && remove_water && !exclude_het &&
+   binding_site_water_radius > 0.0f && !oracle_lig.empty())
+```
+
+With `binding_site_water_radius == 0.0f` the entire block is skipped, `bs_water_keep`
+stays empty and `bs_water_filter_active` stays `false`. No branch downstream of it can
+observe a difference. Bit-identity is a property of the control flow, not an empirical
+observation — Claim 7 is provable, and stronger than Science stated it.
+
+### The problem Science missed: crystal-pose leakage into receptor preparation
+
+`LIB/modify_pdb.cpp:271–276`:
+
+```cpp
+std::string oracle_lig = (oracle_ligand_path != nullptr) ? oracle_ligand_path : "";
+if(oracle_lig.empty()) {
+    const char* env = getenv("FLEXAIDDS_RMSDST");
+    if(env != nullptr) oracle_lig = env;
+}
+```
+
+and the retention criterion at line 54: `d(HOH-O, nearest crystal-ligand heavy atom) ≤ radius`.
+
+**Smart water retention selects which waters to keep using the crystal ligand's
+coordinates** — falling back to `FLEXAIDDS_RMSDST`, the RMSD reference pose. The comment at
+lines 269–271 is candid that the runner "deliberately leaves [reference_ligand] empty to
+keep crystal coordinates out of the GA", then reaches for the RMSD reference instead.
+
+Keeping crystal coordinates out of the GA but using them to prepare the receptor is still
+information leakage: the receptor handed to the search encodes where the answer is. Arm A
+and Arm B of the campaign both enable this. Any success-rate improvement they show is not
+attributable to "better water handling" in a way that would transfer to a prospective
+target, where no crystal ligand exists. This is the same class of issue as the recorded
+seed-echo inflation finding.
+
+**Recommendations:**
+
+1. **Report smart-water results as oracle-assisted**, clearly separated from blind numbers.
+   The engine already distinguishes oracle from blind modes elsewhere; this path should
+   inherit that discipline.
+2. Provide a **prospective variant** that selects bridging waters using the detected cavity
+   (`CavityDetect/`) rather than the crystal ligand. Same two criteria — inside the cavity,
+   H-bonded to protein — with a blind cavity center. That version is publishable; the
+   current one is a diagnostic.
+3. The fallback at `modify_pdb.cpp:283` (no readable ligand → plain B-factor retention)
+   silently changes the protocol mid-campaign per target. It logs to stderr, which is
+   good; it should also be recorded in the per-target provenance JSON so the analysis can
+   segregate those targets.
+
+---
+
+## Claim 8 — The N=85 three-arm campaign is the decisive next gate
+
+**Verdict: refuted as currently designed. The script cannot run on this machine, and even
+if it could, no arm isolates the one lever the canary says works.**
+
+### Blocker 1: the script aborts before doing anything
+
+`ops/run_astex85_twoarm.sh:63–64`:
+
+```bash
+exec 9>"${LOCKFILE}"
+flock -n 9 || { echo "[ABORT] another campaign holds the lock: ${LOCKFILE}" >&2; exit 1; }
+```
+
+`command -v flock` on this machine returns **nothing**. `flock` is a util-linux tool and is
+not present in macOS by default. The `||` catches the `command not found` (exit 127) and
+the script exits 1 with a misleading "another campaign holds the lock" message. **The
+three-arm campaign has never run and cannot run as written.**
+
+Fix: use a portable lock. `mkdir "${LOCKFILE}.d"` is atomic on every POSIX filesystem:
+
+```bash
+LOCKDIR="/tmp/flexaidds_benchmark.lock.d"
+mkdir "${LOCKDIR}" 2>/dev/null || { echo "[ABORT] another campaign holds ${LOCKDIR}" >&2; exit 1; }
+trap 'rmdir "${LOCKDIR}"' EXIT
+```
+
+### Blocker 2: arm failures are silently swallowed
+
+Each arm is wrapped as `( ... ) || { echo "[WARN] ARM X failed rc=$?" ; }` (lines 148, 160,
+172). But `run_arm` ends with `com_summary`, which ends with `echo` — so `run_arm` always
+returns 0, the subshell always exits 0, and the `||` handler is unreachable. A crashed arm
+produces an empty output directory and a clean-looking log. Capture and propagate the
+runner's `rc` explicitly: `return "${rc}"` at the end of `run_arm`.
+
+### Blocker 3 (scientific): no arm isolates COM_FLOOR
+
+This is the fatal design problem given the canary result. The arms are:
+
+| Arm | Water | VCT_NORM | COM_FLOOR | Thermo |
+|---|---|---|---|---|
+| A | smart | off | off | off |
+| B | smart | **on** | 500 | on (inert) |
+| C | stripped | **on** | 500 | off |
+
+The canary found **VCT_NORM = 0/5 and COM_FLOOR = 5/5**. Both arms that carry the com fix
+carry it as `VCT_NORM=1 + COM_FLOOR=500` bundled together — and per Claim 3 these two are
+not independent: `VCT_NORM` multiplies `com` by `100/N` **before** `COM_FLOOR` clamps it
+(`vcfunction.cpp:854` runs before `:884`). With `N < 100` that pre-multiplication inflates
+`com`, driving more poses into the floor's saturated region where the com gradient is
+zero. The composition is actively worse than `COM_FLOOR` alone, and neither B nor C can
+measure `COM_FLOOR` on its own. **The campaign as written cannot deliver the verdict it was
+designed to deliver.**
+
+Two further design notes:
+
+- The header's "thermo gate is INERT" reasoning (lines 30–36) is **correct** — validated in
+  Claim 4 — but it means Arm B spends a full 85-target run on three env vars that provably
+  do nothing. The B−C delta is confounded anyway: B and C differ in *both* water treatment
+  and thermo flags. Since thermo is inert, the delta is interpretable as water — but only
+  because of an argument the script itself has to make in a comment. A clean design would
+  not need the disclaimer.
+- One thing the script gets right that is worth preserving: water retention is applied in
+  `modify_pdb` at engine init from the per-job config, not at cache-prep time, so the
+  shared `--cache` directory does **not** leak water settings between arms. I checked this
+  specifically because it would have invalidated everything; it is fine.
+
+### Redesigned campaign
+
+Drop VCT_NORM entirely (per Claim 3 it should be retired, not tested). Make water and
+com-taming a clean 2×2 with the smallest arm count that answers the question:
+
+| Arm | Water | com taming | Question answered |
+|---|---|---|---|
+| **A0** | all waters kept (status quo) | none | Baseline. Reproduces the blow-up; anchors everything. |
+| **A1** | all waters kept | `COM_FLOOR=500` only | Does the floor alone recover success? (canary says yes, 5/5) |
+| **A2** | **all waters stripped** | none | Is the blow-up water-driven? Given Claim 2, this is now *the* decisive arm. |
+| **A3** | all waters stripped | `COM_FLOOR=500` | Do the two levers compose, or is one redundant? |
+
+`A2` is the arm that adjudicates Claim 2 and it does not currently exist — Arm C confounds
+water-stripping with com-taming, so a null result in Arm C cannot distinguish "water wasn't
+the problem" from "the com fix already handled it". Smart-water retention should be dropped
+from the decisive campaign entirely and run separately as an oracle-assisted study, per
+Claim 7.
+
+If the water typing fix from Claim 2 lands first, add `A2'` (waters kept, typed as `O.3`),
+which is the *scientifically correct* configuration and may make the whole com-taming
+question moot.
+
+---
+
+# Enhancement recommendations
+
+## 1. What pushes FlexAIDdS past the 91.8 % (v127) ceiling
+
+Ordered by expected value per unit of effort, grounded in what this review and the recorded
+project history actually show.
+
+**(a) Fix water typing — `assign_types.cpp:112`.** One line. Waters currently score against
+the two most attractive cells in the matrix while masquerading as carbon. Everything
+downstream — the com blow-up, the Type I/Type II taxonomy, the smart-water feature, the
+three-arm campaign — is built on top of this defect. Fix it before running anything else,
+because it may dissolve the problem the campaign was designed to study.
+
+**(b) Per-contact com cap.** Section "Claim 3 → (a)". One line, exact precedent in the
+wall channel, and it targets the observed single-dominant-contact failure mode more
+precisely than a global floor.
+
+**(c) Close the selection gap, not the search gap.** Project memory is unambiguous that
+near-native poses are *found* and then *not elected* — 22 found vs 8 selected in v102, with
+the near-native always worse in CF by −2 to −86. At a 91.8 % ceiling the remaining ~7
+targets are almost certainly selection failures, not search failures. The levers are
+(i) mode-level ranking by `G_m = <CF>_m − T·S_m` (Claim 4 recommendation 2), and
+(ii) a consensus or orientation-aware rescorer applied *only* to mode representatives,
+where it is cheap and cannot perturb the GA.
+
+**(d) Parameterize the dead matrix rows.** Row 8 (N.3) is entirely zero, and row 40
+(SOLVENT) is entirely zero. Two of the most common chemical entities in a binding site —
+sp3 amine nitrogen and water — have no parameters at all. This is the deepest limitation
+found in this review, and unlike everything else it is a data problem, not a code problem.
+
+**(e) Symmetry-aware RMSD.** Already flagged in the recorded methodology audit. At >90 %
+success, several of the remaining failures may be scoring artifacts of RMSD rather than
+docking failures. Cheap to check and it can only improve the honest number.
+
+A caution: at 91.8 % on Astex-85, seven targets separate you from the ceiling and
+run-to-run GA noise is recorded at ~2 Å with roughly six targets sitting within 0.5 Å of
+the 2 Å cutoff. **Any change below about ±4 targets is not measurable in a single run.**
+Every experiment above needs `OMP_NUM_THREADS=1` plus fixed seeds (the recorded determinism
+protocol) and, ideally, repeats — otherwise you will be attributing noise.
+
+## 2. A principled bound on CF.com, better than a hard soft-floor
+
+The soft floor treats a symptom. The disease is that `com = Σ (matrix_value × area)` has
+**no reference state** — there is no configuration whose com is defined to be zero, so the
+only thing constraining the magnitude is how much surface the pose can bury. A pose that
+buries more always scores better, without limit. This is the same structural flaw that
+made ACF extensive and regressed 1P2Y.
+
+The principled fix is a **reference-state normalization**, in increasing order of ambition:
+
+**Tier 1 — per-contact cap (ship this).** `min(contribution, −E_max)` per contact, `E_max`
+around 200–400. Bounds the outlier, preserves the gradient everywhere else, mirrors the
+wall channel. One line.
+
+**Tier 2 — buried-area normalization.** `com_normalized = com × (A_ref / Σ area)` with
+`A_ref ≈ 300 Å²`. Makes the term intensive in the *correct* extensive variable, and unlike
+count normalization it cannot invert on the pathological pose.
+
+**Tier 3 — an actual reference state.** For each contact, subtract the expectation for that
+atom-type pair over a random-contact ensemble:
+`ΔE_ij = E_ij − <E>_ij`. This is what every knowledge-based potential (DrugScore, PMF,
+ITScore) does, and it is what makes those functions size-transferable. It requires
+computing per-type-pair contact-frequency expectations over a reference database — a real
+project, but it is the difference between a heuristic and a potential of mean force.
+
+Given the recorded null results on matrix magnitude rescaling (`FA_matrix_v1`: 27/85 both
+arms, r ≈ 0), do **not** expect Tier 3 to move accuracy by itself. Its value is that it
+makes the score comparable across ligand sizes, which is what a docking engine needs for
+prospective virtual screening — a different and arguably more important goal than one more
+Astex target.
+
+## 3. The right thermodynamic integration for dG_eff
+
+**Not FEP, not canonical MC. A per-mode entropy correction at cluster election.**
+
+FEP and canonical MC both require sampling that the GA does not produce — the GA generates
+a biased, non-Boltzmann population by construction, so any free energy computed from it is
+not a free energy. The current `dG_eff = <CF> − T·H` already commits this error: `H` is the
+Shannon entropy of a *GA population's* energy histogram, which reflects the GA's
+convergence state (and, per the recorded gen-10 collapse, its failure modes) far more than
+it reflects the physical density of states.
+
+The simpler correction that is actually defensible:
+
+1. **Cluster poses into modes** (already done in `BindingMode.cpp`).
+2. **Within each mode, compute** `S_m = −k Σ p_i ln p_i` over Boltzmann weights
+   `p_i ∝ exp(−β·CF_i)` for member poses. This *is* a configurational entropy estimate over
+   a basin, which is a physically meaningful object even from biased sampling, because it
+   is a property of the local density of poses rather than the global population.
+3. **Rank modes by** `G_m = <CF>_m − T·S_m`. Elect the representative within each mode by
+   CF, exactly as today.
+4. **Validate against ITC data before believing it.** The ITC calibration framework already
+   exists in this repo (recorded in project memory, with ~944 unified BindingDB rows). A
+   thermodynamic term that does not improve correlation against measured ΔG/ΔH/ΔS is not
+   worth its regression risk. This is the single highest-value use of that dataset.
+
+The key discipline: **keep it out of the GA fitness.** Entropy is a basin property. Putting
+a population-derived quantity into per-individual fitness creates the exact
+diversity-fitness feedback loop this codebase has already been bitten by.
+
+## 4. Scoring-architecture changes within reach
+
+**(a) Desolvation — the largest missing physical term, and the one most relevant to the
+water problem.** The current `SAS` channel is a raw solvent-accessible-surface penalty
+(`vcfunction.cpp:777–791`) with no atom-type dependence: burying a charged oxygen and
+burying an aliphatic carbon cost the same. An atom-type-weighted desolvation penalty
+`ΔG_desolv = Σ σ_type · ΔASA_i` (Eisenberg–McLachlan style, five to seven atom classes) is
+a contained change to an existing channel, and it is the term that would *physically*
+prevent burying a ligand in a solvent shell — the failure this whole audit is about.
+Recommended as the highest-value architectural addition.
+
+**(b) Distance-dependent dielectric — already implemented, and worth an audit.**
+`vcfunction.cpp:655`:
+
+```cpp
+double E_elec = KCOULOMB * qA * qB / (FA->dielectric * dist * dist);
+```
+
+The comment above says `E_elec = (332.0637·qA·qB)/(eps·r)` with `eps = dielectric·r`, which
+gives `1/r²` — and the code implements `1/r²`. Code and intent agree, so this is not a bug.
+But note that the *comment on line 654* labels it "distance-dependent dielectric" while the
+form used is the sigmoidal-free simple DDD; if `FA->dielectric` is being set to a bulk value
+like 78 rather than a DDD coefficient (typically 4), the term is being scaled ~20× too
+small. Worth one grep of where `FA->dielectric` is set before the next campaign.
+
+**(c) Directional hydrogen bonding — present but disabled during search.**
+`vcfunction.cpp:664–666` gates the Gaussian H-bond term on
+`use_hbond_search && !hbond_rank_rescore`, i.e. by default it contributes at rank time but
+not during the GA. Since H-bond geometry is the primary thing distinguishing a native pose
+from a shape-complementary false minimum, and Claim 5 shows the nitrogen typing that feeds
+it was wrong until the uncommitted fix, this deserves a clean A/B **after** the N.2 fix
+lands. The recorded v51/v52 history shows a previous attempt over-corrected and collapsed
+`cf_native`; the lesson there was about the *penalty* formulation, not about whether
+directionality belongs in search.
+
+**(d) What not to do.** Do not revisit matrix magnitude rescaling or `r0`/VCT geometry
+tuning. Two independent, well-documented experiments (`FA_matrix_v1`, `lever2_r0`) returned
+clean nulls — deepening the CF wells 18× moved zero poses. The lever is selection and
+physics coverage, not the shape of the existing potential.
+
+---
+
+# Immediate actions
+
+Ordered. The first three are cheap and unblock everything else.
+
+1. **Commit the working-tree fixes.** `LIB/top.cpp`, `LIB/Mol2Reader.cpp` (N.2 → row 7) and
+   `LIB/PoseBust/BustCli.cpp` (schema pin) are correct, validated above, and currently
+   exist only as uncommitted edits. They are one stray `git checkout` from being lost.
+2. **Build with `-DBUILD_TESTING=ON` and run `ctest --output-on-failure`.** No test binaries
+   exist in any `build*/` directory right now, so the "lone failure" claim is unverified and
+   the project is flying without its test suite.
+3. **Fix `assign_types.cpp:112`** (water typing) and correct the stale comment at
+   `vcfunction.cpp:871` (soft-floor formula).
+4. **Fix the campaign script**: replace `flock` with `mkdir`-based locking, propagate
+   `run_arm`'s exit code, correct the `gaboom.cpp:705` citation to `:1238`, and remove the
+   stale `setsid` comment (`setsid` is absent from macOS and is not used in the script).
+5. **Redesign the campaign as A0/A1/A2/A3** (Claim 8), dropping VCT_NORM and moving
+   smart-water to a separate oracle-assisted study.
+6. **Re-baseline Astex-85 after the N.2 and water-typing fixes.** Both change live matrix
+   rows; every number predating them, including the 91.8 % v127 figure, is measured against
+   a different scoring function.

--- a/scripts/elect_paired.py
+++ b/scripts/elect_paired.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Paired offline election: E_CF (FlexAID-2015 style) vs E_S (first-entropy style).
+
+Both rules are applied to the SAME GA population from ONE search, so the only
+variable is the election rule -- the entropy contribution is isolated with zero
+GA stochastic noise (see docs/COMPARATIVE_BENCHMARK_METHODOLOGY.md Sec. 3b).
+
+Reference semantics (LIB/BindingMode.cpp of LeBonhommePharma/FlexAID @1a6ae0b):
+
+    w_i = exp(-(1/T) * CF_i)          # beta = 1/T, NOT 1/(k_B*T)
+    Z   = sum over the WHOLE population of w_i
+    per binding mode (cluster) m:
+        H_m = sum_{i in m} (w_i/Z) * CF_i
+        S_m = -sum_{i in m} (w_i/Z) * ln(w_i/Z)     # Shannon, no reference state
+        G_m = H_m - T * S_m
+
+    E_S  : modes sorted ASCENDING by G_m; mode[0] wins.
+    E_CF : modes ranked by raw CF, lowest wins (== the .cad TCF order).
+    In both cases the elected structure is the mode's lowest-CF member
+    (elect_Representative(false)).
+
+NOTE the normalization: w_i/Z is normalized over the whole population, so the
+within-mode probabilities do NOT sum to 1. That is faithful to the reference and
+is reproduced exactly here.
+
+Numerical stability: clash poses carry CF ~ 1e4, so exp(-CF/T) underflows in
+naive float. All weights are computed in log space with a log-sum-exp shift,
+which is exact for the ratios w_i/Z that the formulas actually need.
+
+Usage:
+    elect_paired.py <run_dir_or_rrd> [--temper 21] [--cutoff 2.0] [--json out.json]
+
+Copyright 2026 Le Bonhomme Pharma
+SPDX-License-Identifier: Apache-2.0
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# CF at or above this is a clash sentinel, not a physical score.
+CLASH_SENTINEL = 10000.0
+
+
+def parse_rrd(path: Path) -> list[dict]:
+    """Parse a FlexAID .rrd, auto-detecting the V1 vs V2 column layout.
+
+    The two reference binaries do NOT write the same columns (verified against
+    the pinned sources and real output):
+
+      V1 `b555e0e` : idx cluster clusRMSD rmsd rmsd_hungarian CF [genes]   (6 numeric)
+      V2 `1a6ae0b` : idx cluster clusRMSD rmsd                CF [genes]   (5 numeric)
+                     (the Hungarian line is commented out on the entropy branch)
+
+    Hardcoding cf=parts[4] silently reads V1's symmetry-corrected RMSD as the
+    CF, which corrupts every downstream weight. Detect instead: the numeric
+    prefix ends at the '[' that opens the gene vector.
+    """
+    poses: list[dict] = []
+    for line in path.read_text(errors="ignore").splitlines():
+        head = line.split("[", 1)[0]  # drop the gene vector
+        parts = head.split()
+        if len(parts) < 5:
+            continue
+        try:
+            n = len(parts)
+            if n >= 6:  # V1 layout: CF is last, Hungarian RMSD precedes it
+                cf, rmsd_h = float(parts[5]), float(parts[4])
+            else:  # V2 layout: CF is col 4, no Hungarian
+                cf, rmsd_h = float(parts[4]), None
+            poses.append(
+                {
+                    "idx": int(parts[0]),
+                    "cluster": int(parts[1]),
+                    "cluster_rmsd": float(parts[2]),
+                    "rmsd_ref": float(parts[3]),
+                    "rmsd_hungarian": rmsd_h,
+                    "cf": cf,
+                    "layout": "V1" if n >= 6 else "V2",
+                }
+            )
+        except ValueError:
+            continue  # header/comment line
+    return poses
+
+
+def elect(poses: list[dict], temper: float) -> dict:
+    """Apply both election rules to one population. Returns both winners."""
+    if not poses:
+        return {"error": "empty population"}
+
+    # Poses beyond the MAXRES ceiling are written with cluster == -1 (unassigned).
+    # Grouping them would fabricate a single spurious mega-mode (observed: 376 of
+    # 500 poses on 1SJ0) that can win an election. Drop them, and count them.
+    n_unassigned = sum(1 for p in poses if p["cluster"] < 0)
+    poses = [p for p in poses if p["cluster"] >= 0]
+    if not poses:
+        return {"error": "all poses unassigned (raise MAXRES to NUMCHROM)"}
+
+    by_cluster: dict[int, list[dict]] = defaultdict(list)
+    for p in poses:
+        by_cluster[p["cluster"]].append(p)
+
+    # --- log-space Boltzmann weights over the WHOLE population -------------
+    # log w_i = -CF_i / T ; log Z = logsumexp(log w_i). Ratios w_i/Z are exact
+    # under the shift, so clash poses (CF~1e4) simply carry ~zero weight
+    # instead of underflowing to a NaN.
+    log_w = {p["idx"]: -p["cf"] / temper for p in poses}
+    m = max(log_w.values())
+    log_Z = m + math.log(sum(math.exp(lw - m) for lw in log_w.values()))
+
+    modes = []
+    for cid, members in by_cluster.items():
+        H = 0.0
+        S = 0.0
+        for p in members:
+            log_p = log_w[p["idx"]] - log_Z  # ln(w_i/Z)
+            prob = math.exp(log_p)
+            if prob <= 0.0:
+                continue  # zero-weight (clash) pose contributes nothing
+            H += prob * p["cf"]
+            S -= prob * log_p
+        rep = min(members, key=lambda p: p["cf"])  # elect_Representative(false)
+        modes.append(
+            {
+                "cluster": cid,
+                "freq": len(members),
+                "tcf": rep["cf"],  # lowest CF in the mode (== .cad TCF)
+                "H": H,
+                "S": S,
+                "G": H - temper * S,
+                "rep_idx": rep["idx"],
+                "rep_rmsd": rep["rmsd_ref"],
+            }
+        )
+
+    e_cf = min(modes, key=lambda x: x["tcf"])  # V1-style: lowest raw CF
+    e_s = min(modes, key=lambda x: x["G"])  # V2-style: lowest G = H - T*S
+    return {
+        "n_poses": len(poses),
+        "n_modes": len(modes),
+        "n_unassigned": n_unassigned,
+        "layout": poses[0].get("layout"),
+        "n_clash": sum(1 for p in poses if p["cf"] >= CLASH_SENTINEL),
+        "temper": temper,
+        "E_CF": e_cf,
+        "E_S": e_s,
+        "agree": e_cf["cluster"] == e_s["cluster"],
+        "modes": sorted(modes, key=lambda x: x["G"]),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("target", type=Path, help=".rrd file, or a dir searched recursively for *.rrd")
+    ap.add_argument("--temper", type=float, default=21.0, help="T (TEMPER); reference ISMB calibration = 21")
+    ap.add_argument("--cutoff", type=float, default=2.0, help="sub-X A success cutoff")
+    ap.add_argument("--json", type=Path, help="write the full per-target report here")
+    args = ap.parse_args()
+
+    rrds = (
+        [args.target]
+        if args.target.is_file()
+        else sorted(args.target.rglob("*.rrd"))
+    )
+    if not rrds:
+        print(f"no .rrd found under {args.target}", file=sys.stderr)
+        return 2
+
+    rows, n_cf, n_s, n_both = [], 0, 0, 0
+    for rrd in rrds:
+        poses = parse_rrd(rrd)
+        if not poses:
+            continue
+        r = elect(poses, args.temper)
+        if "error" in r:
+            continue
+        name = rrd.stem
+        ok_cf = r["E_CF"]["rep_rmsd"] < args.cutoff
+        ok_s = r["E_S"]["rep_rmsd"] < args.cutoff
+        n_cf += ok_cf
+        n_s += ok_s
+        n_both += 1
+        rows.append({"target": name, "ok_cf": ok_cf, "ok_s": ok_s, **r})
+        print(
+            f"{name:<28} poses={r['n_poses']:<5} modes={r['n_modes']:<4} "
+            f"E_CF: rmsd={r['E_CF']['rep_rmsd']:6.2f} {'OK ' if ok_cf else '   '} "
+            f"E_S: rmsd={r['E_S']['rep_rmsd']:6.2f} {'OK ' if ok_s else '   '} "
+            f"{'same' if r['agree'] else 'DIFFER'}"
+        )
+
+    if n_both:
+        # McNemar discordant pairs: the only cells that carry information.
+        b = sum(1 for r in rows if r["ok_cf"] and not r["ok_s"])  # CF wins
+        c = sum(1 for r in rows if r["ok_s"] and not r["ok_cf"])  # S wins
+        print(f"\n{'='*70}\nPAIRED ELECTION RESULT  (n={n_both}, T={args.temper}, cutoff={args.cutoff} A)")
+        print(f"  E_CF (FlexAID-2015 style) : {n_cf}/{n_both} = {100*n_cf/n_both:.1f}%")
+        print(f"  E_S  (first-entropy style): {n_s}/{n_both} = {100*n_s/n_both:.1f}%")
+        print(f"  discordant: E_CF-only={b}  E_S-only={c}  (McNemar uses only these)")
+        if b + c:
+            # exact binomial two-sided p under H0: P(win)=0.5
+            k, n = min(b, c), b + c
+            p = min(1.0, 2 * sum(math.comb(n, i) for i in range(k + 1)) / (2**n))
+            print(f"  McNemar exact p = {p:.4f}")
+        else:
+            print("  McNemar: no discordant pairs -> the rules are indistinguishable here")
+
+    if args.json:
+        args.json.write_text(json.dumps(rows, indent=2))
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/launch_coarse6.sh
+++ b/scripts/launch_coarse6.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# launch_coarse6.sh — 6-target coarse_init probe with per-target grid_step for 1K3U.
+#
+# Targets: 1G9V 1J3J 1K3U 1L7F 1M2Z 1N1M (Astex Diverse subset)
+#
+# Protocol (genuine, no-seeding):
+#   mode UNSET  -> seed_elitism forced OFF by DatasetRunner (seed_echo=0 metric)
+#   coarse_init is ALWAYS ON in this build (not gated on oracle-ceiling), so the
+#   grid_step patch is exercised regardless of mode.
+#   FLEXAIDDS_RESTARTS=8, seed_fraction=0.0, seed_elitism=false,
+#   sas_weight=0.40, hbond_rank=on.
+#   1K3U ONLY: FLEXAIDDS_COARSE_GRID_STEP=1.5 (finer scan for narrow/deep pocket).
+#
+# Because the grid-step env var is process-global, 1K3U runs as a SEPARATE
+# invocation (subdir k3u/) from the other 5 (subdir main/) so the finer grid
+# does not leak onto other targets and result.csv files do not clobber.
+#
+# Copyright 2026 Le Bonhomme Pharma
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RUNNER="${ROOT}/build/benchmark_datasets"
+BINARY="${ROOT}/build/FlexAIDdS"
+
+OUTDIR="${COARSE6_OUTDIR:?set COARSE6_OUTDIR}"
+MAIN_OUT="${OUTDIR}/main"
+K3U_OUT="${OUTDIR}/k3u"
+mkdir -p "${MAIN_OUT}" "${K3U_OUT}"
+
+[[ -x "${RUNNER}" ]] || { echo "FAIL: runner not executable: ${RUNNER}" >&2; exit 1; }
+[[ -x "${BINARY}" ]] || { echo "FAIL: engine not executable: ${BINARY}" >&2; exit 1; }
+
+# Shared genuine-protocol env (no seeding).
+export FLEXAIDDS_BINARY="${BINARY}"
+export FLEXAIDDS_RESTARTS=8
+export FLEXAIDDS_PARALLEL_RESTARTS=0
+export FLEXAIDDS_SEED_ELITISM=0
+export FLEXAIDDS_NATIVE_SEED_FRAC=0
+export FLEXAIDDS_SAS_WEIGHT=0.40
+export FLEXAIDDS_HBOND_RANK=1
+export FLEXAIDDS_VCT_R0=4.0
+export OMP_WAIT_POLICY=passive
+
+POP=1000
+GEN=2000
+TEMP=298
+TIMEOUT=10800
+
+echo "=== COARSE6 LAUNCH $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "RUNNER=${RUNNER}"
+echo "BINARY=${BINARY}"
+echo "OUTDIR=${OUTDIR}"
+echo "mode=UNSET (seed_elitism OFF) RESTARTS=8 pop=${POP} gen=${GEN} T=${TEMP}"
+echo "sas_weight=0.40 hbond_rank=on native_seed_frac=0 vct_r0=4.0"
+echo "runner_sha256=$(shasum -a 256 "${RUNNER}" | awk '{print $1}')"
+echo "engine_sha256=$(shasum -a 256 "${BINARY}" | awk '{print $1}')"
+
+# ---- Phase 1: the 4 standard-grid targets (1M2Z excluded — sentinel, blind placement fails) ---
+echo "--- Phase 1: 1G9V,1J3J,1L7F,1N1M (grid_step default 3.0, vct_r0=4.0) ---"
+"${RUNNER}" \
+  --benchmark astex \
+  --only-codes 1G9V,1J3J,1L7F,1N1M \
+  --output "${MAIN_OUT}/" \
+  --threads 4 \
+  --omp-threads 2 \
+  --ga-population "${POP}" \
+  --ga-generations "${GEN}" \
+  --temperature "${TEMP}" \
+  --job-timeout-seconds "${TIMEOUT}"
+
+# ---- Phase 2: 1K3U with finer coarse grid --------------------------------
+echo "--- Phase 2: 1K3U (FLEXAIDDS_COARSE_GRID_STEP=1.5) ---"
+FLEXAIDDS_COARSE_GRID_STEP=1.5 \
+"${RUNNER}" \
+  --benchmark astex \
+  --only-codes 1K3U \
+  --output "${K3U_OUT}/" \
+  --threads 1 \
+  --omp-threads 8 \
+  --ga-population "${POP}" \
+  --ga-generations "${GEN}" \
+  --temperature "${TEMP}" \
+  --job-timeout-seconds "${TIMEOUT}"
+
+echo "=== COARSE6 DONE $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="


### PR DESCRIPTION
## Scoped merge of the session's vetted working-tree modifications

Every modified/untracked file in the working tree was classified across usefulness, path/secret hygiene, and **claim-correctness**. Only the clean set lands here — nothing unrelated is swept in, per the repo's scoped-commit rule.

### ✅ What lands (10 paths)
| File | Why |
|---|---|
| `scripts/elect_paired.py` | Paired offline election analyzer (`E_CF` vs `E_S`) over **one** GA population → isolates the entropy contribution with zero GA noise. Stdlib-only, SPDX header, compiles clean. |
| `docs/COMPARATIVE_BENCHMARK_METHODOLOGY.md` | Fair three-engine comparison protocol (FlexAID-2015 / first-entropy / FlexAIDdS): pinned SHAs + verified builds, external symmetry-corrected scoring, N=5 seeds, Wilson CIs + McNemar, measured pilot results and its two P0 blockers. |
| `docs/ATOM_TYPES.md` | 40-type NRGDock atom-type reference; matches the code. |
| `docs/audit/AUDIT_2026-07-23.md`, `AUDIT_scoring.md`, `VALIDATION_2026-07-23.md`, `COMMITTER_ADDENDUM_thermo_gate_N2.md` | Integrity records, **relocated from the repo root** into `docs/audit/`. |
| `.gitignore` | Ignore regenerable CTest output + stray compiled test binaries. |
| `.grok/.../resolve_build.py` | One-line correctness fix: quoting `"…:$PATH"` froze the literal string and **wiped `/usr/bin` from PATH**; now only the build dir is quoted. |
| `scripts/launch_coarse6.sh` | Repo-relative launcher (`ROOT="$(cd "$(dirname "$0")/.." && pwd)"`), no machine-specific paths. |

### ⛔ Deliberately held back — scientific integrity
`README.md`, `docs/BENCHMARK.md`, `docs/SCORING.md` are **not** in this PR:

- **`README.md` / `docs/BENCHMARK.md`** headline **"78/85 = 91.8% Astex-85"** as accuracy. That is a Hungarian / best-cluster / seed-echo-inflated figure. Measured genuine **blind top-1 sub-2 Å is far lower** (~21% in this session's clean blind run; the historical 41–52% was itself seed-inflated, and the benchmark `success` column only means "docking ran", not RMSD < 2). The README rewrite also *deletes* the existing "Scientific integrity (read before citing numbers)" section and the S1/S2/S3+BCR admission-metrics discipline.
- **`docs/BENCHMARK.md` / `docs/SCORING.md`** additionally credit the `FLEXAIDDS_THERMO_SCORE` gate with changing pose/cluster election. The `COMMITTER_ADDENDUM` landing in this PR verifies (against `d623c45ea`) that the gate is **printf/diagnostic-only** — ranking is `QuickSort` on CF *before* the thermo compute. The docs describe behavior the code does not have.

**To promote them:** headline the honest blind top-1; keep any Hungarian/best-cluster/seeded figure only as a clearly-labeled *upper-bound / sampling-ceiling diagnostic*; restore the integrity + admission-metrics section; state the thermo gate as reporting-only.

> The audit records landing in this PR are the honest counter-record — and are precisely why those three headline docs are held. **Land the audits, hold the headlines.**

### 🔧 Held for a one-line hygiene fix
`AUDIT_atomtyping.md`, `AUDIT_clustering.md`, `WORKORDER_clustering_medoid.md`, all `ops/launch_*.sh`, `ops/run_astex85_armA_com_tame.sh` — each hardcodes `/Users/lp.more/...`; fix is repo-relative `ROOT` derivation (as in `launch_coarse6.sh`) or dropping the path from the `Repo:` header. `ops/canary_com_tame.env` → rename to `.env.example` (content is benign, no secrets; the extension trips the no-committed-.env convention).

### 🗑 Skipped as regenerable scratch
`flexaid_out.rrg` (431 KB docking output), `diagnostic/` (3.4 MB scratch workspace, ~37 files with absolute paths), `benchmarks/astex_repro/MOVED_TO_ICLOUD.txt` (breadcrumb).

### Verification
- Staged set is **exactly the 10 vetted paths**; 0 unstaged, 0 untracked swept.
- `python3 scripts/check_repo_hygiene.py` → **OK: no tracked .env secrets; agent/skill files have no hardcoded user paths**.
- `grep -rn "/Users/lp.more"` across all 10 merged files → **no hits**.
- `python3 -m py_compile scripts/elect_paired.py` → OK.
- Branched from current `origin/main` (`2e31152c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qM8hUq93cNYaKiek6cBrj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a paired analysis tool for comparing pose-election methods using shared results.
  * Added a coarse benchmark launcher with dedicated handling for specialized grid settings.

* **Documentation**
  * Added atom-typing reference documentation, including mappings, input-format behavior, and validation guidance.
  * Added benchmark comparison methodology and multiple audit and validation reports covering scoring, reproducibility, and known limitations.

* **Bug Fixes**
  * Corrected generated shell environment setup so the existing `PATH` is preserved properly.
  * Expanded ignored build and test artifacts to reduce repository clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->