### PR TITLE
Fix: unblock CI on main — 4 stacked pre-existing failures

### DIFF
--- a/benchmarks/datasets/competition_example.yaml
+++ b/benchmarks/datasets/competition_example.yaml
@@ -28,6 +28,8 @@
 # See also: benchmarks/itc187.yaml (single-ligand thermo), erds_specificity.yaml
 # (Z-score specificity), BENCHMARK_STANDARD.md (add grand section), GPF report.
 
+docking_mode: specialized  # validated by validate_dataset_semantics.py
+
 slug: competition_example
 name: "Grand Canonical Competition / Selectivity Examples"
 description: >

--- a/build_sources.ignore
+++ b/build_sources.ignore
@@ -148,3 +148,22 @@ LIB/native_score.h
 LIB/receptor_prep.h
 LIB/ensemble_pipeline.h
 LIB/shell_exec.h
+
+# Orphans silenced 2026-07-31 to unblock CI on main (see PR "unblock main CI").
+# Same rationale as the block above: headers included transitively or via
+# specific targets only. No build output changes from listing these.
+LIB/ClusterRepMode.h
+LIB/PoseBust/PdbCoords.h
+LIB/ProtocolConfig.h
+LIB/RunReceipt.h
+LIB/ThermoWhiteboard.h
+LIB/cmaes_search.h
+LIB/memetic_gate.h
+LIB/new_search_arch.h
+LIB/niche_distance.h
+src/backends/webgpu/webgpu_eval.h
+
+# Stand-alone Metal microbenchmark tool, never wired into a build target since
+# it landed in 69aa0fab. Listed rather than wired so this CI unblock changes
+# zero build output; wiring it up is a separate, deliberate call.
+tools/metal_microbench_enhanced.cpp

--- a/build_sources.ignore
+++ b/build_sources.ignore
@@ -162,8 +162,3 @@ LIB/memetic_gate.h
 LIB/new_search_arch.h
 LIB/niche_distance.h
 src/backends/webgpu/webgpu_eval.h
-
-# Stand-alone Metal microbenchmark tool, never wired into a build target since
-# it landed in 69aa0fab. Listed rather than wired so this CI unblock changes
-# zero build output; wiring it up is a separate, deliberate call.
-tools/metal_microbench_enhanced.cpp

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1665,11 +1665,11 @@ class DatasetRunner:
                     try:
                         from ..grand_canonical import compute_grand_partition
                         g = compute_grand_partition([(target_id, logz, conc)], temperature_K=298.0)
-                        p_bind = g.binding_probability(target_id) if hasattr(g, 'binding_probability') else (math.exp(logz + math.log(conc)) / math.exp(g.log_Xi) if conc > 0 else 0)
+                        p_bind = g.binding_probability(target_id) if hasattr(g, 'binding_probability') else (math.exp(logz + math.log(conc)) / math.exp(g.log_Xi()) if conc > 0 else 0)
                         grand_summary[target_id] = {
                             'log_Z': logz,
                             'conc_M': conc,
-                            'log_Xi': g.log_Xi,
+                            'log_Xi': g.log_Xi(),
                             'p_bind': p_bind,
                         }
                     except Exception as e:

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1614,7 +1614,7 @@ class DatasetRunner:
                     try:
                         from ..grand_canonical import compute_grand_partition
                         g = compute_grand_partition([(target_id, tr.grand_log_Z, tr.conc_M)], temperature_K=298.0)
-                        tr.grand_xi = g.log_Xi
+                        tr.grand_xi = g.log_Xi()
                     except Exception as e:
                         logger.debug("P3 grand compute: %s", e)
                 try:

--- a/python/tests/test_dataset_runner.py
+++ b/python/tests/test_dataset_runner.py
@@ -199,3 +199,42 @@ def test_log_Xi_is_a_method_not_a_property():
     assert not isinstance(attr, property), "log_Xi became a property — audit all call sites"
     assert callable(g.log_Xi)
     assert isinstance(g.log_Xi(), float)
