### PR TITLE
Fix: make PoseBusters claim-backend degradation loud; pin bust CLI in env

### DIFF
--- a/.grok/skills/flexaidds/scripts/resolve_build.py
+++ b/.grok/skills/flexaidds/scripts/resolve_build.py
@@ -296,11 +296,48 @@ def export_shell(resolution: BuildResolution) -> str:
         f"export FLEXAIDDS_RUNNER_SHA256={_shell_quote(resolution.runner_sha256)}",
         f"export PATH={_shell_quote(build + os.pathsep + os.environ.get('PATH', ''))}",
     ]
+    bust = resolve_posebusters_bin(build)
+    if bust:
+        lines.insert(-1, f"export FLEXAIDDS_POSEBUSTERS_BIN={_shell_quote(bust)}")
     return "\n".join(lines)
 
 
 def _shell_quote(value: str) -> str:
     return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def resolve_posebusters_bin(build_dir: str) -> str | None:
+    """Locate the upstream PoseBusters `bust` CLI.
+
+    claim_ready requires pb_backend == "bust_cli"; when `bust` cannot be found
+    the engine falls back to the in-house NativePoseQC suite and claim_ready
+    becomes unreachable. Exporting the resolved path here keeps runners from
+    depending on whichever PATH the launcher happened to inherit.
+
+    Mirrors the C++ lookup order in LIB/PoseBust/BustCli.cpp:resolve_bust_binary.
+    """
+    env = os.environ.get("FLEXAIDDS_POSEBUSTERS_BIN", "").strip()
+    if env and os.access(env, os.X_OK):
+        return env
+
+    found = shutil.which("bust")
+    if found:
+        return found
+
+    # The repo-local venv is the conventional install site for this project.
+    candidates = []
+    root = os.environ.get("FLEXAIDDS_ROOT", "").strip()
+    if root:
+        candidates.append(Path(root) / ".venv-posebusters" / "bin" / "bust")
+    # build_dir is normally <repo>/build; walk up to the repo root.
+    build_path = Path(build_dir)
+    for parent in (build_path.parent, build_path.parent.parent):
+        candidates.append(parent / ".venv-posebusters" / "bin" / "bust")
+
+    for cand in candidates:
+        if cand.is_file() and os.access(cand, os.X_OK):
+            return str(cand)
+    return None
 
 
 def _parse_env_value(text: str, key: str) -> str | None:
@@ -353,6 +390,13 @@ def sync_flexaidds_env(resolution: BuildResolution) -> Path:
         f"export FLEXAIDDS_ENGINE_SHA256={_shell_quote(resolution.engine_sha256)}",
         f"export FLEXAIDDS_RUNNER_SHA256={_shell_quote(resolution.runner_sha256)}",
         f"export FLEXAIDDS_RESULTS={_shell_quote(results)}",
+        # claim_ready needs pb_backend == bust_cli; pin the CLI so campaigns do
+        # not silently degrade to NativePoseQC when PATH lacks it.
+        *(
+            [f"export FLEXAIDDS_POSEBUSTERS_BIN={_shell_quote(bust)}"]
+            if (bust := resolve_posebusters_bin(resolution.build_dir))
+            else []
+        ),
         # Quote only the build dir; leave :$PATH unquoted so the shell expands PATH.
         # Quoting '…:$PATH' freezes the literal string and wipes /usr/bin from PATH.
         f"export PATH={_shell_quote(resolution.build_dir)}:$PATH",

--- a/LIB/PoseBust/Engine.cpp
+++ b/LIB/PoseBust/Engine.cpp
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <limits>
 #include <sstream>
 #include <string>
@@ -438,6 +439,43 @@ bool write_report_json(const PoseBustReport& report, const std::string& path,
     return true;
 }
 
