### PR TITLE
Fix: CF gate requires --ligand and --config (GATEFIX v2)

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -11,6 +11,13 @@ via the real engine CF path (`vcfunction()` / `score_native_pose()`), computes
 `ΔCF = cf_total(native) − cf_total(decoy)`, and fails if the inverted fraction
 (ΔCF > tol) exceeds MAX_INV_FRAC (default 1/8).
 
+**GATEFIX v2 (mandatory):** every score call must pass production-equivalent
+`--config` (per-target `ops/gates/configs/<PDB>_dock_config.json`) and PDB
+decoys must pass `--ligand` (manifest field 3, crystal SDF). Without `--ligand`,
+PDB poses exit with empty `cf_total` and the gate silently skips. Without
+`--config`, whole-receptor optres inflates CF ~200× (tens of thousands instead of
+tens–low-hundreds) — those absolute numbers are void.
+
 ### Running the gate
 
 ```bash
@@ -19,7 +26,7 @@ cmake --build build --target probe_cf
 
 # Run the gate
 bash ops/gates/cf_gate_probe_cf.sh ops/gates/panel_manifest.tsv
-# Exit 0 = PASS, 1 = FAIL (inverted fraction too high), 2 = no data
+# Exit 0 = PASS, 1 = FAIL (inverted fraction too high), 2 = no data / missing config
 ```
 
 ### CI trigger paths
@@ -38,10 +45,31 @@ data/MC_st0r5.2_6.dat
 
 ### Panel manifest
 
-`ops/gates/panel_manifest.tsv` is tab-separated: `pdb <TAB> receptor.pdb <TAB> native_pose.sdf <TAB> decoy_pose.pdb`
+`ops/gates/panel_manifest.tsv` is tab-separated (5 fields):
+
+```
+pdb <TAB> receptor.pdb <TAB> native_pose.sdf <TAB> decoy_pose.pdb <TAB> dock_config.json
+```
+
+| Field | Role |
+|-------|------|
+| 1 `pdb` | Target ID (label) |
+| 2 `receptor.pdb` | Prepared apo receptor |
+| 3 `native_pose.sdf` | Crystal ligand SDF — scored as native pose **and** used as `--ligand` topology for PDB decoys |
+| 4 `decoy_pose.pdb` | Best-CF non-native pose (`diagnostic/refs/<PDB>/falsemin_armA.pdb`) |
+| 5 `dock_config.json` | Production-equivalent config (`ops/gates/configs/<PDB>_dock_config.json`) passed as `--config` on **both** native and decoy calls |
+
+Paths may be absolute or repo-relative (the gate resolves relative paths against the repo root).
 
 Commented rows (`#`) have no archived decoy yet — populate from the next full
 benchmark run output (`best-CF non-native pose per target`).
+
+### Per-target configs
+
+Canonical gate configs live under `ops/gates/configs/`. They are production
+`dock_config.json` snapshots (scoring / flexibility / normalize_area / hbond knobs)
+with machine paths scrubbed and `ga.seed` pinned to 0 (native-only scoring; seed
+irrelevant). Do not score the gate without them.
 
 ---
 

--- a/ops/gates/cf_gate_probe_cf.sh
+++ b/ops/gates/cf_gate_probe_cf.sh
@@ -5,29 +5,78 @@
 # NATIVE pose and the best DECOY pose, computes ΔCF = cf_total(native) - cf_total(decoy),
 # and FAILS if the inverted fraction (ΔCF>tol) exceeds MAX_INV_FRAC.
 #
+# GATEFIX v2 (ligand + config):
+#   DEFECT 1 — PDB decoys need --ligand (crystal SDF topology) or probe_cf returns
+#              empty cf_total (rc=256) and the gate silently skips the target.
+#   DEFECT 2 — without --config, LOCCLF/optres pocket pruning never applies and CF
+#              is ~200× inflated (whole-receptor optres). Production-equivalent CF
+#              requires per-target dock_config.json on BOTH native and decoy calls.
+#
 # Usage: cf_gate_probe_cf.sh <panel_manifest.tsv> [tol] [max_inv_frac]
