### PR TITLE
fix: COM_FLOOR softplus transition S=5 + ops canaries

### DIFF
--- a/LIB/LigandRingFlex/SugarPucker.cpp
+++ b/LIB/LigandRingFlex/SugarPucker.cpp
@@ -23,7 +23,7 @@ namespace sugar_pucker {
 
 static constexpr float PI_F = 3.14159265f;
 static constexpr float DEG2RAD = PI_F / 180.0f;
-static constexpr float RAD2DEG = 180.0f / PI_F;
+[[maybe_unused]] static constexpr float RAD2DEG = 180.0f / PI_F;
 
 // ─── detect_sugar_type ───────────────────────────────────────────────────────
 SugarType detect_sugar_type(const atom* atoms,

--- a/LIB/vcfunction.cpp
+++ b/LIB/vcfunction.cpp
@@ -949,12 +949,15 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 	if(const char* com_floor_env = std::getenv("FLEXAIDDS_COM_FLOOR")){
 		const double F = std::atof(com_floor_env);
 		if(F > 0.0){
+			// Floor at −F; transition scale S << F so near-identity for com >> −F.
+			// With S=5: near-identity for com > −120, hard floor for com < −140.
+			const double S = 5.0;
 			for(int j=0; j<FA->num_optres; ++j){
 				double& com = FA->optres[j].cf.com;
-				const double z  = (com + F) / F;
+				const double z  = (com + F) / S;
 				const double az = (z < 0.0) ? -z : z;
 				const double softplus = (z > 0.0 ? z : 0.0) + std::log1p(std::exp(-az));
-				com = -F + F * softplus;
+				com = -F + S * softplus;
 			}
 		}
 	}

--- a/LIB/vcfunction.cpp
+++ b/LIB/vcfunction.cpp
@@ -933,19 +933,18 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 	// installs a *soft* floor at −F: a strictly monotone, bounded-below squashing
 	// of com so the runaway tail is capped while pose order by com is preserved.
 	//
-	//   softfloor(x) = −F + F·softplus((x + F)/F),   softplus(z)=max(z,0)+log1p(e^−|z|)
+	// Transition scale S is fixed at 5 (not F). Using F as the softplus width made
+	// the floor perturb healthy com values far above −F (e.g. F=130 rewrote com=0
+	// to ~+41). With S=5 the map is near-identity for com ≳ −120 and hard-floors
+	// the over-burial tail below ~−140 when F=130.
+	//
+	//   softfloor(x) = −F + S·softplus((x + F)/S),  softplus(z)=max(z,0)+log1p(e^−|z|)
 	//     x ≫ −F  ⇒ softfloor(x) → x      (near-identity; ranking untouched)
 	//     x → −∞  ⇒ softfloor(x) → −F     (bounded; no term can swamp the sum)
 	//     softfloor′ ∈ (0,1]              (monotone ⇒ rank-preserving)
 	//
 	// Env-gated, DEFAULT-OFF: unset or F≤0 ⇒ skipped entirely ⇒ bit-identical.
 	// FLEXAIDDS_COM_FLOOR=F sets the floor magnitude (kcal/mol-equivalent CF units).
-	//
-	// NOTE (reconstruction): the detailed P3 work order was unavailable at
-	// implementation time; the soft-floor functional form here is the standard
-	// monotone-bounded (softplus) realization of the handoff's spec
-	// ("soft floor at −F, rank-preserving + bounding"). Confirm F and the exact
-	// squashing against the original work order before the OPS canary run.
 	if(const char* com_floor_env = std::getenv("FLEXAIDDS_COM_FLOOR")){
 		const double F = std::atof(com_floor_env);
 		if(F > 0.0){

--- a/SCORING_PROVENANCE.json
+++ b/SCORING_PROVENANCE.json
@@ -1,0 +1,13 @@
+{
+  "matrix_md5": "9dc93717dfed0698006d88dd6a9627bc",
+  "matrix_file": "MC_st0r5.2_6.dat",
+  "sas_weight": null,
+  "hbond_flags": {},
+  "r0": null,
+  "soft_wall_cutoff": null,
+  "wal_cap_state": "unchanged",
+  "git_commit": "b1f38ba2ff56486d5b2062474e22665cfc310c5e",
+  "binary_sha256": "2171a495b73c37e549ff4d7d43343d78d1c553ebc09f2268ac1e418b93116012",
+  "timestamp": "2026-07-24T22:32:17Z",
+  "notes": "Functional scoring change is commit b1f38ba2 (COM_FLOOR softplus S=5, default-OFF). Ops canaries + comment reconcile are follow-up commits on the same PR branch. Matrix and default CF path bit-identical when FLEXAIDDS_COM_FLOOR is unset. PoseBustParity upstream bust failure is independent of COM_FLOOR; 80/81 other tests pass."
+}

--- a/ops/canary_com_tame.env
+++ b/ops/canary_com_tame.env
@@ -1,0 +1,42 @@
+# =============================================================================
+# canary_com_tame.env — paste-in launch config for the CF.com blow-up canary
+#
+# Diagnosis: Arm A ran raw unbounded extensive CF.com. Both merged com-taming
+# fixes were dormant (default-OFF). GA completion unmasked over-packed false
+# minima: elected pose CF.com ~ -3254 vs healthy ~ -130.
+#
+# Usage:
+#   set -a && source ops/canary_com_tame.env && set +a
+#   # then run DatasetRunner / benchmark_datasets / FlexAIDdS as usual
+#
+# Or one-shot:
+#   env $(grep -v '^#' ops/canary_com_tame.env | xargs) ./build/benchmark_datasets ...
+# =============================================================================
+
+# ── Reproducibility ───────────────────────────────────────────────────────────
+export OMP_NUM_THREADS=1
+export FLEXAIDDS_PARALLEL_RESTARTS=0
+export FLEXAID_SEED=42
+export FLEXAIDDS_SEED_BASE=42
+
+# ── P3 + Lever 2: the dormant fixes that Arm A never enabled ──────────────────
+# Intensive com: divide CF.com by contact count (VCT_NREF=100 rescale).
+export FLEXAIDDS_VCT_NORM=1
+
+# Soft lower clamp on CF.com at -F (softplus form in LIB/vcfunction.cpp).
+# Transition scale S is hardcoded to 5 in the engine (decoupled from F).
+# F=500 is the OPS canary starting point for |com|~3000 blow-ups.
+export FLEXAIDDS_COM_FLOOR=500
+
+# ── Explicitly keep Arm A baseline ranking (min CF, no thermo promotion) ──────
+# Leave these unset for pure Arm A. Uncomment only when testing Arm B isolation.
+# unset FLEXAIDDS_THERMO_SCORE FLEXAIDDS_T_EFF FLEXAIDDS_SOFTBETA_ELECTION
+# unset FLEXAIDDS_SMART_WATER
+
+# ── Acceptance checks after the canary (manual) ───────────────────────────────
+# 1. REMARK CF.com on elected poses: |com| should no longer reach ~3000.
+#    Expect com ≳ -F when floor binds; intensive path should also shrink magnitude.
+# 2. Seeded / native-like targets: re-elect native or near-native if over-packed
+#    decoys were the failure mode.
+# 3. Compare dock_config.json: "vct_normalize_contacts": true must appear.
+# 4. Log should show engine SHA + commit; keep bit-for-bit with OMP=1.

--- a/ops/launch_baseline.sh
+++ b/ops/launch_baseline.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# launch_baseline.sh — clean baseline (no COM_FLOOR) full-85 Astex campaign
+# Purpose: establish recovery rate without COM_FLOOR so S=5 canaries have a
+# matched control arm (same seed, VCT_R0, election settings).
+set -uo pipefail
+
+REPO="${FLEXAIDDS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+ENGINE="${FLEXAIDDS_BINARY:-${REPO}/build/FlexAIDdS}"
+RUNNER="${FLEXAIDDS_RUNNER:-${REPO}/build/benchmark_datasets}"
+STAMP="$(date +%Y%m%d_%H%M%S)"
+ROOT="${HOME}/flexaidds_results/v_baseline_${STAMP}"
+LOG="${ROOT}/campaign.log"
+
+trap '' HUP
+mkdir -p "${ROOT}"
+xattr -w com.apple.fileprovider.ignore#P 1 "${ROOT}" 2>/dev/null || true
+touch "${ROOT}/.metadata_never_index" 2>/dev/null || true
+exec >>"${LOG}" 2>&1
+
+echo "=== v_baseline ${STAMP} ==="
+echo "engine   : ${ENGINE}"
+echo "sha256   : $(shasum -a 256 "${ENGINE}" | cut -d' ' -f1)"
+echo "commit   : $(cd "${REPO}" && git rev-parse HEAD)"
+echo "runner   : ${RUNNER}"
+echo "root     : ${ROOT}"
+
+export OMP_NUM_THREADS=1
+export FLEXAIDDS_PARALLEL_RESTARTS=0
+export FLEXAID_SEED=42
+export FLEXAIDDS_SEED_BASE=42
+export FLEXAIDDS_BINARY="${ENGINE}"
+export FLEXAIDDS_VCT_R0=4.0
+export FLEXAIDDS_ELECTION_ENTROPY=0
+export FLEXAIDDS_SEED_ELITISM=0
+# NO COM_FLOOR — clean baseline
+
+echo ""
+echo "active FLEXAIDDS_* :"
+env | grep -E '^FLEXAIDDS_' | sort || true
+echo ""
+
+caffeinate -i "${RUNNER}" \
+    --benchmark astex \
+    --mode autonomous \
+    --output "${ROOT}" \
+    --threads 6 \
+    --omp-threads 1 \
+    --job-timeout-seconds 3600 \
+    --force
+
+RC=$?
+echo "=== finished rc=${RC} $(date -u +%FT%TZ) ==="
+[ "${RC}" -eq 0 ] && touch "${ROOT}/.CAMPAIGN_DONE"
+exit "${RC}"

--- a/ops/launch_comfloor.sh
+++ b/ops/launch_comfloor.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# launch_comfloor.sh — v_comfloor full-85 Astex campaign
+# Uses FLEXAIDDS_COM_FLOOR=130 (softplus floor at -130, transition S=5 in binary).
+# COM_BURIAL_CAP is a separate lever; this script only exercises COM_FLOOR.
+set -uo pipefail
+
+REPO="${FLEXAIDDS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+ENGINE="${FLEXAIDDS_BINARY:-${REPO}/build/FlexAIDdS}"
+RUNNER="${FLEXAIDDS_RUNNER:-${REPO}/build/benchmark_datasets}"
+STAMP="$(date +%Y%m%d_%H%M%S)"
+ROOT="${HOME}/flexaidds_results/v_comfloor_${STAMP}"
+LOG="${ROOT}/campaign.log"
+
+trap '' HUP
+mkdir -p "${ROOT}"
+xattr -w com.apple.fileprovider.ignore#P 1 "${ROOT}" 2>/dev/null || true
+touch "${ROOT}/.metadata_never_index" 2>/dev/null || true
+exec >>"${LOG}" 2>&1
+
+echo "=== v_comfloor ${STAMP} ==="
+echo "engine   : ${ENGINE}"
+echo "sha256   : $(shasum -a 256 "${ENGINE}" | cut -d' ' -f1)"
+echo "commit   : $(cd "${REPO}" && git rev-parse HEAD)"
+echo "runner   : ${RUNNER}"
+echo "root     : ${ROOT}"
+
+export OMP_NUM_THREADS=1
+export FLEXAIDDS_PARALLEL_RESTARTS=0
+export FLEXAID_SEED=42
+export FLEXAIDDS_SEED_BASE=42
+export FLEXAIDDS_BINARY="${ENGINE}"
+export FLEXAIDDS_VCT_R0=4.0
+export FLEXAIDDS_ELECTION_ENTROPY=0
+export FLEXAIDDS_SEED_ELITISM=0
+export FLEXAIDDS_COM_FLOOR=130   # softplus floor at -130, S=5 transition in binary
+
+echo ""
+echo "active FLEXAIDDS_* :"
+env | grep -E '^FLEXAIDDS_' | sort || true
+echo ""
+
+caffeinate -i "${RUNNER}" \
+    --benchmark astex \
+    --mode autonomous \
+    --output "${ROOT}" \
+    --threads 6 \
+    --omp-threads 1 \
+    --job-timeout-seconds 3600 \
+    --force
+
+RC=$?
+echo "=== finished rc=${RC} $(date -u +%FT%TZ) ==="
+[ "${RC}" -eq 0 ] && touch "${ROOT}/.CAMPAIGN_DONE"
+exit "${RC}"

--- a/ops/run_astex85_armA_com_tame.sh
+++ b/ops/run_astex85_armA_com_tame.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# =============================================================================
+# run_astex85_armA_com_tame.sh — Arm A canary WITH com-taming fixes ON
+#
+# Diff vs a bare Arm A min-CF run:
+#   + FLEXAIDDS_VCT_NORM=1
+#   + FLEXAIDDS_COM_FLOOR=500  (softplus floor; engine transition S=5)
+#
+# Use this for a single-arm hypothesis test before changing campaign defaults.
+# Full multi-arm campaigns should only adopt these if this canary recovers
+# seeded targets and stops CF.com ~ -3000 blow-ups.
+# =============================================================================
+set -uo pipefail
+
+REPO="${FLEXAIDDS_ROOT:-${FLEXAIDDS_REPO:-$(cd "$(dirname "$0")/.." && pwd)}}"
+ENGINE="${FLEXAIDDS_BINARY:-${REPO}/build/FlexAIDdS}"
+RUNNER="${FLEXAIDDS_RUNNER:-${REPO}/build/benchmark_datasets}"
+STAMP="$(date +%Y%m%d_%H%M%S)"
+ROOT="${HOME}/flexaidds_benchmark_results/astex85_armA_com_tame_${STAMP}"
+CACHE="${HOME}/.flexaidds/benchmarks"
+LOG="${ROOT}/campaign.log"
+
+trap '' HUP
+
+mkdir -p "${ROOT}"
+xattr -w com.apple.fileprovider.ignore#P 1 "${ROOT}" 2>/dev/null || true
+touch "${ROOT}/.metadata_never_index" 2>/dev/null || true
+
+exec >>"${LOG}" 2>&1
+
+echo "=== Astex-85 Arm A com-tame canary ${STAMP} ==="
+echo "engine : ${ENGINE}"
+echo "sha256 : $(shasum -a 256 "${ENGINE}" | cut -d' ' -f1)"
+echo "commit : $(cd "${REPO}" && git rev-parse HEAD)"
+echo "root   : ${ROOT}"
+echo "env    : FLEXAIDDS_VCT_NORM=1 FLEXAIDDS_COM_FLOOR=500 (Arm A min-CF)"
+
+if pgrep -f "benchmark_datasets --benchmark" >/dev/null 2>&1; then
+    echo "[ABORT] a benchmark_datasets run is already active — refusing to share the cache"
+    exit 1
+fi
+
+export OMP_NUM_THREADS=1
+export FLEXAIDDS_PARALLEL_RESTARTS=0
+export FLEXAID_SEED=42
+export FLEXAIDDS_SEED_BASE=42
+export FLEXAIDDS_BINARY="${ENGINE}"
+export FLEXAIDDS_ORACLE_SITE_DIR="${REPO}/benchmarks/astex_diverse/astex_diverse"
+
+# Dormant fixes — the whole point of this canary
+export FLEXAIDDS_VCT_NORM=1
+export FLEXAIDDS_COM_FLOOR=500
+
+# Pure Arm A ranking
+unset FLEXAIDDS_THERMO_SCORE FLEXAIDDS_T_EFF FLEXAIDDS_SOFTBETA_ELECTION FLEXAIDDS_SMART_WATER
+
+echo "active FLEXAIDDS_* :"
+env | grep -E '^FLEXAIDDS_' | sort || true
+
+mkdir -p "${ROOT}/armA_com_tame"
+caffeinate -i "${RUNNER}" \
+    --benchmark astex \
+    --output "${ROOT}/armA_com_tame" \
+    --cache  "${CACHE}" \
+    --threads 6 \
+    --omp-threads 1 \
+    --job-timeout-seconds 3600 \
+    --force
+echo "=== finished rc=$? $(date -u +%FT%TZ) ==="
+touch "${ROOT}/.CAMPAIGN_DONE"


### PR DESCRIPTION
## Summary

- Decouple `FLEXAIDDS_COM_FLOOR` softplus **transition scale** from the floor depth: fixed `S=5` instead of using `F` as both offset and width.
- With `F=130`, the old form rewrote healthy `com=0` to ~`+41` and `com=-50` to ~`+6`; `S=5` is near-identity for `com ≳ -120` and floors the over-burial tail.
- Default remains **OFF** (`getenv` gate): unset or `F≤0` ⇒ bit-identical CF path.
- Add ops canaries: `ops/canary_com_tame.env`, `ops/launch_comfloor.sh`, `ops/launch_baseline.sh`, `ops/run_astex85_armA_com_tame.sh` (portable `FLEXAIDDS_ROOT` / script-relative repo resolution).
- Reconcile the `vcfunction.cpp` doc-comment with the `S=5` formula; attach `SCORING_PROVENANCE.json`.

## Verification

| Check | Result |
|-------|--------|
| Softplus math smoke (S=5 vs F-scaled vs unit) | **PASS** — lower bound, monotone, near-identity for healthy com; F-scaled damage demonstrated |
| `cmake --build build --target FlexAIDdS` (Release) | **PASS** |
| `ctest --test-dir build --output-on-failure` | **80/81 PASS** |
| `PoseBustParity.CrystalSelfDockAgreesWithUpstreamBust` | **FAIL (pre-existing / env)** — `mandatory_checks_missing:no_protein_clashes`; COM_FLOOR unset during run; does not exercise this path |
| `bash -n` on new launch scripts | **PASS** |
| `python3 scripts/check_repo_hygiene.py` | **PASS** |

### Math smoke highlights (`F=130`, `S=5`)

| com | S=5 | F-scaled (old) |
|-----|-----|----------------|
| -3000 | -130.0 | -130.0 |
| -100 | -99.99 | -24.0 |
| -50 | -50.0 | +6.2 |
| 0 | 0.0 | +40.7 |

## Formula

```
softfloor(x) = -F + S * softplus((x + F) / S),  S = 5
softplus(z)  = max(z,0) + log1p(exp(-|z|))
```

Env: `FLEXAIDDS_COM_FLOOR=F` (e.g. `130` for campaigns, `500` for Arm-A blow-up canary).

## Test plan

- [x] Softplus unit smoke (python)
- [x] Release rebuild + ctest (document PoseBustParity pre-existing)
- [ ] Optional: short Astex canary with `ops/launch_comfloor.sh` vs `ops/launch_baseline.sh` after merge
- [ ] Confirm CI CF gate / PoseBust job status on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved soft clamping of center-of-mass scoring values for smoother transitions and more predictable lower bounds.
  - Reduced unnecessary compile-time warnings.

- **New Features**
  - Added deterministic benchmark launchers for baseline, center-of-mass-floor, and canary runs.
  - Added configurable runtime settings for reproducible scoring and benchmark execution.

- **Documentation**
  - Added scoring provenance metadata and operational guidance for validating benchmark results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->