+
+
+def test_no_bare_log_Xi_attribute_in_production_runner():
+    """Source-bound guard: every production `log_Xi` must be a CALL.
+
+    Codex's point on the two tests above: both still pass if runner.py:1617 is
+    reverted to `tr.grand_xi = g.log_Xi`, so they document the contract but do
+    not lock the bug. This one fails on exactly that regression.
+
+    AST rather than grep: `.log_Xi` inside a string or comment should not trip
+    it, and `g.log_Xi()` must be distinguished from `g.log_Xi` structurally,
+    which a regex cannot do reliably.
+    """
+    import ast
+    import pathlib
+
+    import flexaidds.dataset_runner.runner as runner_mod
+
+    src_path = pathlib.Path(runner_mod.__file__)
+    tree = ast.parse(src_path.read_text())
+
+    called = {
+        id(node.func)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+    bare = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and node.attr == "log_Xi"
+        and id(node) not in called
+    ]
+    assert not bare, (
+        f"bare `.log_Xi` attribute access (missing parens) at "
+        f"{src_path.name} line(s) {bare} — log_Xi is a method, so this assigns "
+        f"a bound method that fails to JSON-serialize, quietly, inside an "
+        f"except-and-debug-log block"
+    )

--- a/python/tests/test_dataset_runner.py
+++ b/python/tests/test_dataset_runner.py
@@ -160,3 +160,42 @@ def test_dry_run_default_all_metrics_still_strips_docking_power(tmp_path):
     assert dr.dry_run is True
     assert not any(k.startswith("docking_power_") for k in dr.metrics)
     assert not any(k.startswith("docking_power_") for k in dr.ci_95)
+
+
+# ── grand_xi serialization regression (PR #311, Codex review) ────────────────
+#
+# tr.grand_xi = g.log_Xi (bare, no parens) assigned a BOUND METHOD, which then
+# failed to JSON-serialize in _save_target_result. That path is wrapped in
+# `except Exception: logger.debug`, so it failed *quietly* — no red CI, no
+# raised error, just a silently missing number. The full suite did not catch
+# it; Grok found it by reading. These tests lock that path.
+
+def test_grand_xi_serializes_as_number_through_save_path(tmp_path):
+    """The exact quiet-failure path: grand_xi must reach JSON as a number."""
+    import json
+    from flexaidds.grand_canonical import compute_grand_partition
+
+    g = compute_grand_partition([("lig1", -12.5, 1e-6)], temperature_K=298.0)
+
+    # Computed exactly as dataset_runner does at the production call site.
+    grand_xi = g.log_Xi()
+
+    payload = {"target_id": "lig1", "grand_xi": grand_xi}
+    text = json.dumps(payload)  # would raise TypeError on a bound method
+    assert isinstance(json.loads(text)["grand_xi"], (int, float))
+
+
+def test_log_Xi_is_a_method_not_a_property():
+    """Pins the upstream contract the bug depended on.
+
+    If GrandPartitionFunction.log_Xi ever becomes a @property, bare-attribute
+    access starts being correct and this test flips — which is the signal to
+    revisit every `log_Xi()` call site rather than discovering it in a receipt.
+    """
+    from flexaidds.grand_canonical import compute_grand_partition
+
+    g = compute_grand_partition([("lig1", -12.5, 1e-6)], temperature_K=298.0)
+    attr = type(g).__dict__.get("log_Xi")
+    assert not isinstance(attr, property), "log_Xi became a property — audit all call sites"
+    assert callable(g.log_Xi)
+    assert isinstance(g.log_Xi(), float)

--- a/python/tests/test_visualization.py
+++ b/python/tests/test_visualization.py
@@ -193,11 +193,14 @@ class TestLoadPopulation:
 
             # 3 modes × 1 file each = 3 load calls
             assert mock_cmd.load.call_count == 3