-#   manifest rows (tab-sep): pdb <TAB> receptor.pdb <TAB> native_pose.sdf <TAB> decoy_pose.pdb
+#   manifest rows (tab-sep, 5 fields):
+#     pdb <TAB> receptor.pdb <TAB> native_pose.sdf <TAB> decoy_pose.pdb <TAB> dock_config.json
 # Requires: build/probe_cf (built from tools/probe_cf.cpp, commit 81acfed6+).
 set -u
-REPO="/Users/lp.more/Projects/FlexAIDdS"
-PROBE="$REPO/build/probe_cf"
+# Resolve repo root from this script so the gate is portable.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROBE="${FLEXAIDDS_PROBE_CF:-$REPO/build/probe_cf}"
 MANIFEST="${1:?manifest tsv required}"
 TOL="${2:-0.0}"
 MAX_INV_FRAC="${3:-0.125}"
 
 [ -x "$PROBE" ] || { echo "GATE ERROR: $PROBE not built (cmake --build build --target probe_cf)"; exit 2; }
 
-cf() {  # $1=receptor $2=pose  -> echoes cf_total via probe_cf JSON
-  "$PROBE" --receptor "$1" --pose "$2" 2>/dev/null \
+# $1=receptor $2=pose $3=ligand_topology_sdf $4=dock_config.json  -> echoes cf_total
+cf() {
+  local rec="$1" pose="$2" lig="$3" cfg="$4"
+  local -a args=(--receptor "$rec" --pose "$pose")
+  # PDB poses lack Sybyl typing; always supply crystal/topology SDF as --ligand.
+  case "${pose##*.}" in
+    pdb|PDB|ent|ENT)
+      if [ -z "$lig" ] || [ ! -f "$lig" ]; then
+        echo "GATE ERROR: PDB pose requires ligand topology SDF (got: '${lig:-empty}')" >&2
+        return 2
+      fi
+      args+=(--ligand "$lig")
+      ;;
+  esac
+  if [ -z "$cfg" ] || [ ! -f "$cfg" ]; then
+    echo "GATE ERROR: dock_config.json required for production CF (got: '${cfg:-empty}')" >&2
+    return 2
+  fi
+  args+=(--config "$cfg")
+  "$PROBE" "${args[@]}" 2>/dev/null \
     | sed -n 's/.*"cf_total": *\([-0-9.][-0-9.]*\).*/\1/p' | head -1
 }
 
 n=0; inv=0; rows=""
-while IFS=$'\t' read -r pdb rec nat dec; do
+while IFS=$'\t' read -r pdb rec nat dec cfg || [ -n "${pdb:-}" ]; do
   [ -z "${pdb:-}" ] && continue
   case "$pdb" in \#*) continue;; esac