+/// Opt-in strict mode: treat a missing/failed upstream `bust` CLI as a hard
+/// error instead of silently degrading to NativePoseQC. Campaigns that intend
+/// to produce claim_ready rows should set this, because claim_ready requires
+/// pb_backend == "bust_cli" and is otherwise unreachable.
+bool require_bust_cli_from_env() {
+    const char* v = std::getenv("FLEXAIDDS_POSEBUSTERS_REQUIRE_CLI");
+    return v && v[0] && std::string_view(v) != "0";
+}
+
+/// The claim gate degrading is a provenance event, not a routine log line.
+/// Emit it as an unmissable banner so it cannot be read past mid-line the way
+/// the buried `bust_missing:` key was.
+void warn_bust_unavailable(const std::string& stem, const std::string& err,
+                           bool strict) {
+    std::cerr
+        << "\n"
+        << "  ******************************************************************\n"
+        << "  * [POSEBUSTERS] " << (strict ? "ERROR" : "WARNING")
+        << ": upstream `bust` CLI UNAVAILABLE\n"
+        << "  *   target      : " << stem << "\n"
+        << "  *   reason      : " << (err.empty() ? "not found" : err) << "\n";
+    if (strict) {
+        std::cerr
+            << "  *   effect      : pb_ran=0 pb_pass=0 (fail-closed, strict mode)\n";
+    } else {
+        std::cerr
+            << "  *   effect      : fell back to NativePoseQC.\n"
+            << "  *                 pb_pass here is the in-house reimplementation,\n"
+            << "  *                 NOT upstream PoseBusters. claim_ready is\n"
+            << "  *                 UNREACHABLE for this run (needs bust_cli).\n";
+    }
+    std::cerr
+        << "  *   fix         : export FLEXAIDDS_POSEBUSTERS_BIN=/abs/path/to/bust\n"
+        << "  *                 (or put `bust` on PATH before launching)\n"
+        << "  ******************************************************************\n\n";
+}
+
 Backend resolve_backend_from_env() {
     if (const char* v = std::getenv("FLEXAIDDS_POSEBUST")) {
         if (std::string_view(v) == "0") return Backend::Off;
@@ -595,13 +633,30 @@ ElectedPoseBustOutcome validate_elected_pose(
         // Official upstream PoseBusters CLI (default claim backend).
         auto br = run_upstream_bust(pred_sdf, receptor_path, crystal_sdf, pb_dir,
                                     stem);
-        if ((!br.ran || br.backend == "bust_cli_missing") &&
-            opt.native_fallback_if_bust_missing) {
+        const bool bust_unavailable =
+            (!br.ran || br.backend == "bust_cli_missing");
+        if (bust_unavailable && require_bust_cli_from_env()) {
+            // Strict mode: refuse to silently degrade the claim gate. The
+            // native suite still ran above as a diagnostic, but pb_* stays
+            // fail-closed so no downstream table can mistake this for a
+            // chemistry verdict.
+            out.pb_backend = "bust_cli_missing";
+            out.pb_ran = false;
+            out.pb_pass = false;
+            out.pb_failed_keys =
+                "bust_missing:" + (br.error.empty() ? std::string("bust CLI unavailable")
+                                                    : br.error);
+            out.error = out.pb_failed_keys;
+            warn_bust_unavailable(stem, br.error, /*strict=*/true);
+            return out;
+        }
+        if (bust_unavailable && opt.native_fallback_if_bust_missing) {
             fill_from_native("native_pose_qc_fallback");
             if (!br.error.empty()) {
                 if (!out.pb_failed_keys.empty()) out.pb_failed_keys += ';';
                 out.pb_failed_keys += "bust_missing:" + br.error;
             }
+            warn_bust_unavailable(stem, br.error, /*strict=*/false);
         } else {
             out.pb_ran = br.ran;
             out.pb_pass = br.pb_pass;


### PR DESCRIPTION
## Why

Every row of the G4.2 pilot (and its Phase-4 predecessors) recorded `pb_backend=native_pose_qc_fallback` — the upstream `bust` CLI was never found, so the engine silently degraded to the in-house NativePoseQC suite.

`claim_ready` requires `pb_backend == "bust_cli"` (`DatasetRunner.cpp:7651`, `scripts/aggregate_claim_metrics.py:280`). So **`claim_ready` was structurally unreachable**, and every `claim_ready=0` / `pb_pass=0` in those runs reflected a missing binary rather than pose chemistry. Five pilots were read as chemistry nulls on that basis.

The condition *was* reported — as a `bust_missing:` token buried mid-line inside the `failed=[...]` field (`armA.log:86`), which never reached the summary CSV. It was logged unreadably.

Root cause is not only `PATH`. The staged pilot runner (`fb5b1a69`) predates the CMake `find_program` bake that the current build (`c8fe725f`) carries, so all five lookups in `resolve_bust_binary()` missed at once.

## What changed

- **`LIB/PoseBust/Engine.cpp`** — emit an unmissable banner whenever the claim backend degrades, naming target, reason, effect on `claim_ready`, and the fix.
- **`LIB/PoseBust/Engine.cpp`** — opt-in `FLEXAIDDS_POSEBUSTERS_REQUIRE_CLI=1` strict mode that fails closed (`pb_ran=0`, `pb_pass=0`, `backend=bust_cli_missing`) instead of degrading. **Default behaviour is unchanged.**
- **`.grok/skills/flexaidds/scripts/resolve_build.py`** — resolve and export `FLEXAIDDS_POSEBUSTERS_BIN` into `~/.flexaidds_env`, mirroring the C++ lookup order, so runners stop depending on the launcher's `PATH`.

## Verification

Built `FlexAIDdS` clean (`BUILD_RC=0`). Exercised against the **real 1L7F elected pose from the G4.2 pilot**:

| Scenario | Result |
|---|---|
| bust absent, default | `native_pose_qc_fallback`, 26/27, banner shown — reproduces the original pilot row exactly |
| bust absent, strict | `bust_cli_missing`, `pb_ran=0`, fail-closed |
| bust present via env | `bust_cli` — resolution works, no fallback |

Python resolver returns the venv path for the main repo and `None` where no venv exists (degrades to PATH/bake, as intended).

## Known remaining blocker — NOT fixed here

With `bust` correctly wired, parsing still fails: `mandatory_checks_missing:no_protein_clashes`.

`no_protein_clashes` is in the version pin at `BustCli.cpp:73`, but **PoseBusters 0.6.5 does not emit that column**. Upstream's check id is `no_clashes`, surfaced as the CSV column `minimum_distance_to_protein` — which the pin already lists separately at line 72. Verified against the installed `posebusters/config/dock.yml` and the actual CSV header.

So this PR alone does **not** unblock `claim_ready`. That pin is commented "Extend only with deliberate pin bumps" and correcting a claim-gate is a science decision, so I've left it for operator review rather than changing it unilaterally.

## Related finding (separate, no change proposed)

Running upstream `bust 0.6.5` on the pilot's elected poses disagrees with the native suite on 1L7F: native fails `aromatic_ring_flatness` (OOP 0.285 Å vs 0.25), upstream passes **all 22 checks**. On 1N1M both agree the pose clashes. The native ring-perception folds sp2-but-non-aromatic rings into the aromatic-flatness check; upstream keeps those as two separate checks. Worth a follow-up audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically detects and uses the PoseBusters command-line tool when available.
  - Searches configured environments, system paths, and local virtual environments for the executable.

- **Bug Fixes**
  - Added clearer handling when PoseBusters is unavailable.
  - Optional strict mode now stops processing with an explicit error instead of silently continuing.
  - Non-strict mode preserves existing quality checks and displays a prominent warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->