-            # First mode gets red, second blue, third red (wraps)
+            # First mode gets red, second blue, third red (wraps).
+            # Object naming is `{prefix}_mode{id}_pose{rank}` since 2fb4eb76
+            # ("mode identity"), which changed load_population but left these
+            # assertions on the old `mode_NN_NNN` form.
             color_calls = mock_cmd.color.call_args_list
-            assert color_calls[0] == call("red", "mode_01_000")
-            assert color_calls[1] == call("blue", "mode_02_000")
-            assert color_calls[2] == call("red", "mode_03_000")
+            assert color_calls[0] == call("red", "flexaids_mode1_pose1")
+            assert color_calls[1] == call("blue", "flexaids_mode2_pose1")
+            assert color_calls[2] == call("red", "flexaids_mode3_pose1")
         finally:
             viz._PYMOL_AVAILABLE = original_available
             if original_cmd is not None:

--- a/tools/metal_microbench_enhanced.cpp
+++ b/tools/metal_microbench_enhanced.cpp
@@ -1,1 +1,0 @@
-// Updated benchmark with fleet reporting


### PR DESCRIPTION
## Why

`main` at `11ce273c` was red on its own. **No PR in this repo could prove itself in CI** until this lands — including #310 and #312.

**Four** *independent* pre-existing failures, each only visible after the previous one cleared. All four reproduced on `main@11ce273c` before anything was changed here.

| # | Failure | Root cause | When found |
|---|---|---|---|
| 1 | C++ core, all 5 linux variants | `ValidateSources.cmake` orphan guard — 11 orphans | first look |
| 2 | Hygiene / Python / skill / macOS | `competition_example.yaml` missing `docking_mode` | first look |
| 3 | DatasetRunner dry-run | `grand_summary` serialized a bound method → JSON `TypeError` | after #2 cleared |
| 4 | Pure Python results tests | `test_palette_cycles` asserted naming that `2fb4eb76` changed | after CI ran with #1–3 fixed |

## Fixes

**1 — orphan guard.** Listed the 10 orphaned headers in `build_sources.ignore`, the convention that file already establishes. **Zero build output changes**, deliberately: scoring work is mid-flight against the current binary and the build surface must not move underneath it.

**2 — `docking_mode: specialized`.** `competition_example.yaml` is grand-canonical PREP data, declares no crossdock metrics, and `specialized` is what the other six non-docking datasets in this tree use.

**3 — `log_Xi` call parens.** `grand_canonical.GrandPartition.log_Xi` is a plain method, not a `@property`. `runner.py` used `g.log_Xi` bare twice on one line. Fully masked by #2.

**4 — stale `test_palette_cycles` assertions.** `2fb4eb76` ("mode identity") changed `load_population` to emit `{prefix}_mode{id}_pose{rank}` and left the test on the old `mode_NN_NNN` form. Palette behaviour (red, blue, red) was already correct; only the object-name form drifted.

**5 — deleted `tools/metal_microbench_enhanced.cpp`.** 41 bytes, one comment, no code, never wired into a build target since `69aa0fab`. Deleted per review rather than entrenched in the ignore list.

## Verification

```
scripts/validate_sources.py --strict   →  clean, 449 files, no orphans
validate_dataset_semantics.py          →  PASSED, both trees
pytest (exact CI hygiene selection)    →  32 passed, 2 skipped
pytest (exact CI pure-Python selection)→  629 passed, 2 skipped
```

The full `pytest tests/` sweep hits a **pre-existing** collection error (`tests/p0_claim_contract/test_fixed_denominator.py` calls `sys.exit()` at import). Not touched here, and it is why CI runs an explicit file list.

## Reviewers

Codex (correctness) and Grok (paper-over lens) — fix #4 changes a test assertion to match implementation, which is the hunk that most deserves attack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)