-  cn=$(cf "$rec" "$nat"); cd_=$(cf "$rec" "$dec")
-  [ -z "$cn" ] || [ -z "$cd_" ] && { echo "  skip $pdb (probe_cf gave no cf_total)"; continue; }
+  # 5th field required for active rows (GATEFIX v2 defect 2).
+  if [ -z "${cfg:-}" ]; then
+    echo "GATE ERROR: $pdb missing dock_config.json (5th manifest field)" >&2
+    exit 2
+  fi
+  # Resolve relative paths against REPO (manifest may use absolute or repo-relative).
+  for v in rec nat dec cfg; do
+    eval "p=\$$v"
+    case "$p" in
+      /*) ;;
+      *) eval "$v=\"\$REPO/\$p\"" ;;
+    esac
+  done
+  for p in "$rec" "$nat" "$dec" "$cfg"; do
+    [ -f "$p" ] || { echo "GATE ERROR: $pdb missing file: $p" >&2; exit 2; }
+  done
+
+  cn=$(cf "$rec" "$nat" "$nat" "$cfg") || true
+  cd_=$(cf "$rec" "$dec" "$nat" "$cfg") || true
+  if [ -z "$cn" ] || [ -z "$cd_" ]; then
+    echo "  skip $pdb (probe_cf gave no cf_total)"
+    continue
+  fi
   d=$(echo "$cn - $cd_" | bc -l)
   bad=$(echo "$d > $TOL" | bc -l)
   n=$((n+1)); [ "$bad" = 1 ] && inv=$((inv+1))

--- a/ops/gates/configs/1J3J_dock_config.json
+++ b/ops/gates/configs/1J3J_dock_config.json
@@ -1,0 +1,72 @@
+{
+  "flexibility": {
+    "force_rigid": false,
+    "intramolecular": true,
+    "permeability": 0.9,
+    "soft_wall_cutoff": 0.4,
+    "intermolecular_clash_ratio": 0.75,
+    "receptor_rotamer_prep": true
+  },
+  "optimization": {
+    "grid_spacing": 0.375
+  },
+  "output": {
+    "max_results": 50
+  },
+  "scoring": {
+    "normalize_area": true,
+    "vct_dist_weight_r0": 4,
+    "vct_normalize_contacts": false,
+    "gist_enabled": false,
+    "hbond_enabled": true,
+    "hbond_search_enabled": true,
+    "hbond_rank_enabled": false,
+    "metal_coord_enabled": true,
+    "sas_weight": 1.0,
+    "tencom_weight": 0.0,
+    "vct_entropy_weight": 0
+  },
+  "seeding": {
+    "mif_enabled": true
+  },
+  "reference_ligand": {
+    "file": "",
+    "seed_fraction": 0.0,
+    "pose_seed_enabled": false,
+    "k_nearest": 10,
+    "hetatm_fallback": false
+  },
+  "coarse_init": {
+    "enabled": true,
+    "grid_step": 3.0,
+    "n_seeds": 25,
+    "n_orientations": 64
+  },
+  "thermodynamics": {
+    "temperature": 300,
+    "clustering_algorithm": "CF",
+    "cluster_rmsd": 2.0,
+    "classic_entropy_ranking": true,
+    "force_cf_rank_emission": false
+  },
+  "ga": {
+    "num_chromosomes": 1000,
+    "num_generations": 2000,
+    "crossover_rate": 0.8,
+    "mutation_rate": 0.03,
+    "diversity_monitoring": true,
+    "adaptive": true,
+    "adaptive_k": [
+      0.95,
+      0.1,
+      1.0,
+      0.05
+    ],
+    "sharing_alpha": 4,
+    "boom_inject_interval": 100,
+    "boom_inject_fraction": 0,
+    "n_elite": 1,
+    "fitness_model": "SMFREE",
+    "seed": 0
+  }
+}

--- a/ops/gates/configs/1K3U_dock_config.json
+++ b/ops/gates/configs/1K3U_dock_config.json
@@ -1,0 +1,72 @@
+{
+  "flexibility": {
+    "force_rigid": false,
+    "intramolecular": true,
+    "permeability": 0.9,
+    "soft_wall_cutoff": 0.4,
+    "intermolecular_clash_ratio": 0.75,
+    "receptor_rotamer_prep": true
+  },
+  "optimization": {
+    "grid_spacing": 0.375
+  },
+  "output": {
+    "max_results": 50
+  },
+  "scoring": {
+    "normalize_area": true,
+    "vct_dist_weight_r0": 4,
+    "vct_normalize_contacts": false,
+    "gist_enabled": false,
+    "hbond_enabled": true,
+    "hbond_search_enabled": true,
+    "hbond_rank_enabled": false,
+    "metal_coord_enabled": true,
+    "sas_weight": 1.0,
+    "tencom_weight": 0.0,
+    "vct_entropy_weight": 0
+  },
+  "seeding": {
+    "mif_enabled": true
+  },
+  "reference_ligand": {
+    "file": "",
+    "seed_fraction": 0.0,
+    "pose_seed_enabled": false,
+    "k_nearest": 10,
+    "hetatm_fallback": false
+  },
+  "coarse_init": {
+    "enabled": true,
+    "grid_step": 3.0,
+    "n_seeds": 25,
+    "n_orientations": 64
+  },
+  "thermodynamics": {
+    "temperature": 300,
+    "clustering_algorithm": "CF",
+    "cluster_rmsd": 2.0,
+    "classic_entropy_ranking": true,
+    "force_cf_rank_emission": false
+  },
+  "ga": {
+    "num_chromosomes": 1750,
+    "num_generations": 2000,
+    "crossover_rate": 0.8,
+    "mutation_rate": 0.03,
+    "diversity_monitoring": true,
+    "adaptive": true,
+    "adaptive_k": [
+      0.95,
+      0.1,
+      1.0,
+      0.05
+    ],
+    "sharing_alpha": 2.28571,
+    "boom_inject_interval": 100,
+    "boom_inject_fraction": 0,
+    "n_elite": 1,
+    "fitness_model": "SMFREE",
+    "seed": 0
+  }
+}

--- a/ops/gates/configs/1L7F_dock_config.json
+++ b/ops/gates/configs/1L7F_dock_config.json
@@ -1,0 +1,72 @@
+{
+  "flexibility": {
+    "force_rigid": false,
+    "intramolecular": true,
+    "permeability": 0.9,
+    "soft_wall_cutoff": 0.4,
+    "intermolecular_clash_ratio": 0.75,
+    "receptor_rotamer_prep": true
+  },
+  "optimization": {
+    "grid_spacing": 0.375
+  },
+  "output": {
+    "max_results": 50
+  },
+  "scoring": {
+    "normalize_area": true,
+    "vct_dist_weight_r0": 4,
+    "vct_normalize_contacts": false,
+    "gist_enabled": false,
+    "hbond_enabled": true,
+    "hbond_search_enabled": true,
+    "hbond_rank_enabled": false,
+    "metal_coord_enabled": true,
+    "sas_weight": 1.0,
+    "tencom_weight": 0.0,
+    "vct_entropy_weight": 0
+  },
+  "seeding": {
+    "mif_enabled": true
+  },
+  "reference_ligand": {
+    "file": "",
+    "seed_fraction": 0.0,
+    "pose_seed_enabled": false,
+    "k_nearest": 10,
+    "hetatm_fallback": false
+  },
+  "coarse_init": {
+    "enabled": true,
+    "grid_step": 3.0,
+    "n_seeds": 25,
+    "n_orientations": 64
+  },
+  "thermodynamics": {
+    "temperature": 300,
+    "clustering_algorithm": "CF",
+    "cluster_rmsd": 2.0,
+    "classic_entropy_ranking": true,
+    "force_cf_rank_emission": false
+  },
+  "ga": {
+    "num_chromosomes": 2250,
+    "num_generations": 2000,
+    "crossover_rate": 0.8,
+    "mutation_rate": 0.03,
+    "diversity_monitoring": true,
+    "adaptive": true,
+    "adaptive_k": [
+      0.95,
+      0.1,
+      1.0,
+      0.05
+    ],
+    "sharing_alpha": 1.77778,
+    "boom_inject_interval": 100,
+    "boom_inject_fraction": 0,
+    "n_elite": 1,
+    "fitness_model": "SMFREE",
+    "seed": 0
+  }
+}

--- a/ops/gates/configs/1M2Z_dock_config.json
+++ b/ops/gates/configs/1M2Z_dock_config.json
@@ -1,0 +1,72 @@
+{
+  "flexibility": {
+    "force_rigid": false,
+    "intramolecular": true,
+    "permeability": 0.9,
+    "soft_wall_cutoff": 0.4,
+    "intermolecular_clash_ratio": 0.75,
+    "receptor_rotamer_prep": true
+  },
+  "optimization": {
+    "grid_spacing": 0.375
+  },
+  "output": {
+    "max_results": 50
+  },
+  "scoring": {
+    "normalize_area": true,
+    "vct_dist_weight_r0": 4,
+    "vct_normalize_contacts": false,
+    "gist_enabled": false,
+    "hbond_enabled": true,
+    "hbond_search_enabled": true,
+    "hbond_rank_enabled": false,
+    "metal_coord_enabled": true,
+    "sas_weight": 1.0,
+    "tencom_weight": 0.0,
+    "vct_entropy_weight": 0
+  },
+  "seeding": {
+    "mif_enabled": true
+  },
+  "reference_ligand": {
+    "file": "",
+    "seed_fraction": 0.0,
+    "pose_seed_enabled": false,
+    "k_nearest": 10,
+    "hetatm_fallback": false
+  },
+  "coarse_init": {
+    "enabled": true,
+    "grid_step": 3.0,
+    "n_seeds": 25,
+    "n_orientations": 64
+  },
+  "thermodynamics": {
+    "temperature": 300,
+    "clustering_algorithm": "CF",
+    "cluster_rmsd": 2.0,
+    "classic_entropy_ranking": true,
+    "force_cf_rank_emission": false
+  },
+  "ga": {
+    "num_chromosomes": 1000,
+    "num_generations": 2000,
+    "crossover_rate": 0.8,
+    "mutation_rate": 0.03,
+    "diversity_monitoring": true,
+    "adaptive": true,
+    "adaptive_k": [
+      0.95,
+      0.1,
+      1.0,
+      0.05
+    ],
+    "sharing_alpha": 4,
+    "boom_inject_interval": 100,
+    "boom_inject_fraction": 0,
+    "n_elite": 1,
+    "fitness_model": "SMFREE",
+    "seed": 0
+  }
+}

--- a/ops/gates/configs/1N1M_dock_config.json
+++ b/ops/gates/configs/1N1M_dock_config.json
@@ -1,0 +1,72 @@
+{
+  "flexibility": {
+    "force_rigid": false,
+    "intramolecular": true,
+    "permeability": 0.9,
+    "soft_wall_cutoff": 0.4,
+    "intermolecular_clash_ratio": 0.75,
+    "receptor_rotamer_prep": true
+  },
+  "optimization": {
+    "grid_spacing": 0.375
+  },
+  "output": {
+    "max_results": 50
+  },
+  "scoring": {
+    "normalize_area": true,
+    "vct_dist_weight_r0": 4,
+    "vct_normalize_contacts": false,
+    "gist_enabled": false,
+    "hbond_enabled": true,
+    "hbond_search_enabled": true,
+    "hbond_rank_enabled": false,
+    "metal_coord_enabled": true,
+    "sas_weight": 1.0,
+    "tencom_weight": 0.0,
+    "vct_entropy_weight": 0
+  },
+  "seeding": {
+    "mif_enabled": true
+  },
+  "reference_ligand": {
+    "file": "",
+    "seed_fraction": 0.0,
+    "pose_seed_enabled": false,
+    "k_nearest": 10,
+    "hetatm_fallback": false
+  },
+  "coarse_init": {
+    "enabled": true,
+    "grid_step": 3.0,
+    "n_seeds": 25,
+    "n_orientations": 64
+  },
+  "thermodynamics": {
+    "temperature": 300,
+    "clustering_algorithm": "CF",
+    "cluster_rmsd": 2.0,
+    "classic_entropy_ranking": true,
+    "force_cf_rank_emission": false
+  },
+  "ga": {
+    "num_chromosomes": 1000,
+    "num_generations": 2000,
+    "crossover_rate": 0.8,
+    "mutation_rate": 0.03,
+    "diversity_monitoring": true,
+    "adaptive": true,
+    "adaptive_k": [
+      0.95,
+      0.1,
+      1.0,
+      0.05
+    ],
+    "sharing_alpha": 4,
+    "boom_inject_interval": 100,
+    "boom_inject_fraction": 0,
+    "n_elite": 1,
+    "fitness_model": "SMFREE",
+    "seed": 0
+  }
+}

--- a/ops/gates/panel_manifest.tsv
+++ b/ops/gates/panel_manifest.tsv
@@ -1,24 +1,25 @@
 # CF scoring-regression gate — panel manifest (5 clean probes active; 1G9V dropped — see below)
-# Format (tab-separated): pdb <TAB> receptor.pdb <TAB> native_pose.sdf <TAB> decoy_pose.pdb
+# Format (tab-separated, 5 fields):
+#   pdb <TAB> receptor.pdb <TAB> native_pose.sdf <TAB> decoy_pose.pdb <TAB> dock_config.json
 # Receptor: prepared apo PDB (from astex_diverse/astex_diverse/)
-# Native:   crystal ligand SDF (same source)
+# Native:   crystal ligand SDF (same source) — also used as --ligand topology for PDB decoys
 # Decoy:    best-CF non-native pose from diagnostic/refs/ (falsemin_armA = arm-A false-minimum pose)
+# Config:   production-equivalent dock_config.json (ops/gates/configs/) so LOCCLF/optres
+#           pocket pruning applies; without --config absolute CF is ~200× inflated.
 # Commented rows (#) have no archived decoy; populate from next full benchmark run output.
 #
-# NOTE: paths are absolute to the local repo at /Users/lp.more/Projects/FlexAIDdS.
-#       Update REPO prefix if repo is cloned elsewhere, or switch to relative paths via $REPO.
+# Paths may be absolute or repo-relative (resolved against the repo root by cf_gate_probe_cf.sh).
 #
-# pdb	receptor.pdb	native_pose.sdf	decoy_pose.pdb
+# pdb	receptor.pdb	native_pose.sdf	decoy_pose.pdb	dock_config.json
 # 1G9V DROPPED from the scoring gate (2026-07-24): its apo receptor still has 172 un-stripped
-#   HEM atoms 11.2A from the ligand (prep bug) -> probe_cf returns non-physical cf_total=-6165
-#   (com=-15196) vs validated native -49.6, which would mis-fire the gate. 1G9V is also a
-#   search-dominant chain-control (near-native basin sampled at freq=1, only 3.17A), not a clean
-#   scoring probe. The 5 clean probes below (1J3J 1K3U 1L7F 1N1M 1M2Z) are sufficient.
-# 1G9V	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1G9V/1G9V_apo.pdb	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1G9V/1G9V_ligand.sdf	/Users/lp.more/Projects/FlexAIDdS/diagnostic/refs/1G9V/falsemin_armA.pdb
-1J3J	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1J3J/1J3J_apo.pdb	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1J3J/1J3J_ligand.sdf	/Users/lp.more/Projects/FlexAIDdS/diagnostic/refs/1J3J/falsemin_armA.pdb
-1K3U	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1K3U/1K3U_apo.pdb	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1K3U/1K3U_ligand.sdf	/Users/lp.more/Projects/FlexAIDdS/diagnostic/refs/1K3U/falsemin_armA.pdb
-1L7F	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1L7F/1L7F_apo.pdb	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1L7F/1L7F_ligand.sdf	/Users/lp.more/Projects/FlexAIDdS/diagnostic/refs/1L7F/falsemin_armA.pdb
-1N1M	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N1M/1N1M_apo.pdb	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1N1M/1N1M_ligand.sdf	/Users/lp.more/Projects/FlexAIDdS/diagnostic/refs/1N1M/falsemin_armA.pdb
-1M2Z	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1M2Z/1M2Z_apo.pdb	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1M2Z/1M2Z_ligand.sdf	/Users/lp.more/Projects/FlexAIDdS/diagnostic/refs/1M2Z/falsemin_armA.pdb
-# 1LPZ	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1LPZ/1LPZ_apo.pdb	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/1LPZ/1LPZ_ligand.sdf	PLACEHOLDER_no_archived_decoy__populate_from_benchmark_run
-# 2GBP	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2GBP/2GBP_apo.pdb	/Users/lp.more/Projects/FlexAIDdS/benchmarks/astex_diverse/astex_diverse/2GBP/2GBP_ligand.sdf	PLACEHOLDER_no_archived_decoy__populate_from_benchmark_run
+#   HEM atoms 11.2A from the ligand (prep bug) -> probe_cf returns non-physical cf_total without
+#   proper pocket setup. 1G9V is also a search-dominant chain-control, not a clean scoring probe.
+#   The 5 clean probes below (1J3J 1K3U 1L7F 1N1M 1M2Z) are sufficient.
+# 1G9V	benchmarks/astex_diverse/astex_diverse/1G9V/1G9V_apo.pdb	benchmarks/astex_diverse/astex_diverse/1G9V/1G9V_ligand.sdf	diagnostic/refs/1G9V/falsemin_armA.pdb	ops/gates/configs/1G9V_dock_config.json
+1J3J	benchmarks/astex_diverse/astex_diverse/1J3J/1J3J_apo.pdb	benchmarks/astex_diverse/astex_diverse/1J3J/1J3J_ligand.sdf	diagnostic/refs/1J3J/falsemin_armA.pdb	ops/gates/configs/1J3J_dock_config.json
+1K3U	benchmarks/astex_diverse/astex_diverse/1K3U/1K3U_apo.pdb	benchmarks/astex_diverse/astex_diverse/1K3U/1K3U_ligand.sdf	diagnostic/refs/1K3U/falsemin_armA.pdb	ops/gates/configs/1K3U_dock_config.json
+1L7F	benchmarks/astex_diverse/astex_diverse/1L7F/1L7F_apo.pdb	benchmarks/astex_diverse/astex_diverse/1L7F/1L7F_ligand.sdf	diagnostic/refs/1L7F/falsemin_armA.pdb	ops/gates/configs/1L7F_dock_config.json
+1N1M	benchmarks/astex_diverse/astex_diverse/1N1M/1N1M_apo.pdb	benchmarks/astex_diverse/astex_diverse/1N1M/1N1M_ligand.sdf	diagnostic/refs/1N1M/falsemin_armA.pdb	ops/gates/configs/1N1M_dock_config.json
+1M2Z	benchmarks/astex_diverse/astex_diverse/1M2Z/1M2Z_apo.pdb	benchmarks/astex_diverse/astex_diverse/1M2Z/1M2Z_ligand.sdf	diagnostic/refs/1M2Z/falsemin_armA.pdb	ops/gates/configs/1M2Z_dock_config.json
+# 1LPZ	benchmarks/astex_diverse/astex_diverse/1LPZ/1LPZ_apo.pdb	benchmarks/astex_diverse/astex_diverse/1LPZ/1LPZ_ligand.sdf	PLACEHOLDER_no_archived_decoy__populate_from_benchmark_run	ops/gates/configs/1LPZ_dock_config.json
+# 2GBP	benchmarks/astex_diverse/astex_diverse/2GBP/2GBP_apo.pdb	benchmarks/astex_diverse/astex_diverse/2GBP/2GBP_ligand.sdf	PLACEHOLDER_no_archived_decoy__populate_from_benchmark_run	ops/gates/configs/2GBP_dock_config.json


### PR DESCRIPTION
## Summary

Makes the CF scoring-regression merge gate measure **production-equivalent** CF instead of a silent no-op / ~200× inflated artifact.

Two independent defects in the prior gate driver (both proven on this box):

1. **PDB decoys without `--ligand`** — `probe_cf` exits with empty `cf_total` (rc=256); the driver skips the target. All panel decoys are PDBs → the gate could never fail a regressed scorer.
2. **No `--config`** — LOCCLF/optres pocket pruning never applies; whole-receptor CF is ~200× inflated. Same class of artifact as settled fact #10 in the workorders ledger (`normalize_area` / production config).

### Changes
- `ops/gates/cf_gate_probe_cf.sh` — pass `--ligand` for PDB poses (topology = crystal SDF) and require `--config` on every score call.
- `ops/gates/panel_manifest.tsv` — 5th column `dock_config.json`; **relative** repo paths (portable).
- `ops/gates/configs/*_dock_config.json` — production-equivalent configs for the five clean panel targets (1J3J, 1K3U, 1L7F, 1N1M, 1M2Z). 1G9V remains dropped (HEM-bearing apo / search-dominant, not a clean scoring probe).
- `ops/README.md` — documents the mandatory GATEFIX v2 protocol.

No engine / scoring source changes. Default docking paths untouched.

## Test plan
- [x] Path resolution: all five active manifest rows resolve to existing receptor / native SDF / decoy PDB / config files locally.
- [x] Static review: script requires config file; PDB branch requires ligand topology SDF.
- [ ] Full `bash ops/gates/cf_gate_probe_cf.sh ops/gates/panel_manifest.tsv` after the live autonomous baseline finishes (do **not** rebuild shared `build/` or run multi-target `probe_cf` while `v_autonomous_20260724_160919` is using `build/FlexAIDdS`).
- [ ] Confirm gate fails loudly (exit 2) if the 5th column or decoy PDB is missing, instead of skipping.

## Notes for reviewers
- Panel decoys live under `diagnostic/refs/<PDB>/falsemin_armA.pdb` (local panel fixtures; same dependency as the previous absolute-path manifest on `main`).
- This PR is **methodology**, not an accuracy claim. It stops the merge gate from reporting false “no inversion” under un-normalized CF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production-equivalent docking configurations for five scoring-gate targets.
  * Updated CF regression checks to use per-target configurations and ligand topology data for more accurate native and decoy scoring.
  * Added validation for required manifest inputs and clearer handling of missing or unusable scoring results.

* **Documentation**
  * Documented the new five-field manifest format, configuration requirements, path resolution, and exit-code behavior.
  * Clarified that missing configuration or ligand data can invalidate CF results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->