### PR TITLE
Track scoring-locked dock configs (1OQ5/1SQ5/1YGC)

### DIFF
--- a/ops/gates/configs/1OQ5_dock_config.json
+++ b/ops/gates/configs/1OQ5_dock_config.json
@@ -1,0 +1,72 @@
+{
+  "flexibility": {
+    "force_rigid": false,
+    "intramolecular": true,
+    "permeability": 0.9,
+    "soft_wall_cutoff": 0.4,
+    "intermolecular_clash_ratio": 0.75,
+    "receptor_rotamer_prep": true
+  },
+  "optimization": {
+    "grid_spacing": 0.375
+  },
+  "output": {
+    "max_results": 50
+  },
+  "scoring": {
+    "normalize_area": true,
+    "vct_dist_weight_r0": 4,
+    "vct_normalize_contacts": false,
+    "gist_enabled": false,
+    "hbond_enabled": true,
+    "hbond_search_enabled": true,
+    "hbond_rank_enabled": false,
+    "metal_coord_enabled": true,
+    "sas_weight": 1.0,
+    "tencom_weight": 0.0,
+    "vct_entropy_weight": 0
+  },
+  "seeding": {
+    "mif_enabled": true
+  },
+  "reference_ligand": {
+    "file": "",
+    "seed_fraction": 0.0,
+    "pose_seed_enabled": false,
+    "k_nearest": 10,
+    "hetatm_fallback": false
+  },
+  "coarse_init": {
+    "enabled": true,
+    "grid_step": 3.0,
+    "n_seeds": 25,
+    "n_orientations": 64
+  },
+  "thermodynamics": {
+    "temperature": 300,
+    "clustering_algorithm": "CF",
+    "cluster_rmsd": 2.0,
+    "classic_entropy_ranking": true,
+    "force_cf_rank_emission": false
+  },
+  "ga": {
+    "num_chromosomes": 1000,
+    "num_generations": 2000,
+    "crossover_rate": 0.8,
+    "mutation_rate": 0.03,
+    "diversity_monitoring": true,
+    "adaptive": true,
+    "adaptive_k": [
+      0.95,
+      0.1,
+      1.0,
+      0.05
+    ],
+    "sharing_alpha": 4,
+    "boom_inject_interval": 100,
+    "boom_inject_fraction": 0,
+    "n_elite": 1,
+    "fitness_model": "SMFREE",
+    "seed": 0
+  }
+}

--- a/ops/gates/configs/1SQ5_dock_config.json
+++ b/ops/gates/configs/1SQ5_dock_config.json
@@ -1,0 +1,72 @@
+{
+  "flexibility": {
+    "force_rigid": false,
+    "intramolecular": true,
+    "permeability": 0.9,
+    "soft_wall_cutoff": 0.4,
+    "intermolecular_clash_ratio": 0.75,
+    "receptor_rotamer_prep": true
+  },
+  "optimization": {
+    "grid_spacing": 0.375
+  },
+  "output": {
+    "max_results": 50
+  },
+  "scoring": {
+    "normalize_area": true,
+    "vct_dist_weight_r0": 4,
+    "vct_normalize_contacts": false,
+    "gist_enabled": false,
+    "hbond_enabled": true,
+    "hbond_search_enabled": true,
+    "hbond_rank_enabled": false,
+    "metal_coord_enabled": true,
+    "sas_weight": 1.0,
+    "tencom_weight": 0.0,
+    "vct_entropy_weight": 0
+  },
+  "seeding": {
+    "mif_enabled": true
+  },
+  "reference_ligand": {
+    "file": "",
+    "seed_fraction": 0.0,
+    "pose_seed_enabled": false,
+    "k_nearest": 10,
+    "hetatm_fallback": false
+  },
+  "coarse_init": {
+    "enabled": true,
+    "grid_step": 3.0,
+    "n_seeds": 25,
+    "n_orientations": 64
+  },
+  "thermodynamics": {
+    "temperature": 300,
+    "clustering_algorithm": "CF",
+    "cluster_rmsd": 2.0,
+    "classic_entropy_ranking": true,
+    "force_cf_rank_emission": false
+  },
+  "ga": {
+    "num_chromosomes": 1000,
+    "num_generations": 2000,
+    "crossover_rate": 0.8,
+    "mutation_rate": 0.03,
+    "diversity_monitoring": true,
+    "adaptive": true,
+    "adaptive_k": [
+      0.95,
+      0.1,
+      1.0,
+      0.05
+    ],
+    "sharing_alpha": 4,
+    "boom_inject_interval": 100,
+    "boom_inject_fraction": 0,
+    "n_elite": 1,
+    "fitness_model": "SMFREE",
+    "seed": 0
+  }
+}

--- a/ops/gates/configs/1YGC_dock_config.json
+++ b/ops/gates/configs/1YGC_dock_config.json
@@ -1,0 +1,72 @@
+{
+  "flexibility": {
+    "force_rigid": false,
+    "intramolecular": true,
+    "permeability": 0.9,
+    "soft_wall_cutoff": 0.4,
+    "intermolecular_clash_ratio": 0.75,
+    "receptor_rotamer_prep": true
+  },
+  "optimization": {
+    "grid_spacing": 0.375
+  },
+  "output": {
+    "max_results": 50
+  },
+  "scoring": {
+    "normalize_area": true,
+    "vct_dist_weight_r0": 4,
+    "vct_normalize_contacts": false,
+    "gist_enabled": false,
+    "hbond_enabled": true,
+    "hbond_search_enabled": true,
+    "hbond_rank_enabled": false,
+    "metal_coord_enabled": true,
+    "sas_weight": 1.0,
+    "tencom_weight": 0.0,
+    "vct_entropy_weight": 0
+  },
+  "seeding": {
+    "mif_enabled": true
+  },
+  "reference_ligand": {
+    "file": "",
+    "seed_fraction": 0.0,
+    "pose_seed_enabled": false,
+    "k_nearest": 10,
+    "hetatm_fallback": false
+  },
+  "coarse_init": {
+    "enabled": true,
+    "grid_step": 3.0,
+    "n_seeds": 25,
+    "n_orientations": 64
+  },
+  "thermodynamics": {
+    "temperature": 300,
+    "clustering_algorithm": "CF",
+    "cluster_rmsd": 2.0,
+    "classic_entropy_ranking": true,
+    "force_cf_rank_emission": false
+  },
+  "ga": {
+    "num_chromosomes": 1000,
+    "num_generations": 2000,
+    "crossover_rate": 0.8,
+    "mutation_rate": 0.03,
+    "diversity_monitoring": true,
+    "adaptive": true,
+    "adaptive_k": [
+      0.95,
+      0.1,
+      1.0,
+      0.05
+    ],
+    "sharing_alpha": 4,
+    "boom_inject_interval": 100,
+    "boom_inject_fraction": 0,
+    "n_elite": 1,
+    "fitness_model": "SMFREE",
+    "seed": 0
+  }
+}

--- a/ops/gates/configs/SCORING_LOCKED_BASELINE_RECEIPT.json
+++ b/ops/gates/configs/SCORING_LOCKED_BASELINE_RECEIPT.json
@@ -1,0 +1,22 @@
+{
+  "protocol_tier": "legacy_production_runtime",
+  "receptor_prep": "deprecated_historical_second_prep_waters_retained",
+  "receptor_origin_tracked": "benchmarks/astex_diverse/data/astex_diverse/{PDB}/{PDB}_apo.pdb",
+  "receptor_snapshot_committed": "ops/gates/configs/legacy_runtime_receptors/{PDB}_apo.pdb",
+  "receptor_runtime_cache_equivalent": "~/.flexaidds/benchmarks/astex_diverse/{PDB}/{PDB}_apo.pdb",
+  "repository_canonical_prep": "benchmarks/astex_diverse/astex_diverse/{PDB}/{PDB}_apo.pdb (waters stripped, DIFFERENT protocol, different CF)",
+  "scope": "config-provenance-repair + legacy-surface reconstruction; NOT canonical baseline; NOT historical root-cause",
+  "regenerable_from_tracked_state": "inputs only; numeric baseline replayable only while a binary matching recorded SHA is retained; source_commit null => NOT source-regenerable (KNOWN GAP)",
+  "tolerance": 0.0,
+  "binaries": {
+    "FlexAIDdS": {"sha256": "968377d1fbd59948896c2199886d940afb25097a5b1f405862153b304bfd7c14", "built": "2026-07-28T01:56", "source_commit": null},
+    "probe_cf":  {"sha256": "90b3ebf25a0ad2ba12a5fcfa15aa34a8b83b4aeccc59d5cfc9b077063eddcaa7", "built": "2026-07-28T01:55", "source_commit": null}
+  },
+  "config_sha256_all_three": "2f75f024952806990ae683eb35afe2e29ee5def08c2177b305ef7ebe0f39b713",
+  "targets": {
+    "1OQ5": {"receptor": "ops/gates/configs/legacy_runtime_receptors/1OQ5_apo.pdb", "receptor_sha256": "8452399c2354bf0fb380b9e04f42791e7ca2f2398751cb3bac407bdd982eaeb6", "pose": "benchmarks/astex_diverse/astex_diverse/1OQ5/1OQ5_ligand.sdf", "pose_sha256": "c064f28cfa5d0d289e952e6bdb55b547a9bc3c6b240e5942a7f6315fb51f0481", "config": "ops/gates/configs/1OQ5_dock_config.json", "expected_cf_total": -34.229803, "reps": 3},
+    "1SQ5": {"receptor": "ops/gates/configs/legacy_runtime_receptors/1SQ5_apo.pdb", "receptor_sha256": "9a8d26f19cd00e3410ebc7f3a8baeadea311008afc3d016843b957673cd41312", "pose": "benchmarks/astex_diverse/astex_diverse/1SQ5/1SQ5_ligand.sdf", "pose_sha256": "6e074aa266d0fad08b829807170aab7943fad99d76f5b5321f5f7759f4c0186d", "config": "ops/gates/configs/1SQ5_dock_config.json", "expected_cf_total": -73.413683, "reps": 3},
+    "1YGC": {"receptor": "ops/gates/configs/legacy_runtime_receptors/1YGC_apo.pdb", "receptor_sha256": "cae9d69093cb684a8ea60417cfaf4553e349fd063bd47e3ff5c1fa69d427a721", "pose": "benchmarks/astex_diverse/astex_diverse/1YGC/1YGC_ligand.sdf", "pose_sha256": "6f92986cbc23a42fe9cf50d1878b850eb30198d93dd4a335e203f58707b00b05", "config": "ops/gates/configs/1YGC_dock_config.json", "expected_cf_total": -0.871396, "reps": 2}
+  },
+  "repo_canonical_prep_cf_for_reference": {"1OQ5": -34.229803, "1SQ5": -73.790961, "1YGC": 7.303774}
+}

--- a/ops/gates/configs/SCORING_LOCKED_BASELINE_RECEIPT.md
+++ b/ops/gates/configs/SCORING_LOCKED_BASELINE_RECEIPT.md
@@ -1,0 +1,77 @@
+# Scoring-locked baseline provenance receipt
+
+Tracks the reconstructed shared dock configs and a **legacy production-runtime**
+CF receipt for the three scoring-locked targets. This is a provenance repair and
+a legacy-surface reconstruction — NOT a canonical baseline, NOT a historical
+root-cause claim.
+
+## Receptor identity — protocol tier (Codex re-review at 5af6d5f8)
+
+The receptors that reproduce the legacy campaign numbers are the **deprecated
+historical second-prep** copies, which retain crystallographic waters (+metals):
+
+```
+snapshot committed here:  ops/gates/configs/legacy_runtime_receptors/{PDB}_apo.pdb
+true tracked origin:      benchmarks/astex_diverse/data/astex_diverse/{PDB}/{PDB}_apo.pdb   (DEPRECATED)
+byte-identical to:        ~/.flexaidds/benchmarks/astex_diverse/{PDB}/{PDB}_apo.pdb   (runtime cache)
+```
+
+Per `benchmarks/datasets/CANONICAL.md` and `benchmarks/astex_diverse/README.md`,
+the **repository-canonical** receptor tree is
+`benchmarks/astex_diverse/astex_diverse/{PDB}/` (waters stripped) — a *different
+protocol* that gives different CF. The water retention is why the numbers move:
+
+| PDB | legacy prod-runtime (deprecated prep, waters) | repo-canonical (waters stripped) | prior workorder |
+|---|---|---|---|
+| 1OQ5 | -34.229803 | -34.229803 (coincidentally equal) | -34.230 |
+| 1SQ5 | -73.413683 | -73.790961 | -73.414 |
+| 1YGC | -0.871396  | +7.303774  | -0.871 |
+
+The legacy numbers match the prior campaign workorder — i.e. the campaign scored
+against the deprecated water-retaining prep. That is the surface this receipt
+pins. It is a **separate protocol tier** from the repo-canonical Astex prep, and
+must not be called "the canonical baseline."
+
+## Scope — what this establishes and what it does NOT
+
+- **Establishes:** given the exact `{binary, probe_cf, config, receptor, pose}`
+  below, native `cf_total` on the legacy prod-runtime prep is reproducible and
+  deterministic (1OQ5 3x, 1SQ5 3x, 1YGC 2x — bit-identical, tolerance 0.0).
+- **Regenerability (narrowed):** the *inputs* are now tracked (configs + receptor
+  snapshots + pose hashes). The *numeric baseline* is replayable only while a
+  binary matching the recorded SHA is retained — with `source_commit: null` and
+  no committed binary, it is NOT source-regenerable from tracked state. KNOWN GAP.
+- **Does NOT establish:** a canonical baseline (wrong prep), nor the cause of the
+  historical frozen->current drift (older binary vs deleted config, unrecoverable).
+
+## Environment (this box, current state)
+
+| Artifact | SHA256 | Note |
+|---|---|---|
+| `build/FlexAIDdS` | `968377d1fbd59948896c2199886d940afb25097a5b1f405862153b304bfd7c14` | built Jul 28 01:56; source commit NOT captured (KNOWN GAP) |
+| `build/probe_cf`  | `90b3ebf25a0ad2ba12a5fcfa15aa34a8b83b4aeccc59d5cfc9b077063eddcaa7` | built Jul 28 01:55; source commit NOT captured |
+
+Working tree at receipt time is `main` `11ce273c`, but the binary predates it —
+do not assume it was built from `11ce273c`.
+
+All three configs byte-identical (shared template = tracked `1J3J_dock_config.json`):
+`2f75f024952806990ae683eb35afe2e29ee5def08c2177b305ef7ebe0f39b713`
+
+## Per-target — exact paths, hashes, expected CF, repetitions
+
+Command (per target), paths repo-relative:
+```
+build/probe_cf \
+  --receptor ops/gates/configs/legacy_runtime_receptors/<PDB>_apo.pdb \
+  --pose     benchmarks/astex_diverse/astex_diverse/<PDB>/<PDB>_ligand.sdf \
+  --ligand   benchmarks/astex_diverse/astex_diverse/<PDB>/<PDB>_ligand.sdf \
+  --config   ops/gates/configs/<PDB>_dock_config.json
+```
+
+| PDB | legacy-prep receptor SHA256 | pose/ligand SHA256 | expected cf_total | reps |
+|---|---|---|---|---|
+| 1OQ5 | `8452399c2354bf0fb380b9e04f42791e7ca2f2398751cb3bac407bdd982eaeb6` | `c064f28cfa5d0d289e952e6bdb55b547a9bc3c6b240e5942a7f6315fb51f0481` | `-34.229803` | 3 |
+| 1SQ5 | `9a8d26f19cd00e3410ebc7f3a8baeadea311008afc3d016843b957673cd41312` | `6e074aa266d0fad08b829807170aab7943fad99d76f5b5321f5f7759f4c0186d` | `-73.413683` | 3 |
+| 1YGC | `cae9d69093cb684a8ea60417cfaf4553e349fd063bd47e3ff5c1fa69d427a721` | `6f92986cbc23a42fe9cf50d1878b850eb30198d93dd4a335e203f58707b00b05` | `-0.871396`  | 2 |
+
+Tolerance: exact (0.0) — `probe_cf` emits six decimals, bit-reproducible on identical inputs.

--- a/ops/gates/configs/legacy_runtime_receptors/1OQ5_apo.pdb
+++ b/ops/gates/configs/legacy_runtime_receptors/1OQ5_apo.pdb
@@ -1,0 +1,4979 @@
+HEADER    METAL BINDING PROTEIN                   07-MAR-03   1OQ5              
+TITLE     CARBONIC ANHYDRASE II IN COMPLEX WITH NANOMOLAR INHIBITOR             
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: CARBONIC ANHYDRASE II;                                     
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 SYNONYM: CARBONATE DEHYDRATASE II, CA-II, CARBONIC ANHYDRASE C;      
+COMPND   5 EC: 4.2.1.1                                                          
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE   3 ORGANISM_COMMON: HUMAN;                                              
+SOURCE   4 ORGANISM_TAXID: 9606;                                                
+SOURCE   5 OTHER_DETAILS: FROM HUMAN ERYTHROCYTES                               
+KEYWDS    10-STRANDED, TWISTED BETA-SHEET, METAL BINDING PROTEIN                
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    A.WEBER,A.CASINI,A.HEINE,D.KUHN,C.T.SUPURAN,A.SCOZZAFAVA,G.KLEBE      
+REVDAT   4   16-AUG-23 1OQ5    1       REMARK LINK                              
+REVDAT   3   11-OCT-17 1OQ5    1       REMARK                                   
+REVDAT   2   24-FEB-09 1OQ5    1       VERSN                                    
+REVDAT   1   23-MAR-04 1OQ5    0                                                
+JRNL        AUTH   A.WEBER,A.CASINI,A.HEINE,D.KUHN,C.T.SUPURAN,A.SCOZZAFAVA,    
+JRNL        AUTH 2 G.KLEBE                                                      
+JRNL        TITL   UNEXPECTED NANOMOLAR INHIBITION OF CARBONIC ANHYDRASE BY     
+JRNL        TITL 2 COX-2-SELECTIVE CELECOXIB: NEW PHARMACOLOGICAL OPPORTUNITIES 
+JRNL        TITL 3 DUE TO RELATED BINDING SITE RECOGNITION.                     
+JRNL        REF    J.MED.CHEM.                   V.  47   550 2004              
+JRNL        REFN                   ISSN 0022-2623                               
+JRNL        PMID   14736236                                                     
+JRNL        DOI    10.1021/JM030912M                                            
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    1.50 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : SHELXL-97                                            
+REMARK   3   AUTHORS     : G.M.SHELDRICK                                        
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 1.50                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 10.00                          
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : 0.000                          
+REMARK   3   COMPLETENESS FOR RANGE        (%) : 90.5                           
+REMARK   3   CROSS-VALIDATION METHOD           : FREE R                         
+REMARK   3   FREE R VALUE TEST SET SELECTION   : RANDOM                         
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT (NO CUTOFF).                         
+REMARK   3   R VALUE   (WORKING + TEST SET, NO CUTOFF) : 0.131                  
+REMARK   3   R VALUE          (WORKING SET, NO CUTOFF) : 0.124                  
+REMARK   3   FREE R VALUE                  (NO CUTOFF) : 0.189                  
+REMARK   3   FREE R VALUE TEST SET SIZE (%, NO CUTOFF) : 5.000                  
+REMARK   3   FREE R VALUE TEST SET COUNT   (NO CUTOFF) : 1716                   
+REMARK   3   TOTAL NUMBER OF REFLECTIONS   (NO CUTOFF) : 34555                  
+REMARK   3                                                                      
+REMARK   3  FIT/AGREEMENT OF MODEL FOR DATA WITH F>4SIG(F).                     
+REMARK   3   R VALUE   (WORKING + TEST SET, F>4SIG(F)) : 0.127                  
+REMARK   3   R VALUE          (WORKING SET, F>4SIG(F)) : 0.125                  
+REMARK   3   FREE R VALUE                  (F>4SIG(F)) : 0.184                  
+REMARK   3   FREE R VALUE TEST SET SIZE (%, F>4SIG(F)) : 5.000                  
+REMARK   3   FREE R VALUE TEST SET COUNT   (F>4SIG(F)) : 1534                   
+REMARK   3   TOTAL NUMBER OF REFLECTIONS   (F>4SIG(F)) : 30826                  
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS      : 2035                                          
+REMARK   3   NUCLEIC ACID ATOMS : 0                                             
+REMARK   3   HETEROGEN ATOMS    : 27                                            
+REMARK   3   SOLVENT ATOMS      : 233                                           
+REMARK   3                                                                      
+REMARK   3  MODEL REFINEMENT.                                                   
+REMARK   3   OCCUPANCY SUM OF NON-HYDROGEN ATOMS      : 2296.0                  
+REMARK   3   OCCUPANCY SUM OF HYDROGEN ATOMS          : 1983.0                  
+REMARK   3   NUMBER OF DISCRETELY DISORDERED RESIDUES : 2                       
+REMARK   3   NUMBER OF LEAST-SQUARES PARAMETERS       : 20762                   
+REMARK   3   NUMBER OF RESTRAINTS                     : 26228                   
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM RESTRAINT TARGET VALUES.                        
+REMARK   3   BOND LENGTHS                         (A) : 0.009                   
+REMARK   3   ANGLE DISTANCES                      (A) : 0.028                   
+REMARK   3   SIMILAR DISTANCES (NO TARGET VALUES) (A) : 0.000                   
+REMARK   3   DISTANCES FROM RESTRAINT PLANES      (A) : 0.020                   
+REMARK   3   ZERO CHIRAL VOLUMES               (A**3) : 0.048                   
+REMARK   3   NON-ZERO CHIRAL VOLUMES           (A**3) : 0.056                   
+REMARK   3   ANTI-BUMPING DISTANCE RESTRAINTS     (A) : 0.018                   
+REMARK   3   RIGID-BOND ADP COMPONENTS         (A**2) : 0.003                   
+REMARK   3   SIMILAR ADP COMPONENTS            (A**2) : 0.057                   
+REMARK   3   APPROXIMATELY ISOTROPIC ADPS      (A**2) : 0.080                   
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELING.                                              
+REMARK   3   METHOD USED: NULL                                                  
+REMARK   3                                                                      
+REMARK   3  STEREOCHEMISTRY TARGET VALUES : ENGH & HUBER                        
+REMARK   3   SPECIAL CASE: NULL                                                 
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS:                                           
+REMARK   3  ANISOTROPIC SCALING APPLIED BY THE METHOD OF PARKIN, MOEZZI & HOPE, 
+REMARK   3  J.APPL.CRYST.28(1995)53-56                                          
+REMARK   3  ANISOTROPIC REFINEMENT                                              
+REMARK   4                                                                      
+REMARK   4 1OQ5 COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY RCSB ON 19-MAR-03.                  
+REMARK 100 THE DEPOSITION ID IS D_1000018553.                                   
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 26-NOV-02                          
+REMARK 200  TEMPERATURE           (KELVIN) : 103                                
+REMARK 200  PH                             : 8.2                                
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : N                                  
+REMARK 200  RADIATION SOURCE               : ROTATING ANODE                     
+REMARK 200  BEAMLINE                       : NULL                               
+REMARK 200  X-RAY GENERATOR MODEL          : RIGAKU                             
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 1.54178                            
+REMARK 200  MONOCHROMATOR                  : OSMIC MIRRORS                      
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : IMAGE PLATE                        
+REMARK 200  DETECTOR MANUFACTURER          : RIGAKU RAXIS IV                    
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : R-AXIS                             
+REMARK 200  DATA SCALING SOFTWARE          : SCALEPACK                          
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 35103                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 1.500                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 30.000                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : 0.000                              
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 91.5                               
+REMARK 200  DATA REDUNDANCY                : 3.500                              
+REMARK 200  R MERGE                    (I) : NULL                               
+REMARK 200  R SYM                      (I) : 0.09300                            
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 18.8000                            
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 1.50                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 1.53                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 37.0                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : NULL                               
+REMARK 200  R MERGE FOR SHELL          (I) : NULL                               
+REMARK 200  R SYM FOR SHELL            (I) : 0.31100                            
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : 2.800                              
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MOLECULAR REPLACEMENT        
+REMARK 200 SOFTWARE USED: AMORE                                                 
+REMARK 200 STARTING MODEL: PDB ENTRY 1CIL                                       
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 28.80                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 1.73                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: TRIS-HCL, NACL, AMMONIUM SULFATE, PH     
+REMARK 280  8.2, VAPOR DIFFUSION, HANGING DROP, TEMPERATURE 277K                
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 1 21 1                         
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X,Y+1/2,-Z                                             
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.000000  1.000000  0.000000       20.53500            
+REMARK 290   SMTRY3   2  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: MONOMERIC                         
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465     SER A     2                                                      
+REMARK 465     HIS A     3                                                      
+REMARK 465     LYS A   261                                                      
+REMARK 470                                                                      
+REMARK 470 MISSING ATOM                                                         
+REMARK 470 THE FOLLOWING RESIDUES HAVE MISSING ATOMS (M=MODEL NUMBER;           
+REMARK 470 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;          
+REMARK 470 I=INSERTION CODE):                                                   
+REMARK 470   M RES CSSEQI  ATOMS                                                
+REMARK 470     LYS A   9    CG   CD   CE   NZ                                   
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND ANGLES                                       
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,3(1X,A4,2X),12X,F5.1)              
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   ATM2   ATM3                                     
+REMARK 500    ASP A 130   CB  -  CG  -  OD2 ANGL. DEV. =   6.0 DEGREES          
+REMARK 500    ARG A 182   NE  -  CZ  -  NH1 ANGL. DEV. =  -3.2 DEGREES          
+REMARK 500    ARG A 227   NE  -  CZ  -  NH1 ANGL. DEV. =   3.7 DEGREES          
+REMARK 500    ARG A 227   NE  -  CZ  -  NH2 ANGL. DEV. =  -3.5 DEGREES          
+REMARK 500    ARG A 254   NE  -  CZ  -  NH1 ANGL. DEV. =   3.4 DEGREES          
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    ASN A  11       14.09   -141.90                                   
+REMARK 500    LYS A  76      -68.55   -101.53                                   
+REMARK 500    ASN A 244       49.09    -92.17                                   
+REMARK 500    LYS A 252     -131.37     48.05                                   
+REMARK 500    ASN A 253       55.02    -92.12                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 620                                                                      
+REMARK 620 METAL COORDINATION                                                   
+REMARK 620 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 620 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                             
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              ZN A 600  ZN                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 HIS A  94   NE2                                                    
+REMARK 620 2 HIS A  96   NE2 104.7                                              
+REMARK 620 3 HIS A 119   ND1 113.3  98.9                                        
+REMARK 620 4 CEL A 701   N3  108.1 113.1 117.9                                  
+REMARK 620 N                    1     2     3                                   
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ZN A 600                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE CEL A 701                 
+REMARK 900                                                                      
+REMARK 900 RELATED ENTRIES                                                      
+REMARK 900 RELATED ID: 1CIL   RELATED DB: PDB                                   
+REMARK 900 POSITIONS OF HIS-64 AND A BOUND WATER IN HUMAN CARBONIC ANHYDRASE    
+REMARK 900 II UPON BINDING THREE STRUCTURALLY RELATED INHIBITORS                
+REMARK 999                                                                      
+REMARK 999 SEQRES                                                               
+REMARK 999 RESIDUES 125 AND 127 ARE ADJACENT IN THE SEQUENCE.                   
+DBREF  1OQ5 A    2   260  UNP    P00918   CAH2_HUMAN       1    259             
+SEQRES   1 A  259  SER HIS HIS TRP GLY TYR GLY LYS HIS ASN GLY PRO GLU          
+SEQRES   2 A  259  HIS TRP HIS LYS ASP PHE PRO ILE ALA LYS GLY GLU ARG          
+SEQRES   3 A  259  GLN SER PRO VAL ASP ILE ASP THR HIS THR ALA LYS TYR          
+SEQRES   4 A  259  ASP PRO SER LEU LYS PRO LEU SER VAL SER TYR ASP GLN          
+SEQRES   5 A  259  ALA THR SER LEU ARG ILE LEU ASN ASN GLY HIS ALA PHE          
+SEQRES   6 A  259  ASN VAL GLU PHE ASP ASP SER GLN ASP LYS ALA VAL LEU          
+SEQRES   7 A  259  LYS GLY GLY PRO LEU ASP GLY THR TYR ARG LEU ILE GLN          
+SEQRES   8 A  259  PHE HIS PHE HIS TRP GLY SER LEU ASP GLY GLN GLY SER          
+SEQRES   9 A  259  GLU HIS THR VAL ASP LYS LYS LYS TYR ALA ALA GLU LEU          
+SEQRES  10 A  259  HIS LEU VAL HIS TRP ASN THR LYS TYR GLY ASP PHE GLY          
+SEQRES  11 A  259  LYS ALA VAL GLN GLN PRO ASP GLY LEU ALA VAL LEU GLY          
+SEQRES  12 A  259  ILE PHE LEU LYS VAL GLY SER ALA LYS PRO GLY LEU GLN          
+SEQRES  13 A  259  LYS VAL VAL ASP VAL LEU ASP SER ILE LYS THR LYS GLY          
+SEQRES  14 A  259  LYS SER ALA ASP PHE THR ASN PHE ASP PRO ARG GLY LEU          
+SEQRES  15 A  259  LEU PRO GLU SER LEU ASP TYR TRP THR TYR PRO GLY SER          
+SEQRES  16 A  259  LEU THR THR PRO PRO LEU LEU GLU CYS VAL THR TRP ILE          
+SEQRES  17 A  259  VAL LEU LYS GLU PRO ILE SER VAL SER SER GLU GLN VAL          
+SEQRES  18 A  259  LEU LYS PHE ARG LYS LEU ASN PHE ASN GLY GLU GLY GLU          
+SEQRES  19 A  259  PRO GLU GLU LEU MET VAL ASP ASN TRP ARG PRO ALA GLN          
+SEQRES  20 A  259  PRO LEU LYS ASN ARG GLN ILE LYS ALA SER PHE LYS              
+HET     ZN  A 600       1                                                       
+HET    CEL  A 701      26                                                       
+HETNAM      ZN ZINC ION                                                         
+HETNAM     CEL 4-[5-(4-METHYLPHENYL)-3-(TRIFLUOROMETHYL)-1H-PYRAZOL-1-          
+HETNAM   2 CEL  YL]BENZENESULFONAMIDE                                           
+HETSYN     CEL CELECOXIB                                                        
+FORMUL   2   ZN    ZN 2+                                                        
+FORMUL   3  CEL    C17 H14 F3 N3 O2 S                                           
+FORMUL   4  HOH   *233(H2 O)                                                    
+HELIX    1   1 GLY A   12  ASP A   19  5                                   8    
+HELIX    2   2 PHE A   20  GLY A   25  5                                   6    
+HELIX    3   3 LYS A  127  GLY A  129  5                                   3    
+HELIX    4   4 ASP A  130  VAL A  135  1                                   6    
+HELIX    5   5 LYS A  154  GLY A  156  5                                   3    
+HELIX    6   6 LEU A  157  LEU A  164  1                                   8    
+HELIX    7   7 ASP A  165  ILE A  167  5                                   3    
+HELIX    8   8 ASP A  180  LEU A  185  5                                   6    
+HELIX    9   9 SER A  219  ARG A  227  1                                   9    
+SHEET    1   A 2 ASP A  32  ILE A  33  0                                        
+SHEET    2   A 2 THR A 108  VAL A 109  1  O  THR A 108   N  ILE A  33           
+SHEET    1   B16 LYS A  39  TYR A  40  0                                        
+SHEET    2   B16 LYS A 257  ALA A 258  1  N  ALA A 258   O  LYS A  39           
+SHEET    3   B16 TYR A 191  GLY A 196 -1  N  THR A 193   O  LYS A 257           
+SHEET    4   B16 VAL A 207  LEU A 212 -1  O  VAL A 207   N  GLY A 196           
+SHEET    5   B16 LEU A 141  VAL A 150  1  O  LEU A 141   N  THR A 208           
+SHEET    6   B16 ILE A 216  VAL A 218  1  N  ILE A 216   O  PHE A 147           
+SHEET    7   B16 LEU A 141  VAL A 150  1  O  PHE A 147   N  ILE A 216           
+SHEET    8   B16 ALA A 116  ASN A 124 -1  O  ALA A 116   N  LEU A 148           
+SHEET    9   B16 TYR A  88  TRP A  97 -1  N  ARG A  89   O  TRP A 123           
+SHEET   10   B16 VAL A  78  GLY A  81 -1  N  LEU A  79   O  TYR A  88           
+SHEET   11   B16 LEU A  47  SER A  50 -1  N  SER A  48   O  LYS A  80           
+SHEET   12   B16 VAL A  78  GLY A  81 -1  O  VAL A  78   N  SER A  50           
+SHEET   13   B16 TYR A  88  TRP A  97 -1  O  TYR A  88   N  LEU A  79           
+SHEET   14   B16 PHE A  66  PHE A  70 -1  O  PHE A  66   N  PHE A  95           
+SHEET   15   B16 SER A  56  ASN A  61 -1  N  LEU A  57   O  GLU A  69           
+SHEET   16   B16 SER A 173  ASP A 175 -1  O  ALA A 174   N  ILE A  59           
+LINK         NE2 HIS A  94                ZN    ZN A 600     1555   1555  2.00  
+LINK         NE2 HIS A  96                ZN    ZN A 600     1555   1555  1.99  
+LINK         ND1 HIS A 119                ZN    ZN A 600     1555   1555  2.07  
+LINK        ZN    ZN A 600                 N3  CEL A 701     1555   1555  1.97  
+CISPEP   1 SER A   29    PRO A   30          0        -1.29                     
+CISPEP   2 PRO A  201    PRO A  202          0         7.52                     
+SITE     1 AC1  4 HIS A  94  HIS A  96  HIS A 119  CEL A 701                    
+SITE     1 AC2 12 ASN A  67  GLU A  69  GLN A  92  HIS A  94                    
+SITE     2 AC2 12 HIS A  96  HIS A 119  PHE A 131  LEU A 198                    
+SITE     3 AC2 12 THR A 199  THR A 200  PRO A 202   ZN A 600                    
+CRYST1   42.010   41.070   71.930  90.00 104.20  90.00 P 1 21 1      2          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.023804  0.000000  0.006023        0.00000                         
+SCALE2      0.000000  0.024349  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.014341        0.00000                         
+ATOM      1  N   HIS A   4      31.351   3.173   9.274  1.00 59.42           N  
+ANISOU    1  N   HIS A   4     8056   5437   9086  -3195   2169     85       N  
+ATOM      2  CA  HIS A   4      30.878   2.020   8.501  1.00 37.73           C  
+ANISOU    2  CA  HIS A   4     3274   5828   5233  -1760   2125    801       C  
+ATOM      3  C   HIS A   4      30.202   0.979   9.390  1.00 26.54           C  
+ANISOU    3  C   HIS A   4     2220   4058   3805   -370   1388    378       C  
+ATOM      4  O   HIS A   4      30.375  -0.218   9.196  1.00 27.16           O  
+ANISOU    4  O   HIS A   4     2678   4385   3255    297    720    -58       O  
+ATOM      5  CB  HIS A   4      32.005   1.373   7.729  1.00 38.36           C  
+ANISOU    5  CB  HIS A   4     2413   7658   4505   -673   1455   2023       C  
+ATOM      6  CG  HIS A   4      33.236   0.870   8.375  1.00 50.34           C  
+ANISOU    6  CG  HIS A   4     2902   9607   6620   -927   -325   1555       C  
+ATOM      7  ND1 HIS A   4      34.411   0.751   7.660  1.00 50.86           N  
+ANISOU    7  ND1 HIS A   4     1753   9913   7657  -1436   -935    901       N  
+ATOM      8  CD2 HIS A   4      33.533   0.440   9.619  1.00 56.18           C  
+ANISOU    8  CD2 HIS A   4     3249  11058   7037  -1483  -1565   1720       C  
+ATOM      9  CE1 HIS A   4      35.381   0.276   8.444  1.00 56.32           C  
+ANISOU    9  CE1 HIS A   4     2436  11158   7805  -1709  -2070    297       C  
+ATOM     10  NE2 HIS A   4      34.866   0.073   9.648  1.00 58.24           N  
+ANISOU   10  NE2 HIS A   4     2629  11809   7689  -2534  -2420    621       N  
+ATOM     11  N   TRP A   5      29.405   1.392  10.358  1.00 23.38           N  
+ANISOU   11  N   TRP A   5     2414   3471   3000   -560    921    157       N  
+ATOM     12  CA  TRP A   5      28.760   0.437  11.248  1.00 20.56           C  
+ANISOU   12  CA  TRP A   5     1947   2925   2942   -292    733    109       C  
+ATOM     13  C   TRP A   5      27.736  -0.406  10.497  1.00 21.28           C  
+ANISOU   13  C   TRP A   5     2047   3178   2861   -224    609    -60       C  
+ATOM     14  O   TRP A   5      27.186   0.027   9.498  1.00 23.10           O  
+ANISOU   14  O   TRP A   5     2592   3001   3186   -322    340    144       O  
+ATOM     15  CB  TRP A   5      28.069   1.152  12.380  1.00 20.29           C  
+ANISOU   15  CB  TRP A   5     2141   2900   2668   -390    612    159       C  
+ATOM     16  CG  TRP A   5      26.858   1.947  12.070  1.00 19.85           C  
+ANISOU   16  CG  TRP A   5     2277   2558   2707   -302    639    -74       C  
+ATOM     17  CD1 TRP A   5      26.781   3.280  11.769  1.00 23.29           C  
+ANISOU   17  CD1 TRP A   5     2836   2882   3133   -446    442    660       C  
+ATOM     18  CD2 TRP A   5      25.508   1.467  12.038  1.00 20.39           C  
+ANISOU   18  CD2 TRP A   5     2251   2660   2836   -206    397     39       C  
+ATOM     19  NE1 TRP A   5      25.487   3.640  11.546  1.00 23.31           N  
+ANISOU   19  NE1 TRP A   5     3056   2715   3087     -5    466    176       N  
+ATOM     20  CE2 TRP A   5      24.678   2.548  11.707  1.00 20.35           C  
+ANISOU   20  CE2 TRP A   5     2462   2861   2408    120    765     27       C  
+ATOM     21  CE3 TRP A   5      24.955   0.209  12.259  1.00 18.49           C  
+ANISOU   21  CE3 TRP A   5     1850   2757   2418   -203    566   -105       C  
+ATOM     22  CZ2 TRP A   5      23.307   2.410  11.594  1.00 21.57           C  
+ANISOU   22  CZ2 TRP A   5     2530   3088   2578    319    435   -662       C  
+ATOM     23  CZ3 TRP A   5      23.587   0.075  12.145  1.00 19.50           C  
+ANISOU   23  CZ3 TRP A   5     1812   2947   2651    -10    569   -814       C  
+ATOM     24  CH2 TRP A   5      22.770   1.165  11.816  1.00 20.99           C  
+ANISOU   24  CH2 TRP A   5     2013   3103   2859    314    798   -943       C  
+ATOM     25  N   GLY A   6      27.518  -1.601  11.043  1.00 19.35           N  
+ANISOU   25  N   GLY A   6     1651   2908   2792    -47    209   -245       N  
+ATOM     26  CA  GLY A   6      26.594  -2.523  10.414  1.00 19.80           C  
+ANISOU   26  CA  GLY A   6     2194   2844   2486     79     66   -461       C  
+ATOM     27  C   GLY A   6      26.234  -3.617  11.403  1.00 18.64           C  
+ANISOU   27  C   GLY A   6     1738   2639   2708    192    562   -607       C  
+ATOM     28  O   GLY A   6      26.258  -3.369  12.602  1.00 21.09           O  
+ANISOU   28  O   GLY A   6     2627   2740   2646   -286    500   -493       O  
+ATOM     29  N   TYR A   7      25.919  -4.791  10.871  1.00 19.28           N  
+ANISOU   29  N   TYR A   7     1552   2854   2919     52    791   -827       N  
+ATOM     30  CA  TYR A   7      25.532  -5.924  11.717  1.00 21.71           C  
+ANISOU   30  CA  TYR A   7     1870   2799   3581     15   1069   -697       C  
+ATOM     31  C   TYR A   7      26.426  -7.137  11.487  1.00 22.30           C  
+ANISOU   31  C   TYR A   7     1809   2624   4041   -121   1228   -827       C  
+ATOM     32  O   TYR A   7      26.124  -8.246  11.956  1.00 29.08           O  
+ANISOU   32  O   TYR A   7     2246   2779   6026   -270   1312   -230       O  
+ATOM     33  CB  TYR A   7      24.067  -6.244  11.397  1.00 20.28           C  
+ANISOU   33  CB  TYR A   7     1946   2619   3140     52    863   -563       C  
+ATOM     34  CG  TYR A   7      23.117  -5.152  11.850  1.00 16.34           C  
+ANISOU   34  CG  TYR A   7     1756   2133   2320   -258    536   -635       C  
+ATOM     35  CD1 TYR A   7      22.725  -5.127  13.175  1.00 16.74           C  
+ANISOU   35  CD1 TYR A   7     1871   2188   2302   -524    591   -460       C  
+ATOM     36  CD2 TYR A   7      22.616  -4.184  10.996  1.00 17.57           C  
+ANISOU   36  CD2 TYR A   7     1900   2471   2305   -159    776   -371       C  
+ATOM     37  CE1 TYR A   7      21.860  -4.134  13.586  1.00 17.35           C  
+ANISOU   37  CE1 TYR A   7     2639   2267   1687   -177    358   -657       C  
+ATOM     38  CE2 TYR A   7      21.752  -3.176  11.401  1.00 17.58           C  
+ANISOU   38  CE2 TYR A   7     2474   2122   2083   -100    879   -123       C  
+ATOM     39  CZ  TYR A   7      21.378  -3.170  12.731  1.00 17.42           C  
+ANISOU   39  CZ  TYR A   7     2501   2247   1872   -273    677   -385       C  
+ATOM     40  OH  TYR A   7      20.513  -2.209  13.214  1.00 17.47           O  
+ANISOU   40  OH  TYR A   7     2094   2483   2062   -266    569   -388       O  
+ATOM     41  N   GLY A   8      27.530  -6.924  10.762  1.00 25.31           N  
+ANISOU   41  N   GLY A   8     2134   2945   4537   -207   1642  -1130       N  
+ATOM     42  CA  GLY A   8      28.459  -8.005  10.474  1.00 25.56           C  
+ANISOU   42  CA  GLY A   8     2022   3245   4445    -46   1474  -1210       C  
+ATOM     43  C   GLY A   8      29.487  -8.286  11.544  1.00 27.66           C  
+ANISOU   43  C   GLY A   8     3481   3286   3743    407   1469   -435       C  
+ATOM     44  O   GLY A   8      29.555  -7.561  12.554  1.00 29.38           O  
+ANISOU   44  O   GLY A   8     3087   3822   4255    200   1217   -944       O  
+ATOM     45  N   LYS A   9      30.329  -9.304  11.350  1.00 30.51           N  
+ANISOU   45  N   LYS A   9     3336   3372   4884    423    756   -979       N  
+ATOM     46  CA  LYS A   9      31.254  -9.735  12.397  1.00 31.98           C  
+ANISOU   46  CA  LYS A   9     3674   3158   5319    244    464   -672       C  
+ATOM     47  C   LYS A   9      32.285  -8.654  12.710  1.00 29.25           C  
+ANISOU   47  C   LYS A   9     2919   3018   5177    499    702   -315       C  
+ATOM     48  O   LYS A   9      32.761  -8.536  13.832  1.00 30.41           O  
+ANISOU   48  O   LYS A   9     2781   4072   4701   -740   1352   -137       O  
+ATOM     49  CB  LYS A   9      32.013 -11.003  12.042  1.00 31.65           C  
+ANISOU   49  CB  LYS A   9     4620   3117   4290    550    485   -402       C  
+ATOM     50  N   HIS A  10      32.630  -7.890  11.684  1.00 26.82           N  
+ANISOU   50  N   HIS A  10     2099   3204   4887   1037    458   -233       N  
+ATOM     51  CA  HIS A  10      33.638  -6.858  11.842  1.00 29.29           C  
+ANISOU   51  CA  HIS A  10     2565   3590   4974    493   1096   -266       C  
+ATOM     52  C   HIS A  10      33.104  -5.449  12.016  1.00 26.30           C  
+ANISOU   52  C   HIS A  10     2205   3272   4515    174   1720    589       C  
+ATOM     53  O   HIS A  10      33.890  -4.503  12.246  1.00 26.06           O  
+ANISOU   53  O   HIS A  10     1953   3445   4504    630    617     89       O  
+ATOM     54  CB  HIS A  10      34.549  -6.894  10.599  1.00 31.46           C  
+ANISOU   54  CB  HIS A  10     3386   3730   4837    505   1319   -457       C  
+ATOM     55  CG  HIS A  10      35.245  -8.214  10.466  1.00 30.94           C  
+ANISOU   55  CG  HIS A  10     3554   3539   4661    411   1553   -277       C  
+ATOM     56  ND1 HIS A  10      36.423  -8.517  11.110  1.00 32.33           N  
+ANISOU   56  ND1 HIS A  10     4476   3200   4606    686    890   -240       N  
+ATOM     57  CD2 HIS A  10      34.928  -9.292   9.726  1.00 32.41           C  
+ANISOU   57  CD2 HIS A  10     3014   3333   5967    -91   1509   -299       C  
+ATOM     58  CE1 HIS A  10      36.796  -9.744  10.791  1.00 33.79           C  
+ANISOU   58  CE1 HIS A  10     4016   3579   5243    694   1009   -916       C  
+ATOM     59  NE2 HIS A  10      35.900 -10.253   9.944  1.00 35.09           N  
+ANISOU   59  NE2 HIS A  10     3962   3512   5859    422    766   -679       N  
+ATOM     60  N   ASN A  11      31.794  -5.268  11.931  1.00 25.11           N  
+ANISOU   60  N   ASN A  11     2301   3089   4149    159    876   -148       N  
+ATOM     61  CA  ASN A  11      31.261  -3.916  12.147  1.00 23.08           C  
+ANISOU   61  CA  ASN A  11     1931   2937   3899   -148    754   -321       C  
+ATOM     62  C   ASN A  11      29.942  -3.906  12.913  1.00 21.14           C  
+ANISOU   62  C   ASN A  11     1789   3245   2998   -234    398   -590       C  
+ATOM     63  O   ASN A  11      29.248  -2.887  12.951  1.00 22.89           O  
+ANISOU   63  O   ASN A  11     2086   3002   3608   -319    975   -486       O  
+ATOM     64  CB  ASN A  11      31.070  -3.195  10.811  1.00 20.29           C  
+ANISOU   64  CB  ASN A  11     1406   2679   3626    -46    891   -643       C  
+ATOM     65  CG  ASN A  11      29.978  -3.784   9.935  1.00 25.86           C  
+ANISOU   65  CG  ASN A  11     2282   3413   4129   -181    344  -1036       C  
+ATOM     66  OD1 ASN A  11      29.430  -4.831  10.258  1.00 24.89           O  
+ANISOU   66  OD1 ASN A  11     1947   3834   3677   -594    525  -1343       O  
+ATOM     67  ND2 ASN A  11      29.655  -3.121   8.829  1.00 27.39           N  
+ANISOU   67  ND2 ASN A  11     1923   4075   4410    -26    171   -748       N  
+ATOM     68  N   GLY A  12      29.578  -5.029  13.536  1.00 21.40           N  
+ANISOU   68  N   GLY A  12     1483   3235   3415     80    651   -445       N  
+ATOM     69  CA  GLY A  12      28.265  -5.159  14.161  1.00 21.90           C  
+ANISOU   69  CA  GLY A  12     1671   3167   3484    185    880   -552       C  
+ATOM     70  C   GLY A  12      28.253  -4.627  15.569  1.00 19.85           C  
+ANISOU   70  C   GLY A  12     1407   2730   3404    304    650   -358       C  
+ATOM     71  O   GLY A  12      29.181  -3.959  15.992  1.00 18.43           O  
+ANISOU   71  O   GLY A  12     1616   2303   3084    137    485    358       O  
+ATOM     72  N   PRO A  13      27.180  -4.922  16.285  1.00 18.65           N  
+ANISOU   72  N   PRO A  13     1579   2356   3152    172    595   -146       N  
+ATOM     73  CA  PRO A  13      26.942  -4.350  17.611  1.00 18.21           C  
+ANISOU   73  CA  PRO A  13     1448   2292   3180    304    577   -128       C  
+ATOM     74  C   PRO A  13      28.099  -4.381  18.589  1.00 19.26           C  
+ANISOU   74  C   PRO A  13     1789   2279   3250    259    330     13       C  
+ATOM     75  O   PRO A  13      28.212  -3.395  19.335  1.00 19.80           O  
+ANISOU   75  O   PRO A  13     1736   2455   3331    175    402   -106       O  
+ATOM     76  CB  PRO A  13      25.804  -5.227  18.141  1.00 20.63           C  
+ANISOU   76  CB  PRO A  13     1979   2937   2923   -171    455    228       C  
+ATOM     77  CG  PRO A  13      25.023  -5.554  16.921  1.00 19.73           C  
+ANISOU   77  CG  PRO A  13     1365   2855   3277    260    286    113       C  
+ATOM     78  CD  PRO A  13      26.083  -5.794  15.868  1.00 20.71           C  
+ANISOU   78  CD  PRO A  13     1540   3286   3043      0    259   -138       C  
+ATOM     79  N   GLU A  14      28.875  -5.441  18.572  1.00 19.52           N  
+ANISOU   79  N   GLU A  14     1892   2057   3468    165    257    307       N  
+ATOM     80  CA  GLU A  14      30.008  -5.511  19.492  1.00 22.45           C  
+ANISOU   80  CA  GLU A  14     2177   2448   3904    384    -53    211       C  
+ATOM     81  C   GLU A  14      31.099  -4.514  19.116  1.00 20.07           C  
+ANISOU   81  C   GLU A  14     1663   2248   3716    698   -135    146       C  
+ATOM     82  O   GLU A  14      32.012  -4.299  19.935  1.00 21.64           O  
+ANISOU   82  O   GLU A  14     1958   2878   3388    423   -178    513       O  
+ATOM     83  CB  GLU A  14      30.542  -6.948  19.556  1.00 27.30           C  
+ANISOU   83  CB  GLU A  14     2636   2413   5324    376   -452    667       C  
+ATOM     84  CG  GLU A  14      29.426  -7.979  19.833  1.00 28.38           C  
+ANISOU   84  CG  GLU A  14     2692   2390   5699    477    728     -1       C  
+ATOM     85  CD  GLU A  14      28.535  -7.613  20.997  1.00 36.92           C  
+ANISOU   85  CD  GLU A  14     3755   5548   4725   -251    578   -831       C  
+ATOM     86  OE1 GLU A  14      29.106  -7.196  22.030  1.00 47.05           O  
+ANISOU   86  OE1 GLU A  14     5378   7300   5199    710   -896   -924       O  
+ATOM     87  OE2 GLU A  14      27.277  -7.721  20.913  1.00 42.49           O  
+ANISOU   87  OE2 GLU A  14     3427   8041   4676   1313    842  -1954       O  
+ATOM     88  N   HIS A  15      31.038  -3.873  17.945  1.00 19.21           N  
+ANISOU   88  N   HIS A  15     1723   2115   3461    297   -404    -83       N  
+ATOM     89  CA  HIS A  15      32.065  -2.933  17.532  1.00 18.67           C  
+ANISOU   89  CA  HIS A  15     1677   2133   3284    291   -410   -223       C  
+ATOM     90  C   HIS A  15      31.635  -1.474  17.693  1.00 17.54           C  
+ANISOU   90  C   HIS A  15     1004   2150   3508    106   -377   -322       C  
+ATOM     91  O   HIS A  15      32.437  -0.550  17.619  1.00 19.45           O  
+ANISOU   91  O   HIS A  15     1165   2259   3966    -89   -165   -343       O  
+ATOM     92  CB  HIS A  15      32.465  -3.153  16.064  1.00 20.70           C  
+ANISOU   92  CB  HIS A  15     2117   2331   3418    178   -175   -361       C  
+ATOM     93  CG  HIS A  15      33.155  -4.440  15.778  1.00 23.64           C  
+ANISOU   93  CG  HIS A  15     2528   2900   3552    707   -610   -803       C  
+ATOM     94  ND1 HIS A  15      34.502  -4.595  15.898  1.00 26.21           N  
+ANISOU   94  ND1 HIS A  15     2521   3481   3957    866   -453   -684       N  
+ATOM     95  CD2 HIS A  15      32.721  -5.655  15.377  1.00 23.84           C  
+ANISOU   95  CD2 HIS A  15     2855   2902   3299    730     -8  -1167       C  
+ATOM     96  CE1 HIS A  15      34.909  -5.801  15.597  1.00 28.20           C  
+ANISOU   96  CE1 HIS A  15     3021   3887   3808   1393   -475   -909       C  
+ATOM     97  NE2 HIS A  15      33.817  -6.470  15.277  1.00 28.90           N  
+ANISOU   97  NE2 HIS A  15     3436   3138   4407   1305   -703   -813       N  
+ATOM     98  N   TRP A  16      30.339  -1.255  17.909  1.00 17.28           N  
+ANISOU   98  N   TRP A  16      988   2426   3151    157   -338    167       N  
+ATOM     99  CA  TRP A  16      29.782   0.083  17.805  1.00 18.61           C  
+ANISOU   99  CA  TRP A  16     1099   2548   3422    397   -377   -225       C  
+ATOM    100  C   TRP A  16      30.367   1.046  18.834  1.00 17.89           C  
+ANISOU  100  C   TRP A  16      993   2611   3194   -197    106    -58       C  
+ATOM    101  O   TRP A  16      30.474   2.244  18.529  1.00 19.10           O  
+ANISOU  101  O   TRP A  16     1319   2514   3425    119     -9    -62       O  
+ATOM    102  CB  TRP A  16      28.251   0.052  17.958  1.00 16.63           C  
+ANISOU  102  CB  TRP A  16     1127   2081   3113    137   -146   -374       C  
+ATOM    103  CG  TRP A  16      27.556  -0.632  16.822  1.00 15.69           C  
+ANISOU  103  CG  TRP A  16     1072   1942   2948    135     90   -370       C  
+ATOM    104  CD1 TRP A  16      28.095  -1.085  15.659  1.00 17.53           C  
+ANISOU  104  CD1 TRP A  16     1276   2240   3145     23    344   -481       C  
+ATOM    105  CD2 TRP A  16      26.154  -0.956  16.759  1.00 14.16           C  
+ANISOU  105  CD2 TRP A  16     1223   1797   2360   -197    162   -140       C  
+ATOM    106  NE1 TRP A  16      27.139  -1.673  14.852  1.00 18.22           N  
+ANISOU  106  NE1 TRP A  16     1359   2790   2774   -192    451   -502       N  
+ATOM    107  CE2 TRP A  16      25.934  -1.596  15.519  1.00 14.76           C  
+ANISOU  107  CE2 TRP A  16     1392   1869   2348   -185    283   -169       C  
+ATOM    108  CE3 TRP A  16      25.070  -0.769  17.609  1.00 15.53           C  
+ANISOU  108  CE3 TRP A  16     1160   2424   2317     60     59   -295       C  
+ATOM    109  CZ2 TRP A  16      24.678  -2.025  15.158  1.00 15.16           C  
+ANISOU  109  CZ2 TRP A  16     1277   2199   2283     32    317   -706       C  
+ATOM    110  CZ3 TRP A  16      23.826  -1.209  17.223  1.00 15.16           C  
+ANISOU  110  CZ3 TRP A  16     1280   2398   2080   -221    408   -569       C  
+ATOM    111  CH2 TRP A  16      23.632  -1.830  16.014  1.00 15.13           C  
+ANISOU  111  CH2 TRP A  16     1340   2386   2022    126    233   -479       C  
+ATOM    112  N   HIS A  17      30.711   0.502  20.001  1.00 18.15           N  
+ANISOU  112  N   HIS A  17     1335   2488   3075   -159     60   -182       N  
+ATOM    113  CA  HIS A  17      31.171   1.352  21.098  1.00 17.69           C  
+ANISOU  113  CA  HIS A  17     1475   2094   3150   -118    104   -101       C  
+ATOM    114  C   HIS A  17      32.440   2.134  20.744  1.00 19.57           C  
+ANISOU  114  C   HIS A  17     1633   2718   3084   -480      6    -78       C  
+ATOM    115  O   HIS A  17      32.762   3.150  21.333  1.00 20.08           O  
+ANISOU  115  O   HIS A  17     1579   2255   3794   -247     95    -53       O  
+ATOM    116  CB  HIS A  17      31.427   0.528  22.356  1.00 19.32           C  
+ANISOU  116  CB  HIS A  17     1294   2869   3178   -287    -98    157       C  
+ATOM    117  CG  HIS A  17      32.643  -0.329  22.224  1.00 20.95           C  
+ANISOU  117  CG  HIS A  17     1550   3027   3384     -4   -120    362       C  
+ATOM    118  ND1 HIS A  17      33.818   0.064  22.800  1.00 22.01           N  
+ANISOU  118  ND1 HIS A  17     1436   3966   2961    367    -13   -230       N  
+ATOM    119  CD2 HIS A  17      32.911  -1.484  21.588  1.00 18.55           C  
+ANISOU  119  CD2 HIS A  17     1547   2855   2647    -41    184    781       C  
+ATOM    120  CE1 HIS A  17      34.755  -0.853  22.539  1.00 23.36           C  
+ANISOU  120  CE1 HIS A  17     1749   3841   3287    522   -241   -417       C  
+ATOM    121  NE2 HIS A  17      34.225  -1.807  21.794  1.00 20.84           N  
+ANISOU  121  NE2 HIS A  17     1429   3766   2722     20    312    -30       N  
+ATOM    122  N   LYS A  18      33.217   1.683  19.771  1.00 19.19           N  
+ANISOU  122  N   LYS A  18     1069   2901   3319   -271   -180   -155       N  
+ATOM    123  CA  LYS A  18      34.424   2.418  19.394  1.00 19.35           C  
+ANISOU  123  CA  LYS A  18     1224   2875   3252   -262   -177     43       C  
+ATOM    124  C   LYS A  18      34.123   3.763  18.740  1.00 22.32           C  
+ANISOU  124  C   LYS A  18     1968   2705   3806   -338   -516     40       C  
+ATOM    125  O   LYS A  18      34.788   4.758  19.039  1.00 29.68           O  
+ANISOU  125  O   LYS A  18     2784   3357   5138  -1380  -1162    853       O  
+ATOM    126  CB  LYS A  18      35.251   1.503  18.493  1.00 21.53           C  
+ANISOU  126  CB  LYS A  18     1575   3445   3159    335    138    459       C  
+ATOM    127  CG  LYS A  18      35.791   0.305  19.270  1.00 25.33           C  
+ANISOU  127  CG  LYS A  18     1642   3485   4496    385    -66    819       C  
+ATOM    128  CD  LYS A  18      36.620  -0.600  18.396  1.00 23.95           C  
+ANISOU  128  CD  LYS A  18     1368   3637   4096    483   -895    431       C  
+ATOM    129  CE  LYS A  18      35.816  -1.523  17.491  1.00 20.75           C  
+ANISOU  129  CE  LYS A  18     1175   3635   3074   -359   -565   1441       C  
+ATOM    130  NZ  LYS A  18      36.771  -1.884  16.386  1.00 40.50           N  
+ANISOU  130  NZ  LYS A  18     5094   6562   3733   2763    139     58       N  
+ATOM    131  N   ASP A  19      33.100   3.815  17.867  1.00 21.63           N  
+ANISOU  131  N   ASP A  19     1871   2588   3761   -266   -412    201       N  
+ATOM    132  CA  ASP A  19      32.729   5.095  17.275  1.00 23.02           C  
+ANISOU  132  CA  ASP A  19     1996   2927   3825     95     96    451       C  
+ATOM    133  C   ASP A  19      31.679   5.817  18.117  1.00 22.71           C  
+ANISOU  133  C   ASP A  19     2259   2466   3902   -283    307    157       C  
+ATOM    134  O   ASP A  19      31.574   7.034  18.032  1.00 22.20           O  
+ANISOU  134  O   ASP A  19     1687   2423   4324   -478    229    348       O  
+ATOM    135  CB  ASP A  19      32.169   4.920  15.864  1.00 24.14           C  
+ANISOU  135  CB  ASP A  19     2406   2953   3814    837    -16    229       C  
+ATOM    136  CG  ASP A  19      33.223   5.027  14.781  1.00 31.17           C  
+ANISOU  136  CG  ASP A  19     2519   5535   3788   -155      0   -309       C  
+ATOM    137  OD1 ASP A  19      34.393   5.358  15.057  1.00 39.29           O  
+ANISOU  137  OD1 ASP A  19     2504   7948   4475   -542   -485   1234       O  
+ATOM    138  OD2 ASP A  19      32.863   4.779  13.611  1.00 36.53           O  
+ANISOU  138  OD2 ASP A  19     3896   6230   3754   -897     76   -471       O  
+ATOM    139  N   PHE A  20      30.938   5.003  18.850  1.00 20.81           N  
+ANISOU  139  N   PHE A  20     2079   2145   3681    573     56    820       N  
+ATOM    140  CA  PHE A  20      29.808   5.467  19.647  1.00 20.49           C  
+ANISOU  140  CA  PHE A  20     1730   2442   3613   -105    -78    131       C  
+ATOM    141  C   PHE A  20      29.888   4.998  21.085  1.00 21.33           C  
+ANISOU  141  C   PHE A  20     1920   2745   3441   -521   -201   -123       C  
+ATOM    142  O   PHE A  20      29.215   4.072  21.487  1.00 18.08           O  
+ANISOU  142  O   PHE A  20     1715   1911   3244     64   -334   -150       O  
+ATOM    143  CB  PHE A  20      28.503   4.978  19.003  1.00 21.23           C  
+ANISOU  143  CB  PHE A  20     2046   2727   3295   -574   -122    368       C  
+ATOM    144  CG  PHE A  20      28.418   5.484  17.568  1.00 22.13           C  
+ANISOU  144  CG  PHE A  20     1700   3293   3416    -92    129    593       C  
+ATOM    145  CD1 PHE A  20      28.005   6.774  17.292  1.00 23.04           C  
+ANISOU  145  CD1 PHE A  20     1664   3376   3715   -156    446    974       C  
+ATOM    146  CD2 PHE A  20      28.738   4.666  16.506  1.00 22.89           C  
+ANISOU  146  CD2 PHE A  20     1987   3412   3298   -504    141    508       C  
+ATOM    147  CE1 PHE A  20      27.940   7.263  16.010  1.00 25.09           C  
+ANISOU  147  CE1 PHE A  20     2357   3515   3660   -593    -90    940       C  
+ATOM    148  CE2 PHE A  20      28.723   5.123  15.220  1.00 22.84           C  
+ANISOU  148  CE2 PHE A  20     1548   3797   3332   -726    -91    619       C  
+ATOM    149  CZ  PHE A  20      28.319   6.421  14.980  1.00 24.28           C  
+ANISOU  149  CZ  PHE A  20     2097   3560   3567  -1131    -49    826       C  
+ATOM    150  N   PRO A  21      30.765   5.611  21.874  1.00 21.53           N  
+ANISOU  150  N   PRO A  21     1791   2505   3883   -220   -421   -258       N  
+ATOM    151  CA  PRO A  21      31.010   5.128  23.233  1.00 19.81           C  
+ANISOU  151  CA  PRO A  21     1996   2063   3469    -54   -158   -743       C  
+ATOM    152  C   PRO A  21      29.781   5.076  24.120  1.00 22.54           C  
+ANISOU  152  C   PRO A  21     1781   2754   4031   -172   -201   -245       C  
+ATOM    153  O   PRO A  21      29.791   4.304  25.106  1.00 20.37           O  
+ANISOU  153  O   PRO A  21     1200   2554   3985   -214   -255   -336       O  
+ATOM    154  CB  PRO A  21      32.013   6.134  23.818  1.00 25.10           C  
+ANISOU  154  CB  PRO A  21     2502   3452   3582  -1128   -171   -527       C  
+ATOM    155  CG  PRO A  21      32.372   7.067  22.733  1.00 30.87           C  
+ANISOU  155  CG  PRO A  21     3392   4064   4272  -1830  -1009    260       C  
+ATOM    156  CD  PRO A  21      31.594   6.751  21.498  1.00 26.35           C  
+ANISOU  156  CD  PRO A  21     2203   3382   4426   -935  -1039    414       C  
+ATOM    157  N   ILE A  22      28.701   5.786  23.799  1.00 20.11           N  
+ANISOU  157  N   ILE A  22     1564   2524   3551   -442   -220   -197       N  
+ATOM    158  CA  ILE A  22      27.481   5.707  24.598  1.00 18.27           C  
+ANISOU  158  CA  ILE A  22     1852   2247   2844   -318   -217   -621       C  
+ATOM    159  C   ILE A  22      26.859   4.319  24.473  1.00 16.50           C  
+ANISOU  159  C   ILE A  22     1111   2156   3004   -102   -206   -652       C  
+ATOM    160  O   ILE A  22      25.928   3.952  25.195  1.00 18.24           O  
+ANISOU  160  O   ILE A  22     1411   2197   3321     33    184   -640       O  
+ATOM    161  CB  ILE A  22      26.497   6.796  24.147  1.00 18.32           C  
+ANISOU  161  CB  ILE A  22     2069   2080   2812   -140     23   -772       C  
+ATOM    162  CG1 ILE A  22      25.431   7.132  25.169  1.00 19.60           C  
+ANISOU  162  CG1 ILE A  22     1840   2643   2963   -214    295     31       C  
+ATOM    163  CG2 ILE A  22      25.888   6.428  22.783  1.00 18.37           C  
+ANISOU  163  CG2 ILE A  22     1739   2244   2995   -333   -188   -406       C  
+ATOM    164  CD1 ILE A  22      24.482   8.258  24.778  1.00 26.39           C  
+ANISOU  164  CD1 ILE A  22     1895   3562   4571    435    764    498       C  
+ATOM    165  N   ALA A  23      27.355   3.473  23.565  1.00 16.98           N  
+ANISOU  165  N   ALA A  23     1282   1914   3257    -62    141   -471       N  
+ATOM    166  CA  ALA A  23      26.926   2.078  23.417  1.00 15.90           C  
+ANISOU  166  CA  ALA A  23     1389   1960   2691   -310   -157   -358       C  
+ATOM    167  C   ALA A  23      27.025   1.332  24.755  1.00 16.72           C  
+ANISOU  167  C   ALA A  23     1545   2155   2653    130     35   -367       C  
+ATOM    168  O   ALA A  23      26.275   0.374  24.967  1.00 19.26           O  
+ANISOU  168  O   ALA A  23     1906   2553   2859   -152    -31    129       O  
+ATOM    169  CB  ALA A  23      27.755   1.322  22.400  1.00 18.24           C  
+ANISOU  169  CB  ALA A  23     2770   1698   2461    301    -54    -53       C  
+ATOM    170  N   LYS A  24      27.936   1.774  25.621  1.00 18.32           N  
+ANISOU  170  N   LYS A  24     1754   2654   2554    246   -139   -500       N  
+ATOM    171  CA  LYS A  24      28.121   1.159  26.938  1.00 20.38           C  
+ANISOU  171  CA  LYS A  24     1618   3195   2932    504   -108    -22       C  
+ATOM    172  C   LYS A  24      27.469   2.026  28.016  1.00 20.35           C  
+ANISOU  172  C   LYS A  24     1793   3436   2503    281     35     53       C  
+ATOM    173  O   LYS A  24      27.853   1.907  29.174  1.00 23.01           O  
+ANISOU  173  O   LYS A  24     2723   3247   2771   -235   -544      0       O  
+ATOM    174  CB  LYS A  24      29.598   0.970  27.249  1.00 22.50           C  
+ANISOU  174  CB  LYS A  24     1749   3385   3416    559   -555   -537       C  
+ATOM    175  CG  LYS A  24      30.241  -0.088  26.371  1.00 24.97           C  
+ANISOU  175  CG  LYS A  24     1754   4328   3404    926   -428   -735       C  
+ATOM    176  CD  LYS A  24      31.754  -0.174  26.587  1.00 29.56           C  
+ANISOU  176  CD  LYS A  24     1761   4476   4995    943   -464   -701       C  
+ATOM    177  CE  LYS A  24      32.356  -1.094  25.537  1.00 38.17           C  
+ANISOU  177  CE  LYS A  24     2768   5370   6365   2246    -40  -1043       C  
+ATOM    178  NZ  LYS A  24      32.326  -2.509  26.024  1.00 42.13           N  
+ANISOU  178  NZ  LYS A  24     4199   5405   6402   2782    906   -979       N  
+ATOM    179  N   GLY A  25      26.527   2.872  27.623  1.00 20.38           N  
+ANISOU  179  N   GLY A  25     2078   2825   2839    331   -191   -457       N  
+ATOM    180  CA  GLY A  25      25.817   3.788  28.488  1.00 21.02           C  
+ANISOU  180  CA  GLY A  25     2271   2685   3029    -32    217   -423       C  
+ATOM    181  C   GLY A  25      24.894   3.198  29.536  1.00 20.16           C  
+ANISOU  181  C   GLY A  25     2228   3089   2342   -405   -250   -539       C  
+ATOM    182  O   GLY A  25      24.755   1.963  29.608  1.00 21.01           O  
+ANISOU  182  O   GLY A  25     2214   3151   2618   -501   -310   -304       O  
+ATOM    183  N   GLU A  26      24.298   4.069  30.347  1.00 21.24           N  
+ANISOU  183  N   GLU A  26     1637   3544   2890   -191   -165   -637       N  
+ATOM    184  CA  GLU A  26      23.427   3.694  31.459  1.00 22.58           C  
+ANISOU  184  CA  GLU A  26     1594   4555   2428     52   -446   -501       C  
+ATOM    185  C   GLU A  26      21.988   3.457  31.021  1.00 18.85           C  
+ANISOU  185  C   GLU A  26     1552   3417   2192     79   -372    103       C  
+ATOM    186  O   GLU A  26      21.247   2.930  31.861  1.00 20.47           O  
+ANISOU  186  O   GLU A  26     2224   3516   2037   -528   -359   -159       O  
+ATOM    187  CB  GLU A  26      23.455   4.773  32.549  1.00 26.69           C  
+ANISOU  187  CB  GLU A  26     1991   5363   2786   -138   -353  -1084       C  
+ATOM    188  CG  GLU A  26      24.855   4.991  33.117  1.00 31.28           C  
+ANISOU  188  CG  GLU A  26     2291   5993   3600   -234   -860  -1407       C  
+ATOM    189  CD  GLU A  26      25.431   3.767  33.814  1.00 46.09           C  
+ANISOU  189  CD  GLU A  26     4027   7105   6381    429  -2892   -850       C  
+ATOM    190  OE1 GLU A  26      26.616   3.426  33.567  1.00 59.91           O  
+ANISOU  190  OE1 GLU A  26     3974   8145  10644   1349  -4200  -2808       O  
+ATOM    191  OE2 GLU A  26      24.732   3.107  34.629  1.00 53.10           O  
+ANISOU  191  OE2 GLU A  26     6414   6846   6917  -1465  -4524    574       O  
+ATOM    192  N   ARG A  27      21.592   3.820  29.790  1.00 16.59           N  
+ANISOU  192  N   ARG A  27     2123   1935   2246     41   -611    -69       N  
+ATOM    193  CA  ARG A  27      20.189   3.529  29.456  1.00 16.06           C  
+ANISOU  193  CA  ARG A  27     2162   2145   1794     82   -584   -271       C  
+ATOM    194  C   ARG A  27      20.086   3.130  27.987  1.00 14.56           C  
+ANISOU  194  C   ARG A  27     2022   1953   1556     37   -178     38       C  
+ATOM    195  O   ARG A  27      19.370   3.737  27.190  1.00 15.78           O  
+ANISOU  195  O   ARG A  27     2110   2209   1674    188   -283     30       O  
+ATOM    196  CB  ARG A  27      19.334   4.722  29.835  1.00 19.76           C  
+ANISOU  196  CB  ARG A  27     2178   2664   2665    162   -119   -810       C  
+ATOM    197  CG  ARG A  27      19.725   6.032  29.231  1.00 27.90           C  
+ANISOU  197  CG  ARG A  27     4481   2229   3891    596    200   -567       C  
+ATOM    198  CD  ARG A  27      18.681   7.119  29.461  1.00 27.74           C  
+ANISOU  198  CD  ARG A  27     3559   2936   4044    549    420   -102       C  
+ATOM    199  NE  ARG A  27      17.547   7.047  28.530  1.00 25.98           N  
+ANISOU  199  NE  ARG A  27     3906   2330   3634   -163    409    216       N  
+ATOM    200  CZ  ARG A  27      16.608   7.970  28.399  1.00 20.02           C  
+ANISOU  200  CZ  ARG A  27     3289   2349   1968   -410    558    -50       C  
+ATOM    201  NH1 ARG A  27      16.583   9.100  29.120  1.00 25.81           N  
+ANISOU  201  NH1 ARG A  27     3448   3410   2947     20    334  -1173       N  
+ATOM    202  NH2 ARG A  27      15.627   7.815  27.543  1.00 24.53           N  
+ANISOU  202  NH2 ARG A  27     3239   3551   2531   -627    444   -618       N  
+ATOM    203  N   GLN A  28      20.802   2.043  27.694  1.00 14.92           N  
+ANISOU  203  N   GLN A  28     1477   2395   1799    117   -187   -139       N  
+ATOM    204  CA  GLN A  28      20.837   1.515  26.339  1.00 14.70           C  
+ANISOU  204  CA  GLN A  28     1430   2219   1937    -33      3   -206       C  
+ATOM    205  C   GLN A  28      19.685   0.560  26.075  1.00 13.11           C  
+ANISOU  205  C   GLN A  28     1444   1762   1776    191   -104     11       C  
+ATOM    206  O   GLN A  28      19.172  -0.114  26.968  1.00 14.88           O  
+ANISOU  206  O   GLN A  28     1664   2313   1677   -153     24    -88       O  
+ATOM    207  CB  GLN A  28      22.194   0.839  26.059  1.00 15.09           C  
+ANISOU  207  CB  GLN A  28     1501   2080   2153     34    -18   -158       C  
+ATOM    208  CG  GLN A  28      23.341   1.836  25.893  1.00 15.94           C  
+ANISOU  208  CG  GLN A  28     1490   2048   2519    130    360   -372       C  
+ATOM    209  CD  GLN A  28      23.230   2.659  24.628  1.00 18.14           C  
+ANISOU  209  CD  GLN A  28     1790   2412   2690     60    740    -64       C  
+ATOM    210  OE1 GLN A  28      23.423   2.119  23.541  1.00 15.04           O  
+ANISOU  210  OE1 GLN A  28     1140   2008   2567    -77    -28    -63       O  
+ATOM    211  NE2 GLN A  28      22.942   3.956  24.767  1.00 14.94           N  
+ANISOU  211  NE2 GLN A  28     1372   2469   1833     91     46   -155       N  
+ATOM    212  N   SER A  29      19.322   0.517  24.793  1.00 12.96           N  
+ANISOU  212  N   SER A  29     1171   2018   1733     21    102    -12       N  
+ATOM    213  CA  SER A  29      18.288  -0.362  24.298  1.00 12.59           C  
+ANISOU  213  CA  SER A  29     1337   1662   1786     67     61    -41       C  
+ATOM    214  C   SER A  29      18.814  -1.212  23.149  1.00 13.28           C  
+ANISOU  214  C   SER A  29     1539   1754   1752    108    104      8       C  
+ATOM    215  O   SER A  29      19.781  -0.814  22.491  1.00 14.08           O  
+ANISOU  215  O   SER A  29     1806   1818   1725    -35    242    -98       O  
+ATOM    216  CB  SER A  29      17.085   0.445  23.819  1.00 13.47           C  
+ANISOU  216  CB  SER A  29     1348   1374   2396    -76   -209   -160       C  
+ATOM    217  OG  SER A  29      16.455   1.156  24.875  1.00 15.09           O  
+ANISOU  217  OG  SER A  29     1389   1827   2519    299   -341   -382       O  
+ATOM    218  N   PRO A  30      18.168  -2.354  22.886  1.00 13.26           N  
+ANISOU  218  N   PRO A  30     1483   2013   1542    -66   -139   -106       N  
+ATOM    219  CA  PRO A  30      17.017  -2.905  23.595  1.00 14.43           C  
+ANISOU  219  CA  PRO A  30     1773   1959   1751    -95    130    -90       C  
+ATOM    220  C   PRO A  30      17.418  -3.597  24.904  1.00 13.69           C  
+ANISOU  220  C   PRO A  30     1527   1625   2050    369    209     36       C  
+ATOM    221  O   PRO A  30      18.602  -3.632  25.236  1.00 15.65           O  
+ANISOU  221  O   PRO A  30     1600   2277   2069     96     24   -299       O  
+ATOM    222  CB  PRO A  30      16.537  -3.975  22.605  1.00 13.93           C  
+ANISOU  222  CB  PRO A  30     1602   1539   2153     10    145    -43       C  
+ATOM    223  CG  PRO A  30      17.818  -4.495  22.017  1.00 13.71           C  
+ANISOU  223  CG  PRO A  30     1566   1932   1713    107      7    -29       C  
+ATOM    224  CD  PRO A  30      18.631  -3.244  21.804  1.00 14.65           C  
+ANISOU  224  CD  PRO A  30     1353   2038   2176     62     39   -354       C  
+ATOM    225  N   VAL A  31      16.415  -4.125  25.614  1.00 14.11           N  
+ANISOU  225  N   VAL A  31     1591   2078   1694    257    112     32       N  
+ATOM    226  CA  VAL A  31      16.628  -4.855  26.836  1.00 15.14           C  
+ANISOU  226  CA  VAL A  31     1797   2177   1780     90    -54     78       C  
+ATOM    227  C   VAL A  31      15.731  -6.090  26.791  1.00 14.49           C  
+ANISOU  227  C   VAL A  31     1415   2127   1964    248     66     85       C  
+ATOM    228  O   VAL A  31      14.769  -6.170  26.024  1.00 14.60           O  
+ANISOU  228  O   VAL A  31     1797   2035   1715    157    -85     34       O  
+ATOM    229  CB  VAL A  31      16.325  -4.053  28.106  1.00 14.89           C  
+ANISOU  229  CB  VAL A  31     1669   2302   1688   -203    134    176       C  
+ATOM    230  CG1 VAL A  31      17.225  -2.817  28.142  1.00 18.43           C  
+ANISOU  230  CG1 VAL A  31     1889   2635   2478   -539     58   -179       C  
+ATOM    231  CG2 VAL A  31      14.853  -3.682  28.120  1.00 15.54           C  
+ANISOU  231  CG2 VAL A  31     1734   1757   2415   -168     20   -233       C  
+ATOM    232  N   ASP A  32      16.101  -7.026  27.644  1.00 14.81           N  
+ANISOU  232  N   ASP A  32     1760   2170   1697    106   -138      8       N  
+ATOM    233  CA  ASP A  32      15.191  -8.132  27.934  1.00 14.50           C  
+ANISOU  233  CA  ASP A  32     1505   2223   1780    194   -203    170       C  
+ATOM    234  C   ASP A  32      14.129  -7.655  28.920  1.00 14.62           C  
+ANISOU  234  C   ASP A  32     1628   2059   1866     23   -218    -87       C  
+ATOM    235  O   ASP A  32      14.472  -7.015  29.901  1.00 17.44           O  
+ANISOU  235  O   ASP A  32     2156   2259   2213    176   -372   -435       O  
+ATOM    236  CB  ASP A  32      15.920  -9.319  28.509  1.00 16.21           C  
+ANISOU  236  CB  ASP A  32     2233   2229   1699    468   -224    103       C  
+ATOM    237  CG  ASP A  32      14.975 -10.463  28.844  1.00 17.25           C  
+ANISOU  237  CG  ASP A  32     2626   2075   1852    356    -59    -32       C  
+ATOM    238  OD1 ASP A  32      14.311 -10.880  27.879  1.00 16.70           O  
+ANISOU  238  OD1 ASP A  32     2644   1859   1842    315   -229    311       O  
+ATOM    239  OD2 ASP A  32      14.902 -10.930  30.017  1.00 17.29           O  
+ANISOU  239  OD2 ASP A  32     1954   2688   1925    318   -218    196       O  
+ATOM    240  N   ILE A  33      12.877  -7.940  28.626  1.00 14.90           N  
+ANISOU  240  N   ILE A  33     1489   2163   2008     49    -82     71       N  
+ATOM    241  CA  ILE A  33      11.746  -7.612  29.462  1.00 13.20           C  
+ANISOU  241  CA  ILE A  33     1731   1591   1695     59   -101     -5       C  
+ATOM    242  C   ILE A  33      11.417  -8.847  30.286  1.00 13.75           C  
+ANISOU  242  C   ILE A  33     1972   1603   1651    192    -51     41       C  
+ATOM    243  O   ILE A  33      10.850  -9.808  29.803  1.00 15.36           O  
+ANISOU  243  O   ILE A  33     2175   1786   1874   -169     36    123       O  
+ATOM    244  CB  ILE A  33      10.522  -7.189  28.637  1.00 14.42           C  
+ANISOU  244  CB  ILE A  33     1477   1852   2149     85    109    462       C  
+ATOM    245  CG1 ILE A  33      10.832  -5.955  27.792  1.00 15.68           C  
+ANISOU  245  CG1 ILE A  33     1391   2580   1988   -327   -124    798       C  
+ATOM    246  CG2 ILE A  33       9.316  -7.038  29.555  1.00 15.12           C  
+ANISOU  246  CG2 ILE A  33     1572   2326   1847   -258    125    380       C  
+ATOM    247  CD1 ILE A  33       9.827  -5.669  26.707  1.00 17.36           C  
+ANISOU  247  CD1 ILE A  33     1276   2851   2469    259   -193    881       C  
+ATOM    248  N   ASP A  34      11.855  -8.776  31.534  1.00 16.54           N  
+ANISOU  248  N   ASP A  34     2595   2067   1621    174    -80     91       N  
+ATOM    249  CA  ASP A  34      11.518  -9.804  32.505  1.00 16.13           C  
+ANISOU  249  CA  ASP A  34     2541   2074   1512    168     18     12       C  
+ATOM    250  C   ASP A  34      10.117  -9.536  33.049  1.00 18.37           C  
+ANISOU  250  C   ASP A  34     2787   2541   1653    194    264   -210       C  
+ATOM    251  O   ASP A  34       9.904  -8.648  33.860  1.00 20.53           O  
+ANISOU  251  O   ASP A  34     3449   2493   1858    212    512   -288       O  
+ATOM    252  CB  ASP A  34      12.524  -9.832  33.660  1.00 19.37           C  
+ANISOU  252  CB  ASP A  34     3143   2379   1840     89   -450    281       C  
+ATOM    253  CG  ASP A  34      12.265 -11.088  34.481  1.00 23.64           C  
+ANISOU  253  CG  ASP A  34     2555   3257   3172    124   -381   1420       C  
+ATOM    254  OD1 ASP A  34      11.187 -11.177  35.071  1.00 30.13           O  
+ANISOU  254  OD1 ASP A  34     4048   3853   3546    153   1141    682       O  
+ATOM    255  OD2 ASP A  34      13.071 -12.016  34.527  1.00 39.98           O  
+ANISOU  255  OD2 ASP A  34     3331   4073   7788    835    781   3466       O  
+ATOM    256  N   THR A  35       9.163 -10.333  32.580  1.00 17.35           N  
+ANISOU  256  N   THR A  35     2497   2318   1776    261    277     80       N  
+ATOM    257  CA  THR A  35       7.767 -10.050  32.868  1.00 19.17           C  
+ANISOU  257  CA  THR A  35     2579   2788   1915    635    330    407       C  
+ATOM    258  C   THR A  35       7.364 -10.249  34.319  1.00 20.63           C  
+ANISOU  258  C   THR A  35     2929   2648   2261    272    794    721       C  
+ATOM    259  O   THR A  35       6.342  -9.696  34.754  1.00 26.17           O  
+ANISOU  259  O   THR A  35     3057   4678   2208    877    561     83       O  
+ATOM    260  CB  THR A  35       6.836 -10.964  32.027  1.00 19.49           C  
+ANISOU  260  CB  THR A  35     2007   2656   2744    675    735    -35       C  
+ATOM    261  OG1 THR A  35       7.047 -12.316  32.468  1.00 21.25           O  
+ANISOU  261  OG1 THR A  35     2273   2899   2903    473    162    448       O  
+ATOM    262  CG2 THR A  35       7.131 -10.843  30.533  1.00 20.60           C  
+ANISOU  262  CG2 THR A  35     2381   3026   2421   -205   -102    199       C  
+ATOM    263  N   HIS A  36       8.134 -11.016  35.068  1.00 21.85           N  
+ANISOU  263  N   HIS A  36     4032   2205   2063    621    945    720       N  
+ATOM    264  CA  HIS A  36       7.787 -11.202  36.469  1.00 24.86           C  
+ANISOU  264  CA  HIS A  36     4431   2758   2256    214   1208   1026       C  
+ATOM    265  C   HIS A  36       8.357 -10.069  37.309  1.00 26.22           C  
+ANISOU  265  C   HIS A  36     5029   3201   1733    203   1017    907       C  
+ATOM    266  O   HIS A  36       7.875  -9.792  38.416  1.00 33.12           O  
+ANISOU  266  O   HIS A  36     7043   3373   2168   -131   2000    841       O  
+ATOM    267  CB  HIS A  36       8.316 -12.575  36.843  1.00 26.41           C  
+ANISOU  267  CB  HIS A  36     4851   3066   2117    467    675   1116       C  
+ATOM    268  CG  HIS A  36       7.442 -13.652  36.241  1.00 30.70           C  
+ANISOU  268  CG  HIS A  36     6173   2660   2832   1012   -497    607       C  
+ATOM    269  ND1 HIS A  36       7.888 -14.475  35.239  1.00 35.44           N  
+ANISOU  269  ND1 HIS A  36     7587   3288   2589   2006   -810    597       N  
+ATOM    270  CD2 HIS A  36       6.158 -14.023  36.501  1.00 31.54           C  
+ANISOU  270  CD2 HIS A  36     7189   2414   2379   -686   -312    401       C  
+ATOM    271  CE1 HIS A  36       6.920 -15.312  34.903  1.00 40.31           C  
+ANISOU  271  CE1 HIS A  36     8884   2729   3703   1743  -1019    -72       C  
+ATOM    272  NE2 HIS A  36       5.861 -15.062  35.651  1.00 38.24           N  
+ANISOU  272  NE2 HIS A  36     8762   2316   3453     -8   -643   -147       N  
+ATOM    273  N   THR A  37       9.385  -9.393  36.810  1.00 22.50           N  
+ANISOU  273  N   THR A  37     3524   2753   2270    873    756    280       N  
+ATOM    274  CA  THR A  37      10.001  -8.298  37.540  1.00 24.01           C  
+ANISOU  274  CA  THR A  37     4205   2829   2090    998   -470    700       C  
+ATOM    275  C   THR A  37       9.457  -6.936  37.157  1.00 20.41           C  
+ANISOU  275  C   THR A  37     3492   2709   1553    988     12    454       C  
+ATOM    276  O   THR A  37       9.596  -5.966  37.909  1.00 26.28           O  
+ANISOU  276  O   THR A  37     4253   3461   2272   1662   -107   -457       O  
+ATOM    277  CB  THR A  37      11.529  -8.397  37.307  1.00 29.90           C  
+ANISOU  277  CB  THR A  37     3933   3568   3860   1549  -1599   -849       C  
+ATOM    278  OG1 THR A  37      11.976  -9.496  38.101  1.00 38.67           O  
+ANISOU  278  OG1 THR A  37     3889   3816   6988   1233   -626    917       O  
+ATOM    279  CG2 THR A  37      12.246  -7.152  37.773  1.00 37.59           C  
+ANISOU  279  CG2 THR A  37     5709   4176   4398   -604  -1461    621       C  
+ATOM    280  N   ALA A  38       8.821  -6.817  36.000  1.00 20.88           N  
+ANISOU  280  N   ALA A  38     3289   3055   1588   1265     77    523       N  
+ATOM    281  CA  ALA A  38       8.198  -5.551  35.591  1.00 19.00           C  
+ANISOU  281  CA  ALA A  38     2712   2849   1659    884    -54    386       C  
+ATOM    282  C   ALA A  38       7.089  -5.228  36.575  1.00 22.36           C  
+ANISOU  282  C   ALA A  38     3065   2823   2606    842    516    164       C  
+ATOM    283  O   ALA A  38       6.387  -6.133  36.988  1.00 26.42           O  
+ANISOU  283  O   ALA A  38     3986   2832   3221   1154   1341    823       O  
+ATOM    284  CB  ALA A  38       7.619  -5.651  34.203  1.00 21.19           C  
+ANISOU  284  CB  ALA A  38     3229   2907   1916    365   -507    775       C  
+ATOM    285  N   LYS A  39       6.945  -3.972  36.914  1.00 22.04           N  
+ANISOU  285  N   LYS A  39     3180   2832   2362   1149    149    368       N  
+ATOM    286  CA  LYS A  39       5.973  -3.541  37.923  1.00 24.85           C  
+ANISOU  286  CA  LYS A  39     3021   3051   3371   1506    343    122       C  
+ATOM    287  C   LYS A  39       4.755  -2.909  37.282  1.00 21.88           C  
+ANISOU  287  C   LYS A  39     2531   3074   2708    541    303    637       C  
+ATOM    288  O   LYS A  39       4.904  -1.949  36.525  1.00 20.47           O  
+ANISOU  288  O   LYS A  39     2541   2841   2398    298    345    343       O  
+ATOM    289  CB  LYS A  39       6.654  -2.539  38.853  1.00 31.20           C  
+ANISOU  289  CB  LYS A  39     3126   5243   3486   2290   -437  -1231       C  
+ATOM    290  CG  LYS A  39       5.839  -1.959  39.989  1.00 38.85           C  
+ANISOU  290  CG  LYS A  39     3518   5758   5487   2345    469  -2185       C  
+ATOM    291  CD  LYS A  39       5.271  -3.025  40.901  1.00 42.91           C  
+ANISOU  291  CD  LYS A  39     3073   7916   5315   2250   1043  -1374       C  
+ATOM    292  CE  LYS A  39       5.068  -2.563  42.326  1.00 43.53           C  
+ANISOU  292  CE  LYS A  39     3614   8037   4889   1258   -855  -1732       C  
+ATOM    293  NZ  LYS A  39       4.531  -1.192  42.445  1.00 46.14           N  
+ANISOU  293  NZ  LYS A  39     2754   7608   7168    106   1507  -2780       N  
+ATOM    294  N   TYR A  40       3.574  -3.428  37.603  1.00 21.50           N  
+ANISOU  294  N   TYR A  40     2938   2662   2567     84    244    325       N  
+ATOM    295  CA  TYR A  40       2.365  -2.734  37.164  1.00 21.39           C  
+ANISOU  295  CA  TYR A  40     2421   3075   2633   -400   -174    -44       C  
+ATOM    296  C   TYR A  40       2.336  -1.338  37.784  1.00 21.88           C  
+ANISOU  296  C   TYR A  40     2371   3432   2510    528   -388   -397       C  
+ATOM    297  O   TYR A  40       2.556  -1.153  38.990  1.00 25.94           O  
+ANISOU  297  O   TYR A  40     3019   4374   2464   1600   -377   -692       O  
+ATOM    298  CB  TYR A  40       1.110  -3.503  37.569  1.00 25.96           C  
+ANISOU  298  CB  TYR A  40     2967   4618   2280   -857    552    123       C  
+ATOM    299  CG  TYR A  40      -0.131  -2.653  37.408  1.00 31.91           C  
+ANISOU  299  CG  TYR A  40     2691   6583   2852   -348   1122    885       C  
+ATOM    300  CD1 TYR A  40      -0.533  -2.181  36.171  1.00 37.32           C  
+ANISOU  300  CD1 TYR A  40     2799   8117   3265    298   1171   1592       C  
+ATOM    301  CD2 TYR A  40      -0.889  -2.321  38.515  1.00 41.40           C  
+ANISOU  301  CD2 TYR A  40     3967   8729   3035    920   1115    162       C  
+ATOM    302  CE1 TYR A  40      -1.670  -1.402  36.049  1.00 41.49           C  
+ANISOU  302  CE1 TYR A  40     2448   9712   3606    589    923   1266       C  
+ATOM    303  CE2 TYR A  40      -2.027  -1.544  38.393  1.00 45.02           C  
+ANISOU  303  CE2 TYR A  40     3489  10244   3373   1115    924   -289       C  
+ATOM    304  CZ  TYR A  40      -2.414  -1.085  37.159  1.00 45.61           C  
+ANISOU  304  CZ  TYR A  40     2759  10760   3810    884    665    176       C  
+ATOM    305  OH  TYR A  40      -3.546  -0.314  37.082  1.00 53.87           O  
+ANISOU  305  OH  TYR A  40     2193  13663   4612   1433    694    361       O  
+ATOM    306  N   ASP A  41       2.039  -0.343  36.959  1.00 21.66           N  
+ANISOU  306  N   ASP A  41     2658   3248   2324    489    283   -375       N  
+ATOM    307  CA  ASP A  41       1.982   1.051  37.407  1.00 24.54           C  
+ANISOU  307  CA  ASP A  41     3540   3475   2310   1136    172   -648       C  
+ATOM    308  C   ASP A  41       0.595   1.622  37.154  1.00 29.56           C  
+ANISOU  308  C   ASP A  41     4245   5156   1832   2365    316   -454       C  
+ATOM    309  O   ASP A  41       0.245   2.010  36.045  1.00 31.61           O  
+ANISOU  309  O   ASP A  41     4447   5144   2419   1814    547    877       O  
+ATOM    310  CB  ASP A  41       3.066   1.863  36.710  1.00 26.92           C  
+ANISOU  310  CB  ASP A  41     4358   2912   2960    375   -452   -248       C  
+ATOM    311  CG  ASP A  41       3.197   3.295  37.187  1.00 29.99           C  
+ANISOU  311  CG  ASP A  41     5602   3363   2428    566   -471   -901       C  
+ATOM    312  OD1 ASP A  41       2.341   3.717  37.972  1.00 40.70           O  
+ANISOU  312  OD1 ASP A  41     7883   5572   2009   2984   -377   -774       O  
+ATOM    313  OD2 ASP A  41       4.142   4.018  36.787  1.00 39.23           O  
+ANISOU  313  OD2 ASP A  41     7303   3543   4058   -981  -1301   -227       O  
+ATOM    314  N   PRO A  42      -0.231   1.687  38.198  1.00 36.61           N  
+ANISOU  314  N   PRO A  42     4740   6838   2331   3060    929    358       N  
+ATOM    315  CA  PRO A  42      -1.528   2.361  38.074  1.00 42.06           C  
+ANISOU  315  CA  PRO A  42     4829   8077   3074   3443   1309   1118       C  
+ATOM    316  C   PRO A  42      -1.378   3.842  37.717  1.00 41.75           C  
+ANISOU  316  C   PRO A  42     5273   7856   2736   4059   1442    867       C  
+ATOM    317  O   PRO A  42      -2.359   4.479  37.295  1.00 48.60           O  
+ANISOU  317  O   PRO A  42     5926   9292   3248   4919   1594   1573       O  
+ATOM    318  CB  PRO A  42      -2.152   2.250  39.473  1.00 44.98           C  
+ANISOU  318  CB  PRO A  42     4971   8639   3480   3353   1725   1151       C  
+ATOM    319  CG  PRO A  42      -1.331   1.302  40.259  1.00 45.45           C  
+ANISOU  319  CG  PRO A  42     4939   8829   3502   2563   1476   1856       C  
+ATOM    320  CD  PRO A  42      -0.014   1.147  39.549  1.00 41.84           C  
+ANISOU  320  CD  PRO A  42     5205   8032   2662   3391   1260   1068       C  
+ATOM    321  N   SER A  43      -0.177   4.424  37.880  1.00 43.71           N  
+ANISOU  321  N   SER A  43     6511   7619   2479   3128    421    912       N  
+ATOM    322  CA  SER A  43      -0.004   5.828  37.505  1.00 46.89           C  
+ANISOU  322  CA  SER A  43     7812   7345   2658   3373     80    677       C  
+ATOM    323  C   SER A  43      -0.228   5.968  35.991  1.00 45.67           C  
+ANISOU  323  C   SER A  43     7662   6919   2770   3576   -104    765       C  
+ATOM    324  O   SER A  43      -0.680   6.995  35.500  1.00 46.37           O  
+ANISOU  324  O   SER A  43     8727   6001   2891   2815   -103    678       O  
+ATOM    325  CB  SER A  43       1.348   6.456  37.793  1.00 51.16           C  
+ANISOU  325  CB  SER A  43     9114   7142   3181   2366   -457     80       C  
+ATOM    326  OG  SER A  43       2.201   5.878  38.730  1.00 67.55           O  
+ANISOU  326  OG  SER A  43     9780   8615   7271   1819  -2958   1222       O  
+ATOM    327  N   LEU A  44       0.130   4.929  35.250  1.00 40.77           N  
+ANISOU  327  N   LEU A  44     6188   6750   2550   3304   -253    848       N  
+ATOM    328  CA  LEU A  44       0.110   5.031  33.792  1.00 33.67           C  
+ANISOU  328  CA  LEU A  44     2898   7346   2551   1696    274   1002       C  
+ATOM    329  C   LEU A  44      -1.301   5.346  33.310  1.00 37.78           C  
+ANISOU  329  C   LEU A  44     2598   8211   3544    978    240   2238       C  
+ATOM    330  O   LEU A  44      -2.285   4.743  33.725  1.00 45.39           O  
+ANISOU  330  O   LEU A  44     3190  10133   3925    163    619   2502       O  
+ATOM    331  CB  LEU A  44       0.659   3.755  33.153  1.00 31.27           C  
+ANISOU  331  CB  LEU A  44     2934   6659   2289    473   -168    564       C  
+ATOM    332  CG  LEU A  44       2.172   3.576  33.361  1.00 24.69           C  
+ANISOU  332  CG  LEU A  44     3050   4461   1870    759   -191    272       C  
+ATOM    333  CD1 LEU A  44       2.592   2.181  32.909  1.00 25.76           C  
+ANISOU  333  CD1 LEU A  44     3452   3949   2386   -525    774     34       C  
+ATOM    334  CD2 LEU A  44       2.984   4.610  32.601  1.00 26.29           C  
+ANISOU  334  CD2 LEU A  44     2836   3485   3668   1017   -252    483       C  
+ATOM    335  N   LYS A  45      -1.420   6.322  32.404  1.00 40.94           N  
+ANISOU  335  N   LYS A  45     2944   8357   4255   1094   -164   2561       N  
+ATOM    336  CA  LYS A  45      -2.748   6.546  31.825  1.00 42.77           C  
+ANISOU  336  CA  LYS A  45     2784   7910   5558   1931    -60   2191       C  
+ATOM    337  C   LYS A  45      -2.817   5.823  30.481  1.00 40.35           C  
+ANISOU  337  C   LYS A  45     2130   8871   4330    904   -109   3120       C  
+ATOM    338  O   LYS A  45      -1.758   5.490  29.939  1.00 39.38           O  
+ANISOU  338  O   LYS A  45     2091   9336   3537    516   -110   2991       O  
+ATOM    339  CB  LYS A  45      -3.069   8.015  31.697  1.00 50.22           C  
+ANISOU  339  CB  LYS A  45     4551   7848   6684   1438   -145   3461       C  
+ATOM    340  CG  LYS A  45      -2.001   9.080  31.541  1.00 53.77           C  
+ANISOU  340  CG  LYS A  45     4920   8542   6968   1109   1474   3449       C  
+ATOM    341  CD  LYS A  45      -2.396  10.079  30.475  1.00 64.44           C  
+ANISOU  341  CD  LYS A  45     7899   7828   8758    867    363   3905       C  
+ATOM    342  CE  LYS A  45      -1.927  11.498  30.718  1.00 72.46           C  
+ANISOU  342  CE  LYS A  45     9525   7753  10252   1345     -6   2875       C  
+ATOM    343  NZ  LYS A  45      -2.184  12.327  29.496  1.00 79.99           N  
+ANISOU  343  NZ  LYS A  45    12370   6618  11406   2731    884   3363       N  
+ATOM    344  N   PRO A  46      -3.986   5.544  29.910  1.00 43.83           N  
+ANISOU  344  N   PRO A  46     2004  10015   4633    -75    250   3737       N  
+ATOM    345  CA  PRO A  46      -4.057   4.781  28.658  1.00 41.49           C  
+ANISOU  345  CA  PRO A  46     1211   9037   5516   -708    -48   3399       C  
+ATOM    346  C   PRO A  46      -3.233   5.445  27.565  1.00 35.44           C  
+ANISOU  346  C   PRO A  46     1514   7431   4522   -782   -125   2322       C  
+ATOM    347  O   PRO A  46      -3.067   6.642  27.425  1.00 33.90           O  
+ANISOU  347  O   PRO A  46     2321   7088   3469    426    303   2224       O  
+ATOM    348  CB  PRO A  46      -5.535   4.814  28.249  1.00 43.26           C  
+ANISOU  348  CB  PRO A  46     1195   9672   5570     19     82   3813       C  
+ATOM    349  CG  PRO A  46      -6.205   4.972  29.572  1.00 46.89           C  
+ANISOU  349  CG  PRO A  46     1591  10525   5699    644    186   3477       C  
+ATOM    350  CD  PRO A  46      -5.323   5.915  30.354  1.00 48.10           C  
+ANISOU  350  CD  PRO A  46     2021  10921   5333     67    389   3627       C  
+ATOM    351  N   LEU A  47      -2.689   4.582  26.732  1.00 33.25           N  
+ANISOU  351  N   LEU A  47     1808   6229   4594  -1024   -643   2384       N  
+ATOM    352  CA  LEU A  47      -1.974   5.059  25.560  1.00 28.29           C  
+ANISOU  352  CA  LEU A  47     2000   4458   4290   -586   -443   1642       C  
+ATOM    353  C   LEU A  47      -2.952   5.537  24.494  1.00 28.11           C  
+ANISOU  353  C   LEU A  47     2751   3998   3932  -1005  -1029   1066       C  
+ATOM    354  O   LEU A  47      -4.007   4.913  24.310  1.00 29.97           O  
+ANISOU  354  O   LEU A  47     1760   3902   5725   -338   -736   1599       O  
+ATOM    355  CB  LEU A  47      -1.125   3.895  25.060  1.00 32.27           C  
+ANISOU  355  CB  LEU A  47     2951   4317   4992   -595  -1114    548       C  
+ATOM    356  CG  LEU A  47      -0.106   4.225  23.994  1.00 30.61           C  
+ANISOU  356  CG  LEU A  47     2518   3893   5219   -581   -814   -695       C  
+ATOM    357  CD1 LEU A  47       0.984   5.055  24.646  1.00 27.64           C  
+ANISOU  357  CD1 LEU A  47     2286   3665   4551     -2   -890   -863       C  
+ATOM    358  CD2 LEU A  47       0.408   2.939  23.385  1.00 39.79           C  
+ANISOU  358  CD2 LEU A  47     3099   4629   7392   -383  -1556  -2222       C  
+ATOM    359  N   SER A  48      -2.605   6.641  23.828  1.00 21.59           N  
+ANISOU  359  N   SER A  48     1567   3606   3028   -196   -128    489       N  
+ATOM    360  CA  SER A  48      -3.427   7.184  22.763  1.00 22.60           C  
+ANISOU  360  CA  SER A  48     2315   3627   2645    483     79    144       C  
+ATOM    361  C   SER A  48      -2.618   7.190  21.449  1.00 19.39           C  
+ANISOU  361  C   SER A  48     2256   2277   2833   -502    157    -81       C  
+ATOM    362  O   SER A  48      -1.652   7.939  21.328  1.00 22.04           O  
+ANISOU  362  O   SER A  48     2158   2411   3804   -629     69   -576       O  
+ATOM    363  CB  SER A  48      -3.958   8.581  23.110  1.00 24.05           C  
+ANISOU  363  CB  SER A  48     2869   3603   2665    549    310    228       C  
+ATOM    364  OG  SER A  48      -4.503   9.207  21.963  1.00 31.46           O  
+ANISOU  364  OG  SER A  48     4334   4325   3293   1320    168    782       O  
+ATOM    365  N   VAL A  49      -3.067   6.319  20.553  1.00 19.39           N  
+ANISOU  365  N   VAL A  49     1716   2778   2875   -755    101   -175       N  
+ATOM    366  CA  VAL A  49      -2.459   6.170  19.248  1.00 22.31           C  
+ANISOU  366  CA  VAL A  49     2880   2928   2668   -402    127     -3       C  
+ATOM    367  C   VAL A  49      -3.438   6.803  18.258  1.00 23.77           C  
+ANISOU  367  C   VAL A  49     2713   3185   3135   -982   -255    303       C  
+ATOM    368  O   VAL A  49      -4.486   6.210  18.084  1.00 26.20           O  
+ANISOU  368  O   VAL A  49     2645   4179   3131  -1317    172    225       O  
+ATOM    369  CB  VAL A  49      -2.200   4.713  18.837  1.00 26.08           C  
+ANISOU  369  CB  VAL A  49     2976   3366   3569   -157    -69   -795       C  
+ATOM    370  CG1 VAL A  49      -1.511   4.665  17.478  1.00 31.12           C  
+ANISOU  370  CG1 VAL A  49     4092   3786   3945  -1700    579  -1727       C  
+ATOM    371  CG2 VAL A  49      -1.337   3.993  19.865  1.00 27.89           C  
+ANISOU  371  CG2 VAL A  49     2311   3124   5162   -235    -95     -8       C  
+ATOM    372  N   SER A  50      -3.115   7.958  17.698  1.00 22.23           N  
+ANISOU  372  N   SER A  50     2277   2538   3632   -198    142     70       N  
+ATOM    373  CA  SER A  50      -4.058   8.638  16.793  1.00 22.75           C  
+ANISOU  373  CA  SER A  50     2059   2631   3954    172    220    -68       C  
+ATOM    374  C   SER A  50      -3.422   8.754  15.414  1.00 20.84           C  
+ANISOU  374  C   SER A  50     1545   2676   3697    137   -191    -12       C  
+ATOM    375  O   SER A  50      -2.740   9.719  15.094  1.00 22.89           O  
+ANISOU  375  O   SER A  50     2890   2890   2916   -528   -716    188       O  
+ATOM    376  CB  SER A  50      -4.502   9.968  17.394  1.00 25.44           C  
+ANISOU  376  CB  SER A  50     3150   2576   3939    191    312    -94       C  
+ATOM    377  OG  SER A  50      -5.005   9.770  18.708  1.00 33.87           O  
+ANISOU  377  OG  SER A  50     2868   6124   3877    997    511   -516       O  
+ATOM    378  N   TYR A  51      -3.676   7.684  14.653  1.00 23.04           N  
+ANISOU  378  N   TYR A  51     1871   2864   4018   -310    306   -230       N  
+ATOM    379  CA  TYR A  51      -3.040   7.573  13.358  1.00 23.69           C  
+ANISOU  379  CA  TYR A  51     2038   3293   3669     56    -43   -174       C  
+ATOM    380  C   TYR A  51      -3.968   7.806  12.192  1.00 25.83           C  
+ANISOU  380  C   TYR A  51     2453   3122   4240   -126   -475    138       C  
+ATOM    381  O   TYR A  51      -3.543   7.637  11.044  1.00 26.67           O  
+ANISOU  381  O   TYR A  51     2649   3527   3958    -49   -765    334       O  
+ATOM    382  CB  TYR A  51      -2.432   6.176  13.273  1.00 21.27           C  
+ANISOU  382  CB  TYR A  51     2189   3105   2788   -204   -827   -752       C  
+ATOM    383  CG  TYR A  51      -1.134   5.919  13.981  1.00 17.31           C  
+ANISOU  383  CG  TYR A  51     1846   2651   2082   -505   -302   -233       C  
+ATOM    384  CD1 TYR A  51      -0.401   6.899  14.601  1.00 18.57           C  
+ANISOU  384  CD1 TYR A  51     1908   2374   2773   -386   -772    -19       C  
+ATOM    385  CD2 TYR A  51      -0.621   4.634  14.022  1.00 17.32           C  
+ANISOU  385  CD2 TYR A  51     1879   2554   2147   -550    -95   -281       C  
+ATOM    386  CE1 TYR A  51       0.788   6.641  15.244  1.00 15.82           C  
+ANISOU  386  CE1 TYR A  51     1518   2166   2326   -443   -299    191       C  
+ATOM    387  CE2 TYR A  51       0.562   4.333  14.655  1.00 16.93           C  
+ANISOU  387  CE2 TYR A  51     1997   2377   2057   -532   -113   -158       C  
+ATOM    388  CZ  TYR A  51       1.279   5.344  15.274  1.00 16.22           C  
+ANISOU  388  CZ  TYR A  51     1997   2213   1955   -234   -278   -201       C  
+ATOM    389  OH  TYR A  51       2.468   5.032  15.903  1.00 17.03           O  
+ANISOU  389  OH  TYR A  51     2097   1896   2479   -185   -445   -216       O  
+ATOM    390  N   ASP A  52      -5.219   8.190  12.409  1.00 26.42           N  
+ANISOU  390  N   ASP A  52     2331   3143   4563   -178   -481    913       N  
+ATOM    391  CA  ASP A  52      -6.119   8.299  11.262  1.00 31.64           C  
+ANISOU  391  CA  ASP A  52     2367   4956   4698   -730   -598   1330       C  
+ATOM    392  C   ASP A  52      -5.728   9.350  10.237  1.00 31.40           C  
+ANISOU  392  C   ASP A  52     2523   4467   4940   -377   -906   1467       C  
+ATOM    393  O   ASP A  52      -6.093   9.248   9.048  1.00 36.68           O  
+ANISOU  393  O   ASP A  52     4310   4614   5015   -590  -1310   1668       O  
+ATOM    394  CB  ASP A  52      -7.532   8.546  11.796  1.00 34.11           C  
+ANISOU  394  CB  ASP A  52     2406   5600   4954   -152   -709   1502       C  
+ATOM    395  CG  ASP A  52      -7.654   9.857  12.533  1.00 36.98           C  
+ANISOU  395  CG  ASP A  52     3242   5166   5642    489   -591   1814       C  
+ATOM    396  OD1 ASP A  52      -7.026  10.020  13.596  1.00 41.94           O  
+ANISOU  396  OD1 ASP A  52     4469   6953   4512    804    286    516       O  
+ATOM    397  OD2 ASP A  52      -8.384  10.726  12.024  1.00 61.15           O  
+ANISOU  397  OD2 ASP A  52     6396   8372   8465   4253   -937   1560       O  
+ATOM    398  N   GLN A  53      -4.987  10.398  10.562  1.00 31.28           N  
+ANISOU  398  N   GLN A  53     2731   3999   5154   -142      2    768       N  
+ATOM    399  CA  GLN A  53      -4.576  11.350   9.531  1.00 27.83           C  
+ANISOU  399  CA  GLN A  53     3093   2953   4528    373    112     98       C  
+ATOM    400  C   GLN A  53      -3.142  11.198   9.061  1.00 23.75           C  
+ANISOU  400  C   GLN A  53     2910   2760   3353    150   -273     32       C  
+ATOM    401  O   GLN A  53      -2.577  12.113   8.459  1.00 22.87           O  
+ANISOU  401  O   GLN A  53     2940   2685   3067    291   -633    231       O  
+ATOM    402  CB  GLN A  53      -4.752  12.759  10.122  1.00 34.03           C  
+ANISOU  402  CB  GLN A  53     3917   3355   5658    591    471   -524       C  
+ATOM    403  CG  GLN A  53      -6.220  12.982  10.476  1.00 40.72           C  
+ANISOU  403  CG  GLN A  53     3900   4213   7358    678    433  -1622       C  
+ATOM    404  CD  GLN A  53      -6.728  14.020   9.485  1.00 48.07           C  
+ANISOU  404  CD  GLN A  53     4909   4408   8948   1882   -364  -1633       C  
+ATOM    405  OE1 GLN A  53      -6.660  15.220   9.781  1.00 57.65           O  
+ANISOU  405  OE1 GLN A  53     8539   4155   9211    987   1597  -1113       O  
+ATOM    406  NE2 GLN A  53      -7.195  13.496   8.355  1.00 67.12           N  
+ANISOU  406  NE2 GLN A  53     9956   5550   9996   -822  -3447    -66       N  
+ATOM    407  N   ALA A  54      -2.514  10.059   9.331  1.00 22.31           N  
+ANISOU  407  N   ALA A  54     2401   2516   3559   -260   -139    186       N  
+ATOM    408  CA  ALA A  54      -1.143   9.828   8.895  1.00 20.71           C  
+ANISOU  408  CA  ALA A  54     2133   2645   3091   -330   -530    718       C  
+ATOM    409  C   ALA A  54      -1.027  10.002   7.381  1.00 20.78           C  
+ANISOU  409  C   ALA A  54     2435   2511   2950   -318   -518     58       C  
+ATOM    410  O   ALA A  54      -1.900   9.586   6.616  1.00 27.73           O  
+ANISOU  410  O   ALA A  54     3104   3891   3541   -866   -924   -300       O  
+ATOM    411  CB  ALA A  54      -0.728   8.448   9.351  1.00 25.82           C  
+ANISOU  411  CB  ALA A  54     4237   2645   2929    851   -603    -84       C  
+ATOM    412  N   THR A  55       0.058  10.623   6.957  1.00 20.82           N  
+ANISOU  412  N   THR A  55     2605   2594   2712   -302   -429    369       N  
+ATOM    413  CA  THR A  55       0.436  10.811   5.565  1.00 21.69           C  
+ANISOU  413  CA  THR A  55     3263   2297   2682    216   -349    430       C  
+ATOM    414  C   THR A  55       1.836  10.258   5.290  1.00 18.77           C  
+ANISOU  414  C   THR A  55     3120   2192   1820    128   -687    200       C  
+ATOM    415  O   THR A  55       2.816  10.936   5.597  1.00 23.22           O  
+ANISOU  415  O   THR A  55     3316   2364   3142   -184   -449     98       O  
+ATOM    416  CB  THR A  55       0.498  12.284   5.132  1.00 29.04           C  
+ANISOU  416  CB  THR A  55     4299   2807   3927    840   -856   1602       C  
+ATOM    417  OG1 THR A  55      -0.701  12.960   5.472  1.00 35.37           O  
+ANISOU  417  OG1 THR A  55     4689   2882   5869   1078   -919    596       O  
+ATOM    418  CG2 THR A  55       0.602  12.290   3.605  1.00 36.37           C  
+ANISOU  418  CG2 THR A  55     6601   3360   3859   1614  -1206   1836       C  
+ATOM    419  N   SER A  56       1.882   9.066   4.702  1.00 21.26           N  
+ANISOU  419  N   SER A  56     3529   1938   2609     68   -432    323       N  
+ATOM    420  CA  SER A  56       3.185   8.499   4.376  1.00 21.55           C  
+ANISOU  420  CA  SER A  56     3691   2166   2331    -22   -243   -198       C  
+ATOM    421  C   SER A  56       3.685   9.170   3.102  1.00 21.06           C  
+ANISOU  421  C   SER A  56     3665   2293   2044    275   -562    -43       C  
+ATOM    422  O   SER A  56       2.895   9.659   2.282  1.00 26.08           O  
+ANISOU  422  O   SER A  56     4251   3092   2566    439  -1163    -14       O  
+ATOM    423  CB  SER A  56       3.153   6.975   4.229  1.00 22.62           C  
+ANISOU  423  CB  SER A  56     4704   2168   1723    243   -118   -321       C  
+ATOM    424  OG  SER A  56       2.371   6.661   3.090  1.00 27.94           O  
+ANISOU  424  OG  SER A  56     5764   2155   2697    406  -1162   -479       O  
+ATOM    425  N   LEU A  57       4.994   9.197   2.945  1.00 22.00           N  
+ANISOU  425  N   LEU A  57     3819   2525   2016    875    -31    329       N  
+ATOM    426  CA  LEU A  57       5.612   9.842   1.797  1.00 23.70           C  
+ANISOU  426  CA  LEU A  57     4434   2177   2394    949    337    419       C  
+ATOM    427  C   LEU A  57       6.366   8.873   0.912  1.00 22.20           C  
+ANISOU  427  C   LEU A  57     4030   2348   2055    978     88    460       C  
+ATOM    428  O   LEU A  57       6.121   8.787  -0.289  1.00 23.24           O  
+ANISOU  428  O   LEU A  57     3847   2751   2231    809   -306    155       O  
+ATOM    429  CB  LEU A  57       6.631  10.898   2.272  1.00 26.57           C  
+ANISOU  429  CB  LEU A  57     5120   2486   2490    413    507    262       C  
+ATOM    430  CG  LEU A  57       5.969  12.055   3.024  1.00 32.30           C  
+ANISOU  430  CG  LEU A  57     6193   2392   3687    751    268   -110       C  
+ATOM    431  CD1 LEU A  57       7.000  12.891   3.771  1.00 37.30           C  
+ANISOU  431  CD1 LEU A  57     7110   1965   5096   -419    791   -292       C  
+ATOM    432  CD2 LEU A  57       5.159  12.886   2.051  1.00 40.19           C  
+ANISOU  432  CD2 LEU A  57     6739   3295   5236   1453    897   1441       C  
+ATOM    433  N   ARG A  58       7.296   8.194   1.577  1.00 23.04           N  
+ANISOU  433  N   ARG A  58     4366   2517   1870   1124    224    805       N  
+ATOM    434  CA  ARG A  58       8.250   7.386   0.848  1.00 24.72           C  
+ANISOU  434  CA  ARG A  58     3902   3008   2482   1201   -210    241       C  
+ATOM    435  C   ARG A  58       8.685   6.178   1.670  1.00 26.40           C  
+ANISOU  435  C   ARG A  58     4391   3396   2245   1776   -176    243       C  
+ATOM    436  O   ARG A  58       8.531   6.114   2.872  1.00 30.53           O  
+ANISOU  436  O   ARG A  58     6060   3421   2119   2369   -426   -141       O  
+ATOM    437  CB AARG A  58       9.544   8.073   0.488  0.67 26.39           C  
+ANISOU  437  CB AARG A  58     3521   3910   2596   1159   -520    277       C  
+ATOM    438  CB BARG A  58       9.489   8.230   0.490  0.33 25.62           C  
+ANISOU  438  CB BARG A  58     3457   3339   2936   1232   -422     -5       C  
+ATOM    439  CG AARG A  58       9.631   9.471  -0.044  0.67 28.22           C  
+ANISOU  439  CG AARG A  58     3498   3653   3570    245   -612   -111       C  
+ATOM    440  CG BARG A  58       9.344   9.186  -0.676  0.33 25.46           C  
+ANISOU  440  CG BARG A  58     3234   3734   2705    591    -79    102       C  
+ATOM    441  CD AARG A  58      11.097   9.767  -0.382  0.67 32.53           C  
+ANISOU  441  CD AARG A  58     3584   4642   4133     80   -325   -603       C  
+ATOM    442  CD BARG A  58      10.615   9.984  -0.968  0.33 27.33           C  
+ANISOU  442  CD BARG A  58     3385   3882   3118    237   -204   -506       C  
+ATOM    443  NE AARG A  58      11.925   9.530   0.803  0.67 28.70           N  
+ANISOU  443  NE AARG A  58     2569   4321   4014    203    476    602       N  
+ATOM    444  NE BARG A  58      11.496   9.246  -1.882  0.33 25.48           N  
+ANISOU  444  NE BARG A  58     3279   3127   3276    178    102     52       N  
+ATOM    445  CZ AARG A  58      13.226   9.321   0.779  0.67 29.14           C  
+ANISOU  445  CZ AARG A  58     2824   3138   5111    938    601   -162       C  
+ATOM    446  CZ BARG A  58      11.172   9.044  -3.155  0.33 21.76           C  
+ANISOU  446  CZ BARG A  58     3367   2345   2556    -72    970   1090       C  
+ATOM    447  NH1AARG A  58      13.878   9.326  -0.350  0.67 29.68           N  
+ANISOU  447  NH1AARG A  58     2091   4791   4395    350   -260  -3257       N  
+ATOM    448  NH1BARG A  58      10.022   9.533  -3.597  0.33 24.34           N  
+ANISOU  448  NH1BARG A  58     4967   2650   1630   1580    644    770       N  
+ATOM    449  NH2AARG A  58      13.868   9.126   1.899  0.67 24.87           N  
+ANISOU  449  NH2AARG A  58     1386   2843   5220    -95   1196   1191       N  
+ATOM    450  NH2BARG A  58      11.965   8.373  -3.977  0.33 26.06           N  
+ANISOU  450  NH2BARG A  58     5211   2425   2266   1892   1099   2229       N  
+ATOM    451  N   ILE A  59       9.285   5.245   0.942  1.00 23.46           N  
+ANISOU  451  N   ILE A  59     4512   2413   1989    745    237    429       N  
+ATOM    452  CA  ILE A  59       9.951   4.131   1.608  1.00 22.16           C  
+ANISOU  452  CA  ILE A  59     4654   2219   1545    901    -18    -69       C  
+ATOM    453  C   ILE A  59      11.382   4.063   1.087  1.00 22.95           C  
+ANISOU  453  C   ILE A  59     4469   2435   1816    673   -205    241       C  
+ATOM    454  O   ILE A  59      11.652   4.263  -0.093  1.00 20.70           O  
+ANISOU  454  O   ILE A  59     3701   2208   1954   -128   -411    566       O  
+ATOM    455  CB  ILE A  59       9.161   2.842   1.391  1.00 21.77           C  
+ANISOU  455  CB  ILE A  59     4331   2301   1640    889     64     83       C  
+ATOM    456  CG1 ILE A  59       9.701   1.695   2.240  1.00 20.38           C  
+ANISOU  456  CG1 ILE A  59     3601   2411   1731    665     58    245       C  
+ATOM    457  CG2 ILE A  59       9.071   2.461  -0.080  1.00 24.65           C  
+ANISOU  457  CG2 ILE A  59     5556   2077   1732    619   -305     95       C  
+ATOM    458  CD1 ILE A  59       8.884   0.427   2.172  1.00 25.98           C  
+ANISOU  458  CD1 ILE A  59     5510   2063   2297    380   -727   -272       C  
+ATOM    459  N   LEU A  60      12.319   3.801   1.995  1.00 23.42           N  
+ANISOU  459  N   LEU A  60     4622   2527   1751    221   -546   -137       N  
+ATOM    460  CA  LEU A  60      13.739   3.882   1.728  1.00 25.23           C  
+ANISOU  460  CA  LEU A  60     4583   2605   2399     97   -562    177       C  
+ATOM    461  C   LEU A  60      14.497   2.691   2.321  1.00 23.10           C  
+ANISOU  461  C   LEU A  60     4333   2351   2090     -8   -142     99       C  
+ATOM    462  O   LEU A  60      14.261   2.326   3.476  1.00 20.69           O  
+ANISOU  462  O   LEU A  60     3265   2408   2190    -34    -24    153       O  
+ATOM    463  CB  LEU A  60      14.344   5.155   2.328  1.00 31.46           C  
+ANISOU  463  CB  LEU A  60     5714   2242   4000   -802    -14    586       C  
+ATOM    464  CG  LEU A  60      15.855   5.327   2.301  1.00 31.03           C  
+ANISOU  464  CG  LEU A  60     5672   2422   3694   -792   -623    559       C  
+ATOM    465  CD1 LEU A  60      16.309   5.589   0.876  1.00 31.72           C  
+ANISOU  465  CD1 LEU A  60     4907   3290   3856   -870   -691   1110       C  
+ATOM    466  CD2 LEU A  60      16.329   6.463   3.226  1.00 33.95           C  
+ANISOU  466  CD2 LEU A  60     6844   1799   4255   -867  -1179    875       C  
+ATOM    467  N   ASN A  61      15.380   2.136   1.502  1.00 22.30           N  
+ANISOU  467  N   ASN A  61     4784   1788   1900   -403     94   -114       N  
+ATOM    468  CA  ASN A  61      16.390   1.182   1.939  1.00 20.78           C  
+ANISOU  468  CA  ASN A  61     3826   1972   2098   -681    483     -3       C  
+ATOM    469  C   ASN A  61      17.644   1.994   2.283  1.00 23.39           C  
+ANISOU  469  C   ASN A  61     4295   2493   2099  -1202    597   -246       C  
+ATOM    470  O   ASN A  61      18.254   2.541   1.372  1.00 22.17           O  
+ANISOU  470  O   ASN A  61     4080   2603   1739  -1103    675   -547       O  
+ATOM    471  CB  ASN A  61      16.699   0.149   0.881  1.00 20.73           C  
+ANISOU  471  CB  ASN A  61     3559   2047   2271   -704    478   -152       C  
+ATOM    472  CG  ASN A  61      17.736  -0.869   1.313  1.00 22.19           C  
+ANISOU  472  CG  ASN A  61     3793   2237   2399   -525    423    -91       C  
+ATOM    473  OD1 ASN A  61      18.585  -0.639   2.183  1.00 20.17           O  
+ANISOU  473  OD1 ASN A  61     3220   2060   2383   -579    759   -138       O  
+ATOM    474  ND2 ASN A  61      17.682  -2.050   0.713  1.00 20.52           N  
+ANISOU  474  ND2 ASN A  61     3475   2158   2162   -540    430     39       N  
+ATOM    475  N   ASN A  62      17.931   2.049   3.587  1.00 22.12           N  
+ANISOU  475  N   ASN A  62     3941   2325   2138  -1356    462    431       N  
+ATOM    476  CA  ASN A  62      19.100   2.859   3.993  1.00 23.20           C  
+ANISOU  476  CA  ASN A  62     4224   2222   2370  -1387    328    216       C  
+ATOM    477  C   ASN A  62      20.332   2.017   4.300  1.00 25.73           C  
+ANISOU  477  C   ASN A  62     4069   3094   2614  -1029    206   -493       C  
+ATOM    478  O   ASN A  62      21.294   2.512   4.897  1.00 26.62           O  
+ANISOU  478  O   ASN A  62     4639   3106   2371  -1247   -180    -78       O  
+ATOM    479  CB  ASN A  62      18.696   3.732   5.175  1.00 23.97           C  
+ANISOU  479  CB  ASN A  62     4361   2117   2630  -1137    384    209       C  
+ATOM    480  CG  ASN A  62      18.530   2.913   6.434  1.00 24.65           C  
+ANISOU  480  CG  ASN A  62     4948   2304   2112  -1513    -88    -27       C  
+ATOM    481  OD1 ASN A  62      18.564   1.685   6.421  1.00 21.42           O  
+ANISOU  481  OD1 ASN A  62     3859   2351   1928   -786    892    168       O  
+ATOM    482  ND2 ASN A  62      18.378   3.680   7.501  1.00 37.64           N  
+ANISOU  482  ND2 ASN A  62     9043   2476   2784  -1422   1196   -302       N  
+ATOM    483  N   GLY A  63      20.336   0.730   3.904  1.00 21.15           N  
+ANISOU  483  N   GLY A  63     2983   3051   2003  -1120   1073   -294       N  
+ATOM    484  CA  GLY A  63      21.549  -0.057   4.120  1.00 21.85           C  
+ANISOU  484  CA  GLY A  63     2756   3154   2393  -1365    638   -514       C  
+ATOM    485  C   GLY A  63      21.471  -0.782   5.441  1.00 21.16           C  
+ANISOU  485  C   GLY A  63     2527   3385   2126  -1294    248   -639       C  
+ATOM    486  O   GLY A  63      22.277  -1.674   5.692  1.00 24.40           O  
+ANISOU  486  O   GLY A  63     2908   3663   2698   -878    774   -275       O  
+ATOM    487  N   HIS A  64      20.480  -0.372   6.223  1.00 21.16           N  
+ANISOU  487  N   HIS A  64     2688   2919   2433  -1149    553   -185       N  
+ATOM    488  CA  HIS A  64      20.335  -0.994   7.542  1.00 20.92           C  
+ANISOU  488  CA  HIS A  64     2414   2931   2602   -594    609     59       C  
+ATOM    489  C   HIS A  64      18.985  -1.646   7.742  1.00 18.72           C  
+ANISOU  489  C   HIS A  64     2353   2451   2309   -433    253    398       C  
+ATOM    490  O   HIS A  64      18.887  -2.683   8.376  1.00 22.81           O  
+ANISOU  490  O   HIS A  64     2274   3065   3326   -365    142   1149       O  
+ATOM    491  CB  HIS A  64      20.534   0.052   8.659  1.00 24.12           C  
+ANISOU  491  CB  HIS A  64     3127   3605   2433  -1104    205    -42       C  
+ATOM    492  CG  HIS A  64      21.831   0.773   8.520  1.00 26.69           C  
+ANISOU  492  CG  HIS A  64     3098   3590   3455  -1083   -156    188       C  
+ATOM    493  ND1 HIS A  64      23.046   0.139   8.638  1.00 26.74           N  
+ANISOU  493  ND1 HIS A  64     3122   3625   3414   -841    775   -114       N  
+ATOM    494  CD2 HIS A  64      22.116   2.066   8.268  1.00 26.52           C  
+ANISOU  494  CD2 HIS A  64     2974   3697   3406  -1031    331    298       C  
+ATOM    495  CE1 HIS A  64      24.019   1.019   8.461  1.00 26.28           C  
+ANISOU  495  CE1 HIS A  64     3095   3733   3158   -901    332    162       C  
+ATOM    496  NE2 HIS A  64      23.483   2.205   8.232  1.00 24.96           N  
+ANISOU  496  NE2 HIS A  64     2918   3667   2898   -794    899    -86       N  
+ATOM    497  N   ALA A  65      17.942  -1.021   7.218  1.00 17.71           N  
+ANISOU  497  N   ALA A  65     2527   1835   2369   -317    138    -90       N  
+ATOM    498  CA  ALA A  65      16.582  -1.526   7.269  1.00 18.61           C  
+ANISOU  498  CA  ALA A  65     2413   1975   2682   -168     91   -199       C  
+ATOM    499  C   ALA A  65      15.806  -0.811   6.163  1.00 18.79           C  
+ANISOU  499  C   ALA A  65     2579   2204   2357   -778     43     88       C  
+ATOM    500  O   ALA A  65      16.435  -0.083   5.403  1.00 21.05           O  
+ANISOU  500  O   ALA A  65     2829   2537   2631   -512    823     71       O  
+ATOM    501  CB  ALA A  65      15.980  -1.317   8.644  1.00 18.44           C  
+ANISOU  501  CB  ALA A  65     2341   2282   2381   -592    -52    135       C  
+ATOM    502  N   PHE A  66      14.506  -1.038   6.067  1.00 17.72           N  
+ANISOU  502  N   PHE A  66     2335   2268   2130   -194    340     35       N  
+ATOM    503  CA  PHE A  66      13.671  -0.223   5.190  1.00 22.12           C  
+ANISOU  503  CA  PHE A  66     3231   3478   1694    585    165   -100       C  
+ATOM    504  C   PHE A  66      12.822   0.660   6.104  1.00 18.95           C  
+ANISOU  504  C   PHE A  66     2651   2824   1726    247    409    413       C  
+ATOM    505  O   PHE A  66      12.367   0.261   7.174  1.00 17.30           O  
+ANISOU  505  O   PHE A  66     2194   2543   1835   -281    305    268       O  
+ATOM    506  CB  PHE A  66      12.804  -1.021   4.224  1.00 23.59           C  
+ANISOU  506  CB  PHE A  66     3379   3366   2217    616   -174   -111       C  
+ATOM    507  CG  PHE A  66      11.672  -1.843   4.802  1.00 23.69           C  
+ANISOU  507  CG  PHE A  66     3458   3413   2129    565   -129   -120       C  
+ATOM    508  CD1 PHE A  66      10.417  -1.332   5.087  1.00 24.61           C  
+ANISOU  508  CD1 PHE A  66     3221   3647   2483    527   -404     29       C  
+ATOM    509  CD2 PHE A  66      11.863  -3.197   5.055  1.00 22.89           C  
+ANISOU  509  CD2 PHE A  66     3502   2967   2226    161   -419  -1005       C  
+ATOM    510  CE1 PHE A  66       9.438  -2.124   5.630  1.00 23.72           C  
+ANISOU  510  CE1 PHE A  66     3191   3247   2575    360   -432   -503       C  
+ATOM    511  CE2 PHE A  66      10.884  -3.998   5.622  1.00 22.69           C  
+ANISOU  511  CE2 PHE A  66     3274   2833   2512    109   -547  -1155       C  
+ATOM    512  CZ  PHE A  66       9.648  -3.463   5.889  1.00 22.92           C  
+ANISOU  512  CZ  PHE A  66     3308   3084   2317    284   -604   -930       C  
+ATOM    513  N   ASN A  67      12.586   1.880   5.667  1.00 21.97           N  
+ANISOU  513  N   ASN A  67     3197   3286   1865    802    159    842       N  
+ATOM    514  CA  ASN A  67      11.924   2.891   6.460  1.00 21.77           C  
+ANISOU  514  CA  ASN A  67     2944   2769   2556    349    434    721       C  
+ATOM    515  C   ASN A  67      10.802   3.571   5.692  1.00 20.74           C  
+ANISOU  515  C   ASN A  67     3466   2197   2216    428     67    261       C  
+ATOM    516  O   ASN A  67      11.039   4.106   4.605  1.00 22.27           O  
+ANISOU  516  O   ASN A  67     3631   2680   2149    564    286    219       O  
+ATOM    517  CB  ASN A  67      12.944   3.947   6.886  1.00 24.42           C  
+ANISOU  517  CB  ASN A  67     2821   3265   3193    130    418    654       C  
+ATOM    518  CG  ASN A  67      14.170   3.313   7.529  1.00 25.41           C  
+ANISOU  518  CG  ASN A  67     2363   4084   3208    252    836    795       C  
+ATOM    519  OD1 ASN A  67      14.173   3.186   8.735  1.00 24.45           O  
+ANISOU  519  OD1 ASN A  67     2921   3218   3152   -226    210    466       O  
+ATOM    520  ND2 ASN A  67      15.192   2.942   6.756  1.00 36.40           N  
+ANISOU  520  ND2 ASN A  67     3195   6027   4607    986   1404   -131       N  
+ATOM    521  N   VAL A  68       9.630   3.518   6.310  1.00 19.45           N  
+ANISOU  521  N   VAL A  68     3308   2553   1529    713   -270    403       N  
+ATOM    522  CA  VAL A  68       8.487   4.258   5.782  1.00 18.06           C  
+ANISOU  522  CA  VAL A  68     3448   1973   1443    549   -494     52       C  
+ATOM    523  C   VAL A  68       8.433   5.603   6.508  1.00 20.20           C  
+ANISOU  523  C   VAL A  68     4411   1832   1433    362   -216    224       C  
+ATOM    524  O   VAL A  68       8.283   5.642   7.733  1.00 20.55           O  
+ANISOU  524  O   VAL A  68     4480   1969   1360    766   -437    136       O  
+ATOM    525  CB  VAL A  68       7.171   3.471   5.892  1.00 18.87           C  
+ANISOU  525  CB  VAL A  68     3287   1782   2102    744   -185    156       C  
+ATOM    526  CG1 VAL A  68       5.985   4.295   5.411  1.00 19.50           C  
+ANISOU  526  CG1 VAL A  68     3529   1789   2091    586   -887    -21       C  
+ATOM    527  CG2 VAL A  68       7.292   2.190   5.083  1.00 18.99           C  
+ANISOU  527  CG2 VAL A  68     2840   2028   2346    337    365    -78       C  
+ATOM    528  N   GLU A  69       8.611   6.663   5.723  1.00 20.47           N  
+ANISOU  528  N   GLU A  69     3682   2033   2063    209    471    469       N  
+ATOM    529  CA  GLU A  69       8.702   8.032   6.209  1.00 20.67           C  
+ANISOU  529  CA  GLU A  69     3423   2011   2421     36    431    400       C  
+ATOM    530  C   GLU A  69       7.378   8.754   6.007  1.00 23.21           C  
+ANISOU  530  C   GLU A  69     4072   2309   2439    552   -384     19       C  
+ATOM    531  O   GLU A  69       6.742   8.554   4.949  1.00 28.10           O  
+ANISOU  531  O   GLU A  69     5820   2012   2846   1147  -1274   -252       O  
+ATOM    532  CB  GLU A  69       9.856   8.751   5.479  1.00 27.71           C  
+ANISOU  532  CB  GLU A  69     4569   3000   2961   -802    872    561       C  
+ATOM    533  CG  GLU A  69      11.143   8.002   5.784  1.00 32.95           C  
+ANISOU  533  CG  GLU A  69     3484   4237   4797  -1232    893    361       C  
+ATOM    534  CD  GLU A  69      12.392   8.441   5.068  1.00 38.50           C  
+ANISOU  534  CD  GLU A  69     4100   5469   5060  -2329    864    546       C  
+ATOM    535  OE1 GLU A  69      12.390   8.506   3.818  1.00 50.16           O  
+ANISOU  535  OE1 GLU A  69     6974   6823   5260  -1262   1599   2545       O  
+ATOM    536  OE2 GLU A  69      13.390   8.690   5.773  1.00 53.56           O  
+ANISOU  536  OE2 GLU A  69     3972   7983   8394  -2614     20   -586       O  
+ATOM    537  N   PHE A  70       6.971   9.546   6.991  1.00 20.12           N  
+ANISOU  537  N   PHE A  70     3198   2568   1878    346    -19    439       N  
+ATOM    538  CA  PHE A  70       5.735  10.283   7.053  1.00 18.82           C  
+ANISOU  538  CA  PHE A  70     3101   2090   1961    133   -367    561       C  
+ATOM    539  C   PHE A  70       5.951  11.789   7.060  1.00 20.40           C  
+ANISOU  539  C   PHE A  70     2869   2156   2724   -104   -300   1093       C  
+ATOM    540  O   PHE A  70       7.005  12.267   7.456  1.00 21.31           O  
+ANISOU  540  O   PHE A  70     2604   2293   3201     -1     69    569       O  
+ATOM    541  CB  PHE A  70       4.916   9.960   8.309  1.00 17.92           C  
+ANISOU  541  CB  PHE A  70     2934   1383   2493    145     44    489       C  
+ATOM    542  CG  PHE A  70       4.381   8.541   8.275  1.00 16.90           C  
+ANISOU  542  CG  PHE A  70     2610   1440   2373    163   -406    105       C  
+ATOM    543  CD1 PHE A  70       5.205   7.444   8.552  1.00 16.62           C  
+ANISOU  543  CD1 PHE A  70     2462   1398   2455    179    507    453       C  
+ATOM    544  CD2 PHE A  70       3.064   8.294   7.938  1.00 21.03           C  
+ANISOU  544  CD2 PHE A  70     2714   2472   2807   -106   -644    611       C  
+ATOM    545  CE1 PHE A  70       4.716   6.149   8.491  1.00 18.93           C  
+ANISOU  545  CE1 PHE A  70     3228   1455   2510     32   -999    201       C  
+ATOM    546  CE2 PHE A  70       2.567   6.989   7.897  1.00 18.69           C  
+ANISOU  546  CE2 PHE A  70     2442   2682   1979   -399   -233    780       C  
+ATOM    547  CZ  PHE A  70       3.389   5.919   8.162  1.00 20.08           C  
+ANISOU  547  CZ  PHE A  70     3062   2406   2162   -302   -571    457       C  
+ATOM    548  N   ASP A  71       4.886  12.487   6.645  1.00 20.63           N  
+ANISOU  548  N   ASP A  71     2740   2076   3022     51    -21    775       N  
+ATOM    549  CA  ASP A  71       4.977  13.941   6.750  1.00 20.61           C  
+ANISOU  549  CA  ASP A  71     1792   2147   3892    -70   -405    480       C  
+ATOM    550  C   ASP A  71       4.664  14.284   8.201  1.00 20.96           C  
+ANISOU  550  C   ASP A  71     2153   1775   4037   -494    -52    444       C  
+ATOM    551  O   ASP A  71       3.551  14.029   8.649  1.00 27.38           O  
+ANISOU  551  O   ASP A  71     2275   2462   5667   -270    884   -752       O  
+ATOM    552  CB  ASP A  71       4.006  14.554   5.768  1.00 28.49           C  
+ANISOU  552  CB  ASP A  71     3760   2023   5043    -95  -1929    604       C  
+ATOM    553  CG  ASP A  71       3.745  16.026   5.948  1.00 32.72           C  
+ANISOU  553  CG  ASP A  71     4955   1651   5827   -491  -2562   1109       C  
+ATOM    554  OD1 ASP A  71       4.419  16.669   6.769  1.00 31.63           O  
+ANISOU  554  OD1 ASP A  71     5204   1937   4875   -295  -2068    821       O  
+ATOM    555  OD2 ASP A  71       2.843  16.560   5.251  1.00 50.04           O  
+ANISOU  555  OD2 ASP A  71     7625   1803   9586    143  -5578    537       O  
+ATOM    556  N   ASP A  72       5.632  14.850   8.871  1.00 21.88           N  
+ANISOU  556  N   ASP A  72     2823   1679   3812   -573   -591    872       N  
+ATOM    557  CA  ASP A  72       5.522  15.202  10.282  1.00 23.16           C  
+ANISOU  557  CA  ASP A  72     2711   1938   4150    -40   -291    201       C  
+ATOM    558  C   ASP A  72       5.545  16.719  10.438  1.00 24.63           C  
+ANISOU  558  C   ASP A  72     2103   1975   5280    202  -1032    115       C  
+ATOM    559  O   ASP A  72       6.009  17.251  11.454  1.00 26.63           O  
+ANISOU  559  O   ASP A  72     3227   1798   5092   -203   -965    241       O  
+ATOM    560  CB  ASP A  72       6.632  14.529  11.110  1.00 19.93           C  
+ANISOU  560  CB  ASP A  72     2910   1524   3137     36     23     79       C  
+ATOM    561  CG  ASP A  72       8.025  14.953  10.706  1.00 21.07           C  
+ANISOU  561  CG  ASP A  72     2777   2659   2571    -23   -286    328       C  
+ATOM    562  OD1 ASP A  72       8.197  15.595   9.629  1.00 24.84           O  
+ANISOU  562  OD1 ASP A  72     2560   3365   3514    -68   -501   1414       O  
+ATOM    563  OD2 ASP A  72       8.975  14.671  11.462  1.00 23.25           O  
+ANISOU  563  OD2 ASP A  72     2995   3112   2727    179   -332    634       O  
+ATOM    564  N   SER A  73       5.023  17.425   9.423  1.00 24.89           N  
+ANISOU  564  N   SER A  73     2379   2098   4980     61   -578    421       N  
+ATOM    565  CA  SER A  73       5.046  18.884   9.458  1.00 25.40           C  
+ANISOU  565  CA  SER A  73     3105   2107   4439    227   -480    229       C  
+ATOM    566  C   SER A  73       3.782  19.438  10.099  1.00 30.84           C  
+ANISOU  566  C   SER A  73     3277   2385   6056    250    -15    -74       C  
+ATOM    567  O   SER A  73       3.676  20.650  10.304  1.00 32.45           O  
+ANISOU  567  O   SER A  73     3445   2531   6352     30     26   -770       O  
+ATOM    568  CB  SER A  73       5.161  19.531   8.068  1.00 28.53           C  
+ANISOU  568  CB  SER A  73     3805   2446   4588     95   -976    567       C  
+ATOM    569  OG  SER A  73       4.031  19.167   7.309  1.00 29.89           O  
+ANISOU  569  OG  SER A  73     3680   2610   5065     76  -1171    819       O  
+ATOM    570  N   GLN A  74       2.819  18.570  10.396  1.00 30.76           N  
+ANISOU  570  N   GLN A  74     3256   2265   6165    447    180     95       N  
+ATOM    571  CA  GLN A  74       1.717  18.978  11.259  1.00 30.16           C  
+ANISOU  571  CA  GLN A  74     3254   2202   6003    -76      3   -933       C  
+ATOM    572  C   GLN A  74       1.348  17.858  12.230  1.00 30.62           C  
+ANISOU  572  C   GLN A  74     3624   2967   5044    127     35   -833       C  
+ATOM    573  O   GLN A  74       1.874  16.773  12.027  1.00 25.94           O  
+ANISOU  573  O   GLN A  74     2504   2553   4798   -433   -246   -589       O  
+ATOM    574  CB  GLN A  74       0.471  19.296  10.475  1.00 33.37           C  
+ANISOU  574  CB  GLN A  74     2932   3237   6510     39    447    366       C  
+ATOM    575  CG  GLN A  74       0.691  20.203   9.283  1.00 42.02           C  
+ANISOU  575  CG  GLN A  74     3137   4769   8061   -946     -1   1920       C  
+ATOM    576  CD  GLN A  74      -0.646  20.372   8.577  1.00 48.73           C  
+ANISOU  576  CD  GLN A  74     3844   5412   9260   -675   -830   2781       C  
+ATOM    577  OE1 GLN A  74      -1.459  21.127   9.107  1.00 57.36           O  
+ANISOU  577  OE1 GLN A  74     4950   6060  10785   1048  -1750   2563       O  
+ATOM    578  NE2 GLN A  74      -0.765  19.649   7.477  1.00 50.69           N  
+ANISOU  578  NE2 GLN A  74     4904   5137   9218   -412  -2051   3067       N  
+ATOM    579  N   ASP A  75       0.470  18.155  13.187  1.00 34.77           N  
+ANISOU  579  N   ASP A  75     3514   4137   5561    492    229   -840       N  
+ATOM    580  CA  ASP A  75       0.027  17.109  14.125  1.00 35.15           C  
+ANISOU  580  CA  ASP A  75     3299   4779   5277    278    241   -716       C  
+ATOM    581  C   ASP A  75      -0.951  16.186  13.416  1.00 33.85           C  
+ANISOU  581  C   ASP A  75     3315   4747   4801    240   -186    -29       C  
+ATOM    582  O   ASP A  75      -2.180  16.278  13.510  1.00 46.08           O  
+ANISOU  582  O   ASP A  75     3335   8603   5572   -117    213  -2131       O  
+ATOM    583  CB  ASP A  75      -0.591  17.684  15.393  1.00 39.15           C  
+ANISOU  583  CB  ASP A  75     4543   4896   5435    798    405   -787       C  
+ATOM    584  CG  ASP A  75       0.304  17.731  16.607  1.00 40.60           C  
+ANISOU  584  CG  ASP A  75     5963   4561   4901    531    224     11       C  
+ATOM    585  OD1 ASP A  75       1.431  17.181  16.615  1.00 38.80           O  
+ANISOU  585  OD1 ASP A  75     4117   6163   4461  -1001    637    724       O  
+ATOM    586  OD2 ASP A  75      -0.107  18.327  17.630  1.00 52.52           O  
+ANISOU  586  OD2 ASP A  75     8616   5584   5755   1893   -481  -1343       O  
+ATOM    587  N   LYS A  76      -0.409  15.238  12.660  1.00 28.55           N  
+ANISOU  587  N   LYS A  76     3454   3802   3591    257   -653    782       N  
+ATOM    588  CA  LYS A  76      -1.275  14.310  11.929  1.00 31.32           C  
+ANISOU  588  CA  LYS A  76     3746   3553   4600    347  -1434    993       C  
+ATOM    589  C   LYS A  76      -1.358  12.973  12.644  1.00 31.03           C  
+ANISOU  589  C   LYS A  76     2563   4101   5126     99   -343   1545       C  
+ATOM    590  O   LYS A  76      -2.384  12.613  13.202  1.00 53.63           O  
+ANISOU  590  O   LYS A  76     2922   8756   8699   -674    244   3761       O  
+ATOM    591  CB  LYS A  76      -0.760  14.124  10.507  1.00 32.75           C  
+ANISOU  591  CB  LYS A  76     5172   3109   4160  -1028  -1664    924       C  
+ATOM    592  CG  LYS A  76      -1.026  15.320   9.612  1.00 38.31           C  
+ANISOU  592  CG  LYS A  76     6668   2665   5222  -2118  -1800   1368       C  
+ATOM    593  CD  LYS A  76      -0.744  14.992   8.150  1.00 44.47           C  
+ANISOU  593  CD  LYS A  76     9034   2862   5002  -1892  -1476   1986       C  
+ATOM    594  CE  LYS A  76      -1.391  16.000   7.206  1.00 44.76           C  
+ANISOU  594  CE  LYS A  76     9682   1884   5442  -1896  -1053   2089       C  
+ATOM    595  NZ  LYS A  76      -0.533  16.394   6.065  1.00 51.12           N  
+ANISOU  595  NZ  LYS A  76    11522   3572   4330     69   -161   1722       N  
+ATOM    596  N   ALA A  77      -0.279  12.223  12.675  1.00 29.10           N  
+ANISOU  596  N   ALA A  77     3194   3681   4182    393  -1377    887       N  
+ATOM    597  CA  ALA A  77      -0.259  10.930  13.367  1.00 23.15           C  
+ANISOU  597  CA  ALA A  77     2995   2613   3187   -288   -838   -337       C  
+ATOM    598  C   ALA A  77       0.499  11.075  14.686  1.00 20.79           C  
+ANISOU  598  C   ALA A  77     1912   2778   3209    149   -654    202       C  
+ATOM    599  O   ALA A  77       1.708  11.322  14.696  1.00 27.01           O  
+ANISOU  599  O   ALA A  77     1924   4649   3690    -52   -421     38       O  
+ATOM    600  CB  ALA A  77       0.370   9.920  12.439  1.00 28.88           C  
+ANISOU  600  CB  ALA A  77     4165   4190   2618    998    142    286       C  
+ATOM    601  N   VAL A  78      -0.186  10.943  15.821  1.00 20.08           N  
+ANISOU  601  N   VAL A  78     2127   2313   3191   -524   -751    606       N  
+ATOM    602  CA  VAL A  78       0.533  11.221  17.054  1.00 19.92           C  
+ANISOU  602  CA  VAL A  78     2304   2071   3196   -527   -622    328       C  
+ATOM    603  C   VAL A  78       0.284  10.142  18.102  1.00 19.09           C  
+ANISOU  603  C   VAL A  78     2242   2387   2623   -260   -112    136       C  
+ATOM    604  O   VAL A  78      -0.701   9.422  18.097  1.00 19.92           O  
+ANISOU  604  O   VAL A  78     1989   2607   2972   -211   -249    792       O  
+ATOM    605  CB  VAL A  78       0.179  12.588  17.679  1.00 21.04           C  
+ANISOU  605  CB  VAL A  78     2359   2429   3208   -206     76    326       C  
+ATOM    606  CG1 VAL A  78       0.494  13.696  16.688  1.00 24.18           C  
+ANISOU  606  CG1 VAL A  78     3097   2191   3900    284    -13    769       C  
+ATOM    607  CG2 VAL A  78      -1.267  12.627  18.100  1.00 33.27           C  
+ANISOU  607  CG2 VAL A  78     2563   4503   5574    606    812   1270       C  
+ATOM    608  N   LEU A  79       1.272  10.104  18.979  1.00 17.84           N  
+ANISOU  608  N   LEU A  79     2441   1978   2358   -245   -171   -207       N  
+ATOM    609  CA  LEU A  79       1.182   9.256  20.156  1.00 17.18           C  
+ANISOU  609  CA  LEU A  79     1715   2358   2455    -77    126    -69       C  
+ATOM    610  C   LEU A  79       1.163  10.152  21.384  1.00 17.51           C  
+ANISOU  610  C   LEU A  79     1951   2361   2343   -247     95     14       C  
+ATOM    611  O   LEU A  79       1.944  11.105  21.425  1.00 17.99           O  
+ANISOU  611  O   LEU A  79     2075   2489   2272   -361    -27     22       O  
+ATOM    612  CB  LEU A  79       2.405   8.377  20.211  1.00 17.04           C  
+ANISOU  612  CB  LEU A  79     1319   2572   2585   -224   -327   -171       C  
+ATOM    613  CG  LEU A  79       2.550   7.283  21.250  1.00 20.31           C  
+ANISOU  613  CG  LEU A  79     2503   2594   2620    232   -183   -121       C  
+ATOM    614  CD1 LEU A  79       1.423   6.265  21.130  1.00 24.05           C  
+ANISOU  614  CD1 LEU A  79     2874   2204   4062    160   -502    522       C  
+ATOM    615  CD2 LEU A  79       3.904   6.618  21.090  1.00 18.97           C  
+ANISOU  615  CD2 LEU A  79     2894   1599   2714    219    611     26       C  
+ATOM    616  N   LYS A  80       0.280   9.824  22.318  1.00 17.77           N  
+ANISOU  616  N   LYS A  80     2165   2193   2393   -213    169      8       N  
+ATOM    617  CA  LYS A  80       0.103  10.551  23.557  1.00 20.63           C  
+ANISOU  617  CA  LYS A  80     2741   2574   2523    -70    452   -127       C  
+ATOM    618  C   LYS A  80      -0.310   9.573  24.661  1.00 18.90           C  
+ANISOU  618  C   LYS A  80     1812   2695   2673     13    687    -89       C  
+ATOM    619  O   LYS A  80      -0.602   8.410  24.397  1.00 21.14           O  
+ANISOU  619  O   LYS A  80     2171   2949   2913   -509     46     67       O  
+ATOM    620  CB  LYS A  80      -0.948  11.660  23.470  1.00 26.31           C  
+ANISOU  620  CB  LYS A  80     4099   2280   3619    442    410   -278       C  
+ATOM    621  CG  LYS A  80      -0.848  12.589  22.282  1.00 32.61           C  
+ANISOU  621  CG  LYS A  80     4448   3656   4285    869    175    740       C  
+ATOM    622  CD  LYS A  80      -2.099  13.417  22.080  1.00 39.35           C  
+ANISOU  622  CD  LYS A  80     5573   4351   5028   1904   -471    168       C  
+ATOM    623  CE  LYS A  80      -2.603  13.951  23.411  1.00 43.99           C  
+ANISOU  623  CE  LYS A  80     6425   5045   5245   2998   -322    168       C  
+ATOM    624  NZ  LYS A  80      -3.286  15.276  23.235  1.00 56.13           N  
+ANISOU  624  NZ  LYS A  80     8236   5004   8089   3583     39    -66       N  
+ATOM    625  N   GLY A  81      -0.320  10.074  25.889  1.00 20.24           N  
+ANISOU  625  N   GLY A  81     2399   2706   2585    353    554     45       N  
+ATOM    626  CA  GLY A  81      -0.739   9.305  27.031  1.00 19.47           C  
+ANISOU  626  CA  GLY A  81     2263   2529   2607    273    348     90       C  
+ATOM    627  C   GLY A  81       0.287   8.287  27.453  1.00 19.03           C  
+ANISOU  627  C   GLY A  81     1951   1887   3392    -83    491     54       C  
+ATOM    628  O   GLY A  81       1.475   8.367  27.190  1.00 19.94           O  
+ANISOU  628  O   GLY A  81     2046   2313   3216      2    806    118       O  
+ATOM    629  N   GLY A  82      -0.225   7.264  28.158  1.00 22.01           N  
+ANISOU  629  N   GLY A  82     2097   2467   3798     60    826    583       N  
+ATOM    630  CA  GLY A  82       0.755   6.299  28.649  1.00 23.01           C  
+ANISOU  630  CA  GLY A  82     2719   2017   4007     87    263    227       C  
+ATOM    631  C   GLY A  82       1.742   6.966  29.586  1.00 21.96           C  
+ANISOU  631  C   GLY A  82     2265   2316   3762    656    664   -480       C  
+ATOM    632  O   GLY A  82       1.310   7.729  30.459  1.00 23.84           O  
+ANISOU  632  O   GLY A  82     2494   2529   4035    408   1243   -513       O  
+ATOM    633  N   PRO A  83       3.022   6.688  29.386  1.00 20.86           N  
+ANISOU  633  N   PRO A  83     2278   2344   3304    661    768    -80       N  
+ATOM    634  CA  PRO A  83       4.052   7.316  30.197  1.00 20.06           C  
+ANISOU  634  CA  PRO A  83     2220   2893   2508    518    886    259       C  
+ATOM    635  C   PRO A  83       4.415   8.723  29.746  1.00 21.29           C  
+ANISOU  635  C   PRO A  83     2823   2637   2628    378    202    -42       C  
+ATOM    636  O   PRO A  83       5.263   9.381  30.372  1.00 25.64           O  
+ANISOU  636  O   PRO A  83     3449   3609   2685   -377   -232    482       O  
+ATOM    637  CB  PRO A  83       5.258   6.402  29.946  1.00 21.68           C  
+ANISOU  637  CB  PRO A  83     2421   3029   2788    761    625    286       C  
+ATOM    638  CG  PRO A  83       5.040   5.844  28.568  1.00 22.88           C  
+ANISOU  638  CG  PRO A  83     2239   3190   3263    851    549   -330       C  
+ATOM    639  CD  PRO A  83       3.556   5.738  28.396  1.00 21.51           C  
+ANISOU  639  CD  PRO A  83     2210   2664   3298    936    608   -127       C  
+ATOM    640  N   LEU A  84       3.812   9.161  28.655  1.00 19.15           N  
+ANISOU  640  N   LEU A  84     2840   2133   2304    363    308   -317       N  
+ATOM    641  CA  LEU A  84       4.299  10.338  27.968  1.00 17.30           C  
+ANISOU  641  CA  LEU A  84     1858   1925   2790    239   -253   -324       C  
+ATOM    642  C   LEU A  84       3.603  11.604  28.458  1.00 19.04           C  
+ANISOU  642  C   LEU A  84     1960   2018   3255     41    618   -289       C  
+ATOM    643  O   LEU A  84       2.411  11.610  28.766  1.00 22.60           O  
+ANISOU  643  O   LEU A  84     2129   2871   3586     -3    897   -868       O  
+ATOM    644  CB  LEU A  84       4.074  10.243  26.470  1.00 16.42           C  
+ANISOU  644  CB  LEU A  84     1407   2182   2651   -124    211    -25       C  
+ATOM    645  CG  LEU A  84       4.574   8.984  25.771  1.00 16.97           C  
+ANISOU  645  CG  LEU A  84     1837   2180   2431   -165    187    -73       C  
+ATOM    646  CD1 LEU A  84       4.108   8.912  24.334  1.00 17.44           C  
+ANISOU  646  CD1 LEU A  84     2192   2047   2388    561    122    269       C  
+ATOM    647  CD2 LEU A  84       6.096   8.962  25.815  1.00 16.81           C  
+ANISOU  647  CD2 LEU A  84     1784   2287   2315    -33    485   -268       C  
+ATOM    648  N   ASP A  85       4.410  12.639  28.472  1.00 21.77           N  
+ANISOU  648  N   ASP A  85     2487   2051   3734   -145    475   -597       N  
+ATOM    649  CA  ASP A  85       3.946  14.006  28.704  1.00 23.88           C  
+ANISOU  649  CA  ASP A  85     3407   1973   3694    -52    769   -378       C  
+ATOM    650  C   ASP A  85       3.846  14.673  27.353  1.00 26.83           C  
+ANISOU  650  C   ASP A  85     3629   2656   3909    223   1274     94       C  
+ATOM    651  O   ASP A  85       4.783  14.710  26.555  1.00 30.13           O  
+ANISOU  651  O   ASP A  85     4204   3227   4015    348   1731   -509       O  
+ATOM    652  CB  ASP A  85       4.924  14.729  29.630  1.00 33.89           C  
+ANISOU  652  CB  ASP A  85     5434   2240   5203   -361   -457   -979       C  
+ATOM    653  CG  ASP A  85       4.786  14.164  31.031  1.00 39.02           C  
+ANISOU  653  CG  ASP A  85     5741   3995   5089  -1411  -1390   -643       C  
+ATOM    654  OD1 ASP A  85       3.685  13.599  31.260  1.00 51.19           O  
+ANISOU  654  OD1 ASP A  85     5862   8078   5509  -2221  -1548   1190       O  
+ATOM    655  OD2 ASP A  85       5.729  14.280  31.848  1.00 50.01           O  
+ANISOU  655  OD2 ASP A  85     6079   6349   6573  -1383  -2304     -5       O  
+ATOM    656  N   GLY A  86       2.695  15.232  27.021  1.00 26.94           N  
+ANISOU  656  N   GLY A  86     3463   3709   3065   -100    549   -310       N  
+ATOM    657  CA  GLY A  86       2.678  15.910  25.741  1.00 25.22           C  
+ANISOU  657  CA  GLY A  86     3855   2648   3079   -559    534   -539       C  
+ATOM    658  C   GLY A  86       2.459  15.001  24.550  1.00 23.03           C  
+ANISOU  658  C   GLY A  86     3841   1904   3005   -367    626   -237       C  
+ATOM    659  O   GLY A  86       2.043  13.857  24.707  1.00 29.83           O  
+ANISOU  659  O   GLY A  86     4816   2753   3765  -1766    113    -76       O  
+ATOM    660  N   THR A  87       2.741  15.526  23.364  1.00 21.73           N  
+ANISOU  660  N   THR A  87     3403   1948   2904    507    319     22       N  
+ATOM    661  CA  THR A  87       2.431  14.961  22.063  1.00 21.20           C  
+ANISOU  661  CA  THR A  87     2346   2750   2959    667    364   -210       C  
+ATOM    662  C   THR A  87       3.691  14.625  21.283  1.00 18.21           C  
+ANISOU  662  C   THR A  87     1662   2175   3081    298    -86   -408       C  
+ATOM    663  O   THR A  87       4.597  15.439  21.174  1.00 20.66           O  
+ANISOU  663  O   THR A  87     2084   2166   3602     56   -158   -313       O  
+ATOM    664  CB  THR A  87       1.644  15.978  21.224  1.00 22.24           C  
+ANISOU  664  CB  THR A  87     1747   3450   3252    755    407     92       C  
+ATOM    665  OG1 THR A  87       0.463  16.366  21.931  1.00 29.27           O  
+ANISOU  665  OG1 THR A  87     2422   4916   3784   1512    721    -82       O  
+ATOM    666  CG2 THR A  87       1.200  15.351  19.888  1.00 35.37           C  
+ANISOU  666  CG2 THR A  87     3400   6389   3650   2438   -599  -1065       C  
+ATOM    667  N   TYR A  88       3.678  13.413  20.753  1.00 17.23           N  
+ANISOU  667  N   TYR A  88     1361   2181   3006    176    -29   -290       N  
+ATOM    668  CA  TYR A  88       4.783  12.881  19.973  1.00 16.06           C  
+ANISOU  668  CA  TYR A  88     1754   1623   2727    -42    286    -55       C  
+ATOM    669  C   TYR A  88       4.270  12.540  18.576  1.00 15.71           C  
+ANISOU  669  C   TYR A  88     1331   1768   2870    244     24    -16       C  
+ATOM    670  O   TYR A  88       3.272  11.844  18.398  1.00 21.16           O  
+ANISOU  670  O   TYR A  88     2104   2792   3144   -702   -355    613       O  
+ATOM    671  CB  TYR A  88       5.387  11.670  20.636  1.00 18.22           C  
+ANISOU  671  CB  TYR A  88     2103   2173   2645    567     17   -185       C  
+ATOM    672  CG  TYR A  88       6.145  11.874  21.918  1.00 16.36           C  
+ANISOU  672  CG  TYR A  88     1691   1924   2599    -66    294   -135       C  
+ATOM    673  CD1 TYR A  88       5.562  12.300  23.093  1.00 15.83           C  
+ANISOU  673  CD1 TYR A  88     1404   1783   2826    388     20   -500       C  
+ATOM    674  CD2 TYR A  88       7.508  11.647  21.974  1.00 15.23           C  
+ANISOU  674  CD2 TYR A  88     1635   1927   2224   -118    502     36       C  
+ATOM    675  CE1 TYR A  88       6.289  12.483  24.252  1.00 16.83           C  
+ANISOU  675  CE1 TYR A  88     1513   2398   2485    -32    183     76       C  
+ATOM    676  CE2 TYR A  88       8.260  11.814  23.128  1.00 15.05           C  
+ANISOU  676  CE2 TYR A  88     1793   1251   2676    -76    209   -431       C  
+ATOM    677  CZ  TYR A  88       7.641  12.244  24.280  1.00 14.79           C  
+ANISOU  677  CZ  TYR A  88     1354   1580   2684   -538    107   -712       C  
+ATOM    678  OH  TYR A  88       8.386  12.396  25.409  1.00 17.50           O  
+ANISOU  678  OH  TYR A  88     1756   2260   2633     64    -96   -380       O  
+ATOM    679  N   ARG A  89       4.996  13.073  17.602  1.00 16.54           N  
+ANISOU  679  N   ARG A  89     1633   2002   2648   -339    -88   -303       N  
+ATOM    680  CA  ARG A  89       4.651  12.935  16.210  1.00 17.72           C  
+ANISOU  680  CA  ARG A  89     2081   1983   2668    -24   -248   -145       C  
+ATOM    681  C   ARG A  89       5.364  11.816  15.471  1.00 16.85           C  
+ANISOU  681  C   ARG A  89     2277   1675   2452   -131   -281    -38       C  
+ATOM    682  O   ARG A  89       6.595  11.719  15.561  1.00 15.56           O  
+ANISOU  682  O   ARG A  89     2181   1820   1912   -181    -13   -122       O  
+ATOM    683  CB  ARG A  89       5.088  14.237  15.495  1.00 24.27           C  
+ANISOU  683  CB  ARG A  89     4165   1644   3412    -77  -1585    402       C  
+ATOM    684  CG  ARG A  89       3.997  15.261  15.553  1.00 31.20           C  
+ANISOU  684  CG  ARG A  89     4055   2971   4830    437   -613   1534       C  
+ATOM    685  CD  ARG A  89       4.142  16.203  14.349  1.00 28.10           C  
+ANISOU  685  CD  ARG A  89     3569   2029   5080    307   -566   1342       C  
+ATOM    686  NE  ARG A  89       3.568  17.459  14.760  1.00 28.49           N  
+ANISOU  686  NE  ARG A  89     3955   2718   4152    612   -271    915       N  
+ATOM    687  CZ  ARG A  89       3.867  18.657  14.340  1.00 26.86           C  
+ANISOU  687  CZ  ARG A  89     3627   2190   4388    982   -347    528       C  
+ATOM    688  NH1 ARG A  89       4.797  18.814  13.411  1.00 28.61           N  
+ANISOU  688  NH1 ARG A  89     3871   2840   4158    -94   -467    429       N  
+ATOM    689  NH2 ARG A  89       3.219  19.684  14.855  1.00 38.05           N  
+ANISOU  689  NH2 ARG A  89     4241   3076   7140   1113   -477  -1247       N  
+ATOM    690  N   LEU A  90       4.567  11.025  14.746  1.00 15.56           N  
+ANISOU  690  N   LEU A  90     2313   1869   1728   -273   -210    270       N  
+ATOM    691  CA  LEU A  90       5.133   9.939  13.951  1.00 16.43           C  
+ANISOU  691  CA  LEU A  90     2154   2143   1944   -316   -262    -65       C  
+ATOM    692  C   LEU A  90       5.967  10.500  12.813  1.00 15.95           C  
+ANISOU  692  C   LEU A  90     2208   1636   2215    203    -85    105       C  
+ATOM    693  O   LEU A  90       5.462  11.318  12.038  1.00 19.80           O  
+ANISOU  693  O   LEU A  90     2278   2399   2844    374    -49    728       O  
+ATOM    694  CB  LEU A  90       4.005   9.042  13.423  1.00 16.13           C  
+ANISOU  694  CB  LEU A  90     2028   2185   1914    -84   -559     -9       C  
+ATOM    695  CG  LEU A  90       4.477   7.858  12.590  1.00 14.76           C  
+ANISOU  695  CG  LEU A  90     2300   1914   1395   -334   -259    278       C  
+ATOM    696  CD1 LEU A  90       5.239   6.828  13.422  1.00 16.69           C  
+ANISOU  696  CD1 LEU A  90     2678   2112   1551     24    -53    428       C  
+ATOM    697  CD2 LEU A  90       3.314   7.164  11.872  1.00 17.38           C  
+ANISOU  697  CD2 LEU A  90     2126   2691   1787   -309    -81   -360       C  
+ATOM    698  N   ILE A  91       7.222  10.023  12.743  1.00 17.06           N  
+ANISOU  698  N   ILE A  91     2086   1927   2469    112   -108    371       N  
+ATOM    699  CA  ILE A  91       8.087  10.427  11.655  1.00 16.03           C  
+ANISOU  699  CA  ILE A  91     1975   1667   2448    -84   -198    172       C  
+ATOM    700  C   ILE A  91       8.414   9.260  10.730  1.00 16.10           C  
+ANISOU  700  C   ILE A  91     2287   1454   2377   -917    150    163       C  
+ATOM    701  O   ILE A  91       8.523   9.483   9.514  1.00 16.06           O  
+ANISOU  701  O   ILE A  91     2039   1712   2352    -92    -88    335       O  
+ATOM    702  CB  ILE A  91       9.375  11.083  12.167  1.00 16.17           C  
+ANISOU  702  CB  ILE A  91     2230   1733   2181   -149   -118   -307       C  
+ATOM    703  CG1 ILE A  91      10.272  11.461  10.989  1.00 16.92           C  
+ANISOU  703  CG1 ILE A  91     2312   1687   2430   -509   -104    -90       C  
+ATOM    704  CG2 ILE A  91      10.085  10.237  13.191  1.00 15.78           C  
+ANISOU  704  CG2 ILE A  91     2022   1898   2076   -357   -179   -285       C  
+ATOM    705  CD1 ILE A  91      11.399  12.394  11.372  1.00 26.07           C  
+ANISOU  705  CD1 ILE A  91     3147   2466   4292  -1350   -110   -465       C  
+ATOM    706  N   GLN A  92       8.525   8.054  11.287  1.00 16.37           N  
+ANISOU  706  N   GLN A  92     2922   1578   1720   -326    -85    -63       N  
+ATOM    707  CA  GLN A  92       8.841   6.936  10.424  1.00 14.36           C  
+ANISOU  707  CA  GLN A  92     2327   1649   1479   -438     10     88       C  
+ATOM    708  C   GLN A  92       8.569   5.631  11.166  1.00 12.39           C  
+ANISOU  708  C   GLN A  92     1551   1523   1633   -222   -927    335       C  
+ATOM    709  O   GLN A  92       8.557   5.623  12.389  1.00 14.97           O  
+ANISOU  709  O   GLN A  92     2272   1765   1650   -202   -502    377       O  
+ATOM    710  CB  GLN A  92      10.287   6.929   9.935  1.00 17.73           C  
+ANISOU  710  CB  GLN A  92     2199   1961   2576   -231     21    282       C  
+ATOM    711  CG  GLN A  92      11.374   7.021  10.993  1.00 15.19           C  
+ANISOU  711  CG  GLN A  92     2163   1712   1897     71    342    528       C  
+ATOM    712  CD  GLN A  92      12.128   5.743  11.266  1.00 17.55           C  
+ANISOU  712  CD  GLN A  92     1907   1796   2965    227    507    293       C  
+ATOM    713  OE1 GLN A  92      11.535   4.669  11.229  1.00 17.43           O  
+ANISOU  713  OE1 GLN A  92     3007   1598   2016    137    204     11       O  
+ATOM    714  NE2 GLN A  92      13.406   5.822  11.575  1.00 26.06           N  
+ANISOU  714  NE2 GLN A  92     1904   3096   4901    414    200    395       N  
+ATOM    715  N   PHE A  93       8.433   4.559  10.406  1.00 13.75           N  
+ANISOU  715  N   PHE A  93     1847   1580   1798    -34   -348    152       N  
+ATOM    716  CA  PHE A  93       8.549   3.247  11.036  1.00 14.53           C  
+ANISOU  716  CA  PHE A  93     2021   1539   1960     69   -121    105       C  
+ATOM    717  C   PHE A  93       9.546   2.433  10.223  1.00 15.45           C  
+ANISOU  717  C   PHE A  93     2190   1738   1942    184    110    329       C  
+ATOM    718  O   PHE A  93       9.802   2.666   9.040  1.00 15.17           O  
+ANISOU  718  O   PHE A  93     2430   1508   1827    -84    -62     96       O  
+ATOM    719  CB  PHE A  93       7.195   2.544  11.221  1.00 13.95           C  
+ANISOU  719  CB  PHE A  93     2110   1662   1530     51     -3    240       C  
+ATOM    720  CG  PHE A  93       6.463   2.083   9.966  1.00 15.06           C  
+ANISOU  720  CG  PHE A  93     1999   1923   1800    -72     44    -73       C  
+ATOM    721  CD1 PHE A  93       6.801   0.953   9.248  1.00 16.67           C  
+ANISOU  721  CD1 PHE A  93     2227   2292   1816    216     -8   -238       C  
+ATOM    722  CD2 PHE A  93       5.384   2.821   9.488  1.00 16.09           C  
+ANISOU  722  CD2 PHE A  93     2504   1671   1939    -44   -456   -134       C  
+ATOM    723  CE1 PHE A  93       6.136   0.562   8.107  1.00 17.21           C  
+ANISOU  723  CE1 PHE A  93     2631   2084   1822    -30   -165   -119       C  
+ATOM    724  CE2 PHE A  93       4.678   2.436   8.383  1.00 16.63           C  
+ANISOU  724  CE2 PHE A  93     2850   2150   1318     96   -178   -151       C  
+ATOM    725  CZ  PHE A  93       5.042   1.304   7.711  1.00 16.91           C  
+ANISOU  725  CZ  PHE A  93     3177   1602   1644      4   -451     28       C  
+ATOM    726  N   HIS A  94      10.057   1.422  10.900  1.00 14.15           N  
+ANISOU  726  N   HIS A  94     1926   1514   1937     16      4    182       N  
+ATOM    727  CA  HIS A  94      10.917   0.442  10.281  1.00 13.34           C  
+ANISOU  727  CA  HIS A  94     1995   1670   1405     38   -225     28       C  
+ATOM    728  C   HIS A  94      10.801  -0.842  11.121  1.00 12.74           C  
+ANISOU  728  C   HIS A  94     1543   1709   1586    233   -181    153       C  
+ATOM    729  O   HIS A  94      10.126  -0.848  12.136  1.00 13.51           O  
+ANISOU  729  O   HIS A  94     1747   1538   1849     48    141     46       O  
+ATOM    730  CB  HIS A  94      12.383   0.890  10.173  1.00 15.19           C  
+ANISOU  730  CB  HIS A  94     2157   2390   1226   -207    456   -191       C  
+ATOM    731  CG  HIS A  94      12.886   1.161  11.566  1.00 12.90           C  
+ANISOU  731  CG  HIS A  94     1481   1871   1549     37    220   -217       C  
+ATOM    732  ND1 HIS A  94      12.669   2.367  12.191  1.00 13.63           N  
+ANISOU  732  ND1 HIS A  94     1948   1595   1638    -83    114   -101       N  
+ATOM    733  CD2 HIS A  94      13.557   0.381  12.455  1.00 14.59           C  
+ANISOU  733  CD2 HIS A  94     1892   1893   1758    306     84   -273       C  
+ATOM    734  CE1 HIS A  94      13.198   2.309  13.393  1.00 14.98           C  
+ANISOU  734  CE1 HIS A  94     1276   2144   2270    379   -457   -731       C  
+ATOM    735  NE2 HIS A  94      13.747   1.110  13.595  1.00 13.01           N  
+ANISOU  735  NE2 HIS A  94     1374   1940   1629    144    271   -212       N  
+ATOM    736  N   PHE A  95      11.504  -1.840  10.610  1.00 13.56           N  
+ANISOU  736  N   PHE A  95     1445   1905   1803    322    111    215       N  
+ATOM    737  CA  PHE A  95      11.586  -3.168  11.212  1.00 12.92           C  
+ANISOU  737  CA  PHE A  95     1575   1632   1701    182   -254   -204       C  
+ATOM    738  C   PHE A  95      13.056  -3.588  11.394  1.00 13.70           C  
+ANISOU  738  C   PHE A  95     1482   1649   2075    191    -77     89       C  
+ATOM    739  O   PHE A  95      13.960  -3.131  10.737  1.00 15.47           O  
+ANISOU  739  O   PHE A  95     1784   1984   2108    102    290   -121       O  
+ATOM    740  CB  PHE A  95      10.861  -4.234  10.409  1.00 15.50           C  
+ANISOU  740  CB  PHE A  95     2322   2114   1455     -1   -813    -90       C  
+ATOM    741  CG  PHE A  95       9.387  -3.977  10.113  1.00 13.95           C  
+ANISOU  741  CG  PHE A  95     2095   1569   1637   -114   -511   -156       C  
+ATOM    742  CD1 PHE A  95       8.984  -3.099   9.130  1.00 13.94           C  
+ANISOU  742  CD1 PHE A  95     1630   1609   2060     19   -235     68       C  
+ATOM    743  CD2 PHE A  95       8.418  -4.671  10.823  1.00 15.77           C  
+ANISOU  743  CD2 PHE A  95     2444   1693   1854   -304   -563     50       C  
+ATOM    744  CE1 PHE A  95       7.644  -2.926   8.861  1.00 13.57           C  
+ANISOU  744  CE1 PHE A  95     1685   1609   1863   -266   -424    -31       C  
+ATOM    745  CE2 PHE A  95       7.085  -4.491  10.559  1.00 15.34           C  
+ANISOU  745  CE2 PHE A  95     2293   1828   1707   -172   -128    -85       C  
+ATOM    746  CZ  PHE A  95       6.682  -3.625   9.553  1.00 15.57           C  
+ANISOU  746  CZ  PHE A  95     1769   2057   2092   -301   -247    173       C  
+ATOM    747  N   HIS A  96      13.214  -4.496  12.334  1.00 13.37           N  
+ANISOU  747  N   HIS A  96     1752   1615   1715    243   -241   -192       N  
+ATOM    748  CA  HIS A  96      14.374  -5.322  12.530  1.00 12.94           C  
+ANISOU  748  CA  HIS A  96     1633   1399   1885     70   -348    -75       C  
+ATOM    749  C   HIS A  96      13.903  -6.772  12.407  1.00 11.25           C  
+ANISOU  749  C   HIS A  96     1505   1488   1282   -135    241    -70       C  
+ATOM    750  O   HIS A  96      12.820  -7.095  12.922  1.00 14.42           O  
+ANISOU  750  O   HIS A  96     1476   2228   1773    -92    395    -39       O  
+ATOM    751  CB  HIS A  96      15.013  -5.070  13.894  1.00 12.02           C  
+ANISOU  751  CB  HIS A  96     1040   1805   1724    -27     27   -256       C  
+ATOM    752  CG  HIS A  96      15.306  -3.626  14.147  1.00 12.07           C  
+ANISOU  752  CG  HIS A  96     1019   1800   1767     17     20   -305       C  
+ATOM    753  ND1 HIS A  96      16.510  -3.039  13.894  1.00 14.91           N  
+ANISOU  753  ND1 HIS A  96     1118   1944   2604   -108     23    125       N  
+ATOM    754  CD2 HIS A  96      14.516  -2.629  14.614  1.00 13.21           C  
+ANISOU  754  CD2 HIS A  96     1660   1801   1560    269    350      4       C  
+ATOM    755  CE1 HIS A  96      16.459  -1.738  14.217  1.00 16.74           C  
+ANISOU  755  CE1 HIS A  96     2203   1954   2203   -522      9    109       C  
+ATOM    756  NE2 HIS A  96      15.238  -1.466  14.650  1.00 15.95           N  
+ANISOU  756  NE2 HIS A  96     2526   1604   1929    167   -108    138       N  
+ATOM    757  N   TRP A  97      14.667  -7.631  11.755  1.00 11.94           N  
+ANISOU  757  N   TRP A  97     1324   1523   1691    -92    171   -225       N  
+ATOM    758  CA  TRP A  97      14.248  -8.993  11.562  1.00 12.81           C  
+ANISOU  758  CA  TRP A  97     1835   1461   1572    -92     68   -110       C  
+ATOM    759  C   TRP A  97      15.418  -9.955  11.418  1.00 12.79           C  
+ANISOU  759  C   TRP A  97     1803   1423   1633   -120    -20   -148       C  
+ATOM    760  O   TRP A  97      16.570  -9.532  11.317  1.00 13.76           O  
+ANISOU  760  O   TRP A  97     1802   1541   1886   -155    183   -161       O  
+ATOM    761  CB  TRP A  97      13.369  -9.133  10.326  1.00 13.46           C  
+ANISOU  761  CB  TRP A  97     1605   1720   1790   -115    -13   -264       C  
+ATOM    762  CG  TRP A  97      14.028  -8.753   9.030  1.00 13.20           C  
+ANISOU  762  CG  TRP A  97     1865   1564   1586   -113   -153   -358       C  
+ATOM    763  CD1 TRP A  97      14.699  -9.590   8.160  1.00 15.18           C  
+ANISOU  763  CD1 TRP A  97     2432   1656   1681   -492    181   -622       C  
+ATOM    764  CD2 TRP A  97      14.066  -7.451   8.442  1.00 16.23           C  
+ANISOU  764  CD2 TRP A  97     2047   1758   2361   -113    569    -88       C  
+ATOM    765  NE1 TRP A  97      15.157  -8.882   7.077  1.00 16.37           N  
+ANISOU  765  NE1 TRP A  97     2553   1858   1809   -319    219   -431       N  
+ATOM    766  CE2 TRP A  97      14.781  -7.572   7.231  1.00 15.74           C  
+ANISOU  766  CE2 TRP A  97     2138   1960   1884   -113    239   -212       C  
+ATOM    767  CE3 TRP A  97      13.559  -6.202   8.852  1.00 15.03           C  
+ANISOU  767  CE3 TRP A  97     1945   1620   2146   -122    458     19       C  
+ATOM    768  CZ2 TRP A  97      15.016  -6.502   6.403  1.00 15.99           C  
+ANISOU  768  CZ2 TRP A  97     2326   2013   1738   -251     33   -206       C  
+ATOM    769  CZ3 TRP A  97      13.804  -5.134   8.008  1.00 15.94           C  
+ANISOU  769  CZ3 TRP A  97     2232   1768   2056   -256    388     23       C  
+ATOM    770  CH2 TRP A  97      14.517  -5.307   6.818  1.00 15.09           C  
+ANISOU  770  CH2 TRP A  97     1816   2025   1895   -214    138      0       C  
+ATOM    771  N   GLY A  98      15.005 -11.231  11.424  1.00 13.54           N  
+ANISOU  771  N   GLY A  98     1748   1439   1956   -148     85   -249       N  
+ATOM    772  CA  GLY A  98      16.015 -12.263  11.445  1.00 15.34           C  
+ANISOU  772  CA  GLY A  98     2208   1467   2153    128    274   -284       C  
+ATOM    773  C   GLY A  98      16.251 -12.997  10.159  1.00 13.48           C  
+ANISOU  773  C   GLY A  98     1664   1508   1951    -36     93   -132       C  
+ATOM    774  O   GLY A  98      15.572 -12.757   9.166  1.00 16.45           O  
+ANISOU  774  O   GLY A  98     2194   1737   2318     -9   -274    -76       O  
+ATOM    775  N   SER A  99      17.257 -13.883  10.238  1.00 14.97           N  
+ANISOU  775  N   SER A  99     1950   1804   1934    244    -83   -564       N  
+ATOM    776  CA  SER A  99      17.550 -14.792   9.142  1.00 16.25           C  
+ANISOU  776  CA  SER A  99     2153   1889   2134   -270    563   -667       C  
+ATOM    777  C   SER A  99      16.673 -16.051   9.220  1.00 16.23           C  
+ANISOU  777  C   SER A  99     2339   1860   1968   -340    371   -435       C  
+ATOM    778  O   SER A  99      16.556 -16.800   8.248  1.00 19.75           O  
+ANISOU  778  O   SER A  99     3095   2020   2388   -601    544   -706       O  
+ATOM    779  CB  SER A  99      18.996 -15.231   9.112  1.00 16.73           C  
+ANISOU  779  CB  SER A  99     2179   2217   1962   -150    627   -691       C  
+ATOM    780  OG  SER A  99      19.521 -15.715  10.329  1.00 20.01           O  
+ANISOU  780  OG  SER A  99     2704   2601   2299     79    441   -275       O  
+ATOM    781  N   LEU A 100      16.080 -16.286  10.377  1.00 16.65           N  
+ANISOU  781  N   LEU A 100     2016   2091   2219     24    512   -179       N  
+ATOM    782  CA  LEU A 100      15.296 -17.439  10.745  1.00 17.64           C  
+ANISOU  782  CA  LEU A 100     2254   2330   2119   -309    235    -62       C  
+ATOM    783  C   LEU A 100      14.170 -16.957  11.641  1.00 16.29           C  
+ANISOU  783  C   LEU A 100     2194   1504   2491   -315    377    189       C  
+ATOM    784  O   LEU A 100      14.318 -15.928  12.292  1.00 15.79           O  
+ANISOU  784  O   LEU A 100     1841   1641   2518   -137    -29     71       O  
+ATOM    785  CB  LEU A 100      16.085 -18.487  11.515  1.00 23.15           C  
+ANISOU  785  CB  LEU A 100     3490   2298   3009    802    930    164       C  
+ATOM    786  CG  LEU A 100      17.253 -19.176  10.814  1.00 27.15           C  
+ANISOU  786  CG  LEU A 100     3327   3393   3593    764   1479    474       C  
+ATOM    787  CD1 LEU A 100      17.940 -20.190  11.726  1.00 44.01           C  
+ANISOU  787  CD1 LEU A 100     4742   4941   7041   2687   2150   2259       C  
+ATOM    788  CD2 LEU A 100      16.784 -19.906   9.561  1.00 36.32           C  
+ANISOU  788  CD2 LEU A 100     5646   2122   6032    678   1798  -1682       C  
+ATOM    789  N   ASP A 101      13.066 -17.700  11.684  1.00 17.45           N  
+ANISOU  789  N   ASP A 101     2151   1866   2615   -424    202    -81       N  
+ATOM    790  CA  ASP A 101      11.917 -17.178  12.427  1.00 17.16           C  
+ANISOU  790  CA  ASP A 101     1886   2080   2553   -306    -57    -92       C  
+ATOM    791  C   ASP A 101      12.188 -17.078  13.925  1.00 18.93           C  
+ANISOU  791  C   ASP A 101     2524   2103   2565    -23    -91   -375       C  
+ATOM    792  O   ASP A 101      11.480 -16.361  14.634  1.00 19.49           O  
+ANISOU  792  O   ASP A 101     2469   2140   2797   -174    320   -235       O  
+ATOM    793  CB  ASP A 101      10.681 -18.045  12.208  1.00 16.70           C  
+ANISOU  793  CB  ASP A 101     1933   1529   2885   -204   -185    285       C  
+ATOM    794  CG  ASP A 101      10.179 -18.106  10.789  1.00 17.88           C  
+ANISOU  794  CG  ASP A 101     1886   1893   3014   -437   -308    135       C  
+ATOM    795  OD1 ASP A 101      10.617 -17.288   9.966  1.00 20.03           O  
+ANISOU  795  OD1 ASP A 101     2448   2464   2698   -675   -147    129       O  
+ATOM    796  OD2 ASP A 101       9.316 -18.971  10.513  1.00 24.37           O  
+ANISOU  796  OD2 ASP A 101     3030   2221   4009  -1068   -808     20       O  
+ATOM    797  N   GLY A 102      13.187 -17.771  14.438  1.00 16.49           N  
+ANISOU  797  N   GLY A 102     2065   1968   2233   -437    157    -81       N  
+ATOM    798  CA  GLY A 102      13.472 -17.785  15.851  1.00 18.75           C  
+ANISOU  798  CA  GLY A 102     2813   1987   2325   -603     -1    108       C  
+ATOM    799  C   GLY A 102      14.314 -16.658  16.390  1.00 17.18           C  
+ANISOU  799  C   GLY A 102     2407   1978   2143   -432   -363    388       C  
+ATOM    800  O   GLY A 102      14.662 -16.645  17.550  1.00 18.52           O  
+ANISOU  800  O   GLY A 102     2582   2343   2110   -327   -350    423       O  
+ATOM    801  N   GLN A 103      14.623 -15.663  15.553  1.00 16.24           N  
+ANISOU  801  N   GLN A 103     2545   1735   1891   -349   -333    116       N  
+ATOM    802  CA  GLN A 103      15.343 -14.509  16.014  1.00 14.29           C  
+ANISOU  802  CA  GLN A 103     1841   1624   1966    -36    175   -142       C  
+ATOM    803  C   GLN A 103      14.958 -13.349  15.084  1.00 13.41           C  
+ANISOU  803  C   GLN A 103     1679   1640   1776   -247    156   -117       C  
+ATOM    804  O   GLN A 103      14.399 -13.553  14.010  1.00 15.28           O  
+ANISOU  804  O   GLN A 103     2368   1475   1962   -113   -107   -249       O  
+ATOM    805  CB  GLN A 103      16.860 -14.705  15.963  1.00 15.87           C  
+ANISOU  805  CB  GLN A 103     1907   1629   2495    174    359   -165       C  
+ATOM    806  CG  GLN A 103      17.307 -14.992  14.539  1.00 20.09           C  
+ANISOU  806  CG  GLN A 103     2520   2355   2759    754    648   -270       C  
+ATOM    807  CD  GLN A 103      18.689 -15.627  14.531  1.00 22.14           C  
+ANISOU  807  CD  GLN A 103     2800   2974   2637   1192    813    308       C  
+ATOM    808  OE1 GLN A 103      18.887 -16.615  15.242  1.00 36.34           O  
+ANISOU  808  OE1 GLN A 103     3527   4757   5525   1925   1622   2524       O  
+ATOM    809  NE2 GLN A 103      19.617 -15.059  13.775  1.00 21.09           N  
+ANISOU  809  NE2 GLN A 103     2180   2261   3572    412    297    -56       N  
+ATOM    810  N   GLY A 104      15.304 -12.158  15.544  1.00 13.18           N  
+ANISOU  810  N   GLY A 104     1450   1650   1909   -169    155   -278       N  
+ATOM    811  CA  GLY A 104      15.044 -10.963  14.740  1.00 13.28           C  
+ANISOU  811  CA  GLY A 104     1507   1589   1949   -368    196   -301       C  
+ATOM    812  C   GLY A 104      14.595  -9.788  15.576  1.00 12.85           C  
+ANISOU  812  C   GLY A 104     1380   1622   1881   -177    262   -202       C  
+ATOM    813  O   GLY A 104      14.858  -8.661  15.192  1.00 14.73           O  
+ANISOU  813  O   GLY A 104     2092   1631   1872   -201    313   -120       O  
+ATOM    814  N   SER A 105      13.893 -10.035  16.702  1.00 13.92           N  
+ANISOU  814  N   SER A 105     1890   1628   1772   -334    248   -232       N  
+ATOM    815  CA  SER A 105      13.509  -8.889  17.512  1.00 13.51           C  
+ANISOU  815  CA  SER A 105     1773   1892   1467   -196    141   -238       C  
+ATOM    816  C   SER A 105      14.719  -8.342  18.283  1.00 12.81           C  
+ANISOU  816  C   SER A 105     1520   1737   1611    200    128   -433       C  
+ATOM    817  O   SER A 105      15.719  -9.060  18.437  1.00 14.25           O  
+ANISOU  817  O   SER A 105     1786   1481   2148    290    136   -227       O  
+ATOM    818  CB  SER A 105      12.416  -9.198  18.508  1.00 13.63           C  
+ANISOU  818  CB  SER A 105     1685   1780   1713    -14    179     50       C  
+ATOM    819  OG  SER A 105      12.768 -10.153  19.463  1.00 12.70           O  
+ANISOU  819  OG  SER A 105     1591   1474   1761    -21    143   -104       O  
+ATOM    820  N   GLU A 106      14.498  -7.117  18.716  1.00 13.25           N  
+ANISOU  820  N   GLU A 106     1575   1782   1679    441   -162   -508       N  
+ATOM    821  CA  GLU A 106      15.533  -6.414  19.501  1.00 12.98           C  
+ANISOU  821  CA  GLU A 106     1768   1627   1535    157    -99   -284       C  
+ATOM    822  C   GLU A 106      15.240  -6.609  20.975  1.00 11.88           C  
+ANISOU  822  C   GLU A 106     1611   1341   1561    373   -166   -127       C  
+ATOM    823  O   GLU A 106      16.011  -7.167  21.748  1.00 13.55           O  
+ANISOU  823  O   GLU A 106     1339   2026   1785    354   -216    -65       O  
+ATOM    824  CB  GLU A 106      15.602  -4.938  19.086  1.00 14.25           C  
+ANISOU  824  CB  GLU A 106     1753   1917   1746     -7   -125    155       C  
+ATOM    825  CG  GLU A 106      16.016  -4.815  17.629  1.00 13.34           C  
+ANISOU  825  CG  GLU A 106     1943   1275   1853   -242    179   -371       C  
+ATOM    826  CD  GLU A 106      16.752  -3.527  17.348  1.00 12.07           C  
+ANISOU  826  CD  GLU A 106     1046   1425   2114    -79    216   -371       C  
+ATOM    827  OE1 GLU A 106      16.168  -2.471  17.646  1.00 14.08           O  
+ANISOU  827  OE1 GLU A 106     1514   1245   2591     62    463    -92       O  
+ATOM    828  OE2 GLU A 106      17.908  -3.622  16.853  1.00 15.17           O  
+ANISOU  828  OE2 GLU A 106     1282   1949   2533    115    486   -293       O  
+ATOM    829  N   HIS A 107      14.055  -6.155  21.400  1.00 11.98           N  
+ANISOU  829  N   HIS A 107     1473   1216   1862    189     51    138       N  
+ATOM    830  CA  HIS A 107      13.579  -6.510  22.713  1.00 12.42           C  
+ANISOU  830  CA  HIS A 107     1547   1459   1715    300   -107    184       C  
+ATOM    831  C   HIS A 107      13.288  -8.010  22.727  1.00 12.77           C  
+ANISOU  831  C   HIS A 107     1929   1496   1428     71    137     81       C  
+ATOM    832  O   HIS A 107      12.964  -8.592  21.708  1.00 13.30           O  
+ANISOU  832  O   HIS A 107     1893   1729   1429    234    118    -76       O  
+ATOM    833  CB  HIS A 107      12.311  -5.711  23.103  1.00 11.50           C  
+ANISOU  833  CB  HIS A 107     1338   1567   1465    201   -125    318       C  
+ATOM    834  CG  HIS A 107      12.649  -4.256  23.270  1.00 12.00           C  
+ANISOU  834  CG  HIS A 107     1313   1535   1712    220    227     77       C  
+ATOM    835  ND1 HIS A 107      12.631  -3.365  22.232  1.00 12.03           N  
+ANISOU  835  ND1 HIS A 107     1441   1445   1684     73     14     68       N  
+ATOM    836  CD2 HIS A 107      13.089  -3.579  24.346  1.00 13.21           C  
+ANISOU  836  CD2 HIS A 107     1666   1596   1759     37    -36    214       C  
+ATOM    837  CE1 HIS A 107      12.993  -2.178  22.654  1.00 12.09           C  
+ANISOU  837  CE1 HIS A 107     1614   1545   1435     55    218     27       C  
+ATOM    838  NE2 HIS A 107      13.286  -2.270  23.931  1.00 11.71           N  
+ANISOU  838  NE2 HIS A 107     1501   1466   1480    285     98     79       N  
+ATOM    839  N   THR A 108      13.438  -8.577  23.921  1.00 12.31           N  
+ANISOU  839  N   THR A 108     1713   1404   1559     25   -182     55       N  
+ATOM    840  CA  THR A 108      13.068  -9.949  24.196  1.00 11.51           C  
+ANISOU  840  CA  THR A 108     1344   1268   1761    344    207    103       C  
+ATOM    841  C   THR A 108      12.105  -9.980  25.384  1.00 12.60           C  
+ANISOU  841  C   THR A 108     1282   1761   1744    340    184     64       C  
+ATOM    842  O   THR A 108      12.038  -9.017  26.164  1.00 15.72           O  
+ANISOU  842  O   THR A 108     2443   1932   1597    240    382     26       O  
+ATOM    843  CB  THR A 108      14.302 -10.831  24.423  1.00 13.37           C  
+ANISOU  843  CB  THR A 108     1204   1758   2119    433     54     36       C  
+ATOM    844  OG1 THR A 108      15.181 -10.334  25.425  1.00 15.52           O  
+ANISOU  844  OG1 THR A 108     1839   1962   2095    140   -330    392       O  
+ATOM    845  CG2 THR A 108      15.161 -10.892  23.153  1.00 15.94           C  
+ANISOU  845  CG2 THR A 108     1493   2199   2366    635    294   -214       C  
+ATOM    846  N   VAL A 109      11.328 -11.047  25.490  1.00 14.32           N  
+ANISOU  846  N   VAL A 109     1674   2023   1742     76    338    248       N  
+ATOM    847  CA  VAL A 109      10.371 -11.156  26.597  1.00 12.72           C  
+ANISOU  847  CA  VAL A 109     1621   1707   1504     50    181    -50       C  
+ATOM    848  C   VAL A 109      10.667 -12.471  27.310  1.00 14.24           C  
+ANISOU  848  C   VAL A 109     2010   1670   1730   -330    -34    154       C  
+ATOM    849  O   VAL A 109      10.498 -13.543  26.737  1.00 15.81           O  
+ANISOU  849  O   VAL A 109     2141   1711   2155   -162    -68    -75       O  
+ATOM    850  CB  VAL A 109       8.940 -11.102  26.085  1.00 14.93           C  
+ANISOU  850  CB  VAL A 109     1554   2032   2086   -323    101    315       C  
+ATOM    851  CG1 VAL A 109       7.926 -11.217  27.228  1.00 18.53           C  
+ANISOU  851  CG1 VAL A 109     1553   3140   2346    176    188   1047       C  
+ATOM    852  CG2 VAL A 109       8.693  -9.813  25.302  1.00 15.82           C  
+ANISOU  852  CG2 VAL A 109     1642   2299   2072    142    276    438       C  
+ATOM    853  N   ASP A 110      11.132 -12.334  28.548  1.00 14.72           N  
+ANISOU  853  N   ASP A 110     2018   1767   1808    208    -65     50       N  
+ATOM    854  CA  ASP A 110      11.650 -13.467  29.282  1.00 14.97           C  
+ANISOU  854  CA  ASP A 110     1825   1907   1954    262     65    235       C  
+ATOM    855  C   ASP A 110      12.610 -14.293  28.404  1.00 15.89           C  
+ANISOU  855  C   ASP A 110     2031   1738   2267    154    227     87       C  
+ATOM    856  O   ASP A 110      12.543 -15.534  28.341  1.00 18.51           O  
+ANISOU  856  O   ASP A 110     2720   1704   2609    370    -61    163       O  
+ATOM    857  CB  ASP A 110      10.503 -14.317  29.792  1.00 17.04           C  
+ANISOU  857  CB  ASP A 110     2032   2210   2234    157    194    457       C  
+ATOM    858  CG  ASP A 110       9.614 -13.582  30.771  1.00 16.32           C  
+ANISOU  858  CG  ASP A 110     1787   2329   2084    337     93    674       C  
+ATOM    859  OD1 ASP A 110      10.207 -12.729  31.481  1.00 18.82           O  
+ANISOU  859  OD1 ASP A 110     2296   2657   2196    100    379    299       O  
+ATOM    860  OD2 ASP A 110       8.391 -13.850  30.832  1.00 21.99           O  
+ANISOU  860  OD2 ASP A 110     1819   3448   3089    112    268    657       O  
+ATOM    861  N   LYS A 111      13.489 -13.590  27.721  1.00 16.02           N  
+ANISOU  861  N   LYS A 111     1815   2231   2041    181    113    237       N  
+ATOM    862  CA  LYS A 111      14.526 -14.033  26.806  1.00 14.46           C  
+ANISOU  862  CA  LYS A 111     1930   1485   2078    104     79    138       C  
+ATOM    863  C   LYS A 111      14.006 -14.564  25.480  1.00 15.76           C  
+ANISOU  863  C   LYS A 111     2225   1667   2094   -136    119    147       C  
+ATOM    864  O   LYS A 111      14.833 -14.942  24.668  1.00 17.27           O  
+ANISOU  864  O   LYS A 111     2302   2148   2110   -218    203    -30       O  
+ATOM    865  CB  LYS A 111      15.429 -15.084  27.467  1.00 18.68           C  
+ANISOU  865  CB  LYS A 111     2013   1982   3105    289   -335    267       C  
+ATOM    866  CG  LYS A 111      16.204 -14.616  28.698  1.00 21.37           C  
+ANISOU  866  CG  LYS A 111     3533   1912   2674    599   -746    521       C  
+ATOM    867  CD  LYS A 111      17.088 -13.440  28.390  1.00 21.28           C  
+ANISOU  867  CD  LYS A 111     2767   2418   2901    261   -580   -408       C  
+ATOM    868  CE  LYS A 111      17.848 -12.857  29.551  1.00 26.85           C  
+ANISOU  868  CE  LYS A 111     3684   3316   3203    520  -1375   -417       C  
+ATOM    869  NZ  LYS A 111      18.989 -13.689  29.973  1.00 32.20           N  
+ANISOU  869  NZ  LYS A 111     3299   5030   3903    954  -1169   -147       N  
+ATOM    870  N   LYS A 112      12.712 -14.576  25.275  1.00 15.61           N  
+ANISOU  870  N   LYS A 112     2266   1682   1983     31    -62    148       N  
+ATOM    871  CA  LYS A 112      12.099 -14.992  24.014  1.00 16.64           C  
+ANISOU  871  CA  LYS A 112     2506   2060   1754   -314     87    291       C  
+ATOM    872  C   LYS A 112      12.412 -13.973  22.933  1.00 15.89           C  
+ANISOU  872  C   LYS A 112     2656   1661   1719   -328    376    -44       C  
+ATOM    873  O   LYS A 112      12.144 -12.787  23.141  1.00 14.69           O  
+ANISOU  873  O   LYS A 112     2031   1819   1732    152   -130     23       O  
+ATOM    874  CB  LYS A 112      10.574 -15.101  24.137  1.00 17.81           C  
+ANISOU  874  CB  LYS A 112     2476   2272   2021   -618    -53    334       C  
+ATOM    875  CG  LYS A 112       9.883 -15.515  22.837  1.00 19.90           C  
+ANISOU  875  CG  LYS A 112     2727   2768   2066   -403    -53      7       C  
+ATOM    876  CD  LYS A 112       8.366 -15.591  22.989  1.00 23.38           C  
+ANISOU  876  CD  LYS A 112     2564   2815   3504    192   -860   -105       C  
+ATOM    877  CE  LYS A 112       7.710 -15.838  21.635  1.00 23.21           C  
+ANISOU  877  CE  LYS A 112     3026   2657   3136   -652   -534     78       C  
+ATOM    878  NZ  LYS A 112       8.102 -17.146  21.087  1.00 29.32           N  
+ANISOU  878  NZ  LYS A 112     5368   2521   3253   -201   -927    241       N  
+ATOM    879  N   LYS A 113      12.922 -14.462  21.812  1.00 15.26           N  
+ANISOU  879  N   LYS A 113     2000   2067   1732    303    228    124       N  
+ATOM    880  CA  LYS A 113      13.112 -13.636  20.632  1.00 15.32           C  
+ANISOU  880  CA  LYS A 113     1810   2408   1603      9     94    117       C  
+ATOM    881  C   LYS A 113      11.946 -13.835  19.659  1.00 14.18           C  
+ANISOU  881  C   LYS A 113     1739   1638   2012   -431      6    577       C  
+ATOM    882  O   LYS A 113      11.565 -14.969  19.418  1.00 16.33           O  
+ANISOU  882  O   LYS A 113     2133   1447   2626   -200    -89    469       O  
+ATOM    883  CB  LYS A 113      14.427 -14.012  19.941  1.00 13.92           C  
+ANISOU  883  CB  LYS A 113     1805   1568   1918     90    142    364       C  
+ATOM    884  CG  LYS A 113      15.688 -13.627  20.696  1.00 18.01           C  
+ANISOU  884  CG  LYS A 113     1813   2296   2734    228   -119    127       C  
+ATOM    885  CD  LYS A 113      16.923 -14.214  20.056  1.00 18.51           C  
+ANISOU  885  CD  LYS A 113     1831   2376   2826    230    105    387       C  
+ATOM    886  CE  LYS A 113      18.170 -13.568  20.649  1.00 23.29           C  
+ANISOU  886  CE  LYS A 113     1855   3356   3638    199   -127     13       C  
+ATOM    887  NZ  LYS A 113      18.978 -14.519  21.442  1.00 35.88           N  
+ANISOU  887  NZ  LYS A 113     4651   3793   5189    871  -2797   -782       N  
+ATOM    888  N   TYR A 114      11.430 -12.730  19.115  1.00 13.87           N  
+ANISOU  888  N   TYR A 114     1861   1373   2038   -107    -45     59       N  
+ATOM    889  CA  TYR A 114      10.406 -12.852  18.073  1.00 13.99           C  
+ANISOU  889  CA  TYR A 114     2078   1333   1904      3    -92     70       C  
+ATOM    890  C   TYR A 114      11.056 -12.786  16.688  1.00 15.08           C  
+ANISOU  890  C   TYR A 114     1897   1840   1994    -37    -45     23       C  
+ATOM    891  O   TYR A 114      12.235 -12.461  16.569  1.00 15.63           O  
+ANISOU  891  O   TYR A 114     1855   1948   2134     61    -95     45       O  
+ATOM    892  CB  TYR A 114       9.349 -11.773  18.203  1.00 13.47           C  
+ANISOU  892  CB  TYR A 114     1605   1299   2215   -285   -130   -160       C  
+ATOM    893  CG  TYR A 114       8.440 -11.953  19.399  1.00 14.19           C  
+ANISOU  893  CG  TYR A 114     1928   1190   2276   -164     -6    -20       C  
+ATOM    894  CD1 TYR A 114       8.764 -11.547  20.689  1.00 15.35           C  
+ANISOU  894  CD1 TYR A 114     2067   1544   2221    158     15    -77       C  
+ATOM    895  CD2 TYR A 114       7.211 -12.556  19.226  1.00 15.11           C  
+ANISOU  895  CD2 TYR A 114     1877   1616   2249   -301     92    292       C  
+ATOM    896  CE1 TYR A 114       7.861 -11.760  21.718  1.00 17.47           C  
+ANISOU  896  CE1 TYR A 114     2774   1512   2352     38    292    125       C  
+ATOM    897  CE2 TYR A 114       6.306 -12.769  20.245  1.00 17.74           C  
+ANISOU  897  CE2 TYR A 114     2278   2204   2256   -246    209    751       C  
+ATOM    898  CZ  TYR A 114       6.645 -12.364  21.508  1.00 17.43           C  
+ANISOU  898  CZ  TYR A 114     2862   1478   2283   -190    410    619       C  
+ATOM    899  OH  TYR A 114       5.782 -12.541  22.562  1.00 22.82           O  
+ANISOU  899  OH  TYR A 114     3274   2805   2590   -175    875    369       O  
+ATOM    900  N   ALA A 115      10.289 -13.086  15.642  1.00 15.10           N  
+ANISOU  900  N   ALA A 115     1821   1977   1939    209    -51    -39       N  
+ATOM    901  CA  ALA A 115      10.814 -13.093  14.282  1.00 14.46           C  
+ANISOU  901  CA  ALA A 115     1702   1746   2045   -209     39   -362       C  
+ATOM    902  C   ALA A 115      11.200 -11.707  13.790  1.00 14.22           C  
+ANISOU  902  C   ALA A 115     1793   1730   1881   -154    106   -441       C  
+ATOM    903  O   ALA A 115      12.043 -11.541  12.906  1.00 14.62           O  
+ANISOU  903  O   ALA A 115     1443   1857   2253    107    185    -88       O  
+ATOM    904  CB  ALA A 115       9.776 -13.718  13.364  1.00 15.88           C  
+ANISOU  904  CB  ALA A 115     1783   1699   2554     44   -181   -859       C  
+ATOM    905  N   ALA A 116      10.562 -10.695  14.359  1.00 14.30           N  
+ANISOU  905  N   ALA A 116     2172   1743   1520   -306    112   -668       N  
+ATOM    906  CA  ALA A 116      10.864  -9.319  13.934  1.00 13.95           C  
+ANISOU  906  CA  ALA A 116     1778   1720   1804   -104   -263   -377       C  
+ATOM    907  C   ALA A 116      10.321  -8.344  14.958  1.00 13.67           C  
+ANISOU  907  C   ALA A 116     1954   1518   1721   -119    -99   -139       C  
+ATOM    908  O   ALA A 116       9.627  -8.730  15.878  1.00 14.24           O  
+ANISOU  908  O   ALA A 116     2233   1406   1771     -4      4     33       O  
+ATOM    909  CB  ALA A 116      10.300  -9.006  12.559  1.00 14.25           C  
+ANISOU  909  CB  ALA A 116     1553   1931   1930    182   -435   -543       C  
+ATOM    910  N   GLU A 117      10.615  -7.083  14.798  1.00 13.15           N  
+ANISOU  910  N   GLU A 117     1806   1555   1636   -177    191   -203       N  
+ATOM    911  CA  GLU A 117      10.095  -6.038  15.664  1.00 11.46           C  
+ANISOU  911  CA  GLU A 117     1128   1645   1582    202   -145   -116       C  
+ATOM    912  C   GLU A 117       9.897  -4.793  14.814  1.00 12.63           C  
+ANISOU  912  C   GLU A 117     1339   1716   1745    121    -49     14       C  
+ATOM    913  O   GLU A 117      10.793  -4.389  14.093  1.00 14.66           O  
+ANISOU  913  O   GLU A 117     1524   1963   2085     73    170    115       O  
+ATOM    914  CB  GLU A 117      11.072  -5.769  16.789  1.00 13.01           C  
+ANISOU  914  CB  GLU A 117     1452   1779   1713    100   -264   -240       C  
+ATOM    915  CG  GLU A 117      10.579  -4.809  17.867  1.00 11.92           C  
+ANISOU  915  CG  GLU A 117     1480   1384   1666   -239    -75    -93       C  
+ATOM    916  CD  GLU A 117      11.484  -4.776  19.098  1.00 12.77           C  
+ANISOU  916  CD  GLU A 117     1735   1777   1339   -128     80     76       C  
+ATOM    917  OE1 GLU A 117      12.105  -5.804  19.403  1.00 14.60           O  
+ANISOU  917  OE1 GLU A 117     1893   1908   1746      8   -182     61       O  
+ATOM    918  OE2 GLU A 117      11.552  -3.714  19.729  1.00 14.62           O  
+ANISOU  918  OE2 GLU A 117     1752   2076   1728     69   -299   -343       O  
+ATOM    919  N   LEU A 118       8.717  -4.234  14.918  1.00 12.60           N  
+ANISOU  919  N   LEU A 118     1396   1425   1967    111     -5     71       N  
+ATOM    920  CA  LEU A 118       8.322  -2.987  14.305  1.00 12.12           C  
+ANISOU  920  CA  LEU A 118     1410   1369   1827    -18      1     22       C  
+ATOM    921  C   LEU A 118       8.578  -1.839  15.278  1.00 11.87           C  
+ANISOU  921  C   LEU A 118     1439   1405   1667     77    162     44       C  
+ATOM    922  O   LEU A 118       8.164  -1.927  16.427  1.00 13.47           O  
+ANISOU  922  O   LEU A 118     1556   1879   1684   -188    171     44       O  
+ATOM    923  CB  LEU A 118       6.843  -3.056  13.928  1.00 13.17           C  
+ANISOU  923  CB  LEU A 118     1511   1595   1896    -57   -190    444       C  
+ATOM    924  CG  LEU A 118       6.095  -1.765  13.572  1.00 12.68           C  
+ANISOU  924  CG  LEU A 118     1428   1431   1960   -186   -135    453       C  
+ATOM    925  CD1 LEU A 118       6.660  -1.087  12.356  1.00 13.28           C  
+ANISOU  925  CD1 LEU A 118     2172   1138   1737    175    268    131       C  
+ATOM    926  CD2 LEU A 118       4.616  -2.133  13.407  1.00 15.65           C  
+ANISOU  926  CD2 LEU A 118     1264   2291   2391    100     47   -477       C  
+ATOM    927  N   HIS A 119       9.258  -0.794  14.796  1.00 11.87           N  
+ANISOU  927  N   HIS A 119     1615   1315   1579     20    165    -33       N  
+ATOM    928  CA  HIS A 119       9.474   0.451  15.500  1.00 12.16           C  
+ANISOU  928  CA  HIS A 119     1602   1512   1506      5   -104   -135       C  
+ATOM    929  C   HIS A 119       8.773   1.626  14.817  1.00 12.11           C  
+ANISOU  929  C   HIS A 119     1601   1286   1713    -53     -9   -185       C  
+ATOM    930  O   HIS A 119       9.110   1.919  13.684  1.00 14.01           O  
+ANISOU  930  O   HIS A 119     1687   1794   1841    485     86    141       O  
+ATOM    931  CB  HIS A 119      10.970   0.763  15.594  1.00 13.36           C  
+ANISOU  931  CB  HIS A 119     1663   1856   1558   -215   -128    198       C  
+ATOM    932  CG  HIS A 119      11.669  -0.204  16.488  1.00 10.14           C  
+ANISOU  932  CG  HIS A 119     1331   1359   1162    -68    174   -309       C  
+ATOM    933  ND1 HIS A 119      12.994  -0.458  16.512  1.00 13.01           N  
+ANISOU  933  ND1 HIS A 119     1393   1397   2152    238    679     27       N  
+ATOM    934  CD2 HIS A 119      11.106  -1.017  17.427  1.00 13.03           C  
+ANISOU  934  CD2 HIS A 119     1244   2013   1694    235    306    343       C  
+ATOM    935  CE1 HIS A 119      13.293  -1.363  17.403  1.00 13.14           C  
+ANISOU  935  CE1 HIS A 119     1122   1743   2129    -94    211    153       C  
+ATOM    936  NE2 HIS A 119      12.150  -1.738  18.003  1.00 10.97           N  
+ANISOU  936  NE2 HIS A 119     1091   1486   1593    119    201   -120       N  
+ATOM    937  N   LEU A 120       7.786   2.168  15.544  1.00 13.21           N  
+ANISOU  937  N   LEU A 120     1489   1724   1806     69     -1   -140       N  
+ATOM    938  CA  LEU A 120       7.078   3.370  15.113  1.00 12.61           C  
+ANISOU  938  CA  LEU A 120     1679   1531   1581      9    343    -62       C  
+ATOM    939  C   LEU A 120       7.704   4.519  15.905  1.00 12.27           C  
+ANISOU  939  C   LEU A 120     1640   1605   1417    -12   -166    267       C  
+ATOM    940  O   LEU A 120       7.581   4.578  17.123  1.00 12.23           O  
+ANISOU  940  O   LEU A 120     1509   1698   1442    -83    -92    135       O  
+ATOM    941  CB  LEU A 120       5.579   3.236  15.348  1.00 12.94           C  
+ANISOU  941  CB  LEU A 120     1546   1466   1906     64    -82    110       C  
+ATOM    942  CG  LEU A 120       4.910   2.186  14.428  1.00 13.85           C  
+ANISOU  942  CG  LEU A 120     1790   1441   2031    241   -180    -79       C  
+ATOM    943  CD1 LEU A 120       3.946   1.274  15.150  1.00 15.60           C  
+ANISOU  943  CD1 LEU A 120     1706   1655   2567    -79   -164   -219       C  
+ATOM    944  CD2 LEU A 120       4.184   2.863  13.292  1.00 18.65           C  
+ANISOU  944  CD2 LEU A 120     2336   2444   2306    289   -709     76       C  
+ATOM    945  N   VAL A 121       8.418   5.369  15.182  1.00 13.65           N  
+ANISOU  945  N   VAL A 121     1742   1945   1499   -339   -136    227       N  
+ATOM    946  CA  VAL A 121       9.265   6.363  15.793  1.00 12.98           C  
+ANISOU  946  CA  VAL A 121     1076   1910   1946     31   -133    -68       C  
+ATOM    947  C   VAL A 121       8.555   7.717  15.833  1.00 14.13           C  
+ANISOU  947  C   VAL A 121     1243   2113   2014    279   -200   -171       C  
+ATOM    948  O   VAL A 121       8.120   8.198  14.794  1.00 14.95           O  
+ANISOU  948  O   VAL A 121     1844   1803   2035     21   -301    -19       O  
+ATOM    949  CB  VAL A 121      10.603   6.438  15.044  1.00 13.10           C  
+ANISOU  949  CB  VAL A 121     1418   1436   2122    173    181     70       C  
+ATOM    950  CG1 VAL A 121      11.554   7.393  15.784  1.00 16.61           C  
+ANISOU  950  CG1 VAL A 121     1152   2032   3129   -134    475   -439       C  
+ATOM    951  CG2 VAL A 121      11.275   5.085  14.917  1.00 15.38           C  
+ANISOU  951  CG2 VAL A 121     1847   1607   2391    499    142    118       C  
+ATOM    952  N   HIS A 122       8.465   8.300  17.037  1.00 13.98           N  
+ANISOU  952  N   HIS A 122     1342   1894   2076    -95   -171   -271       N  
+ATOM    953  CA  HIS A 122       7.814   9.566  17.256  1.00 13.48           C  
+ANISOU  953  CA  HIS A 122     1434   1706   1981   -139     55     42       C  
+ATOM    954  C   HIS A 122       8.687  10.558  18.016  1.00 13.53           C  
+ANISOU  954  C   HIS A 122     1292   1680   2168    -60    125    -53       C  
+ATOM    955  O   HIS A 122       9.452  10.091  18.868  1.00 15.02           O  
+ANISOU  955  O   HIS A 122     1757   1643   2308     90   -263   -279       O  
+ATOM    956  CB  HIS A 122       6.556   9.350  18.101  1.00 13.72           C  
+ANISOU  956  CB  HIS A 122     1370   1545   2299    -97     92    274       C  
+ATOM    957  CG  HIS A 122       5.656   8.234  17.693  1.00 13.03           C  
+ANISOU  957  CG  HIS A 122     1369   1587   1993    -33     34     61       C  
+ATOM    958  ND1 HIS A 122       5.990   6.920  17.892  1.00 14.74           N  
+ANISOU  958  ND1 HIS A 122     1714   1552   2333   -118   -471    210       N  
+ATOM    959  CD2 HIS A 122       4.453   8.223  17.070  1.00 14.93           C  
+ANISOU  959  CD2 HIS A 122     1420   1859   2393      7   -140    300       C  
+ATOM    960  CE1 HIS A 122       5.026   6.160  17.439  1.00 14.78           C  
+ANISOU  960  CE1 HIS A 122     1502   1650   2463   -148    -51     37       C  
+ATOM    961  NE2 HIS A 122       4.054   6.897  16.919  1.00 16.41           N  
+ANISOU  961  NE2 HIS A 122     1545   2038   2651   -333   -368    413       N  
+ATOM    962  N   TRP A 123       8.532  11.842  17.699  1.00 13.86           N  
+ANISOU  962  N   TRP A 123     1395   1678   2191    -49     51   -100       N  
+ATOM    963  CA  TRP A 123       9.311  12.852  18.387  1.00 14.58           C  
+ANISOU  963  CA  TRP A 123     1775   1669   2097    -89     34   -189       C  
+ATOM    964  C   TRP A 123       8.402  13.852  19.088  1.00 15.02           C  
+ANISOU  964  C   TRP A 123     1585   1927   2196    124   -273   -288       C  
+ATOM    965  O   TRP A 123       7.312  14.165  18.652  1.00 15.41           O  
+ANISOU  965  O   TRP A 123     1574   1822   2458    -50   -303    330       O  
+ATOM    966  CB  TRP A 123      10.296  13.554  17.458  1.00 15.73           C  
+ANISOU  966  CB  TRP A 123     1742   2205   2030   -533   -110   -360       C  
+ATOM    967  CG  TRP A 123       9.685  14.180  16.243  1.00 16.14           C  
+ANISOU  967  CG  TRP A 123     2058   1941   2132   -429     25   -121       C  
+ATOM    968  CD1 TRP A 123       9.442  13.559  15.054  1.00 16.70           C  
+ANISOU  968  CD1 TRP A 123     2072   1783   2492   -329   -729   -152       C  
+ATOM    969  CD2 TRP A 123       9.244  15.533  16.104  1.00 18.19           C  
+ANISOU  969  CD2 TRP A 123     2415   1909   2587   -377    116   -226       C  
+ATOM    970  NE1 TRP A 123       8.874  14.461  14.179  1.00 18.69           N  
+ANISOU  970  NE1 TRP A 123     2560   2084   2459    236   -412   -116       N  
+ATOM    971  CE2 TRP A 123       8.741  15.677  14.799  1.00 18.65           C  
+ANISOU  971  CE2 TRP A 123     2042   2057   2988    185   -238   -246       C  
+ATOM    972  CE3 TRP A 123       9.241  16.628  16.967  1.00 20.31           C  
+ANISOU  972  CE3 TRP A 123     2705   2122   2889   -173    344   -418       C  
+ATOM    973  CZ2 TRP A 123       8.223  16.892  14.325  1.00 22.73           C  
+ANISOU  973  CZ2 TRP A 123     3583   1928   3124    194   -219   -176       C  
+ATOM    974  CZ3 TRP A 123       8.730  17.824  16.504  1.00 23.27           C  
+ANISOU  974  CZ3 TRP A 123     3556   2072   3215    -56    201   -434       C  
+ATOM    975  CH2 TRP A 123       8.228  17.956  15.203  1.00 23.68           C  
+ANISOU  975  CH2 TRP A 123     3992   1591   3414   -545    -83    -99       C  
+ATOM    976  N   ASN A 124       8.948  14.321  20.229  1.00 14.63           N  
+ANISOU  976  N   ASN A 124     1689   1763   2108    135   -169   -255       N  
+ATOM    977  CA  ASN A 124       8.250  15.245  21.108  1.00 15.87           C  
+ANISOU  977  CA  ASN A 124     1872   1551   2607    154   -177   -430       C  
+ATOM    978  C   ASN A 124       8.171  16.630  20.504  1.00 15.87           C  
+ANISOU  978  C   ASN A 124     1647   1662   2722     11   -188   -289       C  
+ATOM    979  O   ASN A 124       9.204  17.260  20.247  1.00 15.69           O  
+ANISOU  979  O   ASN A 124     1656   1927   2381     32     28   -296       O  
+ATOM    980  CB  ASN A 124       9.019  15.285  22.418  1.00 15.99           C  
+ANISOU  980  CB  ASN A 124     2011   1887   2176    -51    152   -354       C  
+ATOM    981  CG  ASN A 124       8.249  15.923  23.558  1.00 17.65           C  
+ANISOU  981  CG  ASN A 124     2697   1404   2606     76    371   -465       C  
+ATOM    982  OD1 ASN A 124       7.405  16.762  23.290  1.00 18.67           O  
+ANISOU  982  OD1 ASN A 124     2132   1626   3335    -18    329   -510       O  
+ATOM    983  ND2 ASN A 124       8.583  15.458  24.773  1.00 20.59           N  
+ANISOU  983  ND2 ASN A 124     3234   2231   2358    258    745   -298       N  
+ATOM    984  N   THR A 125       6.918  17.043  20.277  1.00 17.13           N  
+ANISOU  984  N   THR A 125     1626   1572   3310    117    139    -43       N  
+ATOM    985  CA  THR A 125       6.728  18.289  19.531  1.00 18.47           C  
+ANISOU  985  CA  THR A 125     2292   1533   3194    252   -163   -189       C  
+ATOM    986  C   THR A 125       7.234  19.485  20.318  1.00 19.05           C  
+ANISOU  986  C   THR A 125     2316   1530   3392    284    -70   -323       C  
+ATOM    987  O   THR A 125       7.394  20.574  19.769  1.00 22.13           O  
+ANISOU  987  O   THR A 125     2966   1784   3659   -232    -32   -144       O  
+ATOM    988  CB  THR A 125       5.239  18.466  19.167  1.00 19.05           C  
+ANISOU  988  CB  THR A 125     2354   1478   3405      4   -241    419       C  
+ATOM    989  OG1 THR A 125       4.466  18.518  20.379  1.00 25.15           O  
+ANISOU  989  OG1 THR A 125     2532   3179   3843    969     81   -383       O  
+ATOM    990  CG2 THR A 125       4.751  17.290  18.309  1.00 20.30           C  
+ANISOU  990  CG2 THR A 125     2637   1931   3144     57   -609    280       C  
+ATOM    991  N   LYS A 127       7.502  19.324  21.622  1.00 19.68           N  
+ANISOU  991  N   LYS A 127     2356   1811   3309     36     26   -409       N  
+ATOM    992  CA  LYS A 127       8.080  20.436  22.378  1.00 22.34           C  
+ANISOU  992  CA  LYS A 127     2776   2376   3338   -178    669  -1050       C  
+ATOM    993  C   LYS A 127       9.469  20.855  21.889  1.00 21.25           C  
+ANISOU  993  C   LYS A 127     2571   2051   3452   -176    367   -992       C  
+ATOM    994  O   LYS A 127       9.922  21.976  22.200  1.00 22.70           O  
+ANISOU  994  O   LYS A 127     3263   1912   3450   -248    910  -1089       O  
+ATOM    995  CB  LYS A 127       8.119  20.067  23.854  1.00 28.27           C  
+ANISOU  995  CB  LYS A 127     3933   3500   3307   -981    549   -949       C  
+ATOM    996  CG  LYS A 127       9.432  19.770  24.527  1.00 34.70           C  
+ANISOU  996  CG  LYS A 127     4959   5048   3179    433     35  -1198       C  
+ATOM    997  CD  LYS A 127       9.253  19.770  26.045  1.00 40.64           C  
+ANISOU  997  CD  LYS A 127     5161   6980   3301    389    492   -529       C  
+ATOM    998  CE  LYS A 127       9.540  18.396  26.610  1.00 40.85           C  
+ANISOU  998  CE  LYS A 127     4929   7137   3457    217    684   -237       C  
+ATOM    999  NZ  LYS A 127       9.816  18.488  28.072  1.00 58.19           N  
+ANISOU  999  NZ  LYS A 127     9052   9312   3745    865   -694    140       N  
+ATOM   1000  N   TYR A 128      10.124  19.967  21.135  1.00 16.68           N  
+ANISOU 1000  N   TYR A 128     2130   1497   2712   -408     76   -625       N  
+ATOM   1001  CA  TYR A 128      11.466  20.260  20.649  1.00 17.10           C  
+ANISOU 1001  CA  TYR A 128     1995   1856   2648   -114    -88      5       C  
+ATOM   1002  C   TYR A 128      11.500  20.660  19.184  1.00 17.37           C  
+ANISOU 1002  C   TYR A 128     2155   1972   2471    643    233   -348       C  
+ATOM   1003  O   TYR A 128      12.594  20.878  18.634  1.00 18.39           O  
+ANISOU 1003  O   TYR A 128     2145   2296   2549    335    185   -342       O  
+ATOM   1004  CB  TYR A 128      12.337  19.029  20.903  1.00 17.00           C  
+ANISOU 1004  CB  TYR A 128     2319   1738   2400    -33   -138   -323       C  
+ATOM   1005  CG  TYR A 128      12.399  18.682  22.376  1.00 17.35           C  
+ANISOU 1005  CG  TYR A 128     2615   1599   2377     28   -297   -368       C  
+ATOM   1006  CD1 TYR A 128      12.813  19.651  23.280  1.00 19.46           C  
+ANISOU 1006  CD1 TYR A 128     2852   1893   2650    233   -611   -602       C  
+ATOM   1007  CD2 TYR A 128      12.074  17.422  22.869  1.00 17.77           C  
+ANISOU 1007  CD2 TYR A 128     2485   1649   2619    263   -250   -141       C  
+ATOM   1008  CE1 TYR A 128      12.889  19.369  24.638  1.00 21.49           C  
+ANISOU 1008  CE1 TYR A 128     3472   2195   2497    117   -233   -805       C  
+ATOM   1009  CE2 TYR A 128      12.149  17.147  24.230  1.00 17.15           C  
+ANISOU 1009  CE2 TYR A 128     2267   1807   2441    473    558   -349       C  
+ATOM   1010  CZ  TYR A 128      12.558  18.128  25.102  1.00 22.20           C  
+ANISOU 1010  CZ  TYR A 128     3558   2267   2611    395     29   -540       C  
+ATOM   1011  OH  TYR A 128      12.638  17.872  26.447  1.00 24.12           O  
+ANISOU 1011  OH  TYR A 128     4064   2459   2641    795    -83   -539       O  
+ATOM   1012  N   GLY A 129      10.340  20.778  18.546  1.00 17.96           N  
+ANISOU 1012  N   GLY A 129     2119   2203   2502    245    248    398       N  
+ATOM   1013  CA  GLY A 129      10.232  21.441  17.245  1.00 17.22           C  
+ANISOU 1013  CA  GLY A 129     2405   1680   2457     33    408    330       C  
+ATOM   1014  C   GLY A 129      10.605  20.621  16.031  1.00 18.88           C  
+ANISOU 1014  C   GLY A 129     2837   1835   2502    249    107    116       C  
+ATOM   1015  O   GLY A 129       9.984  20.724  14.949  1.00 19.99           O  
+ANISOU 1015  O   GLY A 129     3082   1986   2528    201     38    306       O  
+ATOM   1016  N   ASP A 130      11.640  19.784  16.155  1.00 18.27           N  
+ANISOU 1016  N   ASP A 130     2546   1897   2500     96    159    -30       N  
+ATOM   1017  CA  ASP A 130      11.996  18.895  15.041  1.00 20.44           C  
+ANISOU 1017  CA  ASP A 130     3327   1913   2527    439    238     53       C  
+ATOM   1018  C   ASP A 130      12.661  17.642  15.587  1.00 19.43           C  
+ANISOU 1018  C   ASP A 130     3265   1599   2519     16   -233   -163       C  
+ATOM   1019  O   ASP A 130      13.071  17.633  16.738  1.00 18.88           O  
+ANISOU 1019  O   ASP A 130     3146   1747   2282    340    121   -202       O  
+ATOM   1020  CB  ASP A 130      12.834  19.628  13.999  1.00 22.90           C  
+ANISOU 1020  CB  ASP A 130     3461   1968   3272   1085   1050    313       C  
+ATOM   1021  CG  ASP A 130      14.251  20.011  14.353  1.00 28.33           C  
+ANISOU 1021  CG  ASP A 130     3196   2126   5442    997   1403    -20       C  
+ATOM   1022  OD1 ASP A 130      14.644  21.203  14.204  1.00 36.34           O  
+ANISOU 1022  OD1 ASP A 130     2967   2993   7847    615   1419   2261       O  
+ATOM   1023  OD2 ASP A 130      15.100  19.218  14.806  1.00 28.15           O  
+ANISOU 1023  OD2 ASP A 130     4471   1950   4273    -84  -1132    101       O  
+ATOM   1024  N   PHE A 131      12.781  16.610  14.778  1.00 17.56           N  
+ANISOU 1024  N   PHE A 131     2625   1663   2384    -76   -129   -151       N  
+ATOM   1025  CA  PHE A 131      13.387  15.368  15.223  1.00 17.32           C  
+ANISOU 1025  CA  PHE A 131     2348   2025   2209    393    132   -367       C  
+ATOM   1026  C   PHE A 131      14.845  15.526  15.627  1.00 16.85           C  
+ANISOU 1026  C   PHE A 131     2208   2343   1852    144    508    -32       C  
+ATOM   1027  O   PHE A 131      15.312  14.922  16.583  1.00 17.32           O  
+ANISOU 1027  O   PHE A 131     2523   1767   2292   -230    -46     76       O  
+ATOM   1028  CB  PHE A 131      13.268  14.386  14.054  1.00 16.58           C  
+ANISOU 1028  CB  PHE A 131     2615   1918   1768    548    189    -72       C  
+ATOM   1029  CG  PHE A 131      13.919  13.048  14.257  1.00 14.58           C  
+ANISOU 1029  CG  PHE A 131     1791   1772   1979    202     76    -54       C  
+ATOM   1030  CD1 PHE A 131      13.247  12.047  14.909  1.00 15.28           C  
+ANISOU 1030  CD1 PHE A 131     2138   1833   1835     59    247   -182       C  
+ATOM   1031  CD2 PHE A 131      15.208  12.833  13.789  1.00 16.45           C  
+ANISOU 1031  CD2 PHE A 131     2017   2043   2188    235    397     22       C  
+ATOM   1032  CE1 PHE A 131      13.868  10.827  15.120  1.00 15.66           C  
+ANISOU 1032  CE1 PHE A 131     2143   1581   2226   -252   -228   -253       C  
+ATOM   1033  CE2 PHE A 131      15.780  11.626  13.998  1.00 17.89           C  
+ANISOU 1033  CE2 PHE A 131     1866   2188   2743    388    210    -91       C  
+ATOM   1034  CZ  PHE A 131      15.128  10.607  14.645  1.00 16.52           C  
+ANISOU 1034  CZ  PHE A 131     1778   1811   2688      5   -695   -172       C  
+ATOM   1035  N   GLY A 132      15.587  16.308  14.812  1.00 18.94           N  
+ANISOU 1035  N   GLY A 132     2791   2294   2113     37    544    127       N  
+ATOM   1036  CA  GLY A 132      17.018  16.402  15.113  1.00 19.62           C  
+ANISOU 1036  CA  GLY A 132     2884   2208   2362   -637    572    266       C  
+ATOM   1037  C   GLY A 132      17.310  17.026  16.450  1.00 20.18           C  
+ANISOU 1037  C   GLY A 132     2643   2522   2501   -115    513    -22       C  
+ATOM   1038  O   GLY A 132      18.283  16.696  17.113  1.00 19.61           O  
+ANISOU 1038  O   GLY A 132     2789   1795   2867    -27    275   -389       O  
+ATOM   1039  N   LYS A 133      16.455  17.956  16.869  1.00 18.26           N  
+ANISOU 1039  N   LYS A 133     1837   2252   2848   -565    519     42       N  
+ATOM   1040  CA  LYS A 133      16.604  18.548  18.187  1.00 18.13           C  
+ANISOU 1040  CA  LYS A 133     1760   2037   3093   -212    384   -174       C  
+ATOM   1041  C   LYS A 133      16.142  17.578  19.272  1.00 17.26           C  
+ANISOU 1041  C   LYS A 133     2017   1907   2635   -483    247   -492       C  
+ATOM   1042  O   LYS A 133      16.687  17.514  20.357  1.00 17.48           O  
+ANISOU 1042  O   LYS A 133     1960   1764   2918   -402    -27   -432       O  
+ATOM   1043  CB  LYS A 133      15.777  19.811  18.296  1.00 20.04           C  
+ANISOU 1043  CB  LYS A 133     1771   2358   3486    102    313     24       C  
+ATOM   1044  CG  LYS A 133      16.373  21.083  17.756  1.00 30.13           C  
+ANISOU 1044  CG  LYS A 133     4450   2239   4761   -629   -914    610       C  
+ATOM   1045  CD  LYS A 133      17.235  21.718  18.857  1.00 41.58           C  
+ANISOU 1045  CD  LYS A 133     5843   3601   6355  -1821  -1449   -241       C  
+ATOM   1046  CE  LYS A 133      17.640  23.103  18.344  1.00 45.34           C  
+ANISOU 1046  CE  LYS A 133     7089   3693   6444  -2197  -1261   -269       C  
+ATOM   1047  NZ  LYS A 133      18.584  22.914  17.198  1.00 50.87           N  
+ANISOU 1047  NZ  LYS A 133     8163   4073   7093   -165   -351   1598       N  
+ATOM   1048  N   ALA A 134      15.072  16.850  18.890  1.00 17.19           N  
+ANISOU 1048  N   ALA A 134     2377   1304   2850   -368   -357   -125       N  
+ATOM   1049  CA  ALA A 134      14.487  15.942  19.870  1.00 17.14           C  
+ANISOU 1049  CA  ALA A 134     1711   1857   2943   -312     66   -201       C  
+ATOM   1050  C   ALA A 134      15.457  14.853  20.284  1.00 15.28           C  
+ANISOU 1050  C   ALA A 134     1818   1672   2314   -422    166     12       C  
+ATOM   1051  O   ALA A 134      15.470  14.471  21.445  1.00 18.13           O  
+ANISOU 1051  O   ALA A 134     2238   2512   2140   -228     26   -257       O  
+ATOM   1052  CB  ALA A 134      13.178  15.349  19.348  1.00 17.33           C  
+ANISOU 1052  CB  ALA A 134     1992   2288   2304   -427   -106   -376       C  
+ATOM   1053  N   VAL A 135      16.275  14.377  19.363  1.00 15.98           N  
+ANISOU 1053  N   VAL A 135     1760   2062   2250   -183     89    152       N  
+ATOM   1054  CA  VAL A 135      17.153  13.264  19.721  1.00 15.44           C  
+ANISOU 1054  CA  VAL A 135     2036   1895   1935   -153      6    -78       C  
+ATOM   1055  C   VAL A 135      18.229  13.699  20.704  1.00 15.37           C  
+ANISOU 1055  C   VAL A 135     1917   1873   2048   -465     -3    209       C  
+ATOM   1056  O   VAL A 135      18.916  12.831  21.271  1.00 18.00           O  
+ANISOU 1056  O   VAL A 135     2231   2095   2513   -272   -294    222       O  
+ATOM   1057  CB  VAL A 135      17.796  12.562  18.516  1.00 17.20           C  
+ANISOU 1057  CB  VAL A 135     2250   2364   1920    -95    266    -23       C  
+ATOM   1058  CG1 VAL A 135      16.704  11.913  17.652  1.00 19.61           C  
+ANISOU 1058  CG1 VAL A 135     2642   2772   2036   -379    291   -464       C  
+ATOM   1059  CG2 VAL A 135      18.648  13.478  17.664  1.00 18.20           C  
+ANISOU 1059  CG2 VAL A 135     2636   1816   2464    -13    569    -47       C  
+ATOM   1060  N   GLN A 136      18.381  15.014  20.923  1.00 16.43           N  
+ANISOU 1060  N   GLN A 136     2121   1924   2197   -453     58      7       N  
+ATOM   1061  CA  GLN A 136      19.382  15.495  21.886  1.00 17.85           C  
+ANISOU 1061  CA  GLN A 136     2017   2418   2347   -768    247   -233       C  
+ATOM   1062  C   GLN A 136      18.815  15.634  23.306  1.00 16.90           C  
+ANISOU 1062  C   GLN A 136     1990   2290   2139   -373     18     49       C  
+ATOM   1063  O   GLN A 136      19.491  16.182  24.176  1.00 19.54           O  
+ANISOU 1063  O   GLN A 136     1732   3302   2389   -201   -114   -365       O  
+ATOM   1064  CB  GLN A 136      19.979  16.826  21.397  1.00 19.38           C  
+ANISOU 1064  CB  GLN A 136     2123   2661   2577   -963    398   -143       C  
+ATOM   1065  CG  GLN A 136      20.597  16.842  20.008  1.00 26.15           C  
+ANISOU 1065  CG  GLN A 136     2748   4368   2821  -1094    789    282       C  
+ATOM   1066  CD  GLN A 136      20.967  18.241  19.551  1.00 32.38           C  
+ANISOU 1066  CD  GLN A 136     3998   5007   3298  -2157    843    599       C  
+ATOM   1067  OE1 GLN A 136      21.631  19.009  20.261  1.00 49.63           O  
+ANISOU 1067  OE1 GLN A 136     6454   5543   6860  -2943  -1060      0       O  
+ATOM   1068  NE2 GLN A 136      20.537  18.627  18.347  1.00 36.18           N  
+ANISOU 1068  NE2 GLN A 136     5248   5118   3379      9   1425    911       N  
+ATOM   1069  N   GLN A 137      17.579  15.173  23.512  1.00 17.85           N  
+ANISOU 1069  N   GLN A 137     2315   2620   1848   -770    187   -245       N  
+ATOM   1070  CA  GLN A 137      16.853  15.365  24.762  1.00 16.27           C  
+ANISOU 1070  CA  GLN A 137     1919   2384   1878   -407    -25   -339       C  
+ATOM   1071  C   GLN A 137      16.464  14.024  25.375  1.00 15.18           C  
+ANISOU 1071  C   GLN A 137     1591   2449   1729   -418     -6   -274       C  
+ATOM   1072  O   GLN A 137      16.172  13.107  24.614  1.00 15.34           O  
+ANISOU 1072  O   GLN A 137     1734   2255   1837   -243   -180   -231       O  
+ATOM   1073  CB  GLN A 137      15.581  16.177  24.631  1.00 19.24           C  
+ANISOU 1073  CB  GLN A 137     2341   2630   2341      6   -503   -425       C  
+ATOM   1074  CG  GLN A 137      15.687  17.378  23.714  1.00 23.36           C  
+ANISOU 1074  CG  GLN A 137     3277   2362   3237    274     77   -278       C  
+ATOM   1075  CD  GLN A 137      16.794  18.298  24.205  1.00 25.41           C  
+ANISOU 1075  CD  GLN A 137     3088   3122   3443   -244     34    491       C  
+ATOM   1076  OE1 GLN A 137      16.972  18.442  25.423  1.00 25.35           O  
+ANISOU 1076  OE1 GLN A 137     2993   3023   3614    123    177   -675       O  
+ATOM   1077  NE2 GLN A 137      17.485  18.871  23.212  1.00 31.54           N  
+ANISOU 1077  NE2 GLN A 137     4630   2789   4564    -95    590   1496       N  
+ATOM   1078  N   PRO A 138      16.496  13.942  26.696  1.00 16.12           N  
+ANISOU 1078  N   PRO A 138     2069   2309   1748     47    305   -452       N  
+ATOM   1079  CA  PRO A 138      16.256  12.646  27.316  1.00 17.03           C  
+ANISOU 1079  CA  PRO A 138     2229   2585   1655   -185   -151   -219       C  
+ATOM   1080  C   PRO A 138      14.816  12.179  27.098  1.00 19.17           C  
+ANISOU 1080  C   PRO A 138     2070   2805   2407   -201    335   -269       C  
+ATOM   1081  O   PRO A 138      14.631  10.963  27.208  1.00 21.79           O  
+ANISOU 1081  O   PRO A 138     2284   2817   3179   -320   -265    -41       O  
+ATOM   1082  CB  PRO A 138      16.506  12.850  28.795  1.00 20.53           C  
+ANISOU 1082  CB  PRO A 138     3532   2630   1639    -68     56   -466       C  
+ATOM   1083  CG  PRO A 138      16.793  14.266  28.996  1.00 25.35           C  
+ANISOU 1083  CG  PRO A 138     4878   2842   1913   -772   -516   -300       C  
+ATOM   1084  CD  PRO A 138      16.845  14.966  27.670  1.00 20.96           C  
+ANISOU 1084  CD  PRO A 138     3493   2771   1698   -568    409   -542       C  
+ATOM   1085  N   ASP A 139      13.905  13.090  26.817  1.00 17.88           N  
+ANISOU 1085  N   ASP A 139     2104   2632   2057   -380   -215   -568       N  
+ATOM   1086  CA  ASP A 139      12.502  12.727  26.561  1.00 16.40           C  
+ANISOU 1086  CA  ASP A 139     2034   2656   1541   -508    160   -296       C  
+ATOM   1087  C   ASP A 139      12.109  13.100  25.136  1.00 13.80           C  
+ANISOU 1087  C   ASP A 139     1542   2000   1700   -527    210   -112       C  
+ATOM   1088  O   ASP A 139      10.975  13.420  24.837  1.00 18.90           O  
+ANISOU 1088  O   ASP A 139     1887   2631   2664    206     68    174       O  
+ATOM   1089  CB  ASP A 139      11.531  13.390  27.542  1.00 20.14           C  
+ANISOU 1089  CB  ASP A 139     2529   3425   1698    365    199   -151       C  
+ATOM   1090  CG  ASP A 139      11.629  14.890  27.586  1.00 21.32           C  
+ANISOU 1090  CG  ASP A 139     2312   3404   2384    657    254   -334       C  
+ATOM   1091  OD1 ASP A 139      12.591  15.411  26.970  1.00 22.29           O  
+ANISOU 1091  OD1 ASP A 139     2368   3172   2930    389    334   -594       O  
+ATOM   1092  OD2 ASP A 139      10.773  15.561  28.192  1.00 25.86           O  
+ANISOU 1092  OD2 ASP A 139     2468   4193   3167    245    435  -1655       O  
+ATOM   1093  N   GLY A 140      13.070  13.054  24.230  1.00 14.81           N  
+ANISOU 1093  N   GLY A 140     1928   1872   1829   -272    406    158       N  
+ATOM   1094  CA  GLY A 140      12.840  13.508  22.897  1.00 12.78           C  
+ANISOU 1094  CA  GLY A 140     1885   1295   1677   -141    400   -213       C  
+ATOM   1095  C   GLY A 140      12.031  12.608  22.007  1.00 12.35           C  
+ANISOU 1095  C   GLY A 140     1092   1300   2300     12     98     -8       C  
+ATOM   1096  O   GLY A 140      11.335  13.144  21.140  1.00 15.11           O  
+ANISOU 1096  O   GLY A 140     1878   1701   2164    269    -47     46       O  
+ATOM   1097  N   LEU A 141      12.170  11.292  22.209  1.00 13.20           N  
+ANISOU 1097  N   LEU A 141     1552   1202   2262    -44     69   -158       N  
+ATOM   1098  CA  LEU A 141      11.520  10.347  21.298  1.00 12.73           C  
+ANISOU 1098  CA  LEU A 141     1151   1507   2179   -126    211   -227       C  
+ATOM   1099  C   LEU A 141      10.634   9.396  22.103  1.00 12.16           C  
+ANISOU 1099  C   LEU A 141      981   1760   1878   -169    -13   -207       C  
+ATOM   1100  O   LEU A 141      10.919   9.164  23.264  1.00 14.02           O  
+ANISOU 1100  O   LEU A 141     1809   1487   2030   -171   -285    -42       O  
+ATOM   1101  CB  LEU A 141      12.496   9.536  20.491  1.00 14.70           C  
+ANISOU 1101  CB  LEU A 141     1549   1808   2228    -47    450   -363       C  
+ATOM   1102  CG  LEU A 141      13.439  10.210  19.507  1.00 17.76           C  
+ANISOU 1102  CG  LEU A 141     1991   2055   2701    533    899    237       C  
+ATOM   1103  CD1 LEU A 141      14.119   9.138  18.616  1.00 15.07           C  
+ANISOU 1103  CD1 LEU A 141     1629   2228   1869    263    302    -55       C  
+ATOM   1104  CD2 LEU A 141      12.783  11.270  18.695  1.00 22.75           C  
+ANISOU 1104  CD2 LEU A 141     3213   2151   3281    705    432    447       C  
+ATOM   1105  N   ALA A 142       9.608   8.890  21.431  1.00 14.51           N  
+ANISOU 1105  N   ALA A 142     1315   2045   2153   -477    -84   -381       N  
+ATOM   1106  CA  ALA A 142       8.832   7.746  21.930  1.00 12.82           C  
+ANISOU 1106  CA  ALA A 142     1116   1795   1960   -221   -357   -272       C  
+ATOM   1107  C   ALA A 142       8.824   6.753  20.775  1.00 12.36           C  
+ANISOU 1107  C   ALA A 142     1412   1556   1728    -88     26     24       C  
+ATOM   1108  O   ALA A 142       8.395   7.078  19.664  1.00 13.27           O  
+ANISOU 1108  O   ALA A 142     2030   1383   1628   -115    -84    -54       O  
+ATOM   1109  CB  ALA A 142       7.439   8.105  22.406  1.00 13.81           C  
+ANISOU 1109  CB  ALA A 142     1552   1445   2249   -130    272    -60       C  
+ATOM   1110  N   VAL A 143       9.288   5.535  21.071  1.00 12.41           N  
+ANISOU 1110  N   VAL A 143     1365   1746   1604    184    182      9       N  
+ATOM   1111  CA  VAL A 143       9.236   4.504  20.057  1.00 12.15           C  
+ANISOU 1111  CA  VAL A 143     1383   1682   1551     66    126     27       C  
+ATOM   1112  C   VAL A 143       8.282   3.405  20.525  1.00 12.44           C  
+ANISOU 1112  C   VAL A 143     1411   1728   1587     49    -75    225       C  
+ATOM   1113  O   VAL A 143       8.479   2.877  21.635  1.00 13.46           O  
+ANISOU 1113  O   VAL A 143     1695   1858   1562      1   -178    264       O  
+ATOM   1114  CB  VAL A 143      10.607   3.928  19.697  1.00 13.08           C  
+ANISOU 1114  CB  VAL A 143     1534   1620   1818     58    261   -126       C  
+ATOM   1115  CG1 VAL A 143      10.470   2.901  18.578  1.00 13.10           C  
+ANISOU 1115  CG1 VAL A 143     1345   1709   1924     80     34   -211       C  
+ATOM   1116  CG2 VAL A 143      11.469   5.093  19.242  1.00 14.92           C  
+ANISOU 1116  CG2 VAL A 143     1640   2263   1767   -583    102   -215       C  
+ATOM   1117  N   LEU A 144       7.267   3.198  19.693  1.00 12.53           N  
+ANISOU 1117  N   LEU A 144     1458   1679   1626     26   -115    277       N  
+ATOM   1118  CA  LEU A 144       6.315   2.119  19.977  1.00 13.27           C  
+ANISOU 1118  CA  LEU A 144     1594   1785   1664   -121    -95     93       C  
+ATOM   1119  C   LEU A 144       6.841   0.870  19.301  1.00 13.45           C  
+ANISOU 1119  C   LEU A 144     1723   1756   1631   -276     48    148       C  
+ATOM   1120  O   LEU A 144       7.004   0.880  18.095  1.00 13.75           O  
+ANISOU 1120  O   LEU A 144     1797   1798   1629     20   -136     67       O  
+ATOM   1121  CB  LEU A 144       4.958   2.537  19.463  1.00 14.28           C  
+ANISOU 1121  CB  LEU A 144     1527   2170   1728   -239   -204     75       C  
+ATOM   1122  CG  LEU A 144       3.771   1.595  19.625  1.00 14.24           C  
+ANISOU 1122  CG  LEU A 144     1747   1524   2139   -222   -456   -186       C  
+ATOM   1123  CD1 LEU A 144       3.513   1.353  21.091  1.00 19.27           C  
+ANISOU 1123  CD1 LEU A 144     1373   3474   2474   -525   -155    649       C  
+ATOM   1124  CD2 LEU A 144       2.551   2.201  18.932  1.00 14.84           C  
+ANISOU 1124  CD2 LEU A 144     1198   2099   2343      6    216    306       C  
+ATOM   1125  N   GLY A 145       7.143  -0.148  20.091  1.00 12.97           N  
+ANISOU 1125  N   GLY A 145     1618   1703   1606   -209    134    112       N  
+ATOM   1126  CA  GLY A 145       7.728  -1.370  19.557  1.00 13.60           C  
+ANISOU 1126  CA  GLY A 145     1432   1816   1921   -155   -262   -156       C  
+ATOM   1127  C   GLY A 145       6.668  -2.457  19.532  1.00 14.03           C  
+ANISOU 1127  C   GLY A 145     1342   1904   2085   -124    -60   -293       C  
+ATOM   1128  O   GLY A 145       5.926  -2.594  20.510  1.00 13.41           O  
+ANISOU 1128  O   GLY A 145     1535   1578   1983    -64    -97   -110       O  
+ATOM   1129  N   ILE A 146       6.578  -3.196  18.435  1.00 12.97           N  
+ANISOU 1129  N   ILE A 146     1439   1439   2050    -86      0   -132       N  
+ATOM   1130  CA  ILE A 146       5.546  -4.205  18.261  1.00 12.02           C  
+ANISOU 1130  CA  ILE A 146     1666   1311   1591   -125     63    136       C  
+ATOM   1131  C   ILE A 146       6.241  -5.445  17.714  1.00 12.57           C  
+ANISOU 1131  C   ILE A 146     1477   1436   1864    -91      6    -63       C  
+ATOM   1132  O   ILE A 146       6.946  -5.383  16.694  1.00 13.83           O  
+ANISOU 1132  O   ILE A 146     1384   1794   2078     -2    112    -16       O  
+ATOM   1133  CB  ILE A 146       4.444  -3.737  17.325  1.00 12.87           C  
+ANISOU 1133  CB  ILE A 146     1618   1394   1879    -43   -172   -317       C  
+ATOM   1134  CG1 ILE A 146       3.833  -2.404  17.788  1.00 14.24           C  
+ANISOU 1134  CG1 ILE A 146     1856   1164   2391    -25   -196    -49       C  
+ATOM   1135  CG2 ILE A 146       3.436  -4.850  17.143  1.00 15.50           C  
+ANISOU 1135  CG2 ILE A 146     1917   1470   2502   -216   -224   -446       C  
+ATOM   1136  CD1 ILE A 146       2.722  -1.833  16.909  1.00 15.69           C  
+ANISOU 1136  CD1 ILE A 146     2577   1588   1795    401   -333   -246       C  
+ATOM   1137  N   PHE A 147       6.079  -6.545  18.399  1.00 12.72           N  
+ANISOU 1137  N   PHE A 147     1687   1441   1703    114     28   -102       N  
+ATOM   1138  CA  PHE A 147       6.671  -7.800  17.999  1.00 13.61           C  
+ANISOU 1138  CA  PHE A 147     1910   1526   1737    265   -201   -135       C  
+ATOM   1139  C   PHE A 147       5.867  -8.423  16.859  1.00 12.27           C  
+ANISOU 1139  C   PHE A 147     1549   1336   1779    -35    107   -106       C  
+ATOM   1140  O   PHE A 147       4.666  -8.286  16.807  1.00 15.71           O  
+ANISOU 1140  O   PHE A 147     1578   2164   2225    306    -33   -518       O  
+ATOM   1141  CB  PHE A 147       6.721  -8.775  19.166  1.00 12.96           C  
+ANISOU 1141  CB  PHE A 147     1528   1453   1943     37    -95    -20       C  
+ATOM   1142  CG  PHE A 147       7.581  -8.315  20.321  1.00 13.13           C  
+ANISOU 1142  CG  PHE A 147     1586   1594   1808    261   -139    -46       C  
+ATOM   1143  CD1 PHE A 147       8.944  -8.170  20.137  1.00 13.90           C  
+ANISOU 1143  CD1 PHE A 147     1625   1618   2037     36   -174   -230       C  
+ATOM   1144  CD2 PHE A 147       7.052  -8.080  21.559  1.00 15.60           C  
+ANISOU 1144  CD2 PHE A 147     2217   1782   1928   -448    188   -147       C  
+ATOM   1145  CE1 PHE A 147       9.769  -7.780  21.171  1.00 12.62           C  
+ANISOU 1145  CE1 PHE A 147     1681   1302   1812     55      3   -340       C  
+ATOM   1146  CE2 PHE A 147       7.862  -7.667  22.608  1.00 15.47           C  
+ANISOU 1146  CE2 PHE A 147     2031   2170   1676   -135    197     -1       C  
+ATOM   1147  CZ  PHE A 147       9.219  -7.550  22.420  1.00 14.64           C  
+ANISOU 1147  CZ  PHE A 147     2013   1662   1887    -45    238   -137       C  
+ATOM   1148  N   LEU A 148       6.601  -9.106  15.979  1.00 13.42           N  
+ANISOU 1148  N   LEU A 148     1614   1837   1648    -76    255   -175       N  
+ATOM   1149  CA  LEU A 148       6.060  -9.938  14.933  1.00 13.10           C  
+ANISOU 1149  CA  LEU A 148     1623   1601   1754    -57    141   -147       C  
+ATOM   1150  C   LEU A 148       6.404 -11.406  15.185  1.00 13.23           C  
+ANISOU 1150  C   LEU A 148     1471   1713   1844    -67     19    -79       C  
+ATOM   1151  O   LEU A 148       7.558 -11.744  15.403  1.00 14.57           O  
+ANISOU 1151  O   LEU A 148     1540   1784   2211    -49    -96    -46       O  
+ATOM   1152  CB  LEU A 148       6.647  -9.571  13.571  1.00 13.83           C  
+ANISOU 1152  CB  LEU A 148     1909   1647   1698   -222    114   -228       C  
+ATOM   1153  CG  LEU A 148       6.121  -8.309  12.881  1.00 13.75           C  
+ANISOU 1153  CG  LEU A 148     1787   1695   1743   -370     31   -106       C  
+ATOM   1154  CD1 LEU A 148       6.293  -7.053  13.730  1.00 14.26           C  
+ANISOU 1154  CD1 LEU A 148     1710   1673   2034    -11   -325   -164       C  
+ATOM   1155  CD2 LEU A 148       6.796  -8.156  11.522  1.00 15.19           C  
+ANISOU 1155  CD2 LEU A 148     1591   2460   1721   -538    -65     13       C  
+ATOM   1156  N   LYS A 149       5.341 -12.213  15.101  1.00 13.72           N  
+ANISOU 1156  N   LYS A 149     1582   1650   1980   -192     18     42       N  
+ATOM   1157  CA  LYS A 149       5.492 -13.651  15.063  1.00 16.53           C  
+ANISOU 1157  CA  LYS A 149     2713   1608   1960    -98   -466    141       C  
+ATOM   1158  C   LYS A 149       4.990 -14.157  13.714  1.00 15.98           C  
+ANISOU 1158  C   LYS A 149     2248   1623   2199     47   -518     -3       C  
+ATOM   1159  O   LYS A 149       4.153 -13.503  13.107  1.00 16.83           O  
+ANISOU 1159  O   LYS A 149     2588   1689   2118    294   -565   -123       O  
+ATOM   1160  CB  LYS A 149       4.756 -14.388  16.176  1.00 18.64           C  
+ANISOU 1160  CB  LYS A 149     3035   1793   2254   -795   -578    176       C  
+ATOM   1161  CG  LYS A 149       3.253 -14.220  16.187  1.00 18.25           C  
+ANISOU 1161  CG  LYS A 149     3120   1806   2009   -595   -343    140       C  
+ATOM   1162  CD  LYS A 149       2.612 -14.869  17.391  1.00 27.41           C  
+ANISOU 1162  CD  LYS A 149     3647   4237   2529  -1484   -287    921       C  
+ATOM   1163  CE  LYS A 149       1.089 -14.893  17.199  1.00 34.87           C  
+ANISOU 1163  CE  LYS A 149     3561   5868   3819  -1976     54    -43       C  
+ATOM   1164  NZ  LYS A 149       0.736 -16.005  16.282  1.00 57.99           N  
+ANISOU 1164  NZ  LYS A 149     6366   5711   9956  -2232  -2842  -1742       N  
+ATOM   1165  N   VAL A 150       5.533 -15.324  13.345  1.00 16.56           N  
+ANISOU 1165  N   VAL A 150     2120   1938   2232    283   -463   -181       N  
+ATOM   1166  CA  VAL A 150       5.112 -15.925  12.077  1.00 16.51           C  
+ANISOU 1166  CA  VAL A 150     2511   1525   2237      3   -551     64       C  
+ATOM   1167  C   VAL A 150       3.922 -16.853  12.304  1.00 17.68           C  
+ANISOU 1167  C   VAL A 150     2637   1084   2998    122   -590    101       C  
+ATOM   1168  O   VAL A 150       3.947 -17.784  13.097  1.00 19.35           O  
+ANISOU 1168  O   VAL A 150     3057   1749   2545   -394   -786    315       O  
+ATOM   1169  CB  VAL A 150       6.302 -16.662  11.444  1.00 18.78           C  
+ANISOU 1169  CB  VAL A 150     3090   1500   2547    -64    -60   -315       C  
+ATOM   1170  CG1 VAL A 150       5.934 -17.459  10.192  1.00 21.38           C  
+ANISOU 1170  CG1 VAL A 150     3950   1493   2681   -497   -133   -314       C  
+ATOM   1171  CG2 VAL A 150       7.373 -15.653  11.087  1.00 21.37           C  
+ANISOU 1171  CG2 VAL A 150     2652   2608   2861   -522   -355   -431       C  
+ATOM   1172  N   GLY A 151       2.860 -16.575  11.569  1.00 17.14           N  
+ANISOU 1172  N   GLY A 151     2226   1433   2854    128   -306    170       N  
+ATOM   1173  CA  GLY A 151       1.666 -17.403  11.561  1.00 20.46           C  
+ANISOU 1173  CA  GLY A 151     2964   1825   2983   -523   -611     61       C  
+ATOM   1174  C   GLY A 151       0.781 -16.936  10.428  1.00 18.96           C  
+ANISOU 1174  C   GLY A 151     2579   1963   2664   -500   -351    -78       C  
+ATOM   1175  O   GLY A 151       1.161 -17.022   9.271  1.00 20.53           O  
+ANISOU 1175  O   GLY A 151     2723   2320   2757   -878   -102      8       O  
+ATOM   1176  N   SER A 152      -0.388 -16.400  10.750  1.00 21.02           N  
+ANISOU 1176  N   SER A 152     2807   2304   2877   -244   -162    139       N  
+ATOM   1177  CA  SER A 152      -1.246 -15.861   9.698  1.00 21.32           C  
+ANISOU 1177  CA  SER A 152     2423   2737   2939   -323     50    482       C  
+ATOM   1178  C   SER A 152      -0.686 -14.558   9.146  1.00 19.19           C  
+ANISOU 1178  C   SER A 152     2823   2415   2055   -412   -132   -101       C  
+ATOM   1179  O   SER A 152       0.042 -13.830   9.827  1.00 21.91           O  
+ANISOU 1179  O   SER A 152     2507   3083   2736   -534   -716     71       O  
+ATOM   1180  CB  SER A 152      -2.659 -15.628  10.237  1.00 29.79           C  
+ANISOU 1180  CB  SER A 152     2455   4384   4480    -84    438    873       C  
+ATOM   1181  OG  SER A 152      -2.650 -14.699  11.317  1.00 46.83           O  
+ANISOU 1181  OG  SER A 152     7023   6819   3952   1827   1927    122       O  
+ATOM   1182  N   ALA A 153      -1.091 -14.236   7.912  1.00 20.09           N  
+ANISOU 1182  N   ALA A 153     2826   2511   2296   -542   -390     47       N  
+ATOM   1183  CA  ALA A 153      -0.651 -12.993   7.308  1.00 19.16           C  
+ANISOU 1183  CA  ALA A 153     3013   2358   1908   -561   -489   -166       C  
+ATOM   1184  C   ALA A 153      -1.290 -11.781   7.965  1.00 20.92           C  
+ANISOU 1184  C   ALA A 153     2962   2480   2506   -504   -367   -285       C  
+ATOM   1185  O   ALA A 153      -2.422 -11.917   8.441  1.00 21.01           O  
+ANISOU 1185  O   ALA A 153     3189   2203   2592   -586   -136   -118       O  
+ATOM   1186  CB  ALA A 153      -1.016 -12.959   5.813  1.00 23.03           C  
+ANISOU 1186  CB  ALA A 153     3564   3199   1988    -59   -805     -6       C  
+ATOM   1187  N   LYS A 154      -0.543 -10.674   7.887  1.00 19.48           N  
+ANISOU 1187  N   LYS A 154     2359   2381   2661   -217   -427   -364       N  
+ATOM   1188  CA  LYS A 154      -1.128  -9.388   8.311  1.00 20.39           C  
+ANISOU 1188  CA  LYS A 154     2430   2402   2913   -129   -646   -386       C  
+ATOM   1189  C   LYS A 154      -1.512  -8.624   7.055  1.00 19.75           C  
+ANISOU 1189  C   LYS A 154     1973   2570   2960      7   -571   -443       C  
+ATOM   1190  O   LYS A 154      -0.627  -8.127   6.329  1.00 20.89           O  
+ANISOU 1190  O   LYS A 154     2016   3140   2780   -165   -752   -242       O  
+ATOM   1191  CB  LYS A 154      -0.123  -8.678   9.210  1.00 18.03           C  
+ANISOU 1191  CB  LYS A 154     2104   1853   2893   -272   -489      3       C  
+ATOM   1192  CG  LYS A 154      -0.671  -7.422   9.906  1.00 19.98           C  
+ANISOU 1192  CG  LYS A 154     3238   2001   2353   -115   -434      3       C  
+ATOM   1193  CD  LYS A 154      -1.499  -7.795  11.115  1.00 24.52           C  
+ANISOU 1193  CD  LYS A 154     4731   2522   2062    -45   -114     71       C  
+ATOM   1194  CE  LYS A 154      -1.662  -6.616  12.065  1.00 28.95           C  
+ANISOU 1194  CE  LYS A 154     6450   2268   2282   -184    456    195       C  
+ATOM   1195  NZ  LYS A 154      -2.849  -6.830  12.940  1.00 40.79           N  
+ANISOU 1195  NZ  LYS A 154     6715   3812   4973    261   1941   -900       N  
+ATOM   1196  N   PRO A 155      -2.794  -8.554   6.737  1.00 21.21           N  
+ANISOU 1196  N   PRO A 155     1932   2805   3321    310   -431   -352       N  
+ATOM   1197  CA  PRO A 155      -3.199  -7.910   5.491  1.00 23.03           C  
+ANISOU 1197  CA  PRO A 155     1910   3474   3364    120   -648   -169       C  
+ATOM   1198  C   PRO A 155      -2.675  -6.483   5.381  1.00 22.63           C  
+ANISOU 1198  C   PRO A 155     2124   3544   2932     29  -1115    119       C  
+ATOM   1199  O   PRO A 155      -2.246  -6.043   4.304  1.00 24.75           O  
+ANISOU 1199  O   PRO A 155     3782   2964   2657    662   -990    142       O  
+ATOM   1200  CB  PRO A 155      -4.720  -7.906   5.597  1.00 23.80           C  
+ANISOU 1200  CB  PRO A 155     1928   3398   3718    316   -493    216       C  
+ATOM   1201  CG  PRO A 155      -5.045  -9.098   6.448  1.00 25.54           C  
+ANISOU 1201  CG  PRO A 155     2091   3560   4052    -16   -810    392       C  
+ATOM   1202  CD  PRO A 155      -3.943  -9.094   7.488  1.00 22.38           C  
+ANISOU 1202  CD  PRO A 155     1834   2773   3895    236   -610    102       C  
+ATOM   1203  N   GLY A 156      -2.669  -5.753   6.484  1.00 20.01           N  
+ANISOU 1203  N   GLY A 156     1683   2944   2976    327   -194    279       N  
+ATOM   1204  CA  GLY A 156      -2.198  -4.378   6.452  1.00 21.66           C  
+ANISOU 1204  CA  GLY A 156     2316   2924   2989    274     32    340       C  
+ATOM   1205  C   GLY A 156      -0.716  -4.211   6.205  1.00 20.86           C  
+ANISOU 1205  C   GLY A 156     2493   2403   3030    148    436    472       C  
+ATOM   1206  O   GLY A 156      -0.292  -3.070   5.994  1.00 25.38           O  
+ANISOU 1206  O   GLY A 156     3077   2561   4005   -245   -403    822       O  
+ATOM   1207  N   LEU A 157       0.051  -5.300   6.214  1.00 20.17           N  
+ANISOU 1207  N   LEU A 157     2444   2747   2472    422   -273    447       N  
+ATOM   1208  CA  LEU A 157       1.476  -5.222   5.914  1.00 19.11           C  
+ANISOU 1208  CA  LEU A 157     2444   2465   2352    238   -350   -100       C  
+ATOM   1209  C   LEU A 157       1.768  -5.433   4.433  1.00 20.00           C  
+ANISOU 1209  C   LEU A 157     2479   2782   2337     55   -356   -161       C  
+ATOM   1210  O   LEU A 157       2.857  -5.152   3.938  1.00 18.77           O  
+ANISOU 1210  O   LEU A 157     2667   2060   2405     49   -260   -116       O  
+ATOM   1211  CB  LEU A 157       2.252  -6.276   6.725  1.00 18.45           C  
+ANISOU 1211  CB  LEU A 157     2156   2446   2409    342    123     72       C  
+ATOM   1212  CG  LEU A 157       3.771  -6.321   6.587  1.00 17.61           C  
+ANISOU 1212  CG  LEU A 157     2013   2329   2348   -263   -470   -271       C  
+ATOM   1213  CD1 LEU A 157       4.413  -5.006   6.980  1.00 21.29           C  
+ANISOU 1213  CD1 LEU A 157     3346   2290   2453   -358  -1297   -189       C  
+ATOM   1214  CD2 LEU A 157       4.365  -7.461   7.421  1.00 20.24           C  
+ANISOU 1214  CD2 LEU A 157     1993   2366   3331    -76   -319     76       C  
+ATOM   1215  N   GLN A 158       0.772  -5.971   3.724  1.00 20.82           N  
+ANISOU 1215  N   GLN A 158     2759   2822   2328   -198   -600    214       N  
+ATOM   1216  CA  GLN A 158       1.057  -6.479   2.385  1.00 20.78           C  
+ANISOU 1216  CA  GLN A 158     2779   2747   2370   -184   -780    127       C  
+ATOM   1217  C   GLN A 158       1.488  -5.349   1.464  1.00 19.57           C  
+ANISOU 1217  C   GLN A 158     2814   2480   2143   -172   -652   -134       C  
+ATOM   1218  O   GLN A 158       2.332  -5.524   0.581  1.00 20.55           O  
+ANISOU 1218  O   GLN A 158     3010   2621   2177    -37   -626   -143       O  
+ATOM   1219  CB  GLN A 158      -0.153  -7.192   1.817  1.00 25.54           C  
+ANISOU 1219  CB  GLN A 158     3564   3032   3109   -879   -883    -83       C  
+ATOM   1220  CG  GLN A 158       0.170  -7.998   0.562  1.00 25.64           C  
+ANISOU 1220  CG  GLN A 158     4186   3017   2540   -504  -1369    242       C  
+ATOM   1221  CD  GLN A 158       1.311  -8.980   0.803  1.00 23.62           C  
+ANISOU 1221  CD  GLN A 158     3477   3036   2460   -782   -445    655       C  
+ATOM   1222  OE1 GLN A 158       1.507  -9.604   1.857  1.00 21.75           O  
+ANISOU 1222  OE1 GLN A 158     3562   2637   2065   -275   -531     52       O  
+ATOM   1223  NE2 GLN A 158       2.095  -9.060  -0.261  1.00 26.62           N  
+ANISOU 1223  NE2 GLN A 158     4425   3207   2482  -1274    -74    187       N  
+ATOM   1224  N   LYS A 159       0.930  -4.147   1.624  1.00 22.90           N  
+ANISOU 1224  N   LYS A 159     3398   2578   2726     28   -283    -76       N  
+ATOM   1225  CA  LYS A 159       1.362  -3.080   0.720  1.00 20.86           C  
+ANISOU 1225  CA  LYS A 159     3222   2640   2065    426   -518    -70       C  
+ATOM   1226  C   LYS A 159       2.843  -2.729   0.882  1.00 21.56           C  
+ANISOU 1226  C   LYS A 159     3595   3183   1414   -417   -304   -567       C  
+ATOM   1227  O   LYS A 159       3.483  -2.369  -0.108  1.00 24.22           O  
+ANISOU 1227  O   LYS A 159     4088   3050   2066   -448   -373    711       O  
+ATOM   1228  CB  LYS A 159       0.560  -1.801   0.907  1.00 29.93           C  
+ANISOU 1228  CB  LYS A 159     5160   2905   3309   1453  -1840   -291       C  
+ATOM   1229  CG  LYS A 159       1.016  -0.730  -0.092  1.00 41.77           C  
+ANISOU 1229  CG  LYS A 159     7711   3455   4703   1321  -2290   1024       C  
+ATOM   1230  CD  LYS A 159       0.108   0.476  -0.040  1.00 50.07           C  
+ANISOU 1230  CD  LYS A 159     8280   3463   7281   1563  -2956   1109       C  
+ATOM   1231  CE  LYS A 159       0.531   1.562  -1.041  1.00 51.25           C  
+ANISOU 1231  CE  LYS A 159     7657   2822   8996   1352  -2308   1151       C  
+ATOM   1232  NZ  LYS A 159       0.394   2.866  -0.327  1.00 58.91           N  
+ANISOU 1232  NZ  LYS A 159     6991   3137  12254    669  -4892   -444       N  
+ATOM   1233  N   VAL A 160       3.357  -2.826   2.095  1.00 20.81           N  
+ANISOU 1233  N   VAL A 160     3127   3168   1611    363   -339   -282       N  
+ATOM   1234  CA  VAL A 160       4.791  -2.690   2.352  1.00 19.55           C  
+ANISOU 1234  CA  VAL A 160     3235   2053   2142   -323   -306    -89       C  
+ATOM   1235  C   VAL A 160       5.582  -3.801   1.687  1.00 18.43           C  
+ANISOU 1235  C   VAL A 160     2491   2176   2336   -522   -438   -255       C  
+ATOM   1236  O   VAL A 160       6.544  -3.545   0.975  1.00 21.51           O  
+ANISOU 1236  O   VAL A 160     2638   2875   2661   -284   -208    169       O  
+ATOM   1237  CB  VAL A 160       5.091  -2.708   3.860  1.00 20.07           C  
+ANISOU 1237  CB  VAL A 160     2765   2699   2162   -743   -419   -267       C  
+ATOM   1238  CG1 VAL A 160       6.589  -2.744   4.097  1.00 21.65           C  
+ANISOU 1238  CG1 VAL A 160     2582   3514   2129  -1303     40    -51       C  
+ATOM   1239  CG2 VAL A 160       4.472  -1.502   4.525  1.00 22.08           C  
+ANISOU 1239  CG2 VAL A 160     3812   2792   1784      4  -1170   -137       C  
+ATOM   1240  N   VAL A 161       5.165  -5.038   1.918  1.00 20.46           N  
+ANISOU 1240  N   VAL A 161     3853   2040   1880   -565   -199   -367       N  
+ATOM   1241  CA  VAL A 161       5.891  -6.167   1.310  1.00 19.22           C  
+ANISOU 1241  CA  VAL A 161     3257   2177   1868   -652    -59   -256       C  
+ATOM   1242  C   VAL A 161       6.012  -6.023  -0.194  1.00 21.35           C  
+ANISOU 1242  C   VAL A 161     3953   2228   1933    -23    119     -2       C  
+ATOM   1243  O   VAL A 161       7.021  -6.273  -0.862  1.00 23.55           O  
+ANISOU 1243  O   VAL A 161     4148   2573   2227   -457    493   -227       O  
+ATOM   1244  CB  VAL A 161       5.132  -7.456   1.715  1.00 22.63           C  
+ANISOU 1244  CB  VAL A 161     4470   1932   2195   -722   -234     44       C  
+ATOM   1245  CG1 VAL A 161       5.529  -8.641   0.877  1.00 25.56           C  
+ANISOU 1245  CG1 VAL A 161     4363   2286   3063   -695   -367   -558       C  
+ATOM   1246  CG2 VAL A 161       5.372  -7.692   3.192  1.00 26.78           C  
+ANISOU 1246  CG2 VAL A 161     5469   2454   2251    858    191    531       C  
+ATOM   1247  N   ASP A 162       4.945  -5.553  -0.842  1.00 23.79           N  
+ANISOU 1247  N   ASP A 162     4056   2821   2163   -523   -427     75       N  
+ATOM   1248  CA  ASP A 162       4.905  -5.597  -2.310  1.00 27.65           C  
+ANISOU 1248  CA  ASP A 162     4082   4270   2153  -1197   -437     45       C  
+ATOM   1249  C   ASP A 162       5.738  -4.498  -2.954  1.00 27.11           C  
+ANISOU 1249  C   ASP A 162     4274   4036   1992  -1023   -308     -7       C  
+ATOM   1250  O   ASP A 162       6.026  -4.550  -4.158  1.00 29.23           O  
+ANISOU 1250  O   ASP A 162     4471   4526   2108  -1313    -66   -265       O  
+ATOM   1251  CB  ASP A 162       3.458  -5.519  -2.789  1.00 27.75           C  
+ANISOU 1251  CB  ASP A 162     4078   4353   2114   -839   -364    556       C  
+ATOM   1252  CG  ASP A 162       2.727  -6.848  -2.663  1.00 29.49           C  
+ANISOU 1252  CG  ASP A 162     3595   4718   2890  -1093    297   -107       C  
+ATOM   1253  OD1 ASP A 162       3.349  -7.926  -2.775  1.00 35.33           O  
+ANISOU 1253  OD1 ASP A 162     3789   4355   5281  -1011  -1138    809       O  
+ATOM   1254  OD2 ASP A 162       1.501  -6.790  -2.468  1.00 36.48           O  
+ANISOU 1254  OD2 ASP A 162     3311   6518   4030  -1295   -435  -1184       O  
+ATOM   1255  N   VAL A 163       6.143  -3.499  -2.170  1.00 23.74           N  
+ANISOU 1255  N   VAL A 163     3968   3043   2009   -181     -2     99       N  
+ATOM   1256  CA  VAL A 163       7.007  -2.472  -2.721  1.00 22.68           C  
+ANISOU 1256  CA  VAL A 163     4131   2433   2055    227    120    109       C  
+ATOM   1257  C   VAL A 163       8.479  -2.801  -2.491  1.00 22.71           C  
+ANISOU 1257  C   VAL A 163     3997   2631   2002   -212    -82    227       C  
+ATOM   1258  O   VAL A 163       9.362  -2.136  -3.038  1.00 22.13           O  
+ANISOU 1258  O   VAL A 163     4305   2344   1761   -228    210    -73       O  
+ATOM   1259  CB  VAL A 163       6.659  -1.095  -2.117  1.00 27.17           C  
+ANISOU 1259  CB  VAL A 163     5151   2733   2439    459   -559   -388       C  
+ATOM   1260  CG1 VAL A 163       7.323  -0.922  -0.764  1.00 37.69           C  
+ANISOU 1260  CG1 VAL A 163     7926   3396   2998   1107  -1843   -618       C  
+ATOM   1261  CG2 VAL A 163       7.066   0.000  -3.087  1.00 40.60           C  
+ANISOU 1261  CG2 VAL A 163     9462   2415   3549   -715  -1729    168       C  
+ATOM   1262  N   LEU A 164       8.782  -3.826  -1.687  1.00 22.18           N  
+ANISOU 1262  N   LEU A 164     3562   2792   2074   -626   -530    360       N  
+ATOM   1263  CA  LEU A 164      10.190  -4.063  -1.358  1.00 21.89           C  
+ANISOU 1263  CA  LEU A 164     3301   2567   2451   -542     75    355       C  
+ATOM   1264  C   LEU A 164      11.049  -4.410  -2.561  1.00 24.10           C  
+ANISOU 1264  C   LEU A 164     4159   2649   2350   -451    182    156       C  
+ATOM   1265  O   LEU A 164      12.257  -4.156  -2.560  1.00 23.47           O  
+ANISOU 1265  O   LEU A 164     4075   2763   2081   -268    577   -387       O  
+ATOM   1266  CB  LEU A 164      10.340  -5.146  -0.291  1.00 18.55           C  
+ANISOU 1266  CB  LEU A 164     2424   2106   2519   -358    184     93       C  
+ATOM   1267  CG  LEU A 164       9.673  -4.813   1.059  1.00 20.02           C  
+ANISOU 1267  CG  LEU A 164     3254   2059   2295     33     85    205       C  
+ATOM   1268  CD1 LEU A 164       9.931  -5.980   2.010  1.00 21.11           C  
+ANISOU 1268  CD1 LEU A 164     4041   1760   2219    -61   -326    -40       C  
+ATOM   1269  CD2 LEU A 164      10.158  -3.501   1.613  1.00 17.82           C  
+ANISOU 1269  CD2 LEU A 164     2670   1981   2120   -147    447    416       C  
+ATOM   1270  N   ASP A 165      10.452  -4.985  -3.590  1.00 26.55           N  
+ANISOU 1270  N   ASP A 165     4594   2617   2876   -601     96   -219       N  
+ATOM   1271  CA  ASP A 165      11.236  -5.325  -4.764  1.00 27.11           C  
+ANISOU 1271  CA  ASP A 165     4318   3361   2620   -475   -223   -376       C  
+ATOM   1272  C   ASP A 165      11.754  -4.077  -5.458  1.00 26.50           C  
+ANISOU 1272  C   ASP A 165     3719   3623   2728   -607     11   -439       C  
+ATOM   1273  O   ASP A 165      12.665  -4.204  -6.278  1.00 34.43           O  
+ANISOU 1273  O   ASP A 165     5395   4207   3479   -205   1231   -434       O  
+ATOM   1274  CB  ASP A 165      10.389  -6.127  -5.747  1.00 35.59           C  
+ANISOU 1274  CB  ASP A 165     6458   3715   3348  -1433   -491   -854       C  
+ATOM   1275  CG  ASP A 165       8.977  -5.594  -5.892  1.00 48.28           C  
+ANISOU 1275  CG  ASP A 165     6399   6423   5523  -1609  -2786   -611       C  
+ATOM   1276  OD1 ASP A 165       8.790  -4.351  -5.915  1.00 46.92           O  
+ANISOU 1276  OD1 ASP A 165     4890   6766   6171   -575  -1784   -632       O  
+ATOM   1277  OD2 ASP A 165       8.079  -6.470  -5.982  1.00 62.23           O  
+ANISOU 1277  OD2 ASP A 165     7279   8061   8304  -2853  -3207   -156       O  
+ATOM   1278  N   SER A 166      11.202  -2.919  -5.162  1.00 24.55           N  
+ANISOU 1278  N   SER A 166     3607   3513   2208   -550     60     19       N  
+ATOM   1279  CA  SER A 166      11.620  -1.691  -5.855  1.00 29.84           C  
+ANISOU 1279  CA  SER A 166     5496   3823   2017   -969    -61    252       C  
+ATOM   1280  C   SER A 166      12.693  -0.962  -5.066  1.00 27.59           C  
+ANISOU 1280  C   SER A 166     5362   2714   2408   -673      3    210       C  
+ATOM   1281  O   SER A 166      13.258   0.048  -5.506  1.00 26.87           O  
+ANISOU 1281  O   SER A 166     5548   2502   2159   -377    215    230       O  
+ATOM   1282  CB  SER A 166      10.393  -0.823  -6.089  1.00 28.80           C  
+ANISOU 1282  CB  SER A 166     5478   3420   2043  -1212    -68    733       C  
+ATOM   1283  OG  SER A 166      10.028  -0.138  -4.894  1.00 35.01           O  
+ANISOU 1283  OG  SER A 166     6899   3543   2860   -561    583    462       O  
+ATOM   1284  N   ILE A 167      12.996  -1.471  -3.874  1.00 22.27           N  
+ANISOU 1284  N   ILE A 167     4154   1993   2312   -577    226     -7       N  
+ATOM   1285  CA  ILE A 167      14.020  -0.822  -3.049  1.00 21.10           C  
+ANISOU 1285  CA  ILE A 167     3982   1713   2323   -705    550   -104       C  
+ATOM   1286  C   ILE A 167      15.001  -1.843  -2.503  1.00 19.76           C  
+ANISOU 1286  C   ILE A 167     3807   1842   1860   -683    525   -354       C  
+ATOM   1287  O   ILE A 167      15.351  -1.841  -1.326  1.00 21.68           O  
+ANISOU 1287  O   ILE A 167     3893   2598   1746  -1042    650     21       O  
+ATOM   1288  CB  ILE A 167      13.415  -0.042  -1.866  1.00 22.62           C  
+ANISOU 1288  CB  ILE A 167     4181   1829   2583   -401    502   -257       C  
+ATOM   1289  CG1 ILE A 167      12.591  -0.919  -0.926  1.00 21.48           C  
+ANISOU 1289  CG1 ILE A 167     4071   1961   2129   -413    476   -510       C  
+ATOM   1290  CG2 ILE A 167      12.632   1.145  -2.395  1.00 27.27           C  
+ANISOU 1290  CG2 ILE A 167     4938   1997   3425     -7    555    -24       C  
+ATOM   1291  CD1 ILE A 167      12.544  -0.458   0.504  1.00 25.47           C  
+ANISOU 1291  CD1 ILE A 167     4999   2724   1953   -108    -31   -450       C  
+ATOM   1292  N   LYS A 168      15.442  -2.717  -3.396  1.00 21.10           N  
+ANISOU 1292  N   LYS A 168     3497   2205   2316   -721    777   -578       N  
+ATOM   1293  CA  LYS A 168      16.185  -3.892  -3.002  1.00 21.59           C  
+ANISOU 1293  CA  LYS A 168     3219   2117   2866   -755    756   -779       C  
+ATOM   1294  C   LYS A 168      17.485  -3.554  -2.294  1.00 21.76           C  
+ANISOU 1294  C   LYS A 168     3595   2174   2499  -1124    489   -237       C  
+ATOM   1295  O   LYS A 168      17.836  -4.210  -1.313  1.00 23.46           O  
+ANISOU 1295  O   LYS A 168     4140   2618   2156  -1341    706   -100       O  
+ATOM   1296  CB  LYS A 168      16.463  -4.771  -4.242  1.00 22.78           C  
+ANISOU 1296  CB  LYS A 168     4016   2158   2480   -515    492   -610       C  
+ATOM   1297  CG  LYS A 168      17.227  -6.013  -3.825  1.00 26.08           C  
+ANISOU 1297  CG  LYS A 168     4317   3079   2516    467   1169   -495       C  
+ATOM   1298  CD  LYS A 168      17.597  -6.861  -5.033  1.00 33.29           C  
+ANISOU 1298  CD  LYS A 168     5812   4148   2690   1505    756   -961       C  
+ATOM   1299  CE  LYS A 168      17.998  -8.251  -4.587  1.00 41.59           C  
+ANISOU 1299  CE  LYS A 168     7453   3792   4559   1799    -89  -1528       C  
+ATOM   1300  NZ  LYS A 168      17.434  -9.250  -5.548  1.00 58.01           N  
+ANISOU 1300  NZ  LYS A 168    12192   4322   5528   1531  -2603  -1477       N  
+ATOM   1301  N   THR A 169      18.168  -2.551  -2.823  1.00 20.99           N  
+ANISOU 1301  N   THR A 169     3398   2505   2071  -1011    532    -72       N  
+ATOM   1302  CA  THR A 169      19.518  -2.226  -2.419  1.00 19.44           C  
+ANISOU 1302  CA  THR A 169     3327   2091   1969   -908    674   -195       C  
+ATOM   1303  C   THR A 169      19.639  -0.868  -1.715  1.00 21.05           C  
+ANISOU 1303  C   THR A 169     4113   2128   1758  -1221    963   -170       C  
+ATOM   1304  O   THR A 169      18.827   0.034  -1.906  1.00 26.65           O  
+ANISOU 1304  O   THR A 169     5017   1727   3382  -1134    351   -227       O  
+ATOM   1305  CB  THR A 169      20.440  -2.231  -3.652  1.00 23.43           C  
+ANISOU 1305  CB  THR A 169     3311   3465   2126   -606    738   -697       C  
+ATOM   1306  OG1 THR A 169      19.913  -1.432  -4.707  1.00 25.63           O  
+ANISOU 1306  OG1 THR A 169     4749   2874   2116  -1272   1119    -94       O  
+ATOM   1307  CG2 THR A 169      20.499  -3.651  -4.215  1.00 29.34           C  
+ANISOU 1307  CG2 THR A 169     4655   3237   3257    -20   1769   -493       C  
+ATOM   1308  N   LYS A 170      20.682  -0.757  -0.881  1.00 24.34           N  
+ANISOU 1308  N   LYS A 170     4261   2696   2291  -1675    728   -332       N  
+ATOM   1309  CA  LYS A 170      21.039   0.447  -0.174  1.00 22.71           C  
+ANISOU 1309  CA  LYS A 170     3834   2292   2505  -1576    900   -146       C  
+ATOM   1310  C   LYS A 170      20.912   1.710  -1.026  1.00 25.84           C  
+ANISOU 1310  C   LYS A 170     4656   2692   2470  -1302   1231    135       C  
+ATOM   1311  O   LYS A 170      21.532   1.756  -2.111  1.00 28.23           O  
+ANISOU 1311  O   LYS A 170     4764   3330   2632  -1520   1423     86       O  
+ATOM   1312  CB  LYS A 170      22.505   0.341   0.286  1.00 23.98           C  
+ANISOU 1312  CB  LYS A 170     3842   3000   2270  -1379    938   -606       C  
+ATOM   1313  CG  LYS A 170      22.963   1.541   1.083  1.00 26.47           C  
+ANISOU 1313  CG  LYS A 170     4276   3484   2296  -1894    965   -726       C  
+ATOM   1314  CD  LYS A 170      24.246   1.274   1.853  1.00 30.93           C  
+ANISOU 1314  CD  LYS A 170     4457   4240   3057  -1836    550   -958       C  
+ATOM   1315  CE  LYS A 170      25.293   0.725   0.890  1.00 39.03           C  
+ANISOU 1315  CE  LYS A 170     4325   6127   4379  -1429   1408   -429       C  
+ATOM   1316  NZ  LYS A 170      26.644   1.304   1.146  1.00 64.39           N  
+ANISOU 1316  NZ  LYS A 170     4151  10476   9839  -2287    914    260       N  
+ATOM   1317  N   GLY A 171      20.148   2.700  -0.548  1.00 25.18           N  
+ANISOU 1317  N   GLY A 171     4431   2627   2510  -1200    930    243       N  
+ATOM   1318  CA  GLY A 171      20.015   4.003  -1.197  1.00 28.27           C  
+ANISOU 1318  CA  GLY A 171     6084   2482   2176  -1284    553    -34       C  
+ATOM   1319  C   GLY A 171      18.826   4.131  -2.126  1.00 26.04           C  
+ANISOU 1319  C   GLY A 171     5492   2091   2314  -1255    991    479       C  
+ATOM   1320  O   GLY A 171      18.452   5.200  -2.629  1.00 34.60           O  
+ANISOU 1320  O   GLY A 171     7311   2010   3827  -1879   -402    983       O  
+ATOM   1321  N   LYS A 172      18.180   2.988  -2.387  1.00 24.50           N  
+ANISOU 1321  N   LYS A 172     5356   1710   2243   -740    616    284       N  
+ATOM   1322  CA  LYS A 172      16.987   3.070  -3.229  1.00 27.94           C  
+ANISOU 1322  CA  LYS A 172     5672   2754   2191   -802    374    279       C  
+ATOM   1323  C   LYS A 172      15.786   3.514  -2.410  1.00 26.67           C  
+ANISOU 1323  C   LYS A 172     5239   2579   2314   -961     77     96       C  
+ATOM   1324  O   LYS A 172      15.585   3.107  -1.255  1.00 26.15           O  
+ANISOU 1324  O   LYS A 172     4764   2769   2404  -1022    161    223       O  
+ATOM   1325  CB  LYS A 172      16.747   1.722  -3.899  1.00 25.19           C  
+ANISOU 1325  CB  LYS A 172     4507   2481   2582   -711    375    483       C  
+ATOM   1326  CG  LYS A 172      17.779   1.359  -4.959  1.00 30.79           C  
+ANISOU 1326  CG  LYS A 172     4228   3712   3759   -863    552   -807       C  
+ATOM   1327  CD  LYS A 172      17.157   0.548  -6.075  1.00 39.24           C  
+ANISOU 1327  CD  LYS A 172     4873   5641   4396   -736    453  -2033       C  
+ATOM   1328  CE  LYS A 172      18.043   0.542  -7.326  1.00 44.48           C  
+ANISOU 1328  CE  LYS A 172     5034   6534   5333   -263   1156  -3308       C  
+ATOM   1329  NZ  LYS A 172      18.033  -0.804  -7.978  1.00 58.50           N  
+ANISOU 1329  NZ  LYS A 172     7567   7279   7382    133    750  -4538       N  
+ATOM   1330  N   SER A 173      14.966   4.361  -3.010  1.00 28.99           N  
+ANISOU 1330  N   SER A 173     6105   2494   2416   -540     96     79       N  
+ATOM   1331  CA  SER A 173      13.703   4.769  -2.400  1.00 29.70           C  
+ANISOU 1331  CA  SER A 173     6400   2556   2327     22    173    522       C  
+ATOM   1332  C   SER A 173      12.592   4.740  -3.450  1.00 26.90           C  
+ANISOU 1332  C   SER A 173     6475   2341   1403   1003    557    326       C  
+ATOM   1333  O   SER A 173      12.824   4.652  -4.660  1.00 33.02           O  
+ANISOU 1333  O   SER A 173     8006   3078   1462   1638    895    458       O  
+ATOM   1334  CB  SER A 173      13.789   6.156  -1.751  1.00 31.55           C  
+ANISOU 1334  CB  SER A 173     7072   2692   2223    183    175    418       C  
+ATOM   1335  OG  SER A 173      14.186   7.146  -2.680  1.00 36.01           O  
+ANISOU 1335  OG  SER A 173     8934   2339   2408    137    732    226       O  
+ATOM   1336  N   ALA A 174      11.371   4.827  -2.929  1.00 29.93           N  
+ANISOU 1336  N   ALA A 174     6390   3038   1942   1995    407   -181       N  
+ATOM   1337  CA  ALA A 174      10.188   4.854  -3.768  1.00 31.46           C  
+ANISOU 1337  CA  ALA A 174     6651   2922   2382   1750     65    340       C  
+ATOM   1338  C   ALA A 174       9.041   5.634  -3.139  1.00 30.66           C  
+ANISOU 1338  C   ALA A 174     6116   3695   1839   1604    352   1016       C  
+ATOM   1339  O   ALA A 174       8.967   5.708  -1.896  1.00 30.90           O  
+ANISOU 1339  O   ALA A 174     6305   3605   1831   1698    225   1159       O  
+ATOM   1340  CB  ALA A 174       9.734   3.430  -4.042  1.00 34.39           C  
+ANISOU 1340  CB  ALA A 174     7879   3508   1680    574    450    369       C  
+ATOM   1341  N   ASP A 175       8.186   6.168  -4.016  1.00 30.74           N  
+ANISOU 1341  N   ASP A 175     5896   4019   1765   1545     58    531       N  
+ATOM   1342  CA  ASP A 175       6.962   6.792  -3.512  1.00 29.28           C  
+ANISOU 1342  CA  ASP A 175     5238   4001   1885    887    -72    194       C  
+ATOM   1343  C   ASP A 175       6.164   5.775  -2.705  1.00 27.60           C  
+ANISOU 1343  C   ASP A 175     5336   3523   1626    557   -620    -54       C  
+ATOM   1344  O   ASP A 175       6.015   4.632  -3.100  1.00 32.04           O  
+ANISOU 1344  O   ASP A 175     6686   3557   1930    780   -485   -278       O  
+ATOM   1345  CB  ASP A 175       6.063   7.361  -4.618  1.00 35.56           C  
+ANISOU 1345  CB  ASP A 175     6398   4059   3053   1783   -345    982       C  
+ATOM   1346  CG  ASP A 175       6.811   8.379  -5.449  1.00 44.19           C  
+ANISOU 1346  CG  ASP A 175     6990   6154   3646    510  -1000   2059       C  
+ATOM   1347  OD1 ASP A 175       7.798   8.935  -4.927  1.00 55.21           O  
+ANISOU 1347  OD1 ASP A 175     6120  10556   4301   -849  -1128   3450       O  
+ATOM   1348  OD2 ASP A 175       6.396   8.615  -6.598  1.00 49.94           O  
+ANISOU 1348  OD2 ASP A 175     7573   8260   3142   -559   -685   2096       O  
+ATOM   1349  N   PHE A 176       5.660   6.237  -1.562  1.00 23.20           N  
+ANISOU 1349  N   PHE A 176     3663   2825   2325    670   -303     10       N  
+ATOM   1350  CA  PHE A 176       4.883   5.333  -0.734  1.00 25.50           C  
+ANISOU 1350  CA  PHE A 176     4210   3041   2439    212   -513    159       C  
+ATOM   1351  C   PHE A 176       3.836   6.157   0.023  1.00 21.09           C  
+ANISOU 1351  C   PHE A 176     3624   2160   2229   -255   -467    650       C  
+ATOM   1352  O   PHE A 176       3.980   6.409   1.218  1.00 28.38           O  
+ANISOU 1352  O   PHE A 176     4844   3748   2191   1425   -713    455       O  
+ATOM   1353  CB  PHE A 176       5.769   4.541   0.224  1.00 22.42           C  
+ANISOU 1353  CB  PHE A 176     3547   3107   1866    245    -99    -92       C  
+ATOM   1354  CG  PHE A 176       5.096   3.283   0.740  1.00 25.20           C  
+ANISOU 1354  CG  PHE A 176     4069   3297   2209    100   -302    328       C  
+ATOM   1355  CD1 PHE A 176       4.820   2.243  -0.130  1.00 26.93           C  
+ANISOU 1355  CD1 PHE A 176     5033   2729   2470    165    204    351       C  
+ATOM   1356  CD2 PHE A 176       4.735   3.144   2.069  1.00 23.66           C  
+ANISOU 1356  CD2 PHE A 176     3292   3483   2216    142   -502    441       C  
+ATOM   1357  CE1 PHE A 176       4.188   1.088   0.313  1.00 26.22           C  
+ANISOU 1357  CE1 PHE A 176     5405   2294   2265    782    547    536       C  
+ATOM   1358  CE2 PHE A 176       4.136   1.993   2.529  1.00 23.47           C  
+ANISOU 1358  CE2 PHE A 176     3937   2797   2185    692   -365    480       C  
+ATOM   1359  CZ  PHE A 176       3.878   0.952   1.655  1.00 25.89           C  
+ANISOU 1359  CZ  PHE A 176     5193   2602   2042    777     70    467       C  
+ATOM   1360  N   THR A 177       2.811   6.568  -0.714  1.00 24.21           N  
+ANISOU 1360  N   THR A 177     4402   2208   2589    131   -952    616       N  
+ATOM   1361  CA  THR A 177       1.709   7.366  -0.184  1.00 24.52           C  
+ANISOU 1361  CA  THR A 177     4147   2727   2443    255   -970    833       C  
+ATOM   1362  C   THR A 177       0.509   6.505   0.218  1.00 25.03           C  
+ANISOU 1362  C   THR A 177     4570   2546   2397     -9   -815    574       C  
+ATOM   1363  O   THR A 177       0.376   5.358  -0.227  1.00 28.54           O  
+ANISOU 1363  O   THR A 177     6083   2558   2203   -238   -855    597       O  
+ATOM   1364  CB  THR A 177       1.216   8.402  -1.212  1.00 23.88           C  
+ANISOU 1364  CB  THR A 177     3800   3211   2061    388   -593    939       C  
+ATOM   1365  OG1 THR A 177       0.895   7.714  -2.432  1.00 30.28           O  
+ANISOU 1365  OG1 THR A 177     6118   3651   1736    994   -388    665       O  
+ATOM   1366  CG2 THR A 177       2.290   9.434  -1.525  1.00 33.60           C  
+ANISOU 1366  CG2 THR A 177     4304   3659   4805    240   -369   2160       C  
+ATOM   1367  N   ASN A 178      -0.345   7.066   1.049  1.00 24.67           N  
+ANISOU 1367  N   ASN A 178     4203   2778   2391    109   -938    730       N  
+ATOM   1368  CA  ASN A 178      -1.619   6.546   1.506  1.00 25.08           C  
+ANISOU 1368  CA  ASN A 178     4331   2840   2360    -52  -1003    824       C  
+ATOM   1369  C   ASN A 178      -1.537   5.215   2.225  1.00 26.89           C  
+ANISOU 1369  C   ASN A 178     4541   2853   2823   -116  -1155    994       C  
+ATOM   1370  O   ASN A 178      -2.485   4.439   2.248  1.00 32.43           O  
+ANISOU 1370  O   ASN A 178     5714   2900   3711   -934  -2308    938       O  
+ATOM   1371  CB  ASN A 178      -2.612   6.387   0.334  1.00 27.67           C  
+ANISOU 1371  CB  ASN A 178     4371   3584   2559   -205  -1159   1034       C  
+ATOM   1372  CG  ASN A 178      -2.817   7.728  -0.357  1.00 28.10           C  
+ANISOU 1372  CG  ASN A 178     3368   3970   3339    137   -993   1498       C  
+ATOM   1373  OD1 ASN A 178      -2.258   8.073  -1.407  1.00 28.68           O  
+ANISOU 1373  OD1 ASN A 178     4150   3540   3208   -206   -930   1262       O  
+ATOM   1374  ND2 ASN A 178      -3.685   8.476   0.297  1.00 31.76           N  
+ANISOU 1374  ND2 ASN A 178     5551   3814   2703    317   -957    430       N  
+ATOM   1375  N   PHE A 179      -0.410   4.915   2.839  1.00 23.83           N  
+ANISOU 1375  N   PHE A 179     4156   2737   2163    290   -351    801       N  
+ATOM   1376  CA  PHE A 179      -0.260   3.790   3.729  1.00 21.75           C  
+ANISOU 1376  CA  PHE A 179     3781   2742   1741   -389   -745    734       C  
+ATOM   1377  C   PHE A 179      -0.758   4.125   5.128  1.00 21.06           C  
+ANISOU 1377  C   PHE A 179     3792   2173   2037    -78   -633    485       C  
+ATOM   1378  O   PHE A 179      -0.329   5.074   5.777  1.00 22.19           O  
+ANISOU 1378  O   PHE A 179     3374   2842   2215   -320   -967    313       O  
+ATOM   1379  CB  PHE A 179       1.205   3.330   3.771  1.00 21.40           C  
+ANISOU 1379  CB  PHE A 179     4129   2791   1210    168   -811    299       C  
+ATOM   1380  CG  PHE A 179       1.270   2.104   4.689  1.00 21.11           C  
+ANISOU 1380  CG  PHE A 179     3822   2701   1497   -151   -593    456       C  
+ATOM   1381  CD1 PHE A 179       0.881   0.892   4.170  1.00 22.22           C  
+ANISOU 1381  CD1 PHE A 179     3764   2746   1932    175   -468     69       C  
+ATOM   1382  CD2 PHE A 179       1.703   2.164   6.021  1.00 20.54           C  
+ANISOU 1382  CD2 PHE A 179     3665   2577   1561     71   -683    596       C  
+ATOM   1383  CE1 PHE A 179       0.893  -0.250   4.958  1.00 21.82           C  
+ANISOU 1383  CE1 PHE A 179     3753   2413   2125    440    -67    -96       C  
+ATOM   1384  CE2 PHE A 179       1.678   1.034   6.822  1.00 20.52           C  
+ANISOU 1384  CE2 PHE A 179     3706   2413   1676    446   -517    490       C  
+ATOM   1385  CZ  PHE A 179       1.272  -0.155   6.280  1.00 22.91           C  
+ANISOU 1385  CZ  PHE A 179     4017   2585   2103      5    -89    377       C  
+ATOM   1386  N   ASP A 180      -1.632   3.261   5.651  1.00 20.54           N  
+ANISOU 1386  N   ASP A 180     3342   2514   1949   -114   -388    -26       N  
+ATOM   1387  CA  ASP A 180      -2.272   3.486   6.940  1.00 18.62           C  
+ANISOU 1387  CA  ASP A 180     2414   2508   2154    464   -605   -288       C  
+ATOM   1388  C   ASP A 180      -1.628   2.644   8.017  1.00 18.37           C  
+ANISOU 1388  C   ASP A 180     2280   2516   2183   -420   -393    413       C  
+ATOM   1389  O   ASP A 180      -1.821   1.412   8.057  1.00 19.17           O  
+ANISOU 1389  O   ASP A 180     2484   2553   2249   -608     16    291       O  
+ATOM   1390  CB  ASP A 180      -3.769   3.162   6.803  1.00 23.73           C  
+ANISOU 1390  CB  ASP A 180     2572   3275   3168     -1   -773    412       C  
+ATOM   1391  CG  ASP A 180      -4.551   3.575   8.040  1.00 24.15           C  
+ANISOU 1391  CG  ASP A 180     1885   3845   3447   -169   -791    123       C  
+ATOM   1392  OD1 ASP A 180      -3.951   3.750   9.124  1.00 21.91           O  
+ANISOU 1392  OD1 ASP A 180     2312   2511   3503    136   -859   -223       O  
+ATOM   1393  OD2 ASP A 180      -5.780   3.720   7.968  1.00 33.93           O  
+ANISOU 1393  OD2 ASP A 180     1915   6591   4384     39   -847    260       O  
+ATOM   1394  N   PRO A 181      -0.854   3.233   8.904  1.00 17.79           N  
+ANISOU 1394  N   PRO A 181     2030   2322   2407    -93   -579    338       N  
+ATOM   1395  CA  PRO A 181      -0.149   2.372   9.882  1.00 17.86           C  
+ANISOU 1395  CA  PRO A 181     1857   2609   2321    354   -200    320       C  
+ATOM   1396  C   PRO A 181      -1.054   1.737  10.923  1.00 16.21           C  
+ANISOU 1396  C   PRO A 181     1852   2195   2110    192   -356    119       C  
+ATOM   1397  O   PRO A 181      -0.639   0.855  11.680  1.00 17.32           O  
+ANISOU 1397  O   PRO A 181     2083   2523   1976    299   -557    162       O  
+ATOM   1398  CB  PRO A 181       0.877   3.318  10.519  1.00 18.66           C  
+ANISOU 1398  CB  PRO A 181     1207   3789   2095     75    -10    283       C  
+ATOM   1399  CG  PRO A 181       0.252   4.664  10.398  1.00 21.03           C  
+ANISOU 1399  CG  PRO A 181     2423   2973   2596   -586   -455    167       C  
+ATOM   1400  CD  PRO A 181      -0.499   4.649   9.087  1.00 19.33           C  
+ANISOU 1400  CD  PRO A 181     2328   2357   2659   -126   -484    208       C  
+ATOM   1401  N   ARG A 182      -2.324   2.143  10.954  1.00 17.35           N  
+ANISOU 1401  N   ARG A 182     1963   2328   2300    333    -79    426       N  
+ATOM   1402  CA  ARG A 182      -3.225   1.443  11.888  1.00 18.66           C  
+ANISOU 1402  CA  ARG A 182     2364   2152   2575    274    377    189       C  
+ATOM   1403  C   ARG A 182      -3.318  -0.044  11.576  1.00 16.68           C  
+ANISOU 1403  C   ARG A 182     1856   2210   2271    239   -493    241       C  
+ATOM   1404  O   ARG A 182      -3.661  -0.862  12.435  1.00 19.50           O  
+ANISOU 1404  O   ARG A 182     2653   2277   2482    -31   -485    397       O  
+ATOM   1405  CB  ARG A 182      -4.631   2.047  11.853  1.00 20.41           C  
+ANISOU 1405  CB  ARG A 182     2420   2652   2683    514    573   -298       C  
+ATOM   1406  CG  ARG A 182      -4.659   3.466  12.423  1.00 21.20           C  
+ANISOU 1406  CG  ARG A 182     2609   2338   3109    511     -1     12       C  
+ATOM   1407  CD  ARG A 182      -5.977   4.154  12.186  1.00 23.65           C  
+ANISOU 1407  CD  ARG A 182     2795   2614   3579    790    179     -7       C  
+ATOM   1408  NE  ARG A 182      -6.269   4.288  10.752  1.00 29.22           N  
+ANISOU 1408  NE  ARG A 182     3130   4028   3943    957   -614    156       N  
+ATOM   1409  CZ  ARG A 182      -7.401   4.878  10.366  1.00 34.61           C  
+ANISOU 1409  CZ  ARG A 182     3489   4917   4742   1516   -422    766       C  
+ATOM   1410  NH1 ARG A 182      -8.213   5.313  11.321  1.00 39.78           N  
+ANISOU 1410  NH1 ARG A 182     3785   5157   6172   1628    693   1047       N  
+ATOM   1411  NH2 ARG A 182      -7.701   5.015   9.081  1.00 39.05           N  
+ANISOU 1411  NH2 ARG A 182     4656   5076   5107   1417   -599   2606       N  
+ATOM   1412  N   GLY A 183      -3.064  -0.388  10.306  1.00 19.36           N  
+ANISOU 1412  N   GLY A 183     2693   2434   2227   -125   -643     37       N  
+ATOM   1413  CA  GLY A 183      -3.147  -1.795   9.913  1.00 20.31           C  
+ANISOU 1413  CA  GLY A 183     2958   2476   2285    -16  -1084     -9       C  
+ATOM   1414  C   GLY A 183      -1.986  -2.628  10.443  1.00 20.80           C  
+ANISOU 1414  C   GLY A 183     2589   2419   2895   -175   -735    343       C  
+ATOM   1415  O   GLY A 183      -1.928  -3.824  10.131  1.00 23.49           O  
+ANISOU 1415  O   GLY A 183     3320   2199   3404   -224  -1028    679       O  
+ATOM   1416  N   LEU A 184      -1.082  -2.020  11.204  1.00 18.76           N  
+ANISOU 1416  N   LEU A 184     2080   2864   2186    158   -382     99       N  
+ATOM   1417  CA  LEU A 184       0.049  -2.761  11.721  1.00 15.96           C  
+ANISOU 1417  CA  LEU A 184     2153   1597   2315   -182   -199    322       C  
+ATOM   1418  C   LEU A 184      -0.101  -3.029  13.216  1.00 17.49           C  
+ANISOU 1418  C   LEU A 184     2210   1953   2482    -23     29    677       C  
+ATOM   1419  O   LEU A 184       0.808  -3.619  13.793  1.00 19.04           O  
+ANISOU 1419  O   LEU A 184     2720   2043   2473    401    -29    580       O  
+ATOM   1420  CB  LEU A 184       1.365  -2.019  11.464  1.00 17.41           C  
+ANISOU 1420  CB  LEU A 184     2007   2282   2327   -118    -90    604       C  
+ATOM   1421  CG  LEU A 184       1.686  -1.794   9.985  1.00 16.63           C  
+ANISOU 1421  CG  LEU A 184     2066   1857   2395    454    157    493       C  
+ATOM   1422  CD1 LEU A 184       2.953  -0.982   9.834  1.00 21.32           C  
+ANISOU 1422  CD1 LEU A 184     1943   3734   2425     -6     76   1031       C  
+ATOM   1423  CD2 LEU A 184       1.806  -3.115   9.248  1.00 24.96           C  
+ANISOU 1423  CD2 LEU A 184     4184   2359   2941   1376   -628    -55       C  
+ATOM   1424  N   LEU A 185      -1.183  -2.586  13.832  1.00 17.26           N  
+ANISOU 1424  N   LEU A 185     2065   2121   2372   -189   -211     23       N  
+ATOM   1425  CA  LEU A 185      -1.342  -2.621  15.271  1.00 16.21           C  
+ANISOU 1425  CA  LEU A 185     1902   1906   2350   -377   -312    104       C  
+ATOM   1426  C   LEU A 185      -2.171  -3.829  15.718  1.00 18.31           C  
+ANISOU 1426  C   LEU A 185     1831   2198   2929   -535   -693    623       C  
+ATOM   1427  O   LEU A 185      -3.157  -4.237  15.080  1.00 23.65           O  
+ANISOU 1427  O   LEU A 185     2654   2609   3723  -1037  -1489   1006       O  
+ATOM   1428  CB  LEU A 185      -2.043  -1.376  15.816  1.00 16.65           C  
+ANISOU 1428  CB  LEU A 185     1265   2249   2811   -612   -137   -363       C  
+ATOM   1429  CG  LEU A 185      -1.529  -0.013  15.396  1.00 16.49           C  
+ANISOU 1429  CG  LEU A 185     1511   2003   2750   -572    -60   -683       C  
+ATOM   1430  CD1 LEU A 185      -2.390   1.161  15.815  1.00 17.46           C  
+ANISOU 1430  CD1 LEU A 185     2108   2356   2169   -112     73   -418       C  
+ATOM   1431  CD2 LEU A 185      -0.126   0.134  15.958  1.00 18.36           C  
+ANISOU 1431  CD2 LEU A 185     1571   2131   3274   -851   -383    613       C  
+ATOM   1432  N   PRO A 186      -1.776  -4.394  16.848  1.00 16.01           N  
+ANISOU 1432  N   PRO A 186     1411   2211   2460    -96   -166    329       N  
+ATOM   1433  CA  PRO A 186      -2.542  -5.515  17.402  1.00 16.85           C  
+ANISOU 1433  CA  PRO A 186     1868   2222   2314   -279    -73    245       C  
+ATOM   1434  C   PRO A 186      -3.810  -5.005  18.092  1.00 16.35           C  
+ANISOU 1434  C   PRO A 186     1765   2037   2408   -404    -21    253       C  
+ATOM   1435  O   PRO A 186      -3.974  -3.796  18.189  1.00 19.34           O  
+ANISOU 1435  O   PRO A 186     1503   1988   3858   -164   -164    538       O  
+ATOM   1436  CB  PRO A 186      -1.585  -6.133  18.418  1.00 16.73           C  
+ANISOU 1436  CB  PRO A 186     1590   2419   2347   -492    -24    413       C  
+ATOM   1437  CG  PRO A 186      -0.834  -4.933  18.909  1.00 17.03           C  
+ANISOU 1437  CG  PRO A 186     2254   2447   1769   -404     48    -22       C  
+ATOM   1438  CD  PRO A 186      -0.621  -4.062  17.680  1.00 14.08           C  
+ANISOU 1438  CD  PRO A 186     1705   1629   2016     38    -94    -10       C  
+ATOM   1439  N   GLU A 187      -4.676  -5.879  18.554  1.00 18.34           N  
+ANISOU 1439  N   GLU A 187     2328   2169   2472   -563    279    324       N  
+ATOM   1440  CA  GLU A 187      -5.893  -5.448  19.237  1.00 18.73           C  
+ANISOU 1440  CA  GLU A 187     1908   2404   2804   -680    119    388       C  
+ATOM   1441  C   GLU A 187      -5.627  -4.691  20.518  1.00 18.41           C  
+ANISOU 1441  C   GLU A 187     1284   2546   3164    148    -22    -58       C  
+ATOM   1442  O   GLU A 187      -6.259  -3.684  20.786  1.00 21.27           O  
+ANISOU 1442  O   GLU A 187     1576   2586   3919    363     68     68       O  
+ATOM   1443  CB  GLU A 187      -6.694  -6.674  19.681  1.00 20.96           C  
+ANISOU 1443  CB  GLU A 187     1663   2063   4240   -374     85    725       C  
+ATOM   1444  CG  GLU A 187      -7.514  -7.300  18.599  1.00 29.73           C  
+ANISOU 1444  CG  GLU A 187     2667   2613   6018   -827   -930    175       C  
+ATOM   1445  CD  GLU A 187      -8.225  -8.558  19.112  1.00 27.99           C  
+ANISOU 1445  CD  GLU A 187     1587   2463   6586   -400    360   -415       C  
+ATOM   1446  OE1 GLU A 187      -8.295  -8.760  20.343  1.00 36.41           O  
+ANISOU 1446  OE1 GLU A 187     3858   3060   6915  -1429  -2113   1396       O  
+ATOM   1447  OE2 GLU A 187      -8.706  -9.326  18.258  1.00 38.81           O  
+ANISOU 1447  OE2 GLU A 187     4271   3223   7250  -1684  -1148     95       O  
+ATOM   1448  N   SER A 188      -4.681  -5.255  21.289  1.00 17.05           N  
+ANISOU 1448  N   SER A 188     1028   2328   3122     24     66   -165       N  
+ATOM   1449  CA  SER A 188      -4.426  -4.732  22.608  1.00 18.66           C  
+ANISOU 1449  CA  SER A 188     1669   2428   2995   -393    -23    144       C  
+ATOM   1450  C   SER A 188      -3.356  -3.669  22.632  1.00 17.26           C  
+ANISOU 1450  C   SER A 188     1896   2437   2224   -496    157    164       C  
+ATOM   1451  O   SER A 188      -2.369  -3.883  21.925  1.00 19.84           O  
+ANISOU 1451  O   SER A 188     2082   2994   2464   -535    406    189       O  
+ATOM   1452  CB  SER A 188      -3.941  -5.913  23.451  1.00 21.88           C  
+ANISOU 1452  CB  SER A 188     1907   3254   3152   -525    802   1249       C  
+ATOM   1453  OG  SER A 188      -4.038  -5.651  24.793  1.00 25.97           O  
+ANISOU 1453  OG  SER A 188     2585   3999   3285    775   1090   1054       O  
+ATOM   1454  N   LEU A 189      -3.536  -2.634  23.432  1.00 18.59           N  
+ANISOU 1454  N   LEU A 189     1743   2401   2918     87   -535   -127       N  
+ATOM   1455  CA  LEU A 189      -2.440  -1.668  23.595  1.00 18.05           C  
+ANISOU 1455  CA  LEU A 189     1977   2468   2414   -211     39   -141       C  
+ATOM   1456  C   LEU A 189      -1.744  -1.793  24.947  1.00 15.93           C  
+ANISOU 1456  C   LEU A 189     1340   2360   2352   -736    297     25       C  
+ATOM   1457  O   LEU A 189      -1.065  -0.886  25.405  1.00 22.19           O  
+ANISOU 1457  O   LEU A 189     2688   2937   2805  -1212    176   -749       O  
+ATOM   1458  CB  LEU A 189      -2.918  -0.214  23.444  1.00 20.08           C  
+ANISOU 1458  CB  LEU A 189     1754   2532   3345   -134   -612   -415       C  
+ATOM   1459  CG  LEU A 189      -3.402   0.228  22.062  1.00 20.88           C  
+ANISOU 1459  CG  LEU A 189     2179   2504   3252   -255    -48    209       C  
+ATOM   1460  CD1 LEU A 189      -3.925   1.648  22.044  1.00 26.13           C  
+ANISOU 1460  CD1 LEU A 189     1990   2809   5129    100   -231    501       C  
+ATOM   1461  CD2 LEU A 189      -2.294   0.088  21.024  1.00 22.90           C  
+ANISOU 1461  CD2 LEU A 189     1812   2897   3993   -499    193    437       C  
+ATOM   1462  N   ASP A 190      -1.861  -2.850  25.707  1.00 17.89           N  
+ANISOU 1462  N   ASP A 190     1671   2427   2700    103    489    268       N  
+ATOM   1463  CA  ASP A 190      -1.157  -3.255  26.899  1.00 18.01           C  
+ANISOU 1463  CA  ASP A 190     1666   2622   2556   -344    305    106       C  
+ATOM   1464  C   ASP A 190       0.344  -3.188  26.549  1.00 16.19           C  
+ANISOU 1464  C   ASP A 190     1689   2274   2187   -306    347   -225       C  
+ATOM   1465  O   ASP A 190       0.715  -3.692  25.494  1.00 16.81           O  
+ANISOU 1465  O   ASP A 190     1762   2510   2115    -43     62   -301       O  
+ATOM   1466  CB  ASP A 190      -1.483  -4.646  27.416  1.00 18.19           C  
+ANISOU 1466  CB  ASP A 190     2072   2919   1920   -405    527    284       C  
+ATOM   1467  CG  ASP A 190      -2.844  -4.770  28.041  1.00 21.65           C  
+ANISOU 1467  CG  ASP A 190     2012   3915   2297  -1017    521   -121       C  
+ATOM   1468  OD1 ASP A 190      -3.458  -3.735  28.381  1.00 25.86           O  
+ANISOU 1468  OD1 ASP A 190     1668   4771   3388   -339    491   -216       O  
+ATOM   1469  OD2 ASP A 190      -3.299  -5.918  28.221  1.00 28.39           O  
+ANISOU 1469  OD2 ASP A 190     2413   4434   3941  -1278    120   1131       O  
+ATOM   1470  N   TYR A 191       1.106  -2.547  27.441  1.00 15.85           N  
+ANISOU 1470  N   TYR A 191     1626   2738   1659   -140    216     16       N  
+ATOM   1471  CA  TYR A 191       2.506  -2.300  27.123  1.00 14.71           C  
+ANISOU 1471  CA  TYR A 191     1630   2191   1768   -174    132     20       C  
+ATOM   1472  C   TYR A 191       3.407  -2.377  28.354  1.00 14.29           C  
+ANISOU 1472  C   TYR A 191     1618   2160   1652    -20    195    156       C  
+ATOM   1473  O   TYR A 191       2.904  -2.295  29.469  1.00 15.39           O  
+ANISOU 1473  O   TYR A 191     1495   2555   1796   -356    274     78       O  
+ATOM   1474  CB  TYR A 191       2.685  -0.928  26.432  1.00 15.24           C  
+ANISOU 1474  CB  TYR A 191     1915   2327   1549    140    303    171       C  
+ATOM   1475  CG  TYR A 191       2.302   0.235  27.324  1.00 15.10           C  
+ANISOU 1475  CG  TYR A 191     1544   2190   2002    -52    150     11       C  
+ATOM   1476  CD1 TYR A 191       3.165   0.867  28.191  1.00 17.24           C  
+ANISOU 1476  CD1 TYR A 191     1974   2369   2205    -26   -214    -12       C  
+ATOM   1477  CD2 TYR A 191       1.005   0.721  27.284  1.00 15.86           C  
+ANISOU 1477  CD2 TYR A 191     1346   2014   2664   -350    438   -118       C  
+ATOM   1478  CE1 TYR A 191       2.808   1.916  28.993  1.00 17.48           C  
+ANISOU 1478  CE1 TYR A 191     1743   2691   2206   -329    107   -243       C  
+ATOM   1479  CE2 TYR A 191       0.613   1.766  28.080  1.00 15.84           C  
+ANISOU 1479  CE2 TYR A 191     1708   1979   2332     55     24     34       C  
+ATOM   1480  CZ  TYR A 191       1.510   2.359  28.918  1.00 15.94           C  
+ANISOU 1480  CZ  TYR A 191     1767   2024   2264   -440    318    124       C  
+ATOM   1481  OH  TYR A 191       1.158   3.391  29.731  1.00 19.30           O  
+ANISOU 1481  OH  TYR A 191     2422   2272   2640   -114     75   -264       O  
+ATOM   1482  N   TRP A 192       4.677  -2.482  27.994  1.00 14.84           N  
+ANISOU 1482  N   TRP A 192     1612   2336   1690   -184    157   -340       N  
+ATOM   1483  CA  TRP A 192       5.759  -2.264  28.928  1.00 14.89           C  
+ANISOU 1483  CA  TRP A 192     1841   1674   2141     42   -292    -45       C  
+ATOM   1484  C   TRP A 192       6.468  -0.966  28.541  1.00 13.98           C  
+ANISOU 1484  C   TRP A 192     1720   1666   1927     45    302   -355       C  
+ATOM   1485  O   TRP A 192       6.545  -0.655  27.359  1.00 17.03           O  
+ANISOU 1485  O   TRP A 192     2345   2239   1888   -437    177   -349       O  
+ATOM   1486  CB  TRP A 192       6.774  -3.382  28.882  1.00 16.01           C  
+ANISOU 1486  CB  TRP A 192     2097   1772   2212    168     29    -92       C  
+ATOM   1487  CG  TRP A 192       6.268  -4.702  29.345  1.00 15.09           C  
+ANISOU 1487  CG  TRP A 192     2055   1725   1952    301    -47    -70       C  
+ATOM   1488  CD1 TRP A 192       5.997  -5.098  30.619  1.00 16.52           C  
+ANISOU 1488  CD1 TRP A 192     2513   1799   1965    450     59    -60       C  
+ATOM   1489  CD2 TRP A 192       5.981  -5.824  28.501  1.00 14.80           C  
+ANISOU 1489  CD2 TRP A 192     1607   1973   2045    -25    204   -215       C  
+ATOM   1490  NE1 TRP A 192       5.553  -6.391  30.610  1.00 17.80           N  
+ANISOU 1490  NE1 TRP A 192     2510   2148   2106    -61    134     51       N  
+ATOM   1491  CE2 TRP A 192       5.537  -6.861  29.330  1.00 16.40           C  
+ANISOU 1491  CE2 TRP A 192     1872   2171   2189   -298    -82    -16       C  
+ATOM   1492  CE3 TRP A 192       6.060  -6.034  27.136  1.00 15.33           C  
+ANISOU 1492  CE3 TRP A 192     1277   2614   1934   -125   -206   -214       C  
+ATOM   1493  CZ2 TRP A 192       5.167  -8.113  28.836  1.00 16.28           C  
+ANISOU 1493  CZ2 TRP A 192     2060   1927   2198     20    -37     88       C  
+ATOM   1494  CZ3 TRP A 192       5.695  -7.267  26.664  1.00 16.32           C  
+ANISOU 1494  CZ3 TRP A 192     1533   2800   1866   -376    -30   -338       C  
+ATOM   1495  CH2 TRP A 192       5.254  -8.295  27.496  1.00 16.88           C  
+ANISOU 1495  CH2 TRP A 192     1945   2249   2219    296   -123   -124       C  
+ATOM   1496  N   THR A 193       6.991  -0.233  29.532  1.00 13.85           N  
+ANISOU 1496  N   THR A 193     1524   1905   1834   -145   -159    139       N  
+ATOM   1497  CA  THR A 193       7.705   1.006  29.193  1.00 13.17           C  
+ANISOU 1497  CA  THR A 193     1531   1956   1515   -166    224   -152       C  
+ATOM   1498  C   THR A 193       8.922   1.175  30.062  1.00 13.34           C  
+ANISOU 1498  C   THR A 193     1745   2118   1205   -429    242   -123       C  
+ATOM   1499  O   THR A 193       8.958   0.759  31.222  1.00 14.77           O  
+ANISOU 1499  O   THR A 193     1785   2428   1400    -85    228    144       O  
+ATOM   1500  CB  THR A 193       6.781   2.211  29.274  1.00 14.34           C  
+ANISOU 1500  CB  THR A 193     1924   1799   1726    -93    366   -453       C  
+ATOM   1501  OG1 THR A 193       7.440   3.414  28.871  1.00 14.68           O  
+ANISOU 1501  OG1 THR A 193     1483   1925   2169    -68    395   -370       O  
+ATOM   1502  CG2 THR A 193       6.323   2.457  30.703  1.00 16.75           C  
+ANISOU 1502  CG2 THR A 193     2666   2220   1480    480    289    -46       C  
+ATOM   1503  N   TYR A 194       9.950   1.768  29.463  1.00 14.03           N  
+ANISOU 1503  N   TYR A 194     1669   2170   1492   -356     98    272       N  
+ATOM   1504  CA  TYR A 194      11.194   2.020  30.182  1.00 14.54           C  
+ANISOU 1504  CA  TYR A 194     1567   1772   2186   -139     30   -123       C  
+ATOM   1505  C   TYR A 194      11.965   3.099  29.421  1.00 13.95           C  
+ANISOU 1505  C   TYR A 194     1747   1749   1805   -259    -61   -230       C  
+ATOM   1506  O   TYR A 194      11.730   3.273  28.218  1.00 14.36           O  
+ANISOU 1506  O   TYR A 194     1667   2088   1700    234     65   -330       O  
+ATOM   1507  CB  TYR A 194      12.041   0.748  30.378  1.00 14.92           C  
+ANISOU 1507  CB  TYR A 194     1947   1704   2019    -21    -98   -295       C  
+ATOM   1508  CG  TYR A 194      12.740   0.327  29.099  1.00 14.21           C  
+ANISOU 1508  CG  TYR A 194     1901   1521   1976    -54    -82   -144       C  
+ATOM   1509  CD1 TYR A 194      12.036  -0.369  28.110  1.00 13.74           C  
+ANISOU 1509  CD1 TYR A 194     1640   1728   1853    126    -79   -126       C  
+ATOM   1510  CD2 TYR A 194      14.066   0.653  28.866  1.00 15.47           C  
+ANISOU 1510  CD2 TYR A 194     1751   2271   1858     60   -288   -122       C  
+ATOM   1511  CE1 TYR A 194      12.668  -0.751  26.932  1.00 14.02           C  
+ANISOU 1511  CE1 TYR A 194     1766   1723   1836   -147    107    -70       C  
+ATOM   1512  CE2 TYR A 194      14.707   0.293  27.703  1.00 14.91           C  
+ANISOU 1512  CE2 TYR A 194     1769   1793   2102     99   -157   -217       C  
+ATOM   1513  CZ  TYR A 194      13.996  -0.403  26.742  1.00 13.10           C  
+ANISOU 1513  CZ  TYR A 194     1574   1485   1920    138   -103      1       C  
+ATOM   1514  OH  TYR A 194      14.684  -0.733  25.602  1.00 14.66           O  
+ANISOU 1514  OH  TYR A 194     1392   2290   1888    289   -162    -97       O  
+ATOM   1515  N   PRO A 195      12.877   3.811  30.080  1.00 13.59           N  
+ANISOU 1515  N   PRO A 195     1367   2008   1787   -207     61   -215       N  
+ATOM   1516  CA  PRO A 195      13.727   4.766  29.409  1.00 13.01           C  
+ANISOU 1516  CA  PRO A 195     1239   1700   2003     23    118   -249       C  
+ATOM   1517  C   PRO A 195      14.959   4.124  28.765  1.00 14.30           C  
+ANISOU 1517  C   PRO A 195     1308   2126   2000    279    185    141       C  
+ATOM   1518  O   PRO A 195      15.656   3.353  29.435  1.00 13.93           O  
+ANISOU 1518  O   PRO A 195     1587   1893   1813    378     33   -218       O  
+ATOM   1519  CB  PRO A 195      14.186   5.682  30.555  1.00 17.65           C  
+ANISOU 1519  CB  PRO A 195     2265   2053   2386   -437     -7   -527       C  
+ATOM   1520  CG  PRO A 195      14.188   4.781  31.748  1.00 16.67           C  
+ANISOU 1520  CG  PRO A 195     1941   2234   2160    -31   -305   -618       C  
+ATOM   1521  CD  PRO A 195      13.058   3.786  31.527  1.00 15.18           C  
+ANISOU 1521  CD  PRO A 195     1609   2381   1777    -92   -119   -182       C  
+ATOM   1522  N   GLY A 196      15.175   4.450  27.488  1.00 13.49           N  
+ANISOU 1522  N   GLY A 196     1283   1909   1935    150    114    -10       N  
+ATOM   1523  CA  GLY A 196      16.273   3.767  26.803  1.00 14.15           C  
+ANISOU 1523  CA  GLY A 196     1467   1765   2144    -30    301   -240       C  
+ATOM   1524  C   GLY A 196      16.861   4.645  25.729  1.00 11.99           C  
+ANISOU 1524  C   GLY A 196     1041   1756   1759   -223    -66   -461       C  
+ATOM   1525  O   GLY A 196      16.948   5.888  25.833  1.00 13.32           O  
+ANISOU 1525  O   GLY A 196     1551   1623   1887     -9      4   -335       O  
+ATOM   1526  N   SER A 197      17.274   4.018  24.655  1.00 13.35           N  
+ANISOU 1526  N   SER A 197     1633   1850   1591    -97   -232   -488       N  
+ATOM   1527  CA  SER A 197      18.015   4.652  23.593  1.00 13.44           C  
+ANISOU 1527  CA  SER A 197     1637   1628   1842     76    178   -648       C  
+ATOM   1528  C   SER A 197      17.614   4.210  22.193  1.00 12.99           C  
+ANISOU 1528  C   SER A 197     1787   1440   1706   -178    -18    -71       C  
+ATOM   1529  O   SER A 197      16.855   3.275  21.989  1.00 12.20           O  
+ANISOU 1529  O   SER A 197     1480   1694   1461   -233    -53    -18       O  
+ATOM   1530  CB  SER A 197      19.505   4.285  23.786  1.00 15.13           C  
+ANISOU 1530  CB  SER A 197     1673   2070   2004    165    -28   -711       C  
+ATOM   1531  OG  SER A 197      19.727   2.961  23.306  1.00 14.91           O  
+ANISOU 1531  OG  SER A 197     1414   2225   2027    358   -165   -792       O  
+ATOM   1532  N   LEU A 198      18.165   4.917  21.210  1.00 13.56           N  
+ANISOU 1532  N   LEU A 198     1673   1549   1930   -205    235    -68       N  
+ATOM   1533  CA  LEU A 198      18.142   4.410  19.856  1.00 12.49           C  
+ANISOU 1533  CA  LEU A 198     1274   1553   1920    -12    343   -104       C  
+ATOM   1534  C   LEU A 198      18.862   3.061  19.860  1.00 12.69           C  
+ANISOU 1534  C   LEU A 198     1287   1602   1931    -25    -56   -103       C  
+ATOM   1535  O   LEU A 198      19.879   2.920  20.562  1.00 13.84           O  
+ANISOU 1535  O   LEU A 198     1297   1788   2173   -121   -227    -95       O  
+ATOM   1536  CB  LEU A 198      18.854   5.359  18.891  1.00 13.44           C  
+ANISOU 1536  CB  LEU A 198     1239   1990   1878     41     10    296       C  
+ATOM   1537  CG  LEU A 198      18.353   6.815  18.863  1.00 15.18           C  
+ANISOU 1537  CG  LEU A 198     1805   1743   2220   -260   -248    222       C  
+ATOM   1538  CD1 LEU A 198      19.291   7.652  18.002  1.00 16.59           C  
+ANISOU 1538  CD1 LEU A 198     2484   1720   2099   -485    342   -368       C  
+ATOM   1539  CD2 LEU A 198      16.914   6.855  18.427  1.00 16.98           C  
+ANISOU 1539  CD2 LEU A 198     1571   2017   2862    519     41   -597       C  
+ATOM   1540  N   THR A 199      18.388   2.119  19.053  1.00 13.42           N  
+ANISOU 1540  N   THR A 199     1393   1549   2157     97   -292   -173       N  
+ATOM   1541  CA  THR A 199      19.054   0.832  19.021  1.00 13.85           C  
+ANISOU 1541  CA  THR A 199     1257   1451   2555    -57    272    -65       C  
+ATOM   1542  C   THR A 199      20.086   0.699  17.896  1.00 15.60           C  
+ANISOU 1542  C   THR A 199     1438   1749   2741   -128    468    -59       C  
+ATOM   1543  O   THR A 199      20.665  -0.370  17.728  1.00 15.26           O  
+ANISOU 1543  O   THR A 199     1843   1774   2181      8    366   -212       O  
+ATOM   1544  CB  THR A 199      18.061  -0.329  18.894  1.00 13.92           C  
+ANISOU 1544  CB  THR A 199     1641   1608   2039   -299    339   -241       C  
+ATOM   1545  OG1 THR A 199      17.464  -0.224  17.579  1.00 15.56           O  
+ANISOU 1545  OG1 THR A 199     2241   1685   1985   -421    246   -186       O  
+ATOM   1546  CG2 THR A 199      16.974  -0.297  19.948  1.00 12.89           C  
+ANISOU 1546  CG2 THR A 199     1648   1133   2116   -186    389   -157       C  
+ATOM   1547  N   THR A 200      20.300   1.753  17.142  1.00 13.91           N  
+ANISOU 1547  N   THR A 200     1104   1696   2484   -342    213   -212       N  
+ATOM   1548  CA  THR A 200      21.398   1.824  16.189  1.00 13.99           C  
+ANISOU 1548  CA  THR A 200     1079   1751   2488   -192    201   -132       C  
+ATOM   1549  C   THR A 200      22.207   3.084  16.467  1.00 12.53           C  
+ANISOU 1549  C   THR A 200      962   1523   2276    -31    241     38       C  
+ATOM   1550  O   THR A 200      21.686   3.995  17.117  1.00 14.45           O  
+ANISOU 1550  O   THR A 200     1412   2018   2061   -132    407   -359       O  
+ATOM   1551  CB  THR A 200      20.935   1.941  14.728  1.00 15.62           C  
+ANISOU 1551  CB  THR A 200     1685   1864   2387     -5    203   -389       C  
+ATOM   1552  OG1 THR A 200      20.254   3.203  14.512  1.00 17.65           O  
+ANISOU 1552  OG1 THR A 200     2385   2203   2119    413    170   -251       O  
+ATOM   1553  CG2 THR A 200      19.961   0.860  14.332  1.00 17.49           C  
+ANISOU 1553  CG2 THR A 200     1628   2382   2636   -191   -118   -331       C  
+ATOM   1554  N   PRO A 201      23.433   3.126  15.972  1.00 13.54           N  
+ANISOU 1554  N   PRO A 201     1030   1977   2137   -179    226   -218       N  
+ATOM   1555  CA  PRO A 201      24.179   4.398  16.051  1.00 14.57           C  
+ANISOU 1555  CA  PRO A 201     1036   2177   2325   -346    174    195       C  
+ATOM   1556  C   PRO A 201      23.324   5.537  15.525  1.00 15.54           C  
+ANISOU 1556  C   PRO A 201     1459   1987   2459   -323    -83    -32       C  
+ATOM   1557  O   PRO A 201      22.559   5.315  14.586  1.00 16.08           O  
+ANISOU 1557  O   PRO A 201     2058   1921   2132   -131   -214     66       O  
+ATOM   1558  CB  PRO A 201      25.374   4.128  15.160  1.00 16.38           C  
+ANISOU 1558  CB  PRO A 201     1194   2611   2419   -385    270    -34       C  
+ATOM   1559  CG  PRO A 201      25.592   2.642  15.284  1.00 16.92           C  
+ANISOU 1559  CG  PRO A 201     1443   2652   2335   -235    862     14       C  
+ATOM   1560  CD  PRO A 201      24.197   2.049  15.355  1.00 14.31           C  
+ANISOU 1560  CD  PRO A 201     1423   2349   1664   -145    856      6       C  
+ATOM   1561  N   PRO A 202      23.351   6.717  16.136  1.00 16.81           N  
+ANISOU 1561  N   PRO A 202     1805   2123   2458   -351    183   -282       N  
+ATOM   1562  CA  PRO A 202      24.263   7.086  17.209  1.00 16.20           C  
+ANISOU 1562  CA  PRO A 202     1552   1940   2664   -576    217   -138       C  
+ATOM   1563  C   PRO A 202      23.911   6.646  18.632  1.00 14.85           C  
+ANISOU 1563  C   PRO A 202     1428   1705   2508   -214    137   -277       C  
+ATOM   1564  O   PRO A 202      24.567   7.096  19.594  1.00 15.73           O  
+ANISOU 1564  O   PRO A 202     1444   1703   2828    129   -145   -384       O  
+ATOM   1565  CB  PRO A 202      24.230   8.625  17.097  1.00 16.70           C  
+ANISOU 1565  CB  PRO A 202     1866   1994   2486   -377     53   -113       C  
+ATOM   1566  CG  PRO A 202      22.866   8.956  16.592  1.00 17.69           C  
+ANISOU 1566  CG  PRO A 202     1998   2025   2699   -427   -218   -322       C  
+ATOM   1567  CD  PRO A 202      22.466   7.827  15.710  1.00 16.03           C  
+ANISOU 1567  CD  PRO A 202     2027   1853   2209   -502    170   -156       C  
+ATOM   1568  N   LEU A 203      22.919   5.811  18.872  1.00 13.79           N  
+ANISOU 1568  N   LEU A 203     1174   1835   2229    -45    357   -244       N  
+ATOM   1569  CA  LEU A 203      22.627   5.160  20.140  1.00 13.80           C  
+ANISOU 1569  CA  LEU A 203     1327   1768   2147    124    246   -273       C  
+ATOM   1570  C   LEU A 203      22.246   6.136  21.255  1.00 14.21           C  
+ANISOU 1570  C   LEU A 203     1487   1816   2094    119    186   -299       C  
+ATOM   1571  O   LEU A 203      22.402   5.875  22.469  1.00 16.32           O  
+ANISOU 1571  O   LEU A 203     2001   2129   2072     67    105   -204       O  
+ATOM   1572  CB  LEU A 203      23.807   4.267  20.591  1.00 14.52           C  
+ANISOU 1572  CB  LEU A 203     1237   1952   2329     97     38   -422       C  
+ATOM   1573  CG  LEU A 203      24.159   3.115  19.637  1.00 13.47           C  
+ANISOU 1573  CG  LEU A 203     1581   1394   2144    119    367     91       C  
+ATOM   1574  CD1 LEU A 203      25.508   2.486  19.974  1.00 17.20           C  
+ANISOU 1574  CD1 LEU A 203     1353   1912   3269     97    194   -459       C  
+ATOM   1575  CD2 LEU A 203      23.075   2.045  19.660  1.00 15.48           C  
+ANISOU 1575  CD2 LEU A 203     1608   2059   2213   -204   -297   -311       C  
+ATOM   1576  N   LEU A 204      21.759   7.299  20.822  1.00 15.10           N  
+ANISOU 1576  N   LEU A 204     1653   1894   2189    287    433   -190       N  
+ATOM   1577  CA  LEU A 204      21.453   8.393  21.729  1.00 15.71           C  
+ANISOU 1577  CA  LEU A 204     1510   1882   2578    160    399   -406       C  
+ATOM   1578  C   LEU A 204      20.388   7.984  22.758  1.00 12.84           C  
+ANISOU 1578  C   LEU A 204      865   1763   2251     60    -15   -681       C  
+ATOM   1579  O   LEU A 204      19.472   7.240  22.402  1.00 15.82           O  
+ANISOU 1579  O   LEU A 204     1424   2082   2506   -315   -363   -547       O  
+ATOM   1580  CB  LEU A 204      20.996   9.639  20.963  1.00 16.14           C  
+ANISOU 1580  CB  LEU A 204     1877   1802   2454    135    174   -527       C  
+ATOM   1581  CG  LEU A 204      22.067  10.279  20.088  1.00 15.87           C  
+ANISOU 1581  CG  LEU A 204     1799   2344   1889    540    248   -276       C  
+ATOM   1582  CD1 LEU A 204      21.496  11.356  19.204  1.00 18.76           C  
+ANISOU 1582  CD1 LEU A 204     1780   2428   2921    390    -50    121       C  
+ATOM   1583  CD2 LEU A 204      23.199  10.844  20.947  1.00 17.96           C  
+ANISOU 1583  CD2 LEU A 204     1970   2389   2465   -115     33    452       C  
+ATOM   1584  N   GLU A 205      20.584   8.461  23.981  1.00 15.23           N  
+ANISOU 1584  N   GLU A 205     1741   1810   2238   -311    -26   -660       N  
+ATOM   1585  CA  GLU A 205      19.735   8.035  25.105  1.00 14.47           C  
+ANISOU 1585  CA  GLU A 205     1785   1535   2177    202    -56   -257       C  
+ATOM   1586  C   GLU A 205      18.558   8.992  25.270  1.00 15.73           C  
+ANISOU 1586  C   GLU A 205     1702   1767   2508    273   -172   -493       C  
+ATOM   1587  O   GLU A 205      18.448   9.745  26.236  1.00 16.74           O  
+ANISOU 1587  O   GLU A 205     1467   2230   2664     92    170   -755       O  
+ATOM   1588  CB  GLU A 205      20.553   7.841  26.397  1.00 14.81           C  
+ANISOU 1588  CB  GLU A 205     1584   1567   2477   -107   -314   -286       C  
+ATOM   1589  CG  GLU A 205      21.526   6.670  26.249  1.00 15.74           C  
+ANISOU 1589  CG  GLU A 205     1245   2143   2593     50   -129   -239       C  
+ATOM   1590  CD  GLU A 205      22.448   6.375  27.405  1.00 14.84           C  
+ANISOU 1590  CD  GLU A 205     1158   1866   2614     -7   -130   -380       C  
+ATOM   1591  OE1 GLU A 205      22.748   7.306  28.185  1.00 21.61           O  
+ANISOU 1591  OE1 GLU A 205     3131   2041   3040    162   -939   -600       O  
+ATOM   1592  OE2 GLU A 205      22.855   5.202  27.563  1.00 18.41           O  
+ANISOU 1592  OE2 GLU A 205     2016   2077   2902    456   -321   -432       O  
+ATOM   1593  N   CYS A 206      17.683   8.919  24.275  1.00 15.58           N  
+ANISOU 1593  N   CYS A 206     1586   2089   2244     91     21   -134       N  
+ATOM   1594  CA  CYS A 206      16.630   9.906  24.093  1.00 14.07           C  
+ANISOU 1594  CA  CYS A 206     1604   1729   2013   -105   -103   -117       C  
+ATOM   1595  C   CYS A 206      15.244   9.292  23.986  1.00 15.87           C  
+ANISOU 1595  C   CYS A 206     1547   1878   2605   -136      9   -311       C  
+ATOM   1596  O   CYS A 206      14.261   9.979  23.638  1.00 15.05           O  
+ANISOU 1596  O   CYS A 206     1563   1658   2499   -320   -121   -262       O  
+ATOM   1597  CB  CYS A 206      16.918  10.734  22.837  1.00 16.69           C  
+ANISOU 1597  CB  CYS A 206     2526   1808   2008   -332     16   -140       C  
+ATOM   1598  SG  CYS A 206      16.940   9.766  21.312  1.00 16.46           S  
+ANISOU 1598  SG  CYS A 206     2277   1935   2043    -63    -49   -241       S  
+ATOM   1599  N   VAL A 207      15.125   7.996  24.252  1.00 14.67           N  
+ANISOU 1599  N   VAL A 207     1465   1972   2135   -160    -62   -123       N  
+ATOM   1600  CA  VAL A 207      13.861   7.326  23.916  1.00 13.01           C  
+ANISOU 1600  CA  VAL A 207     1344   1653   1944     50     45   -200       C  
+ATOM   1601  C   VAL A 207      13.061   6.861  25.118  1.00 12.76           C  
+ANISOU 1601  C   VAL A 207     1604   1324   1919     60    189   -300       C  
+ATOM   1602  O   VAL A 207      13.612   6.152  25.993  1.00 16.57           O  
+ANISOU 1602  O   VAL A 207     1781   2219   2295    152    118    205       O  
+ATOM   1603  CB  VAL A 207      14.152   6.089  23.031  1.00 13.83           C  
+ANISOU 1603  CB  VAL A 207     1754   1809   1692     82    152   -216       C  
+ATOM   1604  CG1 VAL A 207      12.855   5.376  22.660  1.00 13.82           C  
+ANISOU 1604  CG1 VAL A 207     1679   1596   1975    336   -105   -321       C  
+ATOM   1605  CG2 VAL A 207      14.896   6.506  21.767  1.00 14.04           C  
+ANISOU 1605  CG2 VAL A 207     1832   2129   1375    309   -193    218       C  
+ATOM   1606  N   THR A 208      11.770   7.197  25.146  1.00 13.09           N  
+ANISOU 1606  N   THR A 208     1637   1496   1839     62    239   -186       N  
+ATOM   1607  CA  THR A 208      10.848   6.455  25.995  1.00 13.76           C  
+ANISOU 1607  CA  THR A 208     1528   1570   2131    -99     32   -141       C  
+ATOM   1608  C   THR A 208      10.346   5.262  25.184  1.00 13.74           C  
+ANISOU 1608  C   THR A 208     2097   1568   1554   -175     18     82       C  
+ATOM   1609  O   THR A 208       9.677   5.499  24.181  1.00 14.17           O  
+ANISOU 1609  O   THR A 208     1991   1856   1538     -1     40      4       O  
+ATOM   1610  CB  THR A 208       9.678   7.313  26.470  1.00 14.35           C  
+ANISOU 1610  CB  THR A 208     1274   2026   2152   -155    116   -312       C  
+ATOM   1611  OG1 THR A 208      10.186   8.408  27.243  1.00 14.23           O  
+ANISOU 1611  OG1 THR A 208     1769   1822   1815   -103    197   -175       O  
+ATOM   1612  CG2 THR A 208       8.731   6.509  27.347  1.00 17.53           C  
+ANISOU 1612  CG2 THR A 208     2006   1974   2679   -246    529   -156       C  
+ATOM   1613  N   TRP A 209      10.686   4.063  25.602  1.00 12.96           N  
+ANISOU 1613  N   TRP A 209     1249   1501   2172    -23   -133   -113       N  
+ATOM   1614  CA  TRP A 209      10.243   2.865  24.906  1.00 12.34           C  
+ANISOU 1614  CA  TRP A 209     1210   1571   1907    -64    169   -157       C  
+ATOM   1615  C   TRP A 209       8.868   2.455  25.403  1.00 11.59           C  
+ANISOU 1615  C   TRP A 209     1071   1747   1587    -27    118   -390       C  
+ATOM   1616  O   TRP A 209       8.643   2.381  26.631  1.00 13.12           O  
+ANISOU 1616  O   TRP A 209     1461   1935   1589     54    126   -307       O  
+ATOM   1617  CB  TRP A 209      11.256   1.710  25.142  1.00 11.71           C  
+ANISOU 1617  CB  TRP A 209     1080   1686   1682     -1   -102   -552       C  
+ATOM   1618  CG  TRP A 209      12.325   1.855  24.105  1.00 11.08           C  
+ANISOU 1618  CG  TRP A 209     1173   1468   1568    196   -139     56       C  
+ATOM   1619  CD1 TRP A 209      13.572   2.416  24.257  1.00 12.52           C  
+ANISOU 1619  CD1 TRP A 209     1375   1578   1802    -55    142   -256       C  
+ATOM   1620  CD2 TRP A 209      12.282   1.457  22.735  1.00 11.64           C  
+ANISOU 1620  CD2 TRP A 209     1213   1678   1532    251    -93     18       C  
+ATOM   1621  NE1 TRP A 209      14.298   2.394  23.099  1.00 13.11           N  
+ANISOU 1621  NE1 TRP A 209     1349   1818   1815     13    153    -60       N  
+ATOM   1622  CE2 TRP A 209      13.522   1.805  22.140  1.00 12.08           C  
+ANISOU 1622  CE2 TRP A 209     1399   1387   1802     69    116   -101       C  
+ATOM   1623  CE3 TRP A 209      11.303   0.834  21.943  1.00 12.47           C  
+ANISOU 1623  CE3 TRP A 209     1554   1491   1694    -93     31   -173       C  
+ATOM   1624  CZ2 TRP A 209      13.792   1.544  20.807  1.00 12.87           C  
+ANISOU 1624  CZ2 TRP A 209     1187   1875   1829    297     88    -52       C  
+ATOM   1625  CZ3 TRP A 209      11.603   0.586  20.618  1.00 12.30           C  
+ANISOU 1625  CZ3 TRP A 209     1444   1584   1645    128    -32   -147       C  
+ATOM   1626  CH2 TRP A 209      12.834   0.938  20.045  1.00 12.82           C  
+ANISOU 1626  CH2 TRP A 209     1460   1733   1678    152    -51    130       C  
+ATOM   1627  N   ILE A 210       7.998   2.137  24.452  1.00 11.95           N  
+ANISOU 1627  N   ILE A 210     1301   1598   1641    -58     33   -304       N  
+ATOM   1628  CA  ILE A 210       6.680   1.574  24.747  1.00 11.55           C  
+ANISOU 1628  CA  ILE A 210     1239   1507   1643    -24   -235    -66       C  
+ATOM   1629  C   ILE A 210       6.597   0.302  23.910  1.00 11.35           C  
+ANISOU 1629  C   ILE A 210     1061   1631   1622   -114     60   -128       C  
+ATOM   1630  O   ILE A 210       6.524   0.390  22.696  1.00 13.28           O  
+ANISOU 1630  O   ILE A 210     1719   1694   1633    -85     12   -168       O  
+ATOM   1631  CB  ILE A 210       5.557   2.568  24.406  1.00 12.96           C  
+ANISOU 1631  CB  ILE A 210     1375   1939   1608    314    -99   -247       C  
+ATOM   1632  CG1 ILE A 210       5.768   3.847  25.233  1.00 14.48           C  
+ANISOU 1632  CG1 ILE A 210     1414   2105   1982    412     68   -581       C  
+ATOM   1633  CG2 ILE A 210       4.179   1.996  24.649  1.00 14.90           C  
+ANISOU 1633  CG2 ILE A 210     1338   2188   2134    233   -380    352       C  
+ATOM   1634  CD1 ILE A 210       4.911   5.009  24.844  1.00 16.50           C  
+ANISOU 1634  CD1 ILE A 210     1627   1850   2791    144   -191   -249       C  
+ATOM   1635  N   VAL A 211       6.659  -0.838  24.573  1.00 12.58           N  
+ANISOU 1635  N   VAL A 211     1304   1508   1970    -25   -231    -72       N  
+ATOM   1636  CA  VAL A 211       6.678  -2.110  23.849  1.00 12.07           C  
+ANISOU 1636  CA  VAL A 211     1244   1664   1678    -16     38   -122       C  
+ATOM   1637  C   VAL A 211       5.358  -2.831  24.107  1.00 11.62           C  
+ANISOU 1637  C   VAL A 211     1312   1440   1665     -1     31    -73       C  
+ATOM   1638  O   VAL A 211       5.003  -3.095  25.269  1.00 14.30           O  
+ANISOU 1638  O   VAL A 211     1568   2144   1720   -212    186    -46       O  
+ATOM   1639  CB  VAL A 211       7.881  -2.960  24.297  1.00 13.80           C  
+ANISOU 1639  CB  VAL A 211     1330   1862   2052    198    -72   -336       C  
+ATOM   1640  CG1 VAL A 211       7.878  -4.329  23.630  1.00 13.81           C  
+ANISOU 1640  CG1 VAL A 211     1983   1718   1546    146   -252   -121       C  
+ATOM   1641  CG2 VAL A 211       9.184  -2.223  24.048  1.00 14.47           C  
+ANISOU 1641  CG2 VAL A 211     1347   1750   2402    227    -79     20       C  
+ATOM   1642  N   LEU A 212       4.615  -3.108  23.029  1.00 14.39           N  
+ANISOU 1642  N   LEU A 212     1454   2256   1755   -364     55   -292       N  
+ATOM   1643  CA  LEU A 212       3.341  -3.763  23.213  1.00 12.66           C  
+ANISOU 1643  CA  LEU A 212     1144   2022   1644     30     14     27       C  
+ATOM   1644  C   LEU A 212       3.524  -5.242  23.560  1.00 13.34           C  
+ANISOU 1644  C   LEU A 212     1249   2093   1728     87    -53    196       C  
+ATOM   1645  O   LEU A 212       4.391  -5.912  23.026  1.00 15.26           O  
+ANISOU 1645  O   LEU A 212     1456   2296   2045    305   -154   -124       O  
+ATOM   1646  CB  LEU A 212       2.478  -3.666  21.954  1.00 13.60           C  
+ANISOU 1646  CB  LEU A 212     1469   1748   1950    -74   -301    122       C  
+ATOM   1647  CG  LEU A 212       2.122  -2.264  21.484  1.00 13.87           C  
+ANISOU 1647  CG  LEU A 212     1735   1716   1820   -251     50    346       C  
+ATOM   1648  CD1 LEU A 212       1.051  -2.356  20.394  1.00 16.63           C  
+ANISOU 1648  CD1 LEU A 212     1962   1702   2656    175   -472    401       C  
+ATOM   1649  CD2 LEU A 212       1.628  -1.376  22.624  1.00 16.24           C  
+ANISOU 1649  CD2 LEU A 212     1910   1966   2296    316    235    300       C  
+ATOM   1650  N   LYS A 213       2.625  -5.709  24.438  1.00 15.72           N  
+ANISOU 1650  N   LYS A 213     1908   2197   1868     54    207    271       N  
+ATOM   1651  CA  LYS A 213       2.661  -7.088  24.892  1.00 15.72           C  
+ANISOU 1651  CA  LYS A 213     2038   2298   1638     -3    -25    400       C  
+ATOM   1652  C   LYS A 213       2.178  -8.053  23.819  1.00 14.21           C  
+ANISOU 1652  C   LYS A 213     1876   2045   1477    -39    165    618       C  
+ATOM   1653  O   LYS A 213       2.681  -9.154  23.695  1.00 18.44           O  
+ANISOU 1653  O   LYS A 213     2109   2034   2865     10   -665    226       O  
+ATOM   1654  CB  LYS A 213       1.809  -7.247  26.145  1.00 19.99           C  
+ANISOU 1654  CB  LYS A 213     3000   2818   1777   -998    364     -5       C  
+ATOM   1655  CG  LYS A 213       1.314  -8.604  26.564  1.00 32.37           C  
+ANISOU 1655  CG  LYS A 213     5187   4090   3022  -2814    359    531       C  
+ATOM   1656  CD  LYS A 213       0.157  -8.366  27.539  1.00 39.45           C  
+ANISOU 1656  CD  LYS A 213     5447   5643   3899  -2760   1094   1375       C  
+ATOM   1657  CE  LYS A 213      -1.214  -8.132  26.929  1.00 44.63           C  
+ANISOU 1657  CE  LYS A 213     6044   5463   5450   -587    820   1391       C  
+ATOM   1658  NZ  LYS A 213      -1.268  -7.780  25.480  1.00 46.62           N  
+ANISOU 1658  NZ  LYS A 213     6527   5306   5878   -553    236   2067       N  
+ATOM   1659  N   GLU A 214       1.169  -7.622  23.065  1.00 15.39           N  
+ANISOU 1659  N   GLU A 214     1989   2139   1720     23    -85    385       N  
+ATOM   1660  CA  GLU A 214       0.581  -8.507  22.086  1.00 14.96           C  
+ANISOU 1660  CA  GLU A 214     1578   2030   2078   -124    134    255       C  
+ATOM   1661  C   GLU A 214       1.314  -8.416  20.754  1.00 14.64           C  
+ANISOU 1661  C   GLU A 214     1984   1587   1990   -263    179    104       C  
+ATOM   1662  O   GLU A 214       1.391  -7.317  20.199  1.00 14.49           O  
+ANISOU 1662  O   GLU A 214     1865   1628   2013   -245      8    162       O  
+ATOM   1663  CB  GLU A 214      -0.909  -8.148  21.887  1.00 15.81           C  
+ANISOU 1663  CB  GLU A 214     1696   1545   2765    133    -60    -14       C  
+ATOM   1664  CG  GLU A 214      -1.566  -9.127  20.930  1.00 18.15           C  
+ANISOU 1664  CG  GLU A 214     2058   2092   2744   -128   -319     13       C  
+ATOM   1665  CD  GLU A 214      -3.032  -8.932  20.700  1.00 23.64           C  
+ANISOU 1665  CD  GLU A 214     1714   3896   3372   -524    192   -881       C  
+ATOM   1666  OE1 GLU A 214      -3.628  -7.971  21.236  1.00 21.97           O  
+ANISOU 1666  OE1 GLU A 214     1704   2899   3743   -273     26    117       O  
+ATOM   1667  OE2 GLU A 214      -3.596  -9.765  19.953  1.00 34.12           O  
+ANISOU 1667  OE2 GLU A 214     2241   5833   4888   -540   -346  -2365       O  
+ATOM   1668  N   PRO A 215       1.868  -9.498  20.219  1.00 14.91           N  
+ANISOU 1668  N   PRO A 215     1719   1751   2196    -20     25    121       N  
+ATOM   1669  CA  PRO A 215       2.520  -9.427  18.906  1.00 15.10           C  
+ANISOU 1669  CA  PRO A 215     2099   1700   1939   -101   -125   -263       C  
+ATOM   1670  C   PRO A 215       1.476  -9.385  17.793  1.00 15.94           C  
+ANISOU 1670  C   PRO A 215     1446   2425   2187   -156    101    510       C  
+ATOM   1671  O   PRO A 215       0.331  -9.780  18.021  1.00 18.55           O  
+ANISOU 1671  O   PRO A 215     1637   2906   2507   -495    405     55       O  
+ATOM   1672  CB  PRO A 215       3.284 -10.735  18.801  1.00 14.99           C  
+ANISOU 1672  CB  PRO A 215     1929   1818   1949      9   -284   -133       C  
+ATOM   1673  CG  PRO A 215       2.587 -11.658  19.712  1.00 21.45           C  
+ANISOU 1673  CG  PRO A 215     2921   1810   3419    180    765    121       C  
+ATOM   1674  CD  PRO A 215       1.919 -10.844  20.779  1.00 15.78           C  
+ANISOU 1674  CD  PRO A 215     1446   1938   2612    317    -26    360       C  
+ATOM   1675  N   ILE A 216       1.902  -8.931  16.610  1.00 15.78           N  
+ANISOU 1675  N   ILE A 216     1912   2114   1970   -461    167    146       N  
+ATOM   1676  CA  ILE A 216       1.118  -9.177  15.412  1.00 15.34           C  
+ANISOU 1676  CA  ILE A 216     1772   2002   2054   -333    151     61       C  
+ATOM   1677  C   ILE A 216       1.645 -10.434  14.738  1.00 17.21           C  
+ANISOU 1677  C   ILE A 216     2091   1925   2524    101   -655    -44       C  
+ATOM   1678  O   ILE A 216       2.828 -10.774  14.914  1.00 15.49           O  
+ANISOU 1678  O   ILE A 216     1776   2019   2092   -238   -196     31       O  
+ATOM   1679  CB  ILE A 216       1.161  -8.001  14.417  1.00 15.91           C  
+ANISOU 1679  CB  ILE A 216     1997   1858   2190    -12     43     99       C  
+ATOM   1680  CG1 ILE A 216       2.556  -7.629  13.943  1.00 16.81           C  
+ANISOU 1680  CG1 ILE A 216     2382   2119   1885   -186    351    217       C  
+ATOM   1681  CG2 ILE A 216       0.459  -6.803  15.048  1.00 16.65           C  
+ANISOU 1681  CG2 ILE A 216     1942   1963   2421   -165   -269   -457       C  
+ATOM   1682  CD1 ILE A 216       2.588  -6.599  12.827  1.00 17.77           C  
+ANISOU 1682  CD1 ILE A 216     3033   1645   2075   -214    302     49       C  
+ATOM   1683  N   SER A 217       0.759 -11.063  13.983  1.00 16.27           N  
+ANISOU 1683  N   SER A 217     1775   2039   2369    -48   -266   -118       N  
+ATOM   1684  CA  SER A 217       1.150 -12.237  13.205  1.00 16.51           C  
+ANISOU 1684  CA  SER A 217     2057   1974   2244   -137   -117     -3       C  
+ATOM   1685  C   SER A 217       1.383 -11.797  11.773  1.00 15.76           C  
+ANISOU 1685  C   SER A 217     1683   2061   2244   -237   -224      4       C  
+ATOM   1686  O   SER A 217       0.565 -11.029  11.253  1.00 18.32           O  
+ANISOU 1686  O   SER A 217     2486   1900   2574     78   -428     84       O  
+ATOM   1687  CB ASER A 217       0.029 -13.260  13.299  0.47 20.06           C  
+ANISOU 1687  CB ASER A 217     2971   2078   2575   -666     17    146       C  
+ATOM   1688  CB BSER A 217       0.108 -13.343  13.317  0.54 18.72           C  
+ANISOU 1688  CB BSER A 217     2587   2078   2446   -399    401   -195       C  
+ATOM   1689  OG ASER A 217       0.214 -14.417  12.528  0.47 29.65           O  
+ANISOU 1689  OG ASER A 217     4572   2614   4080   -992   -222   -863       O  
+ATOM   1690  OG BSER A 217       0.014 -13.737  14.686  0.54 18.80           O  
+ANISOU 1690  OG BSER A 217     1813   3040   2291   -897    225   -321       O  
+ATOM   1691  N   VAL A 218       2.479 -12.234  11.178  1.00 16.57           N  
+ANISOU 1691  N   VAL A 218     1886   1770   2640   -415    107    -59       N  
+ATOM   1692  CA  VAL A 218       2.724 -12.069   9.753  1.00 16.79           C  
+ANISOU 1692  CA  VAL A 218     1544   2250   2587   -246      1   -209       C  
+ATOM   1693  C   VAL A 218       2.993 -13.436   9.150  1.00 18.29           C  
+ANISOU 1693  C   VAL A 218     2471   2137   2341   -269   -270    -98       C  
+ATOM   1694  O   VAL A 218       3.339 -14.383   9.858  1.00 16.84           O  
+ANISOU 1694  O   VAL A 218     2157   2141   2099   -442   -360   -135       O  
+ATOM   1695  CB  VAL A 218       3.911 -11.138   9.498  1.00 16.07           C  
+ANISOU 1695  CB  VAL A 218     1582   1947   2578    -86    -72    276       C  
+ATOM   1696  CG1 VAL A 218       3.644  -9.783  10.127  1.00 17.32           C  
+ANISOU 1696  CG1 VAL A 218     2024   1831   2727    -95    404    411       C  
+ATOM   1697  CG2 VAL A 218       5.244 -11.711  10.028  1.00 19.35           C  
+ANISOU 1697  CG2 VAL A 218     1597   1978   3778   -166   -536   -245       C  
+ATOM   1698  N   SER A 219       2.844 -13.596   7.860  1.00 18.35           N  
+ANISOU 1698  N   SER A 219     2617   2005   2352    -21   -559    -47       N  
+ATOM   1699  CA  SER A 219       3.065 -14.929   7.296  1.00 18.68           C  
+ANISOU 1699  CA  SER A 219     2510   1941   2647   -290   -495   -198       C  
+ATOM   1700  C   SER A 219       4.544 -15.138   6.994  1.00 16.60           C  
+ANISOU 1700  C   SER A 219     2591   1396   2322   -362   -163    219       C  
+ATOM   1701  O   SER A 219       5.270 -14.161   6.931  1.00 18.01           O  
+ANISOU 1701  O   SER A 219     2763   1259   2823   -374   -252   -197       O  
+ATOM   1702  CB  SER A 219       2.275 -15.087   6.001  1.00 19.58           C  
+ANISOU 1702  CB  SER A 219     2845   1983   2613   -674   -531    -33       C  
+ATOM   1703  OG  SER A 219       2.801 -14.215   4.991  1.00 19.86           O  
+ANISOU 1703  OG  SER A 219     2658   2266   2621   -504    -78    -72       O  
+ATOM   1704  N   SER A 220       4.923 -16.393   6.857  1.00 17.40           N  
+ANISOU 1704  N   SER A 220     2562   1329   2721   -619    -48    -67       N  
+ATOM   1705  CA  SER A 220       6.268 -16.764   6.436  1.00 21.12           C  
+ANISOU 1705  CA  SER A 220     2897   1790   3336     42     41    242       C  
+ATOM   1706  C   SER A 220       6.575 -16.053   5.125  1.00 19.63           C  
+ANISOU 1706  C   SER A 220     2414   2330   2713    123    108   -277       C  
+ATOM   1707  O   SER A 220       7.689 -15.563   4.940  1.00 20.75           O  
+ANISOU 1707  O   SER A 220     2564   2210   3111   -116    -90     45       O  
+ATOM   1708  CB  SER A 220       6.411 -18.297   6.273  1.00 27.25           C  
+ANISOU 1708  CB  SER A 220     4816   1950   3587    580   -218   -376       C  
+ATOM   1709  OG  SER A 220       5.431 -18.705   5.321  1.00 48.53           O  
+ANISOU 1709  OG  SER A 220     5909   4852   7679  -1396  -1247  -2458       O  
+ATOM   1710  N   GLU A 221       5.567 -16.002   4.228  1.00 22.12           N  
+ANISOU 1710  N   GLU A 221     2912   2491   2999   -546   -276   -152       N  
+ATOM   1711  CA  GLU A 221       5.856 -15.360   2.944  1.00 18.93           C  
+ANISOU 1711  CA  GLU A 221     2022   2495   2675    -93    -39   -450       C  
+ATOM   1712  C   GLU A 221       6.200 -13.894   3.120  1.00 18.66           C  
+ANISOU 1712  C   GLU A 221     2476   2457   2155   -138   -180   -206       C  
+ATOM   1713  O   GLU A 221       7.072 -13.367   2.415  1.00 19.89           O  
+ANISOU 1713  O   GLU A 221     2556   2470   2532   -210     92   -444       O  
+ATOM   1714  CB  GLU A 221       4.660 -15.515   2.014  1.00 24.52           C  
+ANISOU 1714  CB  GLU A 221     3324   2697   3296    396  -1101  -1184       C  
+ATOM   1715  CG  GLU A 221       4.459 -16.976   1.616  1.00 27.78           C  
+ANISOU 1715  CG  GLU A 221     4425   2852   3278    143  -1018  -1373       C  
+ATOM   1716  CD  GLU A 221       3.406 -17.679   2.444  1.00 34.05           C  
+ANISOU 1716  CD  GLU A 221     5982   3064   3893   -527   -481  -1062       C  
+ATOM   1717  OE1 GLU A 221       2.923 -18.744   1.978  1.00 44.85           O  
+ANISOU 1717  OE1 GLU A 221     8705   3937   4401  -2100    394  -1527       O  
+ATOM   1718  OE2 GLU A 221       3.053 -17.221   3.542  1.00 34.95           O  
+ANISOU 1718  OE2 GLU A 221     6951   3087   3240  -1058   -367   -522       O  
+ATOM   1719  N   GLN A 222       5.512 -13.243   4.047  1.00 17.91           N  
+ANISOU 1719  N   GLN A 222     2168   2310   2325   -432   -169   -310       N  
+ATOM   1720  CA  GLN A 222       5.740 -11.823   4.235  1.00 16.34           C  
+ANISOU 1720  CA  GLN A 222     1944   2296   1967   -415    -49    -65       C  
+ATOM   1721  C   GLN A 222       7.142 -11.614   4.783  1.00 15.58           C  
+ANISOU 1721  C   GLN A 222     1886   2100   1934   -239     -5   -270       C  
+ATOM   1722  O   GLN A 222       7.909 -10.788   4.303  1.00 16.49           O  
+ANISOU 1722  O   GLN A 222     1937   2140   2188   -346    -42   -236       O  
+ATOM   1723  CB  GLN A 222       4.650 -11.247   5.126  1.00 17.38           C  
+ANISOU 1723  CB  GLN A 222     1819   2164   2619   -381     40   -116       C  
+ATOM   1724  CG  GLN A 222       3.317 -11.055   4.434  1.00 16.78           C  
+ANISOU 1724  CG  GLN A 222     1568   2159   2649   -979    109   -215       C  
+ATOM   1725  CD  GLN A 222       2.235 -10.554   5.376  1.00 16.92           C  
+ANISOU 1725  CD  GLN A 222     1763   2219   2448   -498   -247   -554       C  
+ATOM   1726  OE1 GLN A 222       2.108 -10.917   6.556  1.00 18.82           O  
+ANISOU 1726  OE1 GLN A 222     2092   2598   2462    249    -70   -419       O  
+ATOM   1727  NE2 GLN A 222       1.372  -9.693   4.849  1.00 18.81           N  
+ANISOU 1727  NE2 GLN A 222     2083   2356   2708   -428     30     45       N  
+ATOM   1728  N   VAL A 223       7.514 -12.358   5.821  1.00 17.15           N  
+ANISOU 1728  N   VAL A 223     2408   2007   2100   -281   -308   -239       N  
+ATOM   1729  CA  VAL A 223       8.863 -12.142   6.368  1.00 16.66           C  
+ANISOU 1729  CA  VAL A 223     2352   1882   2097    -65   -281   -367       C  
+ATOM   1730  C   VAL A 223       9.907 -12.590   5.347  1.00 18.51           C  
+ANISOU 1730  C   VAL A 223     2565   1829   2640      7     21   -395       C  
+ATOM   1731  O   VAL A 223      10.973 -11.981   5.321  1.00 18.50           O  
+ANISOU 1731  O   VAL A 223     2638   1946   2446    -71     40     97       O  
+ATOM   1732  CB  VAL A 223       9.088 -12.816   7.730  1.00 19.89           C  
+ANISOU 1732  CB  VAL A 223     2497   2590   2472   -410   -539    197       C  
+ATOM   1733  CG1 VAL A 223       9.182 -14.329   7.547  1.00 34.75           C  
+ANISOU 1733  CG1 VAL A 223     6607   2325   4272  -1071  -1744    792       C  
+ATOM   1734  CG2 VAL A 223      10.343 -12.306   8.399  1.00 23.50           C  
+ANISOU 1734  CG2 VAL A 223     2779   3584   2567   -964   -687    382       C  
+ATOM   1735  N   LEU A 224       9.635 -13.616   4.546  1.00 19.70           N  
+ANISOU 1735  N   LEU A 224     3165   1752   2568   -158    407   -369       N  
+ATOM   1736  CA  LEU A 224      10.632 -14.049   3.555  1.00 20.60           C  
+ANISOU 1736  CA  LEU A 224     3037   2158   2632   -456    397   -577       C  
+ATOM   1737  C   LEU A 224      10.969 -12.912   2.598  1.00 22.01           C  
+ANISOU 1737  C   LEU A 224     2921   2645   2797   -420    374   -204       C  
+ATOM   1738  O   LEU A 224      12.100 -12.812   2.147  1.00 21.88           O  
+ANISOU 1738  O   LEU A 224     2846   2811   2657   -279    219     36       O  
+ATOM   1739  CB  LEU A 224      10.163 -15.286   2.772  1.00 24.01           C  
+ANISOU 1739  CB  LEU A 224     3734   2015   3375    144     -9  -1003       C  
+ATOM   1740  CG  LEU A 224      10.314 -16.592   3.549  1.00 24.99           C  
+ANISOU 1740  CG  LEU A 224     3124   2349   4021  -1024    116   -310       C  
+ATOM   1741  CD1 LEU A 224       9.446 -17.695   2.932  1.00 37.04           C  
+ANISOU 1741  CD1 LEU A 224     5176   3565   5334  -2457  -1225    133       C  
+ATOM   1742  CD2 LEU A 224      11.765 -17.043   3.616  1.00 24.66           C  
+ANISOU 1742  CD2 LEU A 224     3572   2594   3206   -275   -130     44       C  
+ATOM   1743  N   LYS A 225       9.975 -12.079   2.296  1.00 19.66           N  
+ANISOU 1743  N   LYS A 225     2677   2745   2049   -553    133   -374       N  
+ATOM   1744  CA  LYS A 225      10.213 -10.952   1.411  1.00 19.32           C  
+ANISOU 1744  CA  LYS A 225     2680   2954   1706   -469    253   -357       C  
+ATOM   1745  C   LYS A 225      11.083  -9.895   2.079  1.00 20.12           C  
+ANISOU 1745  C   LYS A 225     3224   2683   1737   -562   -273     96       C  
+ATOM   1746  O   LYS A 225      11.875  -9.220   1.403  1.00 19.33           O  
+ANISOU 1746  O   LYS A 225     2542   2718   2084   -224     39   -112       O  
+ATOM   1747  CB  LYS A 225       8.871 -10.422   0.879  1.00 22.22           C  
+ANISOU 1747  CB  LYS A 225     2587   3562   2295   -797    153    370       C  
+ATOM   1748  CG  LYS A 225       8.330 -11.394  -0.177  1.00 28.83           C  
+ANISOU 1748  CG  LYS A 225     3338   3618   3999  -1529   -967    303       C  
+ATOM   1749  CD  LYS A 225       6.874 -11.279  -0.538  1.00 35.26           C  
+ANISOU 1749  CD  LYS A 225     3475   5712   4209   -686  -1072   -615       C  
+ATOM   1750  CE  LYS A 225       6.478 -12.081  -1.763  1.00 43.49           C  
+ANISOU 1750  CE  LYS A 225     4306   7706   4514   -951  -1703  -1193       C  
+ATOM   1751  NZ  LYS A 225       5.594 -11.308  -2.696  1.00 55.68           N  
+ANISOU 1751  NZ  LYS A 225     6525   9280   5350   2837  -2906  -3860       N  
+ATOM   1752  N   PHE A 226      11.006  -9.707   3.389  1.00 18.76           N  
+ANISOU 1752  N   PHE A 226     3006   2267   1855   -280   -174   -184       N  
+ATOM   1753  CA  PHE A 226      11.944  -8.845   4.104  1.00 15.54           C  
+ANISOU 1753  CA  PHE A 226     2844   1452   1608   -300    231     47       C  
+ATOM   1754  C   PHE A 226      13.372  -9.324   3.889  1.00 16.07           C  
+ANISOU 1754  C   PHE A 226     2850   1841   1416   -229    232   -219       C  
+ATOM   1755  O   PHE A 226      14.327  -8.543   3.691  1.00 17.52           O  
+ANISOU 1755  O   PHE A 226     2964   1808   1886   -162    587    -19       O  
+ATOM   1756  CB  PHE A 226      11.697  -8.864   5.610  1.00 14.87           C  
+ANISOU 1756  CB  PHE A 226     2531   1459   1659   -185    250    -34       C  
+ATOM   1757  CG  PHE A 226      10.509  -8.140   6.188  1.00 14.57           C  
+ANISOU 1757  CG  PHE A 226     2348   1491   1698   -189     96     17       C  
+ATOM   1758  CD1 PHE A 226       9.448  -7.737   5.420  1.00 19.37           C  
+ANISOU 1758  CD1 PHE A 226     2759   2559   2041    326    -68    106       C  
+ATOM   1759  CD2 PHE A 226      10.478  -7.888   7.551  1.00 18.72           C  
+ANISOU 1759  CD2 PHE A 226     2039   3242   1830      5    244   -347       C  
+ATOM   1760  CE1 PHE A 226       8.373  -7.098   6.001  1.00 19.72           C  
+ANISOU 1760  CE1 PHE A 226     2238   3157   2099     25     54    149       C  
+ATOM   1761  CE2 PHE A 226       9.427  -7.237   8.147  1.00 20.07           C  
+ANISOU 1761  CE2 PHE A 226     1643   3791   2192   -110    -92   -971       C  
+ATOM   1762  CZ  PHE A 226       8.387  -6.830   7.336  1.00 21.08           C  
+ANISOU 1762  CZ  PHE A 226     1810   3778   2423   -144   -167   -654       C  
+ATOM   1763  N   ARG A 227      13.534 -10.652   3.938  1.00 17.29           N  
+ANISOU 1763  N   ARG A 227     2410   1880   2281   -295    469   -155       N  
+ATOM   1764  CA  ARG A 227      14.886 -11.220   3.890  1.00 17.06           C  
+ANISOU 1764  CA  ARG A 227     2342   1890   2249   -362    326   -292       C  
+ATOM   1765  C   ARG A 227      15.453 -11.238   2.482  1.00 17.95           C  
+ANISOU 1765  C   ARG A 227     2454   2046   2321    -84    409   -281       C  
+ATOM   1766  O   ARG A 227      16.597 -11.675   2.276  1.00 18.94           O  
+ANISOU 1766  O   ARG A 227     2596   2161   2439     45    519   -125       O  
+ATOM   1767  CB  ARG A 227      14.913 -12.621   4.459  1.00 16.14           C  
+ANISOU 1767  CB  ARG A 227     2287   1821   2025   -411   -192   -443       C  
+ATOM   1768  CG  ARG A 227      14.273 -12.794   5.831  1.00 16.92           C  
+ANISOU 1768  CG  ARG A 227     2223   2100   2106    -63   -165    -10       C  
+ATOM   1769  CD  ARG A 227      14.488 -14.201   6.368  1.00 18.20           C  
+ANISOU 1769  CD  ARG A 227     2659   1811   2446   -249     50   -220       C  
+ATOM   1770  NE  ARG A 227      13.845 -14.404   7.665  1.00 16.83           N  
+ANISOU 1770  NE  ARG A 227     2496   1738   2160   -452   -321   -145       N  
+ATOM   1771  CZ  ARG A 227      12.902 -15.271   7.987  1.00 17.37           C  
+ANISOU 1771  CZ  ARG A 227     2941   1547   2112   -686   -375   -181       C  
+ATOM   1772  NH1 ARG A 227      12.369 -16.151   7.129  1.00 25.01           N  
+ANISOU 1772  NH1 ARG A 227     5172   1936   2394  -1653   -219   -422       N  
+ATOM   1773  NH2 ARG A 227      12.470 -15.248   9.252  1.00 17.12           N  
+ANISOU 1773  NH2 ARG A 227     2643   1479   2381   -542    -68   -355       N  
+ATOM   1774  N   LYS A 228      14.709 -10.764   1.504  1.00 16.88           N  
+ANISOU 1774  N   LYS A 228     2287   1914   2212   -509    230   -424       N  
+ATOM   1775  CA  LYS A 228      15.302 -10.649   0.177  1.00 19.59           C  
+ANISOU 1775  CA  LYS A 228     2926   2310   2206   -488    370   -466       C  
+ATOM   1776  C   LYS A 228      15.909  -9.284  -0.111  1.00 18.32           C  
+ANISOU 1776  C   LYS A 228     2457   2286   2217   -300    530   -317       C  
+ATOM   1777  O   LYS A 228      16.598  -9.061  -1.118  1.00 21.48           O  
+ANISOU 1777  O   LYS A 228     3169   2834   2158   -486    679   -317       O  
+ATOM   1778  CB  LYS A 228      14.250 -10.934  -0.892  1.00 20.38           C  
+ANISOU 1778  CB  LYS A 228     2807   2798   2137   -768    298     56       C  
+ATOM   1779  CG  LYS A 228      13.728 -12.343  -0.969  1.00 31.53           C  
+ANISOU 1779  CG  LYS A 228     4209   3731   4040  -2145    278   -522       C  
+ATOM   1780  CD  LYS A 228      12.595 -12.455  -2.000  1.00 39.07           C  
+ANISOU 1780  CD  LYS A 228     4841   5385   4620  -2060   -209  -1854       C  
+ATOM   1781  CE  LYS A 228      12.161 -13.896  -2.157  1.00 41.50           C  
+ANISOU 1781  CE  LYS A 228     5165   5365   5239  -1849    -84  -2620       C  
+ATOM   1782  NZ  LYS A 228      12.204 -14.683  -0.895  1.00 61.56           N  
+ANISOU 1782  NZ  LYS A 228     6928   7272   9190  -1569    978   1245       N  
+ATOM   1783  N   LEU A 229      15.674  -8.341   0.785  1.00 17.48           N  
+ANISOU 1783  N   LEU A 229     2593   1935   2112   -179    607     12       N  
+ATOM   1784  CA  LEU A 229      16.348  -7.051   0.703  1.00 18.23           C  
+ANISOU 1784  CA  LEU A 229     2985   1879   2063   -146    266    122       C  
+ATOM   1785  C   LEU A 229      17.853  -7.246   0.798  1.00 17.38           C  
+ANISOU 1785  C   LEU A 229     2968   1513   2121   -457    152   -460       C  
+ATOM   1786  O   LEU A 229      18.325  -8.292   1.236  1.00 17.87           O  
+ANISOU 1786  O   LEU A 229     2504   1545   2741   -331    566   -302       O  
+ATOM   1787  CB  LEU A 229      15.822  -6.170   1.830  1.00 20.77           C  
+ANISOU 1787  CB  LEU A 229     2905   2264   2721   -636    598   -442       C  
+ATOM   1788  CG  LEU A 229      14.385  -5.678   1.646  1.00 18.95           C  
+ANISOU 1788  CG  LEU A 229     2560   2615   2026   -874   1279     60       C  
+ATOM   1789  CD1 LEU A 229      13.898  -5.007   2.914  1.00 20.79           C  
+ANISOU 1789  CD1 LEU A 229     3236   2173   2491   -950   1066   -529       C  
+ATOM   1790  CD2 LEU A 229      14.281  -4.729   0.472  1.00 25.03           C  
+ANISOU 1790  CD2 LEU A 229     3146   3562   2801   -469   1179    866       C  
+ATOM   1791  N   ASN A 230      18.595  -6.212   0.427  1.00 19.25           N  
+ANISOU 1791  N   ASN A 230     3278   2001   2034   -436    652    102       N  
+ATOM   1792  CA  ASN A 230      20.036  -6.208   0.469  1.00 21.44           C  
+ANISOU 1792  CA  ASN A 230     3282   2757   2106   -877    730   -325       C  
+ATOM   1793  C   ASN A 230      20.567  -5.053   1.317  1.00 22.43           C  
+ANISOU 1793  C   ASN A 230     3335   2925   2264   -356    536   -753       C  
+ATOM   1794  O   ASN A 230      20.035  -3.945   1.317  1.00 20.81           O  
+ANISOU 1794  O   ASN A 230     3117   2781   2010   -558    678   -324       O  
+ATOM   1795  CB  ASN A 230      20.649  -6.014  -0.910  1.00 22.15           C  
+ANISOU 1795  CB  ASN A 230     3504   2827   2086   -943    821   -517       C  
+ATOM   1796  CG  ASN A 230      20.524  -7.168  -1.871  1.00 22.33           C  
+ANISOU 1796  CG  ASN A 230     3050   3040   2394  -1124    730   -770       C  
+ATOM   1797  OD1 ASN A 230      21.012  -7.074  -3.005  1.00 25.36           O  
+ANISOU 1797  OD1 ASN A 230     4591   2700   2345   -560   1007   -589       O  
+ATOM   1798  ND2 ASN A 230      19.908  -8.279  -1.547  1.00 24.84           N  
+ANISOU 1798  ND2 ASN A 230     3606   3171   2659  -1417    509   -686       N  
+ATOM   1799  N   PHE A 231      21.656  -5.363   2.017  1.00 19.79           N  
+ANISOU 1799  N   PHE A 231     2777   2402   2339   -777    905   -350       N  
+ATOM   1800  CA  PHE A 231      22.404  -4.356   2.754  1.00 21.37           C  
+ANISOU 1800  CA  PHE A 231     3375   2797   1947  -1022    887   -487       C  
+ATOM   1801  C   PHE A 231      23.311  -3.560   1.815  1.00 19.61           C  
+ANISOU 1801  C   PHE A 231     2562   2537   2352   -796    940   -702       C  
+ATOM   1802  O   PHE A 231      23.610  -2.400   2.080  1.00 23.10           O  
+ANISOU 1802  O   PHE A 231     3765   2666   2347  -1212    801   -705       O  
+ATOM   1803  CB  PHE A 231      23.341  -4.970   3.768  1.00 22.17           C  
+ANISOU 1803  CB  PHE A 231     2872   3183   2368  -1007    886   -455       C  
+ATOM   1804  CG  PHE A 231      22.835  -5.531   5.067  1.00 21.22           C  
+ANISOU 1804  CG  PHE A 231     2946   3183   1933   -753    583   -566       C  
+ATOM   1805  CD1 PHE A 231      22.083  -4.723   5.902  1.00 20.41           C  
+ANISOU 1805  CD1 PHE A 231     2102   3532   2123   -446    466   -309       C  
+ATOM   1806  CD2 PHE A 231      23.126  -6.832   5.431  1.00 21.38           C  
+ANISOU 1806  CD2 PHE A 231     2758   3083   2282   -907    892   -539       C  
+ATOM   1807  CE1 PHE A 231      21.646  -5.233   7.117  1.00 21.08           C  
+ANISOU 1807  CE1 PHE A 231     2682   3152   2175   -605    704   -498       C  
+ATOM   1808  CE2 PHE A 231      22.697  -7.343   6.638  1.00 21.41           C  
+ANISOU 1808  CE2 PHE A 231     3181   2996   1959   -713    761   -658       C  
+ATOM   1809  CZ  PHE A 231      21.946  -6.536   7.473  1.00 19.32           C  
+ANISOU 1809  CZ  PHE A 231     2578   2993   1771   -774    302   -773       C  
+ATOM   1810  N   ASN A 232      23.759  -4.244   0.776  1.00 22.40           N  
+ANISOU 1810  N   ASN A 232     3238   2660   2613   -768   1400   -727       N  
+ATOM   1811  CA  ASN A 232      24.664  -3.618  -0.176  1.00 24.32           C  
+ANISOU 1811  CA  ASN A 232     2908   3766   2568   -751   1238   -410       C  
+ATOM   1812  C   ASN A 232      23.912  -2.688  -1.115  1.00 24.55           C  
+ANISOU 1812  C   ASN A 232     2979   3808   2542   -685   1415   -334       C  
+ATOM   1813  O   ASN A 232      22.696  -2.719  -1.264  1.00 23.09           O  
+ANISOU 1813  O   ASN A 232     3075   3476   2222   -906   1040   -508       O  
+ATOM   1814  CB  ASN A 232      25.411  -4.714  -0.958  1.00 23.43           C  
+ANISOU 1814  CB  ASN A 232     2145   3667   3089  -1102   1326   -514       C  
+ATOM   1815  CG  ASN A 232      24.433  -5.704  -1.547  1.00 21.34           C  
+ANISOU 1815  CG  ASN A 232     1983   3603   2521   -941   1104   -211       C  
+ATOM   1816  OD1 ASN A 232      23.880  -6.517  -0.808  1.00 24.16           O  
+ANISOU 1816  OD1 ASN A 232     3211   3326   2644  -1402   1543   -650       O  
+ATOM   1817  ND2 ASN A 232      24.221  -5.594  -2.840  1.00 28.68           N  
+ANISOU 1817  ND2 ASN A 232     3634   4439   2823  -1058    282    370       N  
+ATOM   1818  N   GLY A 233      24.746  -1.868  -1.745  1.00 24.17           N  
+ANISOU 1818  N   GLY A 233     3192   3317   2673   -789   1526   -596       N  
+ATOM   1819  CA  GLY A 233      24.382  -1.061  -2.878  1.00 27.13           C  
+ANISOU 1819  CA  GLY A 233     4185   3647   2476   -959   1396   -535       C  
+ATOM   1820  C   GLY A 233      24.234  -1.844  -4.175  1.00 28.96           C  
+ANISOU 1820  C   GLY A 233     4436   3870   2697  -1021   1312   -777       C  
+ATOM   1821  O   GLY A 233      24.771  -2.931  -4.321  1.00 29.82           O  
+ANISOU 1821  O   GLY A 233     4004   3959   3368  -1133   1858  -1022       O  
+ATOM   1822  N   GLU A 234      23.487  -1.259  -5.112  1.00 31.26           N  
+ANISOU 1822  N   GLU A 234     4860   4109   2910  -1574    789   -569       N  
+ATOM   1823  CA  GLU A 234      23.294  -1.831  -6.422  1.00 31.53           C  
+ANISOU 1823  CA  GLU A 234     4455   4856   2667  -1858   1295   -630       C  
+ATOM   1824  C   GLU A 234      24.665  -2.063  -7.059  1.00 36.86           C  
+ANISOU 1824  C   GLU A 234     4395   5596   4013  -1944   1446  -1255       C  
+ATOM   1825  O   GLU A 234      25.570  -1.230  -6.931  1.00 36.03           O  
+ANISOU 1825  O   GLU A 234     4601   5798   3290  -2178   1482   -899       O  
+ATOM   1826  CB  GLU A 234      22.419  -0.921  -7.298  1.00 35.85           C  
+ANISOU 1826  CB  GLU A 234     4615   6070   2937  -1858    907   -134       C  
+ATOM   1827  CG  GLU A 234      22.072  -1.569  -8.637  1.00 38.66           C  
+ANISOU 1827  CG  GLU A 234     5079   6870   2742  -2189   1057   -129       C  
+ATOM   1828  CD  GLU A 234      21.267  -0.704  -9.575  1.00 42.92           C  
+ANISOU 1828  CD  GLU A 234     4840   7823   3644  -1271     73   -970       C  
+ATOM   1829  OE1 GLU A 234      20.886   0.425  -9.191  1.00 43.53           O  
+ANISOU 1829  OE1 GLU A 234     4306   7472   4759  -1561   1600   -322       O  
+ATOM   1830  OE2 GLU A 234      21.006  -1.134 -10.724  1.00 47.17           O  
+ANISOU 1830  OE2 GLU A 234     3274  10836   3814   -609    -58  -1657       O  
+ATOM   1831  N   GLY A 235      24.780  -3.209  -7.730  1.00 36.26           N  
+ANISOU 1831  N   GLY A 235     4255   5079   4442  -1460   1451   -843       N  
+ATOM   1832  CA  GLY A 235      25.991  -3.624  -8.404  1.00 38.65           C  
+ANISOU 1832  CA  GLY A 235     4430   5620   4635   -724   1451   -314       C  
+ATOM   1833  C   GLY A 235      27.145  -3.949  -7.468  1.00 38.21           C  
+ANISOU 1833  C   GLY A 235     4079   6360   4079  -1555   1516   -471       C  
+ATOM   1834  O   GLY A 235      28.291  -4.009  -7.922  1.00 44.37           O  
+ANISOU 1834  O   GLY A 235     4362   9508   2989   -673   1572   -373       O  
+ATOM   1835  N   GLU A 236      26.841  -4.168  -6.197  1.00 34.38           N  
+ANISOU 1835  N   GLU A 236     3197   5911   3954  -1763   1672  -1272       N  
+ATOM   1836  CA  GLU A 236      27.809  -4.649  -5.216  1.00 37.35           C  
+ANISOU 1836  CA  GLU A 236     3951   6590   3649  -1520   1609  -1070       C  
+ATOM   1837  C   GLU A 236      27.485  -6.114  -4.912  1.00 36.32           C  
+ANISOU 1837  C   GLU A 236     3952   6316   3532   -906   2234  -1274       C  
+ATOM   1838  O   GLU A 236      26.344  -6.499  -5.206  1.00 35.31           O  
+ANISOU 1838  O   GLU A 236     4702   5426   3287  -1107    828    433       O  
+ATOM   1839  CB  GLU A 236      27.789  -3.814  -3.937  1.00 39.18           C  
+ANISOU 1839  CB  GLU A 236     4434   6468   3984  -1375   1335  -1290       C  
+ATOM   1840  CG  GLU A 236      28.402  -2.434  -3.995  1.00 46.34           C  
+ANISOU 1840  CG  GLU A 236     5706   6656   5247  -1939    229  -1095       C  
+ATOM   1841  CD  GLU A 236      28.004  -1.504  -2.872  1.00 45.14           C  
+ANISOU 1841  CD  GLU A 236     6247   5823   5082  -2400    763   -614       C  
+ATOM   1842  OE1 GLU A 236      27.956  -0.274  -3.122  1.00 46.94           O  
+ANISOU 1842  OE1 GLU A 236     6550   5941   5346  -2566   1899   -233       O  
+ATOM   1843  OE2 GLU A 236      27.741  -1.938  -1.726  1.00 44.16           O  
+ANISOU 1843  OE2 GLU A 236     5243   5634   5900   -952   1783     71       O  
+ATOM   1844  N   PRO A 237      28.423  -6.880  -4.381  1.00 36.36           N  
+ANISOU 1844  N   PRO A 237     3607   6617   3592  -1506   1669  -1048       N  
+ATOM   1845  CA  PRO A 237      28.179  -8.258  -3.948  1.00 35.49           C  
+ANISOU 1845  CA  PRO A 237     3115   6525   3845  -1384   1330  -1022       C  
+ATOM   1846  C   PRO A 237      26.999  -8.312  -2.973  1.00 29.12           C  
+ANISOU 1846  C   PRO A 237     2919   4947   3197   -835    978  -1068       C  
+ATOM   1847  O   PRO A 237      26.889  -7.549  -2.039  1.00 31.73           O  
+ANISOU 1847  O   PRO A 237     4177   4263   3615  -1396   1285  -1085       O  
+ATOM   1848  CB  PRO A 237      29.446  -8.669  -3.196  1.00 37.15           C  
+ANISOU 1848  CB  PRO A 237     2760   6904   4452  -1452   1417   -972       C  
+ATOM   1849  CG  PRO A 237      30.491  -7.863  -3.923  1.00 40.69           C  
+ANISOU 1849  CG  PRO A 237     3322   7123   5017  -2042   1077   -414       C  
+ATOM   1850  CD  PRO A 237      29.841  -6.520  -4.159  1.00 39.12           C  
+ANISOU 1850  CD  PRO A 237     3531   6914   4418  -1706   2255  -1191       C  
+ATOM   1851  N   GLU A 238      26.134  -9.273  -3.261  1.00 24.18           N  
+ANISOU 1851  N   GLU A 238     2392   3997   2797    -87    999  -1038       N  
+ATOM   1852  CA  GLU A 238      24.911  -9.379  -2.511  1.00 22.88           C  
+ANISOU 1852  CA  GLU A 238     2290   3639   2764     73    906  -1214       C  
+ATOM   1853  C   GLU A 238      25.139  -9.887  -1.084  1.00 26.66           C  
+ANISOU 1853  C   GLU A 238     2611   4656   2863     75   1088   -804       C  
+ATOM   1854  O   GLU A 238      25.708 -10.950  -0.866  1.00 25.24           O  
+ANISOU 1854  O   GLU A 238     2230   4607   2753   -190    401   -896       O  
+ATOM   1855  CB  GLU A 238      23.900 -10.306  -3.201  1.00 26.85           C  
+ANISOU 1855  CB  GLU A 238     2855   3229   4117   -419   -172    -82       C  
+ATOM   1856  CG  GLU A 238      22.568 -10.385  -2.457  1.00 27.82           C  
+ANISOU 1856  CG  GLU A 238     3264   3118   4191   -915    188   -461       C  
+ATOM   1857  CD  GLU A 238      21.472 -11.024  -3.281  1.00 25.74           C  
+ANISOU 1857  CD  GLU A 238     2849   2705   4227   -386    598  -1204       C  
+ATOM   1858  OE1 GLU A 238      21.793 -11.993  -4.017  1.00 38.08           O  
+ANISOU 1858  OE1 GLU A 238     5066   4035   5368   1788  -1240  -2344       O  
+ATOM   1859  OE2 GLU A 238      20.309 -10.563  -3.216  1.00 23.19           O  
+ANISOU 1859  OE2 GLU A 238     2981   2940   2891    -75    647   -219       O  
+ATOM   1860  N   GLU A 239      24.653  -9.096  -0.140  1.00 26.13           N  
+ANISOU 1860  N   GLU A 239     3018   4251   2658   -527   1124   -846       N  
+ATOM   1861  CA  GLU A 239      24.587  -9.379   1.258  1.00 24.02           C  
+ANISOU 1861  CA  GLU A 239     2630   3790   2708   -901    920   -818       C  
+ATOM   1862  C   GLU A 239      23.137  -9.221   1.716  1.00 20.72           C  
+ANISOU 1862  C   GLU A 239     2643   2724   2504   -690    880   -868       C  
+ATOM   1863  O   GLU A 239      22.611  -8.104   1.752  1.00 24.79           O  
+ANISOU 1863  O   GLU A 239     3550   2512   3356   -698   1274   -675       O  
+ATOM   1864  CB  GLU A 239      25.448  -8.389   2.039  1.00 32.41           C  
+ANISOU 1864  CB  GLU A 239     3039   5526   3752  -1483    263  -1407       C  
+ATOM   1865  CG  GLU A 239      26.915  -8.548   1.672  1.00 45.24           C  
+ANISOU 1865  CG  GLU A 239     2546   8240   6404   -415  -1001  -2497       C  
+ATOM   1866  CD  GLU A 239      27.612  -9.431   2.707  1.00 58.83           C  
+ANISOU 1866  CD  GLU A 239     5516   8561   8277    104  -3886  -3107       C  
+ATOM   1867  OE1 GLU A 239      28.350  -8.859   3.528  1.00 64.89           O  
+ANISOU 1867  OE1 GLU A 239     4386  10882   9387   1998  -3965  -5696       O  
+ATOM   1868  OE2 GLU A 239      27.390 -10.662   2.672  1.00 86.63           O  
+ANISOU 1868  OE2 GLU A 239    12140   7947  12830   1129  -7488  -2928       O  
+ATOM   1869  N   LEU A 240      22.503 -10.346   2.025  1.00 20.79           N  
+ANISOU 1869  N   LEU A 240     2491   2575   2833   -246   1046   -444       N  
+ATOM   1870  CA  LEU A 240      21.088 -10.261   2.344  1.00 19.32           C  
+ANISOU 1870  CA  LEU A 240     2081   2651   2608   -572    227   -943       C  
+ATOM   1871  C   LEU A 240      20.939  -9.472   3.648  1.00 16.49           C  
+ANISOU 1871  C   LEU A 240     1672   2432   2162   -651    459   -478       C  
+ATOM   1872  O   LEU A 240      21.726  -9.613   4.591  1.00 19.02           O  
+ANISOU 1872  O   LEU A 240     2587   2478   2163    -27    105   -316       O  
+ATOM   1873  CB  LEU A 240      20.482 -11.639   2.483  1.00 17.80           C  
+ANISOU 1873  CB  LEU A 240     1599   2262   2902     10   -471   -595       C  
+ATOM   1874  CG  LEU A 240      20.334 -12.498   1.226  1.00 20.88           C  
+ANISOU 1874  CG  LEU A 240     2512   2358   3065   -290   -266   -805       C  
+ATOM   1875  CD1 LEU A 240      19.642 -13.805   1.542  1.00 27.04           C  
+ANISOU 1875  CD1 LEU A 240     4044   1804   4427   -243   -524   -563       C  
+ATOM   1876  CD2 LEU A 240      19.568 -11.735   0.170  1.00 22.86           C  
+ANISOU 1876  CD2 LEU A 240     3791   3050   1845   -105    383   -454       C  
+ATOM   1877  N   MET A 241      19.901  -8.641   3.604  1.00 17.77           N  
+ANISOU 1877  N   MET A 241     2278   2739   1733   -176    312   -321       N  
+ATOM   1878  CA  MET A 241      19.514  -7.832   4.753  1.00 16.28           C  
+ANISOU 1878  CA  MET A 241     2093   2612   1481   -368    404   -242       C  
+ATOM   1879  C   MET A 241      18.712  -8.716   5.711  1.00 17.11           C  
+ANISOU 1879  C   MET A 241     1964   2597   1941   -302    403    -20       C  
+ATOM   1880  O   MET A 241      17.489  -8.831   5.589  1.00 17.25           O  
+ANISOU 1880  O   MET A 241     1930   2253   2370   -315    388   -258       O  
+ATOM   1881  CB  MET A 241      18.720  -6.595   4.361  1.00 19.17           C  
+ANISOU 1881  CB  MET A 241     2652   2591   2040   -188    829    -29       C  
+ATOM   1882  CG  MET A 241      18.389  -5.678   5.541  1.00 21.33           C  
+ANISOU 1882  CG  MET A 241     3960   1801   2342   -497    341   -259       C  
+ATOM   1883  SD  MET A 241      17.432  -4.248   5.043  1.00 20.42           S  
+ANISOU 1883  SD  MET A 241     3341   1996   2423   -561    696   -111       S  
+ATOM   1884  CE  MET A 241      18.775  -3.185   4.499  1.00 22.16           C  
+ANISOU 1884  CE  MET A 241     3651   1674   3093   -480   1303   -337       C  
+ATOM   1885  N   VAL A 242      19.483  -9.307   6.618  1.00 16.92           N  
+ANISOU 1885  N   VAL A 242     2245   2148   2036   -595     59   -111       N  
+ATOM   1886  CA  VAL A 242      18.947 -10.190   7.663  1.00 16.06           C  
+ANISOU 1886  CA  VAL A 242     2353   1861   1890   -119    351   -311       C  
+ATOM   1887  C   VAL A 242      19.733  -9.949   8.954  1.00 15.25           C  
+ANISOU 1887  C   VAL A 242     2035   1798   1960   -319    436   -284       C  
+ATOM   1888  O   VAL A 242      20.907  -9.553   8.937  1.00 17.54           O  
+ANISOU 1888  O   VAL A 242     2100   2134   2431   -581    594   -374       O  
+ATOM   1889  CB  VAL A 242      18.973 -11.692   7.292  1.00 16.11           C  
+ANISOU 1889  CB  VAL A 242     2434   1956   1730   -420    910   -480       C  
+ATOM   1890  CG1 VAL A 242      18.115 -11.974   6.069  1.00 17.12           C  
+ANISOU 1890  CG1 VAL A 242     2981   1741   1781   -293    617   -317       C  
+ATOM   1891  CG2 VAL A 242      20.400 -12.165   7.085  1.00 18.32           C  
+ANISOU 1891  CG2 VAL A 242     2733   2062   2167    113    895    -52       C  
+ATOM   1892  N   ASP A 243      19.106 -10.217  10.091  1.00 14.85           N  
+ANISOU 1892  N   ASP A 243     1930   1858   1852   -213    367   -208       N  
+ATOM   1893  CA  ASP A 243      19.719 -10.086  11.405  1.00 13.73           C  
+ANISOU 1893  CA  ASP A 243     1525   1674   2017   -206    247   -336       C  
+ATOM   1894  C   ASP A 243      20.260  -8.673  11.647  1.00 13.36           C  
+ANISOU 1894  C   ASP A 243     1242   1695   2139   -398    360     73       C  
+ATOM   1895  O   ASP A 243      21.347  -8.463  12.177  1.00 17.51           O  
+ANISOU 1895  O   ASP A 243     1360   2329   2963   -285     45   -554       O  
+ATOM   1896  CB  ASP A 243      20.780 -11.171  11.538  1.00 14.70           C  
+ANISOU 1896  CB  ASP A 243     1543   1918   2124      8    497   -398       C  
+ATOM   1897  CG  ASP A 243      20.189 -12.561  11.623  1.00 16.05           C  
+ANISOU 1897  CG  ASP A 243     1885   1781   2431     64    573   -235       C  
+ATOM   1898  OD1 ASP A 243      19.140 -12.704  12.279  1.00 15.34           O  
+ANISOU 1898  OD1 ASP A 243     1799   1844   2184    -67    363   -312       O  
+ATOM   1899  OD2 ASP A 243      20.787 -13.500  11.041  1.00 18.58           O  
+ANISOU 1899  OD2 ASP A 243     1614   2035   3409    176    344   -675       O  
+ATOM   1900  N   ASN A 244      19.409  -7.717  11.279  1.00 14.36           N  
+ANISOU 1900  N   ASN A 244     2000   1779   1675     91    192   -256       N  
+ATOM   1901  CA  ASN A 244      19.688  -6.305  11.530  1.00 13.60           C  
+ANISOU 1901  CA  ASN A 244     1540   1779   1848    -70    537   -146       C  
+ATOM   1902  C   ASN A 244      19.090  -5.871  12.861  1.00 12.80           C  
+ANISOU 1902  C   ASN A 244     1706   1429   1730    -77    380    -70       C  
+ATOM   1903  O   ASN A 244      18.388  -4.861  12.919  1.00 14.46           O  
+ANISOU 1903  O   ASN A 244     2082   1686   1728    266    274   -208       O  
+ATOM   1904  CB  ASN A 244      19.137  -5.489  10.361  1.00 14.12           C  
+ANISOU 1904  CB  ASN A 244     1709   1908   1748    220    792   -125       C  
+ATOM   1905  CG  ASN A 244      17.644  -5.637  10.138  1.00 15.86           C  
+ANISOU 1905  CG  ASN A 244     1971   2477   1578   -291    178   -163       C  
+ATOM   1906  OD1 ASN A 244      16.983  -6.496  10.712  1.00 16.50           O  
+ANISOU 1906  OD1 ASN A 244     1790   1969   2512   -181     46    -95       O  
+ATOM   1907  ND2 ASN A 244      17.111  -4.768   9.299  1.00 19.96           N  
+ANISOU 1907  ND2 ASN A 244     2033   3240   2311   -894   -371    576       N  
+ATOM   1908  N   TRP A 245      19.342  -6.641  13.914  1.00 13.93           N  
+ANISOU 1908  N   TRP A 245     1749   1780   1763     -6    181     22       N  
+ATOM   1909  CA  TRP A 245      18.914  -6.374  15.270  1.00 12.61           C  
+ANISOU 1909  CA  TRP A 245     1737   1322   1732   -157    132     89       C  
+ATOM   1910  C   TRP A 245      20.130  -6.308  16.206  1.00 12.75           C  
+ANISOU 1910  C   TRP A 245     1308   1876   1661   -204    454    -28       C  
+ATOM   1911  O   TRP A 245      21.110  -7.041  16.010  1.00 16.13           O  
+ANISOU 1911  O   TRP A 245     1759   2194   2176    220     90   -581       O  
+ATOM   1912  CB  TRP A 245      17.959  -7.451  15.799  1.00 13.26           C  
+ANISOU 1912  CB  TRP A 245     1675   1393   1970   -283    -31    220       C  
+ATOM   1913  CG  TRP A 245      18.396  -8.875  15.628  1.00 13.71           C  
+ANISOU 1913  CG  TRP A 245     1766   1444   1998   -236    115    180       C  
+ATOM   1914  CD1 TRP A 245      18.284  -9.624  14.485  1.00 13.65           C  
+ANISOU 1914  CD1 TRP A 245     1703   1612   1872   -112    367    158       C  
+ATOM   1915  CD2 TRP A 245      18.993  -9.754  16.583  1.00 15.54           C  
+ANISOU 1915  CD2 TRP A 245     2533   1489   1882     60    213    222       C  
+ATOM   1916  NE1 TRP A 245      18.771 -10.897  14.652  1.00 14.74           N  
+ANISOU 1916  NE1 TRP A 245     2211   1614   1775     29    482    213       N  
+ATOM   1917  CE2 TRP A 245      19.220 -10.999  15.956  1.00 14.31           C  
+ANISOU 1917  CE2 TRP A 245     1951   1513   1972   -138    240    178       C  
+ATOM   1918  CE3 TRP A 245      19.366  -9.598  17.920  1.00 19.99           C  
+ANISOU 1918  CE3 TRP A 245     3349   1893   2352    288   -708   -121       C  
+ATOM   1919  CZ2 TRP A 245      19.795 -12.051  16.640  1.00 15.12           C  
+ANISOU 1919  CZ2 TRP A 245     1981   1592   2171    101    290    221       C  
+ATOM   1920  CZ3 TRP A 245      19.942 -10.654  18.606  1.00 17.84           C  
+ANISOU 1920  CZ3 TRP A 245     2286   2227   2265    312   -361     47       C  
+ATOM   1921  CH2 TRP A 245      20.141 -11.865  17.946  1.00 16.68           C  
+ANISOU 1921  CH2 TRP A 245     2183   1995   2159    218    195    370       C  
+ATOM   1922  N   ARG A 246      20.040  -5.421  17.175  1.00 12.52           N  
+ANISOU 1922  N   ARG A 246     1286   1764   1705   -138    279    -38       N  
+ATOM   1923  CA  ARG A 246      20.972  -5.317  18.286  1.00 13.15           C  
+ANISOU 1923  CA  ARG A 246     1328   1617   2051     57      9    -65       C  
+ATOM   1924  C   ARG A 246      20.455  -6.234  19.394  1.00 13.91           C  
+ANISOU 1924  C   ARG A 246     1451   1999   1836    -72   -150     21       C  
+ATOM   1925  O   ARG A 246      19.270  -6.240  19.684  1.00 14.59           O  
+ANISOU 1925  O   ARG A 246     1556   2008   1978      5    178    -36       O  
+ATOM   1926  CB  ARG A 246      21.083  -3.891  18.818  1.00 14.23           C  
+ANISOU 1926  CB  ARG A 246     1604   1813   1991    -24    104   -258       C  
+ATOM   1927  CG  ARG A 246      22.208  -3.654  19.797  1.00 15.02           C  
+ANISOU 1927  CG  ARG A 246     1649   1900   2159     32    -39   -325       C  
+ATOM   1928  CD  ARG A 246      22.047  -2.277  20.439  1.00 15.52           C  
+ANISOU 1928  CD  ARG A 246     1397   1912   2588   -287     91   -427       C  
+ATOM   1929  NE  ARG A 246      23.329  -1.930  21.052  1.00 15.17           N  
+ANISOU 1929  NE  ARG A 246     1008   2027   2729    -87    291   -535       N  
+ATOM   1930  CZ  ARG A 246      23.524  -0.963  21.936  1.00 15.07           C  
+ANISOU 1930  CZ  ARG A 246     1438   2457   1831    182   -125   -343       C  
+ATOM   1931  NH1 ARG A 246      22.524  -0.187  22.358  1.00 16.32           N  
+ANISOU 1931  NH1 ARG A 246     1731   2224   2244    260     54   -514       N  
+ATOM   1932  NH2 ARG A 246      24.744  -0.734  22.408  1.00 17.94           N  
+ANISOU 1932  NH2 ARG A 246     1644   2832   2341    260   -523   -466       N  
+ATOM   1933  N   PRO A 247      21.363  -6.973  20.025  1.00 15.78           N  
+ANISOU 1933  N   PRO A 247     1728   2139   2130    285     75    152       N  
+ATOM   1934  CA  PRO A 247      20.943  -7.796  21.159  1.00 14.99           C  
+ANISOU 1934  CA  PRO A 247     1845   2051   1800    227   -261     17       C  
+ATOM   1935  C   PRO A 247      20.631  -6.946  22.397  1.00 13.36           C  
+ANISOU 1935  C   PRO A 247     1246   1852   1979    160   -193     59       C  
+ATOM   1936  O   PRO A 247      20.955  -5.781  22.490  1.00 15.23           O  
+ANISOU 1936  O   PRO A 247     1394   1914   2478     24    245   -125       O  
+ATOM   1937  CB  PRO A 247      22.147  -8.681  21.413  1.00 20.53           C  
+ANISOU 1937  CB  PRO A 247     2383   2642   2774   1042    614    504       C  
+ATOM   1938  CG  PRO A 247      23.305  -8.024  20.753  1.00 24.02           C  
+ANISOU 1938  CG  PRO A 247     2096   2815   4217    937    371   1155       C  
+ATOM   1939  CD  PRO A 247      22.783  -7.074  19.734  1.00 16.63           C  
+ANISOU 1939  CD  PRO A 247     1717   2053   2548    392     42    -17       C  
+ATOM   1940  N   ALA A 248      19.983  -7.624  23.350  1.00 15.73           N  
+ANISOU 1940  N   ALA A 248     2113   1894   1970    -33     90    -77       N  
+ATOM   1941  CA  ALA A 248      19.608  -7.026  24.619  1.00 13.70           C  
+ANISOU 1941  CA  ALA A 248     1682   1634   1890    390   -192     44       C  
+ATOM   1942  C   ALA A 248      20.833  -6.492  25.338  1.00 13.49           C  
+ANISOU 1942  C   ALA A 248     1285   1998   1841    407    152   -153       C  
+ATOM   1943  O   ALA A 248      21.889  -7.135  25.337  1.00 17.39           O  
+ANISOU 1943  O   ALA A 248     1612   2123   2872    627   -211   -391       O  
+ATOM   1944  CB  ALA A 248      18.884  -8.031  25.503  1.00 17.56           C  
+ANISOU 1944  CB  ALA A 248     1537   2857   2277    -49    237    204       C  
+ATOM   1945  N   GLN A 249      20.635  -5.333  25.931  1.00 13.69           N  
+ANISOU 1945  N   GLN A 249     1120   1793   2288    149    187   -152       N  
+ATOM   1946  CA  GLN A 249      21.694  -4.610  26.650  1.00 15.88           C  
+ANISOU 1946  CA  GLN A 249     1809   2076   2147   -120   -195     99       C  
+ATOM   1947  C   GLN A 249      21.427  -4.587  28.143  1.00 15.77           C  
+ANISOU 1947  C   GLN A 249     1625   2200   2168    301   -191    182       C  
+ATOM   1948  O   GLN A 249      20.295  -4.858  28.562  1.00 17.49           O  
+ANISOU 1948  O   GLN A 249     1785   2274   2586    249    168    -77       O  
+ATOM   1949  CB  GLN A 249      21.761  -3.185  26.080  1.00 15.59           C  
+ANISOU 1949  CB  GLN A 249     1310   2120   2494   -225    -14    232       C  
+ATOM   1950  CG  GLN A 249      22.042  -3.093  24.588  1.00 16.43           C  
+ANISOU 1950  CG  GLN A 249     1456   2370   2415   -360   -138    353       C  
+ATOM   1951  CD  GLN A 249      23.380  -3.732  24.253  1.00 16.11           C  
+ANISOU 1951  CD  GLN A 249     1601   2171   2351   -467     12    -81       C  
+ATOM   1952  OE1 GLN A 249      24.404  -3.354  24.847  1.00 17.63           O  
+ANISOU 1952  OE1 GLN A 249     1414   2537   2748   -250     -3   -323       O  
+ATOM   1953  NE2 GLN A 249      23.363  -4.677  23.312  1.00 20.01           N  
+ANISOU 1953  NE2 GLN A 249     2796   2389   2417   -139   -395   -222       N  
+ATOM   1954  N   PRO A 250      22.439  -4.299  28.932  1.00 18.38           N  
+ANISOU 1954  N   PRO A 250     2079   2660   2245     50   -438      9       N  
+ATOM   1955  CA  PRO A 250      22.244  -4.332  30.380  1.00 20.53           C  
+ANISOU 1955  CA  PRO A 250     2357   3187   2257    876   -459     77       C  
+ATOM   1956  C   PRO A 250      21.182  -3.357  30.864  1.00 18.64           C  
+ANISOU 1956  C   PRO A 250     1741   2658   2682    206   -414   -210       C  
+ATOM   1957  O   PRO A 250      21.207  -2.205  30.433  1.00 19.11           O  
+ANISOU 1957  O   PRO A 250     1701   3054   2506    600    129    287       O  
+ATOM   1958  CB  PRO A 250      23.598  -3.870  30.918  1.00 21.81           C  
+ANISOU 1958  CB  PRO A 250     2323   3481   2481   1664   -968   -494       C  
+ATOM   1959  CG  PRO A 250      24.580  -4.269  29.839  1.00 23.36           C  
+ANISOU 1959  CG  PRO A 250     2214   3988   2674    881   -671   -559       C  
+ATOM   1960  CD  PRO A 250      23.829  -3.978  28.552  1.00 20.69           C  
+ANISOU 1960  CD  PRO A 250     1984   3378   2499   -167   -591   -284       C  
+ATOM   1961  N   LEU A 251      20.302  -3.821  31.747  1.00 19.98           N  
+ANISOU 1961  N   LEU A 251     2891   2150   2550    444     86    -80       N  
+ATOM   1962  CA  LEU A 251      19.217  -2.987  32.245  1.00 18.08           C  
+ANISOU 1962  CA  LEU A 251     2720   2240   1909    293     -1   -104       C  
+ATOM   1963  C   LEU A 251      19.746  -1.906  33.180  1.00 18.37           C  
+ANISOU 1963  C   LEU A 251     3197   2231   1552    671   -607    100       C  
+ATOM   1964  O   LEU A 251      19.146  -0.834  33.250  1.00 17.38           O  
+ANISOU 1964  O   LEU A 251     2209   2049   2345    199   -655    -55       O  
+ATOM   1965  CB  LEU A 251      18.183  -3.840  32.966  1.00 21.06           C  
+ANISOU 1965  CB  LEU A 251     3105   2776   2123    232    103    436       C  
+ATOM   1966  CG  LEU A 251      16.915  -3.180  33.477  1.00 21.92           C  
+ANISOU 1966  CG  LEU A 251     3379   2658   2292   -115    628    -79       C  
+ATOM   1967  CD1 LEU A 251      16.098  -2.524  32.373  1.00 22.95           C  
+ANISOU 1967  CD1 LEU A 251     3173   2031   3516    288    126   -228       C  
+ATOM   1968  CD2 LEU A 251      16.011  -4.195  34.175  1.00 28.09           C  
+ANISOU 1968  CD2 LEU A 251     3085   2913   4676   -131    593    797       C  
+ATOM   1969  N   LYS A 252      20.835  -2.218  33.870  1.00 19.32           N  
+ANISOU 1969  N   LYS A 252     2785   2362   2193    624   -530    167       N  
+ATOM   1970  CA  LYS A 252      21.417  -1.248  34.821  1.00 21.67           C  
+ANISOU 1970  CA  LYS A 252     2803   3133   2299    564   -632   -182       C  
+ATOM   1971  C   LYS A 252      20.371  -0.641  35.748  1.00 22.70           C  
+ANISOU 1971  C   LYS A 252     3112   3477   2037    565   -532   -235       C  
+ATOM   1972  O   LYS A 252      19.587  -1.427  36.288  1.00 24.34           O  
+ANISOU 1972  O   LYS A 252     3326   3186   2735    859   -132     81       O  
+ATOM   1973  CB  LYS A 252      22.224  -0.211  34.026  1.00 22.97           C  
+ANISOU 1973  CB  LYS A 252     3336   2880   2510    159   -207   -834       C  
+ATOM   1974  CG  LYS A 252      23.359  -0.912  33.291  1.00 26.14           C  
+ANISOU 1974  CG  LYS A 252     4424   2938   2571     44    563  -1270       C  
+ATOM   1975  CD  LYS A 252      24.365   0.051  32.722  1.00 28.27           C  
+ANISOU 1975  CD  LYS A 252     3467   3250   4023   -208    374  -1744       C  
+ATOM   1976  CE  LYS A 252      25.550  -0.733  32.164  1.00 32.42           C  
+ANISOU 1976  CE  LYS A 252     3795   4449   4076    353    458  -1864       C  
+ATOM   1977  NZ  LYS A 252      26.276   0.090  31.161  1.00 38.90           N  
+ANISOU 1977  NZ  LYS A 252     2921   6863   4995   1558    404    341       N  
+ATOM   1978  N   ASN A 253      20.330   0.669  35.915  1.00 22.32           N  
+ANISOU 1978  N   ASN A 253     2542   3518   2420    374    -14   -335       N  
+ATOM   1979  CA  ASN A 253      19.561   1.314  36.959  1.00 28.02           C  
+ANISOU 1979  CA  ASN A 253     2328   4745   3572    776   -174  -1367       C  
+ATOM   1980  C   ASN A 253      18.170   1.667  36.427  1.00 27.00           C  
+ANISOU 1980  C   ASN A 253     3130   3842   3286   1270   -830  -1549       C  
+ATOM   1981  O   ASN A 253      17.860   2.854  36.545  1.00 34.30           O  
+ANISOU 1981  O   ASN A 253     4905   4051   4077   1907   -659  -1916       O  
+ATOM   1982  CB  ASN A 253      20.269   2.558  37.492  1.00 34.76           C  
+ANISOU 1982  CB  ASN A 253     3312   5260   4635    811   -890  -2257       C  
+ATOM   1983  CG  ASN A 253      19.639   3.242  38.686  1.00 39.34           C  
+ANISOU 1983  CG  ASN A 253     4112   5475   5360    694   -280  -2596       C  
+ATOM   1984  OD1 ASN A 253      19.007   2.618  39.542  1.00 49.57           O  
+ANISOU 1984  OD1 ASN A 253     2716  10715   5405   1047   -402   -754       O  
+ATOM   1985  ND2 ASN A 253      19.789   4.563  38.822  1.00 59.50           N  
+ANISOU 1985  ND2 ASN A 253     7157   5745   9705   1231  -2704  -4703       N  
+ATOM   1986  N   ARG A 254      17.483   0.637  35.909  1.00 21.83           N  
+ANISOU 1986  N   ARG A 254     2562   3787   1946    215     50   -149       N  
+ATOM   1987  CA  ARG A 254      16.139   0.865  35.382  1.00 18.63           C  
+ANISOU 1987  CA  ARG A 254     2492   2645   1940    445    331      6       C  
+ATOM   1988  C   ARG A 254      15.112  -0.166  35.816  1.00 20.07           C  
+ANISOU 1988  C   ARG A 254     2582   2905   2139    278    269     83       C  
+ATOM   1989  O   ARG A 254      15.333  -1.343  36.043  1.00 23.65           O  
+ANISOU 1989  O   ARG A 254     2782   2804   3400    -30    -93    200       O  
+ATOM   1990  CB  ARG A 254      16.165   0.917  33.842  1.00 17.74           C  
+ANISOU 1990  CB  ARG A 254     2528   2310   1901    200     41   -101       C  
+ATOM   1991  CG  ARG A 254      17.076   2.024  33.327  1.00 16.08           C  
+ANISOU 1991  CG  ARG A 254     2145   2286   1679    400   -104    -84       C  
+ATOM   1992  CD  ARG A 254      17.162   1.985  31.805  1.00 19.28           C  
+ANISOU 1992  CD  ARG A 254     2497   3088   1739    798    355     17       C  
+ATOM   1993  NE  ARG A 254      18.055   0.941  31.319  1.00 17.27           N  
+ANISOU 1993  NE  ARG A 254     2046   2912   1602    701    -73     28       N  
+ATOM   1994  CZ  ARG A 254      18.282   0.667  30.032  1.00 13.53           C  
+ANISOU 1994  CZ  ARG A 254     1892   1640   1611    -56    -48    -60       C  
+ATOM   1995  NH1 ARG A 254      17.698   1.319  29.020  1.00 15.16           N  
+ANISOU 1995  NH1 ARG A 254     1834   2257   1670    341   -368   -237       N  
+ATOM   1996  NH2 ARG A 254      19.134  -0.305  29.747  1.00 14.57           N  
+ANISOU 1996  NH2 ARG A 254     2198   1529   1808     59   -143   -128       N  
+ATOM   1997  N   GLN A 255      13.895   0.332  35.905  1.00 21.83           N  
+ANISOU 1997  N   GLN A 255     2387   3074   2833     92     60   -702       N  
+ATOM   1998  CA  GLN A 255      12.727  -0.497  36.160  1.00 22.95           C  
+ANISOU 1998  CA  GLN A 255     2538   3572   2610   -233   -242   -602       C  
+ATOM   1999  C   GLN A 255      11.826  -0.401  34.925  1.00 21.89           C  
+ANISOU 1999  C   GLN A 255     2811   2914   2593   -129   -302   -340       C  
+ATOM   2000  O   GLN A 255      11.572   0.668  34.367  1.00 29.02           O  
+ANISOU 2000  O   GLN A 255     3807   2587   4632     51  -1569   -423       O  
+ATOM   2001  CB  GLN A 255      11.956  -0.089  37.407  1.00 29.04           C  
+ANISOU 2001  CB  GLN A 255     3525   4881   2629  -1110    413   -728       C  
+ATOM   2002  CG  GLN A 255      11.290  -1.161  38.240  1.00 40.97           C  
+ANISOU 2002  CG  GLN A 255     5573   6293   3701  -1424    914    534       C  
+ATOM   2003  CD  GLN A 255      10.738  -0.746  39.581  1.00 47.57           C  
+ANISOU 2003  CD  GLN A 255     6373   7761   3942  -2374   1661    282       C  
+ATOM   2004  OE1 GLN A 255       9.732  -1.337  40.025  1.00 56.82           O  
+ANISOU 2004  OE1 GLN A 255     6067   8732   6791  -2242   2959   -646       O  
+ATOM   2005  NE2 GLN A 255      11.319   0.226  40.292  1.00 55.38           N  
+ANISOU 2005  NE2 GLN A 255     8471   7672   4897  -2926   2843   -823       N  
+ATOM   2006  N   ILE A 256      11.364  -1.561  34.501  1.00 17.23           N  
+ANISOU 2006  N   ILE A 256     1911   2705   1931    -31      5     86       N  
+ATOM   2007  CA  ILE A 256      10.363  -1.638  33.447  1.00 16.94           C  
+ANISOU 2007  CA  ILE A 256     1514   2881   2043    245    145   -218       C  
+ATOM   2008  C   ILE A 256       9.010  -1.662  34.122  1.00 16.70           C  
+ANISOU 2008  C   ILE A 256     1731   2645   1971    414    299    363       C  
+ATOM   2009  O   ILE A 256       8.869  -2.394  35.082  1.00 16.92           O  
+ANISOU 2009  O   ILE A 256     2177   2364   1887    275    146    217       O  
+ATOM   2010  CB  ILE A 256      10.623  -2.868  32.581  1.00 17.44           C  
+ANISOU 2010  CB  ILE A 256     1672   2757   2196    210     82   -215       C  
+ATOM   2011  CG1 ILE A 256      12.048  -2.805  32.017  1.00 19.07           C  
+ANISOU 2011  CG1 ILE A 256     1579   2566   3102    391    156   -582       C  
+ATOM   2012  CG2 ILE A 256       9.577  -3.013  31.507  1.00 20.22           C  
+ANISOU 2012  CG2 ILE A 256     1810   2978   2895     12   -205   -643       C  
+ATOM   2013  CD1 ILE A 256      12.342  -3.900  31.033  1.00 23.77           C  
+ANISOU 2013  CD1 ILE A 256     3028   3076   2927    796    518   -663       C  
+ATOM   2014  N   LYS A 257       8.149  -0.805  33.584  1.00 16.80           N  
+ANISOU 2014  N   LYS A 257     1821   2893   1667    609    247    212       N  
+ATOM   2015  CA  LYS A 257       6.797  -0.661  34.119  1.00 16.46           C  
+ANISOU 2015  CA  LYS A 257     1703   2759   1791    453    160    316       C  
+ATOM   2016  C   LYS A 257       5.794  -1.290  33.168  1.00 17.05           C  
+ANISOU 2016  C   LYS A 257     2102   2555   1819   -107    230    531       C  
+ATOM   2017  O   LYS A 257       5.998  -1.218  31.963  1.00 19.12           O  
+ANISOU 2017  O   LYS A 257     2597   2859   1807   -691    288    252       O  
+ATOM   2018  CB  LYS A 257       6.429   0.800  34.342  1.00 18.77           C  
+ANISOU 2018  CB  LYS A 257     1902   2976   2255    619     57   -275       C  
+ATOM   2019  CG  LYS A 257       7.239   1.531  35.405  1.00 25.59           C  
+ANISOU 2019  CG  LYS A 257     3044   4014   2664   -377     36   -672       C  
+ATOM   2020  CD  LYS A 257       7.138   0.869  36.766  1.00 36.64           C  
+ANISOU 2020  CD  LYS A 257     5360   5631   2929    539  -1601    292       C  
+ATOM   2021  CE  LYS A 257       7.909   1.689  37.792  1.00 44.33           C  
+ANISOU 2021  CE  LYS A 257     6713   6445   3684    864  -2452   -400       C  
+ATOM   2022  NZ  LYS A 257       8.148   1.033  39.107  1.00 53.21           N  
+ANISOU 2022  NZ  LYS A 257     9561   7062   3596   1524  -3182   -604       N  
+ATOM   2023  N   ALA A 258       4.732  -1.846  33.734  1.00 17.72           N  
+ANISOU 2023  N   ALA A 258     1866   2877   1990    175    449    393       N  
+ATOM   2024  CA  ALA A 258       3.699  -2.481  32.922  1.00 18.06           C  
+ANISOU 2024  CA  ALA A 258     1843   2729   2289    -11    546    361       C  
+ATOM   2025  C   ALA A 258       2.390  -1.719  33.046  1.00 18.14           C  
+ANISOU 2025  C   ALA A 258     1946   2969   1976    135    360     58       C  
+ATOM   2026  O   ALA A 258       2.088  -1.218  34.129  1.00 18.45           O  
+ANISOU 2026  O   ALA A 258     2292   2871   1849    206    319    142       O  
+ATOM   2027  CB  ALA A 258       3.418  -3.905  33.367  1.00 18.88           C  
+ANISOU 2027  CB  ALA A 258     2651   2854   1667    -50    190    587       C  
+ATOM   2028  N   SER A 259       1.660  -1.672  31.948  1.00 17.19           N  
+ANISOU 2028  N   SER A 259     1877   2879   1777     40    552    118       N  
+ATOM   2029  CA  SER A 259       0.417  -0.917  31.961  1.00 17.72           C  
+ANISOU 2029  CA  SER A 259     2007   2509   2216     59    331    213       C  
+ATOM   2030  C   SER A 259      -0.751  -1.781  32.385  1.00 17.53           C  
+ANISOU 2030  C   SER A 259     1773   2587   2302     88    221    170       C  
+ATOM   2031  O   SER A 259      -1.876  -1.270  32.459  1.00 22.81           O  
+ANISOU 2031  O   SER A 259     1956   3028   3680    290    615    247       O  
+ATOM   2032  CB  SER A 259       0.148  -0.367  30.569  1.00 19.01           C  
+ANISOU 2032  CB  SER A 259     2302   2706   2216   -264      8    203       C  
+ATOM   2033  OG  SER A 259      -0.339  -1.384  29.718  1.00 16.78           O  
+ANISOU 2033  OG  SER A 259     1393   2635   2349   -117    321     68       O  
+ATOM   2034  N   PHE A 260      -0.469  -3.050  32.599  1.00 17.38           N  
+ANISOU 2034  N   PHE A 260     1916   2613   2075     -7    130    334       N  
+ATOM   2035  CA  PHE A 260      -1.528  -4.042  32.827  1.00 19.90           C  
+ANISOU 2035  CA  PHE A 260     2319   2826   2418   -327    -59    384       C  
+ATOM   2036  C   PHE A 260      -1.177  -4.932  34.004  1.00 29.60           C  
+ANISOU 2036  C   PHE A 260     3207   4628   3413  -1307   -456   1899       C  
+ATOM   2037  O   PHE A 260       0.037  -5.073  34.261  1.00 28.51           O  
+ANISOU 2037  O   PHE A 260     3480   4004   3349   -838   -747   1955       O  
+ATOM   2038  CB  PHE A 260      -1.726  -4.898  31.570  1.00 22.67           C  
+ANISOU 2038  CB  PHE A 260     2051   3333   3230   -127    -48   -416       C  
+ATOM   2039  CG  PHE A 260      -0.432  -5.620  31.168  1.00 22.64           C  
+ANISOU 2039  CG  PHE A 260     2415   2837   3349    205    123    343       C  
+ATOM   2040  CD1 PHE A 260       0.523  -4.974  30.412  1.00 19.66           C  
+ANISOU 2040  CD1 PHE A 260     2464   2632   2373    288    127   -114       C  
+ATOM   2041  CD2 PHE A 260      -0.195  -6.924  31.566  1.00 28.60           C  
+ANISOU 2041  CD2 PHE A 260     3222   2996   4649     93    -93    908       C  
+ATOM   2042  CE1 PHE A 260       1.700  -5.623  30.058  1.00 22.29           C  
+ANISOU 2042  CE1 PHE A 260     2590   2427   3450    291    316   -153       C  
+ATOM   2043  CE2 PHE A 260       0.968  -7.587  31.212  1.00 27.90           C  
+ANISOU 2043  CE2 PHE A 260     3698   2516   4386    397   -321    624       C  
+ATOM   2044  CZ  PHE A 260       1.923  -6.936  30.450  1.00 25.61           C  
+ANISOU 2044  CZ  PHE A 260     3335   2673   3724    614   -246     55       C  
+TER    2045      PHE A 260                                                      
+HETATM 2046 ZN    ZN A 600      14.469   0.268  15.256  1.00 13.87          ZN  
+ANISOU 2046 ZN    ZN A 600     1654   1817   1799   -107     58   -102      ZN  
+ANISOU 2047  S1  CEL A 701     1642   1902   2367    -72     70    -79       S  
+ANISOU 2048  C15 CEL A 701     1406   1811   2600   -214   -408    118       C  
+ANISOU 2049  C14 CEL A 701     1693   2733   2503    254   -185    686       C  
+ANISOU 2050  C13 CEL A 701     2078   2242   1756    334   -103    199       C  
+ANISOU 2051  C12 CEL A 701     2103   2457   2078     44     -2    266       C  
+ANISOU 2052  C17 CEL A 701     1661   1912   2810    -11    434   -165       C  
+ANISOU 2053  C16 CEL A 701     1553   1726   2752    131    351   -188       C  
+ANISOU 2054  N2  CEL A 701     2427   2643   2752    -89   -118    573       N  
+ANISOU 2055  C3  CEL A 701     3417   2923   2892   -587   -472    836       C  
+ANISOU 2056  C5  CEL A 701     4490   3561   3218   -866  -1055    754       C  
+ANISOU 2057  C10 CEL A 701     3292   3790   3481   -940   -788    392       C  
+ANISOU 2058  C9  CEL A 701     5380   4507   3852   -867  -1722    144       C  
+ANISOU 2059  C8  CEL A 701     6663   4584   4190  -1101  -2635    367       C  
+ANISOU 2060  C11 CEL A 701     8448   5614   2396  -1066  -1900    568       C  
+ANISOU 2061  C7  CEL A 701     7101   4374   4366   -953  -2922    633       C  
+ANISOU 2062  C6  CEL A 701     6427   3657   3638   -883  -2260    906       C  
+ANISOU 2063  C2  CEL A 701     3311   2610   2351   -308    319    225       C  
+ANISOU 2064  C1  CEL A 701     3074   2496   3018   -205   -396    747       C  
+ANISOU 2065  C4  CEL A 701     3854   2590   3341   -639  -1157   1450       C  
+ANISOU 2066  F3  CEL A 701     2639   3858   4331   -197    478    860       F  
+ANISOU 2067  F2  CEL A 701     2662   4179   3169  -1048   -504   1039       F  
+ANISOU 2068  F1  CEL A 701     4014   2363   4135   -687   -677     36       F  
+ANISOU 2069  N1  CEL A 701     2629   2450   2777   -159   -108    483       N  
+ANISOU 2070  N3  CEL A 701     1541   1641   2705    -58   -596   -276       N  
+ANISOU 2071  O2  CEL A 701     1529   2364   2049   -108    311   -345       O  
+ANISOU 2072  O1  CEL A 701     1920   1516   2427     42   -135    -78       O  
+HETATM 2073  O   HOH A 702       7.326  12.347  27.885  1.00 21.44           O  
+ANISOU 2073  O   HOH A 702     2379   3740   2025    315    361   -577       O  
+HETATM 2074  O   HOH A 703      19.879  -2.188  15.761  1.00 15.12           O  
+ANISOU 2074  O   HOH A 703     1746   1886   2115     74    359    -53       O  
+HETATM 2075  O   HOH A 704       4.089  -6.500  20.394  1.00 14.26           O  
+ANISOU 2075  O   HOH A 704     1439   2078   1900    220    239     53       O  
+HETATM 2076  O   HOH A 705      16.622 -11.544  18.014  1.00 15.99           O  
+ANISOU 2076  O   HOH A 705     2248   1883   1946    241    -39   -153       O  
+HETATM 2077  O   HOH A 706      17.340 -13.903  24.422  1.00 19.19           O  
+ANISOU 2077  O   HOH A 706     2445   2054   2793    252   -128   -189       O  
+HETATM 2078  O   HOH A 707      25.936  -2.997  20.986  1.00 18.57           O  
+ANISOU 2078  O   HOH A 707     1270   2973   2814    196    173   -294       O  
+HETATM 2079  O   HOH A 708       6.791 -14.660  29.020  1.00 26.94           O  
+ANISOU 2079  O   HOH A 708     3336   4015   2885   -106    442   -544       O  
+HETATM 2080  O   HOH A 709      13.094 -13.559  11.402  1.00 16.26           O  
+ANISOU 2080  O   HOH A 709     1880   1877   2420    -14     24   -212       O  
+HETATM 2081  O   HOH A 710      17.622 -11.329  25.176  1.00 16.03           O  
+ANISOU 2081  O   HOH A 710     2109   1685   2295    -48    264    327       O  
+HETATM 2082  O   HOH A 711      22.313   0.166  29.376  1.00 21.87           O  
+ANISOU 2082  O   HOH A 711     2172   3509   2629    323   -579    -94       O  
+HETATM 2083  O   HOH A 712      17.529  -9.200  20.884  1.00 17.05           O  
+ANISOU 2083  O   HOH A 712     1542   2484   2450      7    262   -260       O  
+HETATM 2084  O   HOH A 713      -0.489  -5.286  23.528  1.00 18.76           O  
+ANISOU 2084  O   HOH A 713     1623   2713   2794   -147     81   -337       O  
+HETATM 2085  O   HOH A 714       0.156   9.737   1.885  1.00 21.96           O  
+ANISOU 2085  O   HOH A 714     3483   2592   2271     68   -593    225       O  
+HETATM 2086  O   HOH A 715      18.483  -6.779  29.163  1.00 18.21           O  
+ANISOU 2086  O   HOH A 715     1973   2186   2761     72   -343     -9       O  
+HETATM 2087  O   HOH A 716      19.010 -10.382  22.827  1.00 15.36           O  
+ANISOU 2087  O   HOH A 716     1469   2390   1976    290    -27    138       O  
+HETATM 2088  O   HOH A 717      24.746   6.937  29.802  1.00 25.36           O  
+ANISOU 2088  O   HOH A 717     2818   3182   3637    -64   -997   -446       O  
+HETATM 2089  O   HOH A 718      25.916  -5.757  22.137  1.00 25.76           O  
+ANISOU 2089  O   HOH A 718     2012   3671   4106    272    482    161       O  
+HETATM 2090  O   HOH A 719      36.439   4.859  20.834  1.00 32.89           O  
+ANISOU 2090  O   HOH A 719     3900   4726   3871  -2362    582    286       O  
+HETATM 2091  O   HOH A 720      11.684  -8.222  -1.180  1.00 24.76           O  
+ANISOU 2091  O   HOH A 720     3949   2820   2640    777     69    303       O  
+HETATM 2092  O   HOH A 721       7.532 -16.599  14.806  1.00 23.76           O  
+ANISOU 2092  O   HOH A 721     3235   3015   2779    612   -518   -466       O  
+HETATM 2093  O   HOH A 722       4.956 -10.348  24.440  1.00 20.54           O  
+ANISOU 2093  O   HOH A 722     2335   2734   2733    178   -282    149       O  
+HETATM 2094  O   HOH A 723       3.064  12.371  11.374  1.00 23.97           O  
+ANISOU 2094  O   HOH A 723     2856   3344   2906     39   -408   -342       O  
+HETATM 2095  O   HOH A 724       9.084   4.733  30.730  1.00 21.68           O  
+ANISOU 2095  O   HOH A 724     3193   2609   2436   -332   -234   -402       O  
+HETATM 2096  O   HOH A 725      -2.127  -9.704  14.213  1.00 25.17           O  
+ANISOU 2096  O   HOH A 725     2405   4145   3014   -529   -984    735       O  
+HETATM 2097  O   HOH A 726      28.701   8.055  21.698  1.00 23.11           O  
+ANISOU 2097  O   HOH A 726     1456   3421   3905    258    -83    -14       O  
+HETATM 2098  O   HOH A 727      12.991 -17.370  21.800  1.00 27.96           O  
+ANISOU 2098  O   HOH A 727     4538   2522   3563    947   -300   -470       O  
+HETATM 2099  O   HOH A 728      -5.615  -0.534  14.324  1.00 25.04           O  
+ANISOU 2099  O   HOH A 728     2884   4116   2512    803   -489    423       O  
+HETATM 2100  O   HOH A 729       4.663  -8.060  32.946  1.00 25.43           O  
+ANISOU 2100  O   HOH A 729     4112   2629   2923   -274     11    900       O  
+HETATM 2101  O   HOH A 730      10.533 -16.265  17.203  1.00 24.30           O  
+ANISOU 2101  O   HOH A 730     3357   1992   3883   -104   -306     96       O  
+HETATM 2102  O   HOH A 731      29.293  -7.489  16.600  1.00 27.27           O  
+ANISOU 2102  O   HOH A 731     3247   3478   3635    284    281   -387       O  
+HETATM 2103  O   HOH A 732      -1.925  -0.946   6.919  1.00 27.98           O  
+ANISOU 2103  O   HOH A 732     3795   2605   4232   -599   -300    -37       O  
+HETATM 2104  O   HOH A 733      -4.045  -5.900   8.985  1.00 25.05           O  
+ANISOU 2104  O   HOH A 733     3692   3691   2135    513    375    472       O  
+HETATM 2105  O   HOH A 734       8.241 -15.290  16.971  1.00 23.26           O  
+ANISOU 2105  O   HOH A 734     3248   2786   2804     54   -702    239       O  
+HETATM 2106  O   HOH A 735       0.796  12.664  26.682  1.00 22.47           O  
+ANISOU 2106  O   HOH A 735     2918   2411   3209    221    439    142       O  
+HETATM 2107  O   HOH A 736      32.641  -4.981  22.557  1.00 32.35           O  
+ANISOU 2107  O   HOH A 736     4673   3918   3700    268    134    794       O  
+HETATM 2108  O   HOH A 737      34.221  -3.915  24.555  1.00 31.88           O  
+ANISOU 2108  O   HOH A 737     2548   4729   4836    -67    491    375       O  
+HETATM 2109  O   HOH A 738      11.489  -6.118  34.046  1.00 30.31           O  
+ANISOU 2109  O   HOH A 738     4578   3133   3805   1019    967    764       O  
+HETATM 2110  O   HOH A 739      16.309 -10.136  32.109  1.00 26.06           O  
+ANISOU 2110  O   HOH A 739     3793   3538   2572   -948     94   -143       O  
+HETATM 2111  O   HOH A 740      -2.179 -11.508  11.331  1.00 25.85           O  
+ANISOU 2111  O   HOH A 740     3055   4059   2706   -105    335    295       O  
+HETATM 2112  O   HOH A 741       3.070 -18.454   8.007  1.00 21.35           O  
+ANISOU 2112  O   HOH A 741     2807   1948   3355   -409    -64   -460       O  
+HETATM 2113  O   HOH A 742      25.733  -5.053   7.920  1.00 32.76           O  
+ANISOU 2113  O   HOH A 742     4108   5362   2977   -338      7   -838       O  
+HETATM 2114  O   HOH A 743      -5.146   5.349  15.477  1.00 30.60           O  
+ANISOU 2114  O   HOH A 743     3548   4801   3276   -227   -340   -666       O  
+HETATM 2115  O   HOH A 744      25.424  -1.568  26.595  1.00 21.88           O  
+ANISOU 2115  O   HOH A 744     3018   2498   2796   -676   -389   -304       O  
+HETATM 2116  O   HOH A 745      26.474   9.111  20.248  1.00 25.05           O  
+ANISOU 2116  O   HOH A 745     2765   2574   4179   -510   -786    -73       O  
+HETATM 2117  O   HOH A 746      25.287  -0.617  28.808  1.00 32.32           O  
+ANISOU 2117  O   HOH A 746     4101   3402   4776  -1157    645  -1448       O  
+HETATM 2118  O   HOH A 747      20.580  12.655  23.440  1.00 23.34           O  
+ANISOU 2118  O   HOH A 747     2737   2995   3135   -118   -446   -449       O  
+HETATM 2119  O   HOH A 748      29.707  -1.990  21.105  1.00 20.06           O  
+ANISOU 2119  O   HOH A 748     1476   2271   3876    507   -126    362       O  
+HETATM 2120  O   HOH A 749      22.371  10.583  24.495  1.00 26.91           O  
+ANISOU 2120  O   HOH A 749     3425   3654   3148  -1508   -321   -921       O  
+HETATM 2121  O   HOH A 750       7.992 -14.876  26.604  1.00 23.56           O  
+ANISOU 2121  O   HOH A 750     2904   3048   2999   -139   -135   -227       O  
+HETATM 2122  O   HOH A 751      19.205 -15.559  25.336  1.00 29.99           O  
+ANISOU 2122  O   HOH A 751     3483   3641   4271    164   -691    669       O  
+HETATM 2123  O   HOH A 752      20.918 -12.361  22.134  1.00 23.67           O  
+ANISOU 2123  O   HOH A 752     2762   2325   3905    242   -354    -62       O  
+HETATM 2124  O   HOH A 753      12.136  -4.043  35.831  1.00 28.32           O  
+ANISOU 2124  O   HOH A 753     3616   3773   3370    143  -1126    433       O  
+HETATM 2125  O   HOH A 754       6.296 -16.549  18.741  1.00 22.82           O  
+ANISOU 2125  O   HOH A 754     3703   2851   2117   -845   -380    210       O  
+HETATM 2126  O   HOH A 755      15.105  -2.606  -6.305  1.00 32.27           O  
+ANISOU 2126  O   HOH A 755     5705   3900   2656    654    263    -27       O  
+HETATM 2127  O   HOH A 756       1.861  11.920   8.921  1.00 20.82           O  
+ANISOU 2127  O   HOH A 756     2855   2653   2404    181    -63    209       O  
+HETATM 2128  O   HOH A 757      32.212   3.255  25.905  1.00 31.94           O  
+ANISOU 2128  O   HOH A 757     2376   5730   4030    902   -459    130       O  
+HETATM 2129  O   HOH A 758       0.959 -14.944   3.032  1.00 32.12           O  
+ANISOU 2129  O   HOH A 758     4610   4700   2894  -1174  -1153    430       O  
+HETATM 2130  O   HOH A 759      34.337   2.171  24.615  1.00 28.33           O  
+ANISOU 2130  O   HOH A 759     2583   4179   4004     10   -405    207       O  
+HETATM 2131  O   HOH A 760      -2.786   1.169   3.943  1.00 32.64           O  
+ANISOU 2131  O   HOH A 760     6401   3323   2677  -1125   -631   -389       O  
+HETATM 2132  O   HOH A 761      22.244  -9.793  25.135  1.00 31.52           O  
+ANISOU 2132  O   HOH A 761     4387   3188   4401    486  -1582   -249       O  
+HETATM 2133  O   HOH A 762       8.396   9.870  28.690  1.00 35.44           O  
+ANISOU 2133  O   HOH A 762     4515   4873   4078   1188    252   -260       O  
+HETATM 2134  O   HOH A 763      19.955  -9.253  28.917  1.00 25.80           O  
+ANISOU 2134  O   HOH A 763     3198   3296   3308    585   -500    269       O  
+HETATM 2135  O   HOH A 764      12.660 -13.507  36.684  1.00 29.21           O  
+ANISOU 2135  O   HOH A 764     3078   3258   4761     16    115   1018       O  
+HETATM 2136  O   HOH A 765       4.275 -11.947  26.358  1.00 33.73           O  
+ANISOU 2136  O   HOH A 765     3647   4478   4690   -106   -247   1454       O  
+HETATM 2137  O   HOH A 766      10.120  -9.253  -2.882  1.00 40.78           O  
+ANISOU 2137  O   HOH A 766     6393   4854   4248    408   -740    570       O  
+HETATM 2138  O   HOH A 767      17.483 -10.971  -2.796  1.00 29.83           O  
+ANISOU 2138  O   HOH A 767     3795   3764   3776   -216    349   -741       O  
+HETATM 2139  O   HOH A 768      14.183 -12.904  31.567  1.00 23.79           O  
+ANISOU 2139  O   HOH A 768     3062   2697   3280     24   -165     40       O  
+HETATM 2140  O   HOH A 769      32.206  -7.514  -0.686  1.00 39.97           O  
+ANISOU 2140  O   HOH A 769     4779   5107   5301   1382  -1462     95       O  
+HETATM 2141  O   HOH A 770      11.131  16.785  12.226  1.00 25.66           O  
+ANISOU 2141  O   HOH A 770     3862   3443   2444   1023   -303   -553       O  
+HETATM 2142  O   HOH A 771      -1.128 -16.709  13.812  1.00 34.79           O  
+ANISOU 2142  O   HOH A 771     3546   5059   4615   -990     45  -1182       O  
+HETATM 2143  O   HOH A 772       3.156 -10.317  31.330  1.00 31.36           O  
+ANISOU 2143  O   HOH A 772     2261   4170   5485     72   -513   1668       O  
+HETATM 2144  O   HOH A 773       6.230  22.065  17.806  1.00 31.09           O  
+ANISOU 2144  O   HOH A 773     4551   3769   3493    304    138    856       O  
+HETATM 2145  O   HOH A 774       2.674  -1.564  -2.510  1.00 34.70           O  
+ANISOU 2145  O   HOH A 774     5993   3842   3351   -470  -1919    757       O  
+HETATM 2146  O   HOH A 775      19.781 -11.130  27.022  1.00 29.71           O  
+ANISOU 2146  O   HOH A 775     3815   3057   4416    848  -1406   -454       O  
+HETATM 2147  O   HOH A 776       7.473 -19.171  15.011  1.00 29.14           O  
+ANISOU 2147  O   HOH A 776     4112   2324   4637    406  -1156   -442       O  
+HETATM 2148  O   HOH A 777      13.821 -14.979   1.433  1.00 27.88           O  
+ANISOU 2148  O   HOH A 777     2420   4111   4063   -386    238    -27       O  
+HETATM 2149  O   HOH A 778      -4.871  -4.217  13.166  1.00 34.99           O  
+ANISOU 2149  O   HOH A 778     4593   5136   3566   2181    408    242       O  
+HETATM 2150  O   HOH A 779      12.953 -20.198  10.412  1.00 31.21           O  
+ANISOU 2150  O   HOH A 779     5158   3188   3512   -784   -826   -892       O  
+HETATM 2151  O   HOH A 780      10.105 -17.728   7.329  1.00 29.47           O  
+ANISOU 2151  O   HOH A 780     3652   4415   3132   -412   -225   -746       O  
+HETATM 2152  O   HOH A 781      35.297   7.703  19.403  1.00 37.48           O  
+ANISOU 2152  O   HOH A 781     4022   4599   5620   -754   1369   -817       O  
+HETATM 2153  O   HOH A 782      23.802  -2.403   7.661  1.00 30.83           O  
+ANISOU 2153  O   HOH A 782     4015   2734   4965   -769    102   -833       O  
+HETATM 2154  O   HOH A 783       8.267 -17.579  26.298  1.00 30.64           O  
+ANISOU 2154  O   HOH A 783     3578   3510   4555    888    892    229       O  
+HETATM 2155  O   HOH A 784      36.201  -2.070  25.178  1.00 23.11           O  
+ANISOU 2155  O   HOH A 784     1871   3225   3686      8    210   -116       O  
+HETATM 2156  O   HOH A 785      20.523  -6.551  32.737  1.00 31.85           O  
+ANISOU 2156  O   HOH A 785     4820   3743   3538    139   -117   -225       O  
+HETATM 2157  O   HOH A 786      -3.904   6.445   8.612  1.00 36.79           O  
+ANISOU 2157  O   HOH A 786     3989   4711   5278    659   -972   -659       O  
+HETATM 2158  O   HOH A 787       3.416  -5.672  39.571  1.00 37.82           O  
+ANISOU 2158  O   HOH A 787     4330   5591   4449    691   1149   1472       O  
+HETATM 2159  O   HOH A 788       7.073  16.130  27.311  1.00 31.72           O  
+ANISOU 2159  O   HOH A 788     5147   3683   3222   -621   1727   -546       O  
+HETATM 2160  O   HOH A 789      32.656   1.456  15.836  1.00 33.60           O  
+ANISOU 2160  O   HOH A 789     3351   4567   4849   1138    992    521       O  
+HETATM 2161  O   HOH A 790      23.590 -11.268   5.205  1.00 29.81           O  
+ANISOU 2161  O   HOH A 790     3988   4234   3103    490    246   -124       O  
+HETATM 2162  O   HOH A 791      23.759  -9.557   9.543  1.00 31.46           O  
+ANISOU 2162  O   HOH A 791     3596   3583   4774   -412    -79   -481       O  
+HETATM 2163  O   HOH A 792      20.103 -15.565  17.803  1.00 34.95           O  
+ANISOU 2163  O   HOH A 792     4599   3616   5067   1288    247    681       O  
+HETATM 2164  O   HOH A 793      21.489   2.452  -6.646  1.00 35.97           O  
+ANISOU 2164  O   HOH A 793     4758   4882   4025   -725    283   1437       O  
+HETATM 2165  O   HOH A 794       0.532  10.385  30.077  1.00 30.05           O  
+ANISOU 2165  O   HOH A 794     3439   3839   4139   -301   1603  -1462       O  
+HETATM 2166  O   HOH A 795      22.890 -12.257  20.565  1.00 32.07           O  
+ANISOU 2166  O   HOH A 795     3933   3180   5072    867    961    375       O  
+HETATM 2167  O   HOH A 796      -4.914  -4.466  33.790  1.00 35.43           O  
+ANISOU 2167  O   HOH A 796     2610   5241   5609   -721    666   1578       O  
+HETATM 2168  O   HOH A 797      13.748  -6.642  -2.275  1.00 38.90           O  
+ANISOU 2168  O   HOH A 797     5332   4184   5265  -1004    -49   1000       O  
+HETATM 2169  O   HOH A 798      15.859   4.073  37.666  1.00 41.31           O  
+ANISOU 2169  O   HOH A 798     4055   5085   6554   -496    294  -1765       O  
+HETATM 2170  O   HOH A 799       5.490 -14.315  25.466  1.00 40.05           O  
+ANISOU 2170  O   HOH A 799     3947   5290   5981   1330    -66   -901       O  
+HETATM 2171  O   HOH A 800      22.412  -4.593  34.586  1.00 35.43           O  
+ANISOU 2171  O   HOH A 800     5796   3980   3686   2370   -837     70       O  
+HETATM 2172  O   HOH A 801      10.464 -17.361  19.931  1.00 31.01           O  
+ANISOU 2172  O   HOH A 801     2707   4071   5004   -371    563    -64       O  
+HETATM 2173  O   HOH A 802       5.484  10.901  -1.885  1.00 33.02           O  
+ANISOU 2173  O   HOH A 802     4684   4001   3860      1     98   1208       O  
+HETATM 2174  O   HOH A 803       7.862 -20.305  12.282  1.00 41.06           O  
+ANISOU 2174  O   HOH A 803     4806   5261   5535   -574    141   2126       O  
+HETATM 2175  O   HOH A 804       3.349 -19.372  17.599  1.00 40.80           O  
+ANISOU 2175  O   HOH A 804     6203   3689   5610  -1188  -1512    570       O  
+HETATM 2176  O   HOH A 805       5.733 -19.742  13.238  1.00 30.35           O  
+ANISOU 2176  O   HOH A 805     3891   3040   4601    511   -916    499       O  
+HETATM 2177  O   HOH A 806      31.502  -8.952  16.129  1.00 32.76           O  
+ANISOU 2177  O   HOH A 806     4689   3463   4295   -912    -43    663       O  
+HETATM 2178  O   HOH A 807       3.900  12.788  -2.127  1.00 41.04           O  
+ANISOU 2178  O   HOH A 807     5496   5261   4836   -383   -304    248       O  
+HETATM 2179  O   HOH A 808      29.748  -2.803  23.687  1.00 38.08           O  
+ANISOU 2179  O   HOH A 808     5597   5319   3551  -1177   -590    252       O  
+HETATM 2180  O   HOH A 809      29.009  -6.564  -0.439  1.00 36.80           O  
+ANISOU 2180  O   HOH A 809     4674   5614   3695  -1524   1304  -2166       O  
+HETATM 2181  O   HOH A 810      19.827  10.941  28.111  1.00 32.97           O  
+ANISOU 2181  O   HOH A 810     4537   3701   4288     36   -682  -1335       O  
+HETATM 2182  O   HOH A 811      -4.976   8.435  27.202  1.00 40.50           O  
+ANISOU 2182  O   HOH A 811     4322   5095   5969   1088    181    432       O  
+HETATM 2183  O   HOH A 812       2.218 -10.421  -3.321  1.00 36.32           O  
+ANISOU 2183  O   HOH A 812     5224   4678   3900   -240  -2193   -557       O  
+HETATM 2184  O   HOH A 813      23.927 -10.455  18.192  1.00 39.80           O  
+ANISOU 2184  O   HOH A 813     4719   4448   5956   -203   -485    777       O  
+HETATM 2185  O   HOH A 814      33.028  -4.459   7.908  1.00 37.61           O  
+ANISOU 2185  O   HOH A 814     4346   5488   4455    558   1065  -1115       O  
+HETATM 2186  O   HOH A 815      10.435  10.510  25.573  1.00 17.08           O  
+ANISOU 2186  O   HOH A 815     1839   2149   2502    129    115    259       O  
+HETATM 2187  O   HOH A 816      16.060   9.531   5.871  1.00 33.01           O  
+ANISOU 2187  O   HOH A 816     4672   4129   3741  -1064   1316    -45       O  
+HETATM 2188  O   HOH A 817       4.304 -12.608  28.713  1.00 35.18           O  
+ANISOU 2188  O   HOH A 817     2988   6562   3817    108     89    897       O  
+HETATM 2189  O   HOH A 818      31.618  -7.088   8.855  1.00 38.36           O  
+ANISOU 2189  O   HOH A 818     4226   4804   5547    429   1539  -1372       O  
+HETATM 2190  O   HOH A 819       0.126  -4.837  -2.193  1.00 33.57           O  
+ANISOU 2190  O   HOH A 819     4678   4640   3439   -172   -413   -908       O  
+HETATM 2191  O   HOH A 820       1.541  -2.274  41.237  1.00 32.27           O  
+ANISOU 2191  O   HOH A 820     4793   4969   2499   -244   -427    248       O  
+HETATM 2192  O   HOH A 821      26.358  -9.278  18.992  1.00 37.28           O  
+ANISOU 2192  O   HOH A 821     4616   3740   5811   -200    447  -1250       O  
+HETATM 2193  O   HOH A 822      19.683  13.277  26.034  1.00 34.02           O  
+ANISOU 2193  O   HOH A 822     4459   5036   3432   1871   1386   -441       O  
+HETATM 2194  O   HOH A 823      20.762   2.933  34.589  1.00 32.53           O  
+ANISOU 2194  O   HOH A 823     4681   4775   2902    510    -34   -651       O  
+HETATM 2195  O   HOH A 824       4.478 -13.790  32.656  1.00 39.89           O  
+ANISOU 2195  O   HOH A 824     3674   6620   4863    -47    749    462       O  
+HETATM 2196  O   HOH A 825      15.233  18.658  27.564  1.00 33.49           O  
+ANISOU 2196  O   HOH A 825     3149   5880   3696    125   -181   -220       O  
+HETATM 2197  O   HOH A 826      35.549  -5.659  25.917  1.00 37.39           O  
+ANISOU 2197  O   HOH A 826     4333   4821   5052   -514   1348   -347       O  
+HETATM 2198  O   HOH A 827      12.792   2.545  -6.543  1.00 35.76           O  
+ANISOU 2198  O   HOH A 827     5526   3904   4157   -215   1810    150       O  
+HETATM 2199  O   HOH A 828      -4.400  -8.659  17.712  1.00 33.49           O  
+ANISOU 2199  O   HOH A 828     4079   2735   5910    147   -164   -478       O  
+HETATM 2200  O   HOH A 829       2.507 -19.570   5.579  1.00 41.50           O  
+ANISOU 2200  O   HOH A 829     5834   5033   4900  -3136   1467  -1026       O  
+HETATM 2201  O   HOH A 830      22.959 -13.815   9.495  1.00 35.20           O  
+ANISOU 2201  O   HOH A 830     3846   4588   4939    849    348     64       O  
+HETATM 2202  O   HOH A 831      22.619  -9.536  15.670  1.00 38.44           O  
+ANISOU 2202  O   HOH A 831     2166   4989   7453     22    530   1027       O  
+HETATM 2203  O   HOH A 832      -3.083   1.146  26.670  1.00 38.78           O  
+ANISOU 2203  O   HOH A 832     5868   4600   4268  -1331     58    339       O  
+HETATM 2204  O   HOH A 833       2.497  22.092  14.834  1.00 42.88           O  
+ANISOU 2204  O   HOH A 833     6557   4636   5099    578    -15   1263       O  
+HETATM 2205  O   HOH A 834      13.954 -18.216  24.132  1.00 36.99           O  
+ANISOU 2205  O   HOH A 834     6605   3233   4217    853   -363   -132       O  
+HETATM 2206  O   HOH A 835       5.733 -18.142  23.132  1.00 35.16           O  
+ANISOU 2206  O   HOH A 835     4647   3424   5288    375    972    706       O  
+HETATM 2207  O   HOH A 836       3.522  -4.887  42.342  1.00 34.79           O  
+ANISOU 2207  O   HOH A 836     5819   3951   3450   -248    618     27       O  
+HETATM 2208  O   HOH A 837      20.666  15.875  16.348  1.00 36.44           O  
+ANISOU 2208  O   HOH A 837     3146   4770   5932   -316   1062   -573       O  
+HETATM 2209  O   HOH A 838      14.572  -3.322  37.705  1.00 35.64           O  
+ANISOU 2209  O   HOH A 838     4989   3334   5220    384   -481    -28       O  
+HETATM 2210  O   HOH A 839      36.053   0.623  26.037  1.00 31.44           O  
+ANISOU 2210  O   HOH A 839     4124   4042   3780   1395    256   -116       O  
+HETATM 2211  O   HOH A 840       2.018  14.343  13.011  1.00 48.79           O  
+ANISOU 2211  O   HOH A 840     6951   6400   5188    310  -1103   1258       O  
+HETATM 2212  O   HOH A 841      27.214  -3.420  27.775  1.00 50.44           O  
+ANISOU 2212  O   HOH A 841     6787   6042   6335    605  -1079    293       O  
+HETATM 2213  O   HOH A 842       8.071  15.351  31.733  1.00 39.33           O  
+ANISOU 2213  O   HOH A 842     3949   5870   5125   -613   -143  -1333       O  
+HETATM 2214  O   HOH A 843      27.370   7.189  29.075  1.00 48.41           O  
+ANISOU 2214  O   HOH A 843     5486   5808   7099  -2620  -1414    457       O  
+HETATM 2215  O   HOH A 844      -3.030  10.483  20.276  1.00 30.71           O  
+ANISOU 2215  O   HOH A 844     2538   4679   4450   -659    764    239       O  
+HETATM 2216  O   HOH A 845       3.629 -14.358  22.089  1.00 33.26           O  
+ANISOU 2216  O   HOH A 845     3488   5281   3869     17    809   1676       O  
+HETATM 2217  O   HOH A 846      15.628  17.712  12.188  1.00 40.67           O  
+ANISOU 2217  O   HOH A 846     4998   6507   3946   2821   1223   1535       O  
+HETATM 2218  O   HOH A 847       5.672  -8.384  37.503  1.00 40.01           O  
+ANISOU 2218  O   HOH A 847     6642   3659   4903   -764   -624    284       O  
+HETATM 2219  O   HOH A 848       7.934  -6.934  -3.260  1.00 39.13           O  
+ANISOU 2219  O   HOH A 848     6438   4315   4115    692   -871  -1657       O  
+HETATM 2220  O   HOH A 849      19.988 -15.325  -2.214  1.00 39.66           O  
+ANISOU 2220  O   HOH A 849     5186   4272   5611   -742    281     40       O  
+HETATM 2221  O   HOH A 850      28.137  -1.390  30.152  1.00 33.20           O  
+ANISOU 2221  O   HOH A 850     3948   5067   3600   1055     50     71       O  
+HETATM 2222  O   HOH A 851       0.505  15.484  28.915  1.00 44.62           O  
+ANISOU 2222  O   HOH A 851     6229   4521   6205    884    489  -1081       O  
+HETATM 2223  O   HOH A 852      26.508   2.699   8.383  1.00 34.67           O  
+ANISOU 2223  O   HOH A 852     3635   6172   3366   -180    888   -602       O  
+HETATM 2224  O   HOH A 853       3.244  -1.282  45.290  1.00 43.09           O  
+ANISOU 2224  O   HOH A 853     5568   6791   4012    444   -562    482       O  
+HETATM 2225  O   HOH A 854      17.824   1.196  11.106  1.00 44.05           O  
+ANISOU 2225  O   HOH A 854     5743   5456   5539    134  -1081  -1719       O  
+HETATM 2226  O   HOH A 855      19.365 -10.351  31.722  1.00 46.04           O  
+ANISOU 2226  O   HOH A 855     5902   6634   4957    731   -139   -315       O  
+HETATM 2227  O   HOH A 856      -3.039  -1.491  29.269  1.00 33.37           O  
+ANISOU 2227  O   HOH A 856     1980   6375   4323    457     58  -1707       O  
+HETATM 2228  O   HOH A 857      16.997  22.253  15.293  1.00 36.00           O  
+ANISOU 2228  O   HOH A 857     3415   4147   6115   -258   -192    652       O  
+HETATM 2229  O   HOH A 858       8.227 -20.148   8.438  1.00 34.47           O  
+ANISOU 2229  O   HOH A 858     4505   3648   4945    -15   -985   -747       O  
+HETATM 2230  O   HOH A 859       3.046   5.966  -3.648  1.00 36.17           O  
+ANISOU 2230  O   HOH A 859     5350   5609   2782   1332   -705   -106       O  
+HETATM 2231  O   HOH A 860      14.588 -17.569   5.438  1.00 37.99           O  
+ANISOU 2231  O   HOH A 860     5902   3663   4871    896   -673    -19       O  
+HETATM 2232  O   HOH A 861      -0.055 -17.822   6.728  1.00 41.14           O  
+ANISOU 2232  O   HOH A 861     4663   4248   6721    448     82     13       O  
+HETATM 2233  O   HOH A 862      15.954   5.289  -5.690  1.00 36.51           O  
+ANISOU 2233  O   HOH A 862     5522   4586   3766  -1076   1139    766       O  
+HETATM 2234  O   HOH A 863       8.835  18.226   9.298  1.00 44.54           O  
+ANISOU 2234  O   HOH A 863     5023   5184   6715   -627    475    945       O  
+HETATM 2235  O   HOH A 864      25.010  11.824  23.676  1.00 34.62           O  
+ANISOU 2235  O   HOH A 864     4127   3819   5208    -51   -368  -1061       O  
+HETATM 2236  O   HOH A 865       4.101 -15.837  20.394  1.00 34.39           O  
+ANISOU 2236  O   HOH A 865     3528   4208   5333   -353   -832    646       O  
+HETATM 2237  O   HOH A 866      22.821  14.340  22.756  1.00 34.95           O  
+ANISOU 2237  O   HOH A 866     3794   3339   6147  -1081   -685   -624       O  
+HETATM 2238  O   HOH A 867      -6.958   8.138  15.150  1.00 39.07           O  
+ANISOU 2238  O   HOH A 867     4310   5624   4911   -468  -1494    333       O  
+HETATM 2239  O   HOH A 868      21.657  -7.978  -5.429  1.00 38.28           O  
+ANISOU 2239  O   HOH A 868     4325   5263   4957    -86    -71    751       O  
+HETATM 2240  O   HOH A 869       9.997 -13.430  34.215  1.00 32.56           O  
+ANISOU 2240  O   HOH A 869     4916   3152   4305    156   -679   -145       O  
+HETATM 2241  O   HOH A 870       8.672  14.482  29.334  1.00 42.16           O  
+ANISOU 2241  O   HOH A 870     4597   5232   6190   -812    982  -2338       O  
+HETATM 2242  O   HOH A 871      -2.444 -16.052   6.070  1.00 40.25           O  
+ANISOU 2242  O   HOH A 871     5353   4441   5497  -1718  -2222    208       O  
+HETATM 2243  O   HOH A 872       2.025  15.869   9.117  1.00 39.80           O  
+ANISOU 2243  O   HOH A 872     5058   4274   5791   -419  -1925    355       O  
+HETATM 2244  O   HOH A 873      -0.688   7.656   4.773  1.00 23.24           O  
+ANISOU 2244  O   HOH A 873     3209   2694   2928    -42   -966    601       O  
+HETATM 2245  O   HOH A 874      21.260   0.785  -4.652  1.00 29.37           O  
+ANISOU 2245  O   HOH A 874     5055   3685   2421  -1025   1030    116       O  
+HETATM 2246  O   HOH A 875      18.624  -1.435  11.587  1.00 26.34           O  
+ANISOU 2246  O   HOH A 875     1937   5170   2901    358    347   -214       O  
+HETATM 2247  O   HOH A 876      14.282 -18.247  19.526  1.00 22.95           O  
+ANISOU 2247  O   HOH A 876     3615   2346   2759   -361    131    155       O  
+HETATM 2248  O   HOH A 877       4.735  17.841  23.627  1.00 35.18           O  
+ANISOU 2248  O   HOH A 877     4254   3203   5909   -259   1742  -1676       O  
+HETATM 2249  O   HOH A 878      -1.667  -3.895   2.883  1.00 31.43           O  
+ANISOU 2249  O   HOH A 878     3879   4234   3827   1231    235    424       O  
+HETATM 2250  O   HOH A 879      -4.348  11.423  13.248  1.00 37.25           O  
+ANISOU 2250  O   HOH A 879     4154   4742   5258  -1170   -698    253       O  
+HETATM 2251  O   HOH A 880      -2.088   2.068  34.600  1.00 38.76           O  
+ANISOU 2251  O   HOH A 880     2949   8484   3293    -88    800   1033       O  
+HETATM 2252  O   HOH A 881      -1.339   3.235  30.055  1.00 31.06           O  
+ANISOU 2252  O   HOH A 881     2697   5039   4067    198    911   -830       O  
+HETATM 2253  O   HOH A 882      23.624  -9.614  13.034  1.00 38.64           O  
+ANISOU 2253  O   HOH A 882     4785   4626   5269  -1046  -1494    479       O  
+HETATM 2254  O   HOH A 883      31.288   7.752  12.898  1.00 43.96           O  
+ANISOU 2254  O   HOH A 883     3829   6697   6175   -178    866   1486       O  
+HETATM 2255  O   HOH A 884      -3.514  13.812   6.113  1.00 42.68           O  
+ANISOU 2255  O   HOH A 884     5294   6259   4663    285    491    650       O  
+HETATM 2256  O   HOH A 885      -2.223   1.629  32.349  1.00 45.17           O  
+ANISOU 2256  O   HOH A 885     5631   5428   6102   -649   -108    952       O  
+HETATM 2257  O   HOH A 886      27.536  -4.441   6.647  1.00 48.45           O  
+ANISOU 2257  O   HOH A 886     6234   7055   5118    945   1103     29       O  
+HETATM 2258  O   HOH A 887      -4.531   6.048   4.086  1.00 45.68           O  
+ANISOU 2258  O   HOH A 887     5335   6783   5240    925   -311  -1751       O  
+HETATM 2259  O   HOH A 888      11.009  17.327  29.926  1.00 38.75           O  
+ANISOU 2259  O   HOH A 888     5207   5476   4039    396    764  -1025       O  
+HETATM 2260  O   HOH A 889      11.983   7.992  28.923  1.00 41.29           O  
+ANISOU 2260  O   HOH A 889     5322   4657   5708   1322  -2268  -1527       O  
+HETATM 2261  O   HOH A 890      30.487   9.436  18.767  1.00 44.66           O  
+ANISOU 2261  O   HOH A 890     4951   4281   7739  -1020    527   1286       O  
+HETATM 2262  O   HOH A 891      26.288  10.724  22.128  1.00 39.71           O  
+ANISOU 2262  O   HOH A 891     4671   4843   5575     67  -1942  -1554       O  
+HETATM 2263  O   HOH A 892      12.814 -17.963  26.521  1.00 34.11           O  
+ANISOU 2263  O   HOH A 892     5639   3580   3742   -316   -726    692       O  
+HETATM 2264  O   HOH A 893      32.058  -2.371   7.289  1.00 43.64           O  
+ANISOU 2264  O   HOH A 893     4542   5860   6179     80   1023   1451       O  
+HETATM 2265  O   HOH A 894      19.111   3.958  11.564  1.00 45.74           O  
+ANISOU 2265  O   HOH A 894     5685   5461   6233  -1014   -731   -706       O  
+HETATM 2266  O   HOH A 895      13.809 -13.659  38.902  1.00 44.09           O  
+ANISOU 2266  O   HOH A 895     5323   5918   5510   1379   -343    273       O  
+HETATM 2267  O   HOH A 896       5.766  -8.908  -4.097  1.00 48.42           O  
+ANISOU 2267  O   HOH A 896     6021   5654   6722   -202  -1482   -965       O  
+HETATM 2268  O   HOH A 897      19.846  -4.083  36.411  1.00 38.48           O  
+ANISOU 2268  O   HOH A 897     5728   4802   4089   -124   -542    421       O  
+HETATM 2269  O   HOH A 898      12.317   9.701   8.076  1.00 40.51           O  
+ANISOU 2269  O   HOH A 898     4736   5816   4839    842    355    -69       O  
+HETATM 2270  O   HOH A 899      13.800  -6.860  32.609  1.00 24.36           O  
+ANISOU 2270  O   HOH A 899     3675   3165   2416     24   -429   -866       O  
+HETATM 2271  O   HOH A 900      18.905   6.499   7.487  1.00 41.11           O  
+ANISOU 2271  O   HOH A 900     7051   3419   5148   -952    916   -569       O  
+HETATM 2272  O   HOH A 901      25.026  -1.329   4.864  1.00 44.18           O  
+ANISOU 2272  O   HOH A 901     5895   5943   4949  -1333   1224    -98       O  
+HETATM 2273  O   HOH A 902      18.079   8.076   6.034  1.00 38.07           O  
+ANISOU 2273  O   HOH A 902     5316   5281   3869   -457  -1232   -482       O  
+HETATM 2274  O   HOH A 903      -3.071   1.768   1.372  1.00 44.59           O  
+ANISOU 2274  O   HOH A 903     6402   5486   5053   -136   -673   1013       O  
+HETATM 2275  O   HOH A 904      35.907  -8.904  22.167  1.00 38.95           O  
+ANISOU 2275  O   HOH A 904     5944   2913   5943   -915   -985    353       O  
+HETATM 2276  O   HOH A 905      22.005  -5.092  -7.712  1.00 41.94           O  
+ANISOU 2276  O   HOH A 905     7197   3428   5311   -165  -1301   -785       O  
+HETATM 2277  O   HOH A 906      10.242   2.770  33.672  1.00 37.89           O  
+ANISOU 2277  O   HOH A 906     4871   3413   6110   -342   1030   -613       O  
+HETATM 2278  O   HOH A 907       8.519   5.672  -6.848  1.00 36.54           O  
+ANISOU 2278  O   HOH A 907     5839   5346   2697   1513   -356    460       O  
+HETATM 2279  O   HOH A 908      14.215  -8.088  -4.457  1.00 34.83           O  
+ANISOU 2279  O   HOH A 908     5054   4229   3952   -596     33    831       O  
+HETATM 2280  O   HOH A 909      -2.351  -8.961  16.678  1.00 42.12           O  
+ANISOU 2280  O   HOH A 909     4493   5482   6027  -1548   1104  -1460       O  
+HETATM 2281  O   HOH A 910       1.752  19.197  18.956  1.00 38.24           O  
+ANISOU 2281  O   HOH A 910     4626   4362   5541     85   -431   -106       O  
+HETATM 2282  O   HOH A 911       3.269  -6.789  35.179  1.00 45.33           O  
+ANISOU 2282  O   HOH A 911     7552   4970   4701    363     -7   1257       O  
+HETATM 2283  O   HOH A 912      31.155  -0.594  13.878  1.00 35.74           O  
+ANISOU 2283  O   HOH A 912     2879   5367   5335  -1063     62   -328       O  
+HETATM 2284  O   HOH A 913      15.879  -7.749  34.132  1.00 43.39           O  
+ANISOU 2284  O   HOH A 913     4736   5499   6252   -743  -1554   1012       O  
+HETATM 2285  O   HOH A 914      19.182  -2.711  -6.851  1.00 33.41           O  
+ANISOU 2285  O   HOH A 914     6019   4035   2641   -577    470    348       O  
+HETATM 2286  O   HOH A 915      -4.598  12.885  19.628  1.00 47.07           O  
+ANISOU 2286  O   HOH A 915     6909   4978   5998   1057    504    824       O  
+HETATM 2287  O   HOH A 916      -5.147  -5.964  30.098  1.00 43.01           O  
+ANISOU 2287  O   HOH A 916     4464   7686   4192   -466   1018   2121       O  
+HETATM 2288  O   HOH A 917       5.863   4.590  38.308  1.00 45.28           O  
+ANISOU 2288  O   HOH A 917     6021   5936   5249   1315   -175  -1750       O  
+HETATM 2289  O   HOH A 918      25.958  -3.798  34.224  1.00 44.89           O  
+ANISOU 2289  O   HOH A 918     4560   5669   6829   1540    166    631       O  
+HETATM 2290  O   HOH A 919       7.594 -14.469  -0.110  1.00 43.27           O  
+ANISOU 2290  O   HOH A 919     6603   5576   4262   -688   -830  -1703       O  
+HETATM 2291  O   HOH A 920      16.705   2.860   9.554  1.00 41.13           O  
+ANISOU 2291  O   HOH A 920     5363   6049   4217    705   1143   -210       O  
+HETATM 2292  O   HOH A 921      -4.454  -1.740  32.014  1.00 43.17           O  
+ANISOU 2292  O   HOH A 921     4028   6036   6338  -1654     78    556       O  
+HETATM 2293  O   HOH A 922      -8.029  -1.766  13.545  1.00 39.34           O  
+ANISOU 2293  O   HOH A 922     4293   5196   5457    440    278   -726       O  
+HETATM 2294  O   HOH A 923      22.566 -15.858  14.032  1.00 42.50           O  
+ANISOU 2294  O   HOH A 923     4152   4934   7064    586   1062   1413       O  
+HETATM 2295  O   HOH A 924      17.718 -18.138   6.264  1.00 44.25           O  
+ANISOU 2295  O   HOH A 924     6378   6143   4293   1791    -75   -370       O  
+HETATM 2296  O   HOH A 925      -4.845  10.571   6.110  1.00 49.09           O  
+ANISOU 2296  O   HOH A 925     6002   6537   6113   -462    185    969       O  
+HETATM 2297  O   HOH A 926      16.903  -6.477  31.241  1.00 45.45           O  
+ANISOU 2297  O   HOH A 926     7105   5325   4840   -196   -445   1009       O  
+HETATM 2298  O   HOH A 927      12.499  -2.060   7.851  1.00 25.15           O  
+ANISOU 2298  O   HOH A 927     3972   2835   2750   -122    696     83       O  
+HETATM 2299  O   HOH A 928       7.916   1.298  -6.179  1.00 38.46           O  
+ANISOU 2299  O   HOH A 928     5984   3774   4854    767    620   -558       O  
+HETATM 2300  O   HOH A 929       7.327  16.573   6.187  1.00 47.63           O  
+ANISOU 2300  O   HOH A 929     5130   4755   8214   -777    359    381       O  
+HETATM 2301  O   HOH A 930      26.427  13.075  20.436  1.00 43.42           O  
+ANISOU 2301  O   HOH A 930     5591   3755   7153   -157   -544   -820       O  
+HETATM 2302  O   HOH A 931      17.270 -13.586  -1.867  1.00 41.33           O  
+ANISOU 2302  O   HOH A 931     5630   4796   5277   -646    861   -676       O  
+HETATM 2303  O   HOH A 932      -3.857 -13.266  12.650  1.00 50.41           O  
+ANISOU 2303  O   HOH A 932     6283   5133   7739   -192    411  -1739       O  
+HETATM 2304  O   HOH A 933      25.950  -1.602   2.779  1.00 42.33           O  
+ANISOU 2304  O   HOH A 933     5721   4714   5648  -1740     19     -8       O  
+HETATM 2305  O   HOH A 934       0.790  -3.033  -3.690  1.00 44.11           O  
+ANISOU 2305  O   HOH A 934     5789   5494   5476    240  -2125   -307       O  
+CONECT  735 2046                                                                
+CONECT  756 2046                                                                
+CONECT  933 2046                                                                
+CONECT 2046  735  756  933 2070                                                 
+CONECT 2047 2048 2070 2071 2072                                                 
+CONECT 2048 2047 2049 2053                                                      
+CONECT 2049 2048 2050                                                           
+CONECT 2050 2049 2051                                                           
+CONECT 2051 2050 2052 2054                                                      
+CONECT 2052 2051 2053                                                           
+CONECT 2053 2048 2052                                                           
+CONECT 2054 2051 2055 2069                                                      
+CONECT 2055 2054 2056 2063                                                      
+CONECT 2056 2055 2057 2062                                                      
+CONECT 2057 2056 2058                                                           
+CONECT 2058 2057 2059                                                           
+CONECT 2059 2058 2060 2061                                                      
+CONECT 2060 2059                                                                
+CONECT 2061 2059 2062                                                           
+CONECT 2062 2056 2061                                                           
+CONECT 2063 2055 2064                                                           
+CONECT 2064 2063 2065 2069                                                      
+CONECT 2065 2064 2066 2067 2068                                                 
+CONECT 2066 2065                                                                
+CONECT 2067 2065                                                                
+CONECT 2068 2065                                                                
+CONECT 2069 2054 2064                                                           
+CONECT 2070 2046 2047                                                           
+CONECT 2071 2047                                                                
+CONECT 2072 2047                                                                
+MASTER      262    0    2    9   18    0    4    6 2295    1   30   20          
+END                                                                             

--- a/ops/gates/configs/legacy_runtime_receptors/1SQ5_apo.pdb
+++ b/ops/gates/configs/legacy_runtime_receptors/1SQ5_apo.pdb
@@ -1,0 +1,11411 @@
+HEADER    TRANSFERASE                             17-MAR-04   1SQ5              
+TITLE     CRYSTAL STRUCTURE OF E. COLI PANTOTHENATE KINASE                      
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: PANTOTHENATE KINASE;                                       
+COMPND   3 CHAIN: A, B, C, D;                                                   
+COMPND   4 SYNONYM: PANTOTHENIC ACID KINASE, RTS PROTEIN;                       
+COMPND   5 EC: 2.7.1.33;                                                        
+COMPND   6 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: ESCHERICHIA COLI;                               
+SOURCE   3 ORGANISM_TAXID: 562;                                                 
+SOURCE   4 GENE: COAA, RTS, PANK, B3974, C4933, Z5545, ECS4901;                 
+SOURCE   5 EXPRESSION_SYSTEM: ESCHERICHIA COLI BL21(DE3);                       
+SOURCE   6 EXPRESSION_SYSTEM_TAXID: 469008;                                     
+SOURCE   7 EXPRESSION_SYSTEM_STRAIN: BL21(DE3);                                 
+SOURCE   8 EXPRESSION_SYSTEM_VECTOR_TYPE: PET;                                  
+SOURCE   9 EXPRESSION_SYSTEM_PLASMID: PET21A                                    
+KEYWDS    P-LOOP, TRANSFERASE                                                   
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    R.A.IVEY,Y.-M.ZHANG,K.G.VIRGA,K.HEVENER,R.E.LEE,C.O.ROCK,S.JACKOWSKI, 
+AUTHOR   2 H.-W.PARK                                                            
+REVDAT   3   14-FEB-24 1SQ5    1       REMARK                                   
+REVDAT   2   24-FEB-09 1SQ5    1       VERSN                                    
+REVDAT   1   28-SEP-04 1SQ5    0                                                
+JRNL        AUTH   R.A.IVEY,Y.-M.ZHANG,K.G.VIRGA,K.HEVENER,R.E.LEE,C.O.ROCK,    
+JRNL        AUTH 2 S.JACKOWSKI,H.-W.PARK                                        
+JRNL        TITL   THE STRUCTURE OF THE PANTOTHENATE KINASE.ADP.PANTOTHENATE    
+JRNL        TITL 2 TERNARY COMPLEX REVEALS THE RELATIONSHIP BETWEEN THE BINDING 
+JRNL        TITL 3 SITES FOR SUBSTRATE, ALLOSTERIC REGULATOR, AND               
+JRNL        TITL 4 ANTIMETABOLITES.                                             
+JRNL        REF    J.BIOL.CHEM.                  V. 279 35622 2004              
+JRNL        REFN                   ISSN 0021-9258                               
+JRNL        PMID   15136582                                                     
+JRNL        DOI    10.1074/JBC.M403152200                                       
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    2.20 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : CNS                                                  
+REMARK   3   AUTHORS     : BRUNGER,ADAMS,CLORE,DELANO,GROS,GROSSE-              
+REMARK   3               : KUNSTLEVE,JIANG,KUSZEWSKI,NILGES,PANNU,              
+REMARK   3               : READ,RICE,SIMONSON,WARREN                            
+REMARK   3                                                                      
+REMARK   3  REFINEMENT TARGET : NULL                                            
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 2.20                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 20.00                          
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : 2.000                          
+REMARK   3   DATA CUTOFF HIGH         (ABS(F)) : NULL                           
+REMARK   3   DATA CUTOFF LOW          (ABS(F)) : NULL                           
+REMARK   3   COMPLETENESS (WORKING+TEST)   (%) : 99.2                           
+REMARK   3   NUMBER OF REFLECTIONS             : 65592                          
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   CROSS-VALIDATION METHOD          : MOLEMAN2                        
+REMARK   3   FREE R VALUE TEST SET SELECTION  : NULL                            
+REMARK   3   R VALUE            (WORKING SET) : 0.187                           
+REMARK   3   FREE R VALUE                     : 0.225                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : NULL                            
+REMARK   3   FREE R VALUE TEST SET COUNT      : NULL                            
+REMARK   3   ESTIMATED ERROR OF FREE R VALUE  : NULL                            
+REMARK   3                                                                      
+REMARK   3  FIT IN THE HIGHEST RESOLUTION BIN.                                  
+REMARK   3   TOTAL NUMBER OF BINS USED           : 50                           
+REMARK   3   BIN RESOLUTION RANGE HIGH       (A) : 2.20                         
+REMARK   3   BIN RESOLUTION RANGE LOW        (A) : 2.21                         
+REMARK   3   BIN COMPLETENESS (WORKING+TEST) (%) : NULL                         
+REMARK   3   REFLECTIONS IN BIN    (WORKING SET) : 776                          
+REMARK   3   BIN R VALUE           (WORKING SET) : 0.2120                       
+REMARK   3   BIN FREE R VALUE                    : 0.2430                       
+REMARK   3   BIN FREE R VALUE TEST SET SIZE  (%) : NULL                         
+REMARK   3   BIN FREE R VALUE TEST SET COUNT     : 87                           
+REMARK   3   ESTIMATED ERROR OF BIN FREE R VALUE : NULL                         
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 9650                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 168                                     
+REMARK   3   SOLVENT ATOMS            : 885                                     
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : NULL                           
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : 29.40                          
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : NULL                                                 
+REMARK   3    B22 (A**2) : NULL                                                 
+REMARK   3    B33 (A**2) : NULL                                                 
+REMARK   3    B12 (A**2) : NULL                                                 
+REMARK   3    B13 (A**2) : NULL                                                 
+REMARK   3    B23 (A**2) : NULL                                                 
+REMARK   3                                                                      
+REMARK   3  ESTIMATED COORDINATE ERROR.                                         
+REMARK   3   ESD FROM LUZZATI PLOT        (A) : 0.41                            
+REMARK   3   ESD FROM SIGMAA              (A) : 0.43                            
+REMARK   3   LOW RESOLUTION CUTOFF        (A) : NULL                            
+REMARK   3                                                                      
+REMARK   3  CROSS-VALIDATED ESTIMATED COORDINATE ERROR.                         
+REMARK   3   ESD FROM C-V LUZZATI PLOT    (A) : 0.43                            
+REMARK   3   ESD FROM C-V SIGMAA          (A) : 0.43                            
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.                                   
+REMARK   3   BOND LENGTHS                 (A) : 0.008                           
+REMARK   3   BOND ANGLES            (DEGREES) : 1.400                           
+REMARK   3   DIHEDRAL ANGLES        (DEGREES) : NULL                            
+REMARK   3   IMPROPER ANGLES        (DEGREES) : NULL                            
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL MODEL : NULL                                      
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL FACTOR RESTRAINTS.    RMS    SIGMA                
+REMARK   3   MAIN-CHAIN BOND              (A**2) : NULL  ; NULL                 
+REMARK   3   MAIN-CHAIN ANGLE             (A**2) : NULL  ; NULL                 
+REMARK   3   SIDE-CHAIN BOND              (A**2) : NULL  ; NULL                 
+REMARK   3   SIDE-CHAIN ANGLE             (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELING.                                              
+REMARK   3   METHOD USED : NULL                                                 
+REMARK   3   KSOL        : NULL                                                 
+REMARK   3   BSOL        : NULL                                                 
+REMARK   3                                                                      
+REMARK   3  NCS MODEL : NULL                                                    
+REMARK   3                                                                      
+REMARK   3  NCS RESTRAINTS.                         RMS   SIGMA/WEIGHT          
+REMARK   3   GROUP  1  POSITIONAL            (A) : NULL  ; NULL                 
+REMARK   3   GROUP  1  B-FACTOR           (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  PARAMETER FILE  1  : NULL                                           
+REMARK   3  TOPOLOGY FILE  1   : NULL                                           
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 1SQ5 COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY RCSB ON 03-MAY-04.                  
+REMARK 100 THE DEPOSITION ID IS D_1000021907.                                   
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : NULL                               
+REMARK 200  TEMPERATURE           (KELVIN) : 100.0                              
+REMARK 200  PH                             : NULL                               
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : APS                                
+REMARK 200  BEAMLINE                       : 22-ID                              
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 1.0000                             
+REMARK 200  MONOCHROMATOR                  : NULL                               
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : CCD                                
+REMARK 200  DETECTOR MANUFACTURER          : MARRESEARCH                        
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : DENZO                              
+REMARK 200  DATA SCALING SOFTWARE          : SCALEPACK                          
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 70252                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 2.200                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 20.000                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : 2.000                              
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 99.2                               
+REMARK 200  DATA REDUNDANCY                : 3.600                              
+REMARK 200  R MERGE                    (I) : NULL                               
+REMARK 200  R SYM                      (I) : 0.06900                            
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 15.2000                            
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 2.20                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 2.28                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 98.4                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : 3.60                               
+REMARK 200  R MERGE FOR SHELL          (I) : NULL                               
+REMARK 200  R SYM FOR SHELL            (I) : 0.03400                            
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : 3.300                              
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MOLECULAR REPLACEMENT        
+REMARK 200 SOFTWARE USED: NULL                                                  
+REMARK 200 STARTING MODEL: NULL                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 53.74                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.66                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: VAPOR DIFFUSION, HANGING DROP            
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: C 1 2 1                          
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X,Y,-Z                                                 
+REMARK 290       3555   X+1/2,Y+1/2,Z                                           
+REMARK 290       4555   -X+1/2,Y+1/2,-Z                                         
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1   3  1.000000  0.000000  0.000000       90.60150            
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000       90.82750            
+REMARK 290   SMTRY3   3  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   4 -1.000000  0.000000  0.000000       90.60150            
+REMARK 290   SMTRY2   4  0.000000  1.000000  0.000000       90.82750            
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1, 2, 3                                                 
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: DIMERIC                           
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: DIMERIC                    
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 5410 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 25950 ANGSTROM**2                       
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -39.0 KCAL/MOL                        
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, D                                  
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 2                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: DIMERIC                           
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: B                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   2 -1.000000  0.000000  0.000000      169.09827            
+REMARK 350   BIOMT2   2  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   2  0.000000  0.000000 -1.000000       45.84694            
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 3                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: DIMERIC                           
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: C                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   2 -1.000000  0.000000  0.000000       12.10473            
+REMARK 350   BIOMT2   2  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   2  0.000000  0.000000 -1.000000      -45.84694            
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465     SER A  1026                                                      
+REMARK 465     VAL A  1027                                                      
+REMARK 465     PRO A  1028                                                      
+REMARK 465     THR A  1030                                                      
+REMARK 465     GLY A  1084                                                      
+REMARK 465     GLN A  1192                                                      
+REMARK 465     ASP B  2025                                                      
+REMARK 465     SER B  2026                                                      
+REMARK 465     VAL B  2027                                                      
+REMARK 465     PRO B  2028                                                      
+REMARK 465     MET B  2029                                                      
+REMARK 465     THR B  2030                                                      
+REMARK 465     ASP C  3025                                                      
+REMARK 465     SER C  3026                                                      
+REMARK 465     VAL C  3027                                                      
+REMARK 465     PRO C  3028                                                      
+REMARK 465     GLY C  3084                                                      
+REMARK 465     GLN C  3085                                                      
+REMARK 465     ILE C  3087                                                      
+REMARK 465     HIS C  3118                                                      
+REMARK 465     ARG C  3120                                                      
+REMARK 465     GLN C  3192                                                      
+REMARK 465     SER D  4026                                                      
+REMARK 465     VAL D  4027                                                      
+REMARK 465     PRO D  4028                                                      
+REMARK 465     GLN D  4192                                                      
+REMARK 470                                                                      
+REMARK 470 MISSING ATOM                                                         
+REMARK 470 THE FOLLOWING RESIDUES HAVE MISSING ATOMS (M=MODEL NUMBER;           
+REMARK 470 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;          
+REMARK 470 I=INSERTION CODE):                                                   
+REMARK 470   M RES CSSEQI  ATOMS                                                
+REMARK 470     LEU A1031    CG   CD1  CD2                                       
+REMARK 470     GLU A1033    CG   CD   OE1  OE2                                  
+REMARK 470     GLU A1044    CG   CD   OE1  OE2                                  
+REMARK 470     ARG A1071    CG   CD   NE   CZ   NH1  NH2                        
+REMARK 470     ASN A1083    CG   OD1  ND2                                       
+REMARK 470     ARG A1086    CG   CD   NE   CZ   NH1  NH2                        
+REMARK 470     ARG A1119    CG   CD   NE   CZ   NH1  NH2                        
+REMARK 470     LEU A1178    CG   CD1  CD2                                       
+REMARK 470     ASP A1185    CG   OD1  OD2                                       
+REMARK 470     LYS A1246    CG   CD   CE   NZ                                   
+REMARK 470     LYS A1264    CG   CD   CE   NZ                                   
+REMARK 470     GLU A1268    CG   CD   OE1  OE2                                  
+REMARK 470     LYS B2040    CG   CD   CE   NZ                                   
+REMARK 470     ASN B2083    CG   OD1  ND2                                       
+REMARK 470     GLN B2085    CG   CD   OE1  NE2                                  
+REMARK 470     ARG B2086    CG   CD   NE   CZ   NH1  NH2                        
+REMARK 470     ARG B2119    CG   CD   NE   CZ   NH1  NH2                        
+REMARK 470     ARG B2120    CG   CD   NE   CZ   NH1  NH2                        
+REMARK 470     LEU B2178    CG   CD1  CD2                                       
+REMARK 470     ASP B2185    CG   OD1  OD2                                       
+REMARK 470     LYS B2246    CG   CD   CE   NZ                                   
+REMARK 470     GLU B2268    CG   CD   OE1  OE2                                  
+REMARK 470     GLU C3033    CG   CD   OE1  OE2                                  
+REMARK 470     LYS C3040    CG   CD   CE   NZ                                   
+REMARK 470     GLU C3049    CG   CD   OE1  OE2                                  
+REMARK 470     ASN C3083    CG   OD1  ND2                                       
+REMARK 470     ARG C3086    CG   CD   NE   CZ   NH1  NH2                        
+REMARK 470     ARG C3119    CG   CD   NE   CZ   NH1  NH2                        
+REMARK 470     LYS C3137    CG   CD   CE   NZ                                   
+REMARK 470     LEU C3178    CG   CD1  CD2                                       
+REMARK 470     GLU D4033    CG   CD   OE1  OE2                                  
+REMARK 470     LYS D4040    CG   CD   CE   NZ                                   
+REMARK 470     GLN D4085    CG   CD   OE1  NE2                                  
+REMARK 470     ARG D4086    CG   CD   NE   CZ   NH1  NH2                        
+REMARK 470     ARG D4119    CG   CD   NE   CZ   NH1  NH2                        
+REMARK 470     ARG D4120    CG   CD   NE   CZ   NH1  NH2                        
+REMARK 470     LYS D4137    CG   CD   CE   NZ                                   
+REMARK 470     ASP D4185    CG   OD1  OD2                                       
+REMARK 470     ASP D4256    CG   OD1  OD2                                       
+REMARK 470     LYS D4264    CG   CD   CE   NZ                                   
+REMARK 470     GLU D4268    CG   CD   OE1  OE2                                  
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS                                             
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS THAT ARE RELATED BY CRYSTALLOGRAPHIC             
+REMARK 500 SYMMETRY ARE IN CLOSE CONTACT.  AN ATOM LOCATED WITHIN 0.15          
+REMARK 500 ANGSTROMS OF A SYMMETRY RELATED ATOM IS ASSUMED TO BE ON A           
+REMARK 500 SPECIAL POSITION AND IS, THEREFORE, LISTED IN REMARK 375             
+REMARK 500 INSTEAD OF REMARK 500.  ATOMS WITH NON-BLANK ALTERNATE               
+REMARK 500 LOCATION INDICATORS ARE NOT INCLUDED IN THE CALCULATIONS.            
+REMARK 500                                                                      
+REMARK 500 DISTANCE CUTOFF:                                                     
+REMARK 500 2.2 ANGSTROMS FOR CONTACTS NOT INVOLVING HYDROGEN ATOMS              
+REMARK 500 1.6 ANGSTROMS FOR CONTACTS INVOLVING HYDROGEN ATOMS                  
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI  SSYMOP   DISTANCE          
+REMARK 500   NE2  GLN C  3014     NE2  GLN C  3014     2555     2.13            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    PRO A1011        5.96    -69.20                                   
+REMARK 500    ASP A1213       74.06   -161.24                                   
+REMARK 500    SER A1304     -165.90   -128.02                                   
+REMARK 500    ASN B2083     -160.78    -77.36                                   
+REMARK 500    GLN B2085       73.79     66.00                                   
+REMARK 500    ASP B2185       61.26   -119.39                                   
+REMARK 500    GLN B2192       57.42     31.76                                   
+REMARK 500    ASP B2213       73.28   -161.44                                   
+REMARK 500    SER B2304     -162.27   -128.34                                   
+REMARK 500    ASP C3213       73.11   -161.24                                   
+REMARK 500    ASN D4083       49.09    -76.99                                   
+REMARK 500    ASP D4213       73.37   -161.07                                   
+REMARK 500    ALA D4305      136.61    -39.73                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE PAU A 6001                
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE PAU C 6002                
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC3                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE PAU B 6003                
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC4                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE PAU D 6004                
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC5                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ADP A 5001                
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC6                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ADP B 5002                
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC7                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ADP C 5003                
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC8                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ADP D 5004                
+REMARK 900                                                                      
+REMARK 900 RELATED ENTRIES                                                      
+REMARK 900 RELATED ID: 1ESM   RELATED DB: PDB                                   
+REMARK 900 E. COLI PANK COMPLEXED TO COENZYME A                                 
+REMARK 900 RELATED ID: 1ESN   RELATED DB: PDB                                   
+REMARK 900 E. COLI PANK COMPLEXED TO MG-AMP-PNP                                 
+DBREF  1SQ5 A 1009  1316  UNP    P0A6I3   COAA_ECOLI       9    316             
+DBREF  1SQ5 B 2009  2316  UNP    P0A6I3   COAA_ECOLI       9    316             
+DBREF  1SQ5 C 3009  3316  UNP    P0A6I3   COAA_ECOLI       9    316             
+DBREF  1SQ5 D 4009  4316  UNP    P0A6I3   COAA_ECOLI       9    316             
+SEQRES   1 A  308  MET THR PRO TYR LEU GLN PHE ASP ARG ASN GLN TRP ALA          
+SEQRES   2 A  308  ALA LEU ARG ASP SER VAL PRO MET THR LEU SER GLU ASP          
+SEQRES   3 A  308  GLU ILE ALA ARG LEU LYS GLY ILE ASN GLU ASP LEU SER          
+SEQRES   4 A  308  LEU GLU GLU VAL ALA GLU ILE TYR LEU PRO LEU SER ARG          
+SEQRES   5 A  308  LEU LEU ASN PHE TYR ILE SER SER ASN LEU ARG ARG GLN          
+SEQRES   6 A  308  ALA VAL LEU GLU GLN PHE LEU GLY THR ASN GLY GLN ARG          
+SEQRES   7 A  308  ILE PRO TYR ILE ILE SER ILE ALA GLY SER VAL ALA VAL          
+SEQRES   8 A  308  GLY LYS SER THR THR ALA ARG VAL LEU GLN ALA LEU LEU          
+SEQRES   9 A  308  SER ARG TRP PRO GLU HIS ARG ARG VAL GLU LEU ILE THR          
+SEQRES  10 A  308  THR ASP GLY PHE LEU HIS PRO ASN GLN VAL LEU LYS GLU          
+SEQRES  11 A  308  ARG GLY LEU MET LYS LYS LYS GLY PHE PRO GLU SER TYR          
+SEQRES  12 A  308  ASP MET HIS ARG LEU VAL LYS PHE VAL SER ASP LEU LYS          
+SEQRES  13 A  308  SER GLY VAL PRO ASN VAL THR ALA PRO VAL TYR SER HIS          
+SEQRES  14 A  308  LEU ILE TYR ASP VAL ILE PRO ASP GLY ASP LYS THR VAL          
+SEQRES  15 A  308  VAL GLN PRO ASP ILE LEU ILE LEU GLU GLY LEU ASN VAL          
+SEQRES  16 A  308  LEU GLN SER GLY MET ASP TYR PRO HIS ASP PRO HIS HIS          
+SEQRES  17 A  308  VAL PHE VAL SER ASP PHE VAL ASP PHE SER ILE TYR VAL          
+SEQRES  18 A  308  ASP ALA PRO GLU ASP LEU LEU GLN THR TRP TYR ILE ASN          
+SEQRES  19 A  308  ARG PHE LEU LYS PHE ARG GLU GLY ALA PHE THR ASP PRO          
+SEQRES  20 A  308  ASP SER TYR PHE HIS ASN TYR ALA LYS LEU THR LYS GLU          
+SEQRES  21 A  308  GLU ALA ILE LYS THR ALA MET THR LEU TRP LYS GLU ILE          
+SEQRES  22 A  308  ASN TRP LEU ASN LEU LYS GLN ASN ILE LEU PRO THR ARG          
+SEQRES  23 A  308  GLU ARG ALA SER LEU ILE LEU THR LYS SER ALA ASN HIS          
+SEQRES  24 A  308  ALA VAL GLU GLU VAL ARG LEU ARG LYS                          
+SEQRES   1 B  308  MET THR PRO TYR LEU GLN PHE ASP ARG ASN GLN TRP ALA          
+SEQRES   2 B  308  ALA LEU ARG ASP SER VAL PRO MET THR LEU SER GLU ASP          
+SEQRES   3 B  308  GLU ILE ALA ARG LEU LYS GLY ILE ASN GLU ASP LEU SER          
+SEQRES   4 B  308  LEU GLU GLU VAL ALA GLU ILE TYR LEU PRO LEU SER ARG          
+SEQRES   5 B  308  LEU LEU ASN PHE TYR ILE SER SER ASN LEU ARG ARG GLN          
+SEQRES   6 B  308  ALA VAL LEU GLU GLN PHE LEU GLY THR ASN GLY GLN ARG          
+SEQRES   7 B  308  ILE PRO TYR ILE ILE SER ILE ALA GLY SER VAL ALA VAL          
+SEQRES   8 B  308  GLY LYS SER THR THR ALA ARG VAL LEU GLN ALA LEU LEU          
+SEQRES   9 B  308  SER ARG TRP PRO GLU HIS ARG ARG VAL GLU LEU ILE THR          
+SEQRES  10 B  308  THR ASP GLY PHE LEU HIS PRO ASN GLN VAL LEU LYS GLU          
+SEQRES  11 B  308  ARG GLY LEU MET LYS LYS LYS GLY PHE PRO GLU SER TYR          
+SEQRES  12 B  308  ASP MET HIS ARG LEU VAL LYS PHE VAL SER ASP LEU LYS          
+SEQRES  13 B  308  SER GLY VAL PRO ASN VAL THR ALA PRO VAL TYR SER HIS          
+SEQRES  14 B  308  LEU ILE TYR ASP VAL ILE PRO ASP GLY ASP LYS THR VAL          
+SEQRES  15 B  308  VAL GLN PRO ASP ILE LEU ILE LEU GLU GLY LEU ASN VAL          
+SEQRES  16 B  308  LEU GLN SER GLY MET ASP TYR PRO HIS ASP PRO HIS HIS          
+SEQRES  17 B  308  VAL PHE VAL SER ASP PHE VAL ASP PHE SER ILE TYR VAL          
+SEQRES  18 B  308  ASP ALA PRO GLU ASP LEU LEU GLN THR TRP TYR ILE ASN          
+SEQRES  19 B  308  ARG PHE LEU LYS PHE ARG GLU GLY ALA PHE THR ASP PRO          
+SEQRES  20 B  308  ASP SER TYR PHE HIS ASN TYR ALA LYS LEU THR LYS GLU          
+SEQRES  21 B  308  GLU ALA ILE LYS THR ALA MET THR LEU TRP LYS GLU ILE          
+SEQRES  22 B  308  ASN TRP LEU ASN LEU LYS GLN ASN ILE LEU PRO THR ARG          
+SEQRES  23 B  308  GLU ARG ALA SER LEU ILE LEU THR LYS SER ALA ASN HIS          
+SEQRES  24 B  308  ALA VAL GLU GLU VAL ARG LEU ARG LYS                          
+SEQRES   1 C  308  MET THR PRO TYR LEU GLN PHE ASP ARG ASN GLN TRP ALA          
+SEQRES   2 C  308  ALA LEU ARG ASP SER VAL PRO MET THR LEU SER GLU ASP          
+SEQRES   3 C  308  GLU ILE ALA ARG LEU LYS GLY ILE ASN GLU ASP LEU SER          
+SEQRES   4 C  308  LEU GLU GLU VAL ALA GLU ILE TYR LEU PRO LEU SER ARG          
+SEQRES   5 C  308  LEU LEU ASN PHE TYR ILE SER SER ASN LEU ARG ARG GLN          
+SEQRES   6 C  308  ALA VAL LEU GLU GLN PHE LEU GLY THR ASN GLY GLN ARG          
+SEQRES   7 C  308  ILE PRO TYR ILE ILE SER ILE ALA GLY SER VAL ALA VAL          
+SEQRES   8 C  308  GLY LYS SER THR THR ALA ARG VAL LEU GLN ALA LEU LEU          
+SEQRES   9 C  308  SER ARG TRP PRO GLU HIS ARG ARG VAL GLU LEU ILE THR          
+SEQRES  10 C  308  THR ASP GLY PHE LEU HIS PRO ASN GLN VAL LEU LYS GLU          
+SEQRES  11 C  308  ARG GLY LEU MET LYS LYS LYS GLY PHE PRO GLU SER TYR          
+SEQRES  12 C  308  ASP MET HIS ARG LEU VAL LYS PHE VAL SER ASP LEU LYS          
+SEQRES  13 C  308  SER GLY VAL PRO ASN VAL THR ALA PRO VAL TYR SER HIS          
+SEQRES  14 C  308  LEU ILE TYR ASP VAL ILE PRO ASP GLY ASP LYS THR VAL          
+SEQRES  15 C  308  VAL GLN PRO ASP ILE LEU ILE LEU GLU GLY LEU ASN VAL          
+SEQRES  16 C  308  LEU GLN SER GLY MET ASP TYR PRO HIS ASP PRO HIS HIS          
+SEQRES  17 C  308  VAL PHE VAL SER ASP PHE VAL ASP PHE SER ILE TYR VAL          
+SEQRES  18 C  308  ASP ALA PRO GLU ASP LEU LEU GLN THR TRP TYR ILE ASN          
+SEQRES  19 C  308  ARG PHE LEU LYS PHE ARG GLU GLY ALA PHE THR ASP PRO          
+SEQRES  20 C  308  ASP SER TYR PHE HIS ASN TYR ALA LYS LEU THR LYS GLU          
+SEQRES  21 C  308  GLU ALA ILE LYS THR ALA MET THR LEU TRP LYS GLU ILE          
+SEQRES  22 C  308  ASN TRP LEU ASN LEU LYS GLN ASN ILE LEU PRO THR ARG          
+SEQRES  23 C  308  GLU ARG ALA SER LEU ILE LEU THR LYS SER ALA ASN HIS          
+SEQRES  24 C  308  ALA VAL GLU GLU VAL ARG LEU ARG LYS                          
+SEQRES   1 D  308  MET THR PRO TYR LEU GLN PHE ASP ARG ASN GLN TRP ALA          
+SEQRES   2 D  308  ALA LEU ARG ASP SER VAL PRO MET THR LEU SER GLU ASP          
+SEQRES   3 D  308  GLU ILE ALA ARG LEU LYS GLY ILE ASN GLU ASP LEU SER          
+SEQRES   4 D  308  LEU GLU GLU VAL ALA GLU ILE TYR LEU PRO LEU SER ARG          
+SEQRES   5 D  308  LEU LEU ASN PHE TYR ILE SER SER ASN LEU ARG ARG GLN          
+SEQRES   6 D  308  ALA VAL LEU GLU GLN PHE LEU GLY THR ASN GLY GLN ARG          
+SEQRES   7 D  308  ILE PRO TYR ILE ILE SER ILE ALA GLY SER VAL ALA VAL          
+SEQRES   8 D  308  GLY LYS SER THR THR ALA ARG VAL LEU GLN ALA LEU LEU          
+SEQRES   9 D  308  SER ARG TRP PRO GLU HIS ARG ARG VAL GLU LEU ILE THR          
+SEQRES  10 D  308  THR ASP GLY PHE LEU HIS PRO ASN GLN VAL LEU LYS GLU          
+SEQRES  11 D  308  ARG GLY LEU MET LYS LYS LYS GLY PHE PRO GLU SER TYR          
+SEQRES  12 D  308  ASP MET HIS ARG LEU VAL LYS PHE VAL SER ASP LEU LYS          
+SEQRES  13 D  308  SER GLY VAL PRO ASN VAL THR ALA PRO VAL TYR SER HIS          
+SEQRES  14 D  308  LEU ILE TYR ASP VAL ILE PRO ASP GLY ASP LYS THR VAL          
+SEQRES  15 D  308  VAL GLN PRO ASP ILE LEU ILE LEU GLU GLY LEU ASN VAL          
+SEQRES  16 D  308  LEU GLN SER GLY MET ASP TYR PRO HIS ASP PRO HIS HIS          
+SEQRES  17 D  308  VAL PHE VAL SER ASP PHE VAL ASP PHE SER ILE TYR VAL          
+SEQRES  18 D  308  ASP ALA PRO GLU ASP LEU LEU GLN THR TRP TYR ILE ASN          
+SEQRES  19 D  308  ARG PHE LEU LYS PHE ARG GLU GLY ALA PHE THR ASP PRO          
+SEQRES  20 D  308  ASP SER TYR PHE HIS ASN TYR ALA LYS LEU THR LYS GLU          
+SEQRES  21 D  308  GLU ALA ILE LYS THR ALA MET THR LEU TRP LYS GLU ILE          
+SEQRES  22 D  308  ASN TRP LEU ASN LEU LYS GLN ASN ILE LEU PRO THR ARG          
+SEQRES  23 D  308  GLU ARG ALA SER LEU ILE LEU THR LYS SER ALA ASN HIS          
+SEQRES  24 D  308  ALA VAL GLU GLU VAL ARG LEU ARG LYS                          
+HET    PAU  A6001      15                                                       
+HET    ADP  A5001      27                                                       
+HET    PAU  B6003      15                                                       
+HET    ADP  B5002      27                                                       
+HET    PAU  C6002      15                                                       
+HET    ADP  C5003      27                                                       
+HET    PAU  D6004      15                                                       
+HET    ADP  D5004      27                                                       
+HETNAM     PAU PANTOTHENOIC ACID                                                
+HETNAM     ADP ADENOSINE-5'-DIPHOSPHATE                                         
+HETSYN     PAU N-[(2R)-2,4-DIHYDROXY-3,3-DIMETHYLBUTANOYL]-BETA-                
+HETSYN   2 PAU  ALANINE                                                         
+FORMUL   5  PAU    4(C9 H17 N O5)                                               
+FORMUL   6  ADP    4(C10 H15 N5 O10 P2)                                         
+FORMUL  13  HOH   *885(H2 O)                                                    
+HELIX    1   1 ARG A 1017  LEU A 1023  1                                   7    
+HELIX    2   2 SER A 1032  ASN A 1043  1                                  12    
+HELIX    3   3 SER A 1047  ILE A 1054  1                                   8    
+HELIX    4   4 ILE A 1054  GLY A 1081  1                                  28    
+HELIX    5   5 GLY A 1100  SER A 1113  1                                  14    
+HELIX    6   6 ASP A 1127  LEU A 1130  5                                   4    
+HELIX    7   7 PRO A 1132  GLY A 1140  1                                   9    
+HELIX    8   8 PHE A 1147  TYR A 1151  5                                   5    
+HELIX    9   9 ASP A 1152  LYS A 1164  1                                  13    
+HELIX   10  10 SER A 1206  TYR A 1210  5                                   5    
+HELIX   11  11 PHE A 1218  VAL A 1223  5                                   6    
+HELIX   12  12 PRO A 1232  GLY A 1250  1                                  19    
+HELIX   13  13 PHE A 1259  LYS A 1264  1                                   6    
+HELIX   14  14 THR A 1266  ILE A 1281  1                                  16    
+HELIX   15  15 ILE A 1281  ASN A 1289  1                                   9    
+HELIX   16  16 ILE A 1290  ALA A 1297  5                                   8    
+HELIX   17  17 ALA A 1305  HIS A 1307  5                                   3    
+HELIX   18  18 ARG B 2017  ALA B 2022  1                                   6    
+HELIX   19  19 SER B 2032  ASN B 2043  1                                  12    
+HELIX   20  20 SER B 2047  ILE B 2054  1                                   8    
+HELIX   21  21 ILE B 2054  GLY B 2081  1                                  28    
+HELIX   22  22 GLY B 2100  SER B 2113  1                                  14    
+HELIX   23  23 ASP B 2127  LEU B 2130  5                                   4    
+HELIX   24  24 PRO B 2132  ARG B 2139  1                                   8    
+HELIX   25  25 PHE B 2147  TYR B 2151  5                                   5    
+HELIX   26  26 ASP B 2152  LYS B 2164  1                                  13    
+HELIX   27  27 SER B 2206  TYR B 2210  5                                   5    
+HELIX   28  28 PHE B 2218  VAL B 2223  5                                   6    
+HELIX   29  29 PRO B 2232  GLY B 2250  1                                  19    
+HELIX   30  30 SER B 2257  ALA B 2263  5                                   7    
+HELIX   31  31 THR B 2266  ILE B 2281  1                                  16    
+HELIX   32  32 ILE B 2281  ASN B 2289  1                                   9    
+HELIX   33  33 ILE B 2290  ALA B 2297  5                                   8    
+HELIX   34  34 ALA B 2305  HIS B 2307  5                                   3    
+HELIX   35  35 ARG C 3017  ALA C 3022  1                                   6    
+HELIX   36  36 SER C 3032  ASN C 3043  1                                  12    
+HELIX   37  37 SER C 3047  ILE C 3054  1                                   8    
+HELIX   38  38 ILE C 3054  GLY C 3081  1                                  28    
+HELIX   39  39 GLY C 3100  SER C 3113  1                                  14    
+HELIX   40  40 ASP C 3127  LEU C 3130  5                                   4    
+HELIX   41  41 PRO C 3132  ARG C 3139  1                                   8    
+HELIX   42  42 PHE C 3147  TYR C 3151  5                                   5    
+HELIX   43  43 ASP C 3152  LYS C 3164  1                                  13    
+HELIX   44  44 SER C 3206  TYR C 3210  5                                   5    
+HELIX   45  45 PHE C 3218  VAL C 3223  5                                   6    
+HELIX   46  46 PRO C 3232  GLY C 3250  1                                  19    
+HELIX   47  47 SER C 3257  LEU C 3265  5                                   9    
+HELIX   48  48 THR C 3266  ILE C 3281  1                                  16    
+HELIX   49  49 ILE C 3281  ASN C 3289  1                                   9    
+HELIX   50  50 ILE C 3290  ALA C 3297  5                                   8    
+HELIX   51  51 ALA C 3305  HIS C 3307  5                                   3    
+HELIX   52  52 ARG D 4017  ALA D 4022  1                                   6    
+HELIX   53  53 SER D 4032  ASN D 4043  1                                  12    
+HELIX   54  54 SER D 4047  ILE D 4054  1                                   8    
+HELIX   55  55 ILE D 4054  GLY D 4081  1                                  28    
+HELIX   56  56 GLY D 4100  SER D 4113  1                                  14    
+HELIX   57  57 ASP D 4127  LEU D 4130  5                                   4    
+HELIX   58  58 PRO D 4132  ARG D 4139  1                                   8    
+HELIX   59  59 PHE D 4147  TYR D 4151  5                                   5    
+HELIX   60  60 ASP D 4152  LYS D 4164  1                                  13    
+HELIX   61  61 SER D 4206  TYR D 4210  5                                   5    
+HELIX   62  62 PHE D 4218  VAL D 4223  5                                   6    
+HELIX   63  63 PRO D 4232  ALA D 4251  1                                  20    
+HELIX   64  64 SER D 4257  LEU D 4265  5                                   9    
+HELIX   65  65 THR D 4266  ILE D 4281  1                                  16    
+HELIX   66  66 ILE D 4281  ASN D 4289  1                                   9    
+HELIX   67  67 ILE D 4290  ALA D 4297  5                                   8    
+HELIX   68  68 ALA D 4305  HIS D 4307  5                                   3    
+SHEET    1   A 7 TYR A1012  ASP A1016  0                                        
+SHEET    2   A 7 VAL A1309  ARG A1315 -1  O  LEU A1314   N  LEU A1013           
+SHEET    3   A 7 LEU A1299  LYS A1303 -1  N  ILE A1300   O  ARG A1313           
+SHEET    4   A 7 PHE A1225  ASP A1230  1  N  ASP A1230   O  LYS A1303           
+SHEET    5   A 7 TYR A1089  GLY A1095  1  N  ALA A1094   O  ILE A1227           
+SHEET    6   A 7 ILE A1195  GLU A1199  1  O  LEU A1198   N  ILE A1091           
+SHEET    7   A 7 VAL A1121  THR A1125  1  N  GLU A1122   O  ILE A1197           
+SHEET    1   B 2 VAL A1170  ALA A1172  0                                        
+SHEET    2   B 2 LYS A1188  VAL A1190 -1  O  VAL A1190   N  VAL A1170           
+SHEET    1   C 2 TYR A1175  SER A1176  0                                        
+SHEET    2   C 2 ASP A1181  VAL A1182 -1  O  ASP A1181   N  SER A1176           
+SHEET    1   D 7 TYR B2012  ASP B2016  0                                        
+SHEET    2   D 7 VAL B2309  ARG B2315 -1  O  LEU B2314   N  LEU B2013           
+SHEET    3   D 7 LEU B2299  LYS B2303 -1  N  THR B2302   O  GLU B2310           
+SHEET    4   D 7 PHE B2225  ASP B2230  1  N  ASP B2230   O  LEU B2301           
+SHEET    5   D 7 TYR B2089  GLY B2095  1  N  ALA B2094   O  ILE B2227           
+SHEET    6   D 7 ILE B2195  GLU B2199  1  O  LEU B2198   N  ILE B2091           
+SHEET    7   D 7 VAL B2121  THR B2125  1  N  GLU B2122   O  ILE B2197           
+SHEET    1   E 2 ASN B2169  ALA B2172  0                                        
+SHEET    2   E 2 LYS B2188  VAL B2191 -1  O  VAL B2190   N  VAL B2170           
+SHEET    1   F 2 TYR B2175  SER B2176  0                                        
+SHEET    2   F 2 ASP B2181  VAL B2182 -1  O  ASP B2181   N  SER B2176           
+SHEET    1   G 7 TYR C3012  ASP C3016  0                                        
+SHEET    2   G 7 VAL C3309  ARG C3315 -1  O  LEU C3314   N  LEU C3013           
+SHEET    3   G 7 LEU C3299  LYS C3303 -1  N  ILE C3300   O  ARG C3313           
+SHEET    4   G 7 PHE C3225  ASP C3230  1  N  ASP C3230   O  LYS C3303           
+SHEET    5   G 7 TYR C3089  GLY C3095  1  N  ALA C3094   O  ILE C3227           
+SHEET    6   G 7 ILE C3195  GLU C3199  1  O  LEU C3198   N  ILE C3091           
+SHEET    7   G 7 GLU C3122  THR C3125  1  N  GLU C3122   O  ILE C3197           
+SHEET    1   H 2 VAL C3170  ALA C3172  0                                        
+SHEET    2   H 2 LYS C3188  VAL C3190 -1  O  VAL C3190   N  VAL C3170           
+SHEET    1   I 2 TYR C3175  SER C3176  0                                        
+SHEET    2   I 2 ASP C3181  VAL C3182 -1  O  ASP C3181   N  SER C3176           
+SHEET    1   J 7 TYR D4012  ASP D4016  0                                        
+SHEET    2   J 7 VAL D4309  ARG D4315 -1  O  LEU D4314   N  LEU D4013           
+SHEET    3   J 7 LEU D4299  LYS D4303 -1  N  ILE D4300   O  ARG D4313           
+SHEET    4   J 7 PHE D4225  ASP D4230  1  N  ASP D4230   O  LEU D4301           
+SHEET    5   J 7 TYR D4089  GLY D4095  1  N  ALA D4094   O  ILE D4227           
+SHEET    6   J 7 ILE D4195  GLU D4199  1  O  LEU D4198   N  ILE D4091           
+SHEET    7   J 7 VAL D4121  THR D4125  1  N  ILE D4124   O  ILE D4197           
+SHEET    1   K 2 VAL D4170  ALA D4172  0                                        
+SHEET    2   K 2 LYS D4188  VAL D4190 -1  O  VAL D4190   N  VAL D4170           
+SHEET    1   L 2 TYR D4175  SER D4176  0                                        
+SHEET    2   L 2 ASP D4181  VAL D4182 -1  O  ASP D4181   N  SER D4176           
+SITE     1 AC1 13 ASP A1127  LYS A1145  GLY A1146  HIS A1177                    
+SITE     2 AC1 13 LEU A1201  TYR A1240  ILE A1281  ASN A1282                    
+SITE     3 AC1 13 HOH A7117  HOH A7278  HOH A7588  HOH A7601                    
+SITE     4 AC1 13 HOH A7650                                                     
+SITE     1 AC2 10 ASP C3127  LYS C3145  GLY C3146  HIS C3177                    
+SITE     2 AC2 10 TYR C3240  ASN C3282  HOH C7257  HOH C7262                    
+SITE     3 AC2 10 HOH C7263  HOH C7729                                          
+SITE     1 AC3 11 ASP B2127  LYS B2145  GLY B2146  HIS B2177                    
+SITE     2 AC3 11 TYR B2240  ASN B2282  HOH B7277  HOH B7311                    
+SITE     3 AC3 11 HOH B7326  HOH B7662  HOH B7759                               
+SITE     1 AC4 11 ASP D4127  LYS D4145  GLY D4146  HIS D4177                    
+SITE     2 AC4 11 TYR D4240  ASN D4282  HOH D7391  HOH D7449                    
+SITE     3 AC4 11 HOH D7487  HOH D7493  HOH D7540                               
+SITE     1 AC5 20 ASN A1043  ASP A1045  LEU A1046  SER A1096                    
+SITE     2 AC5 20 ALA A1098  VAL A1099  GLY A1100  LYS A1101                    
+SITE     3 AC5 20 SER A1102  THR A1103  ARG A1243  LYS A1303                    
+SITE     4 AC5 20 HIS A1307  HOH A7100  HOH A7255  HOH A7281                    
+SITE     5 AC5 20 HOH A7496  HOH A7533  HOH A7575  HOH A7672                    
+SITE     1 AC6 21 ASN B2043  ASP B2045  LEU B2046  SER B2096                    
+SITE     2 AC6 21 ALA B2098  VAL B2099  GLY B2100  LYS B2101                    
+SITE     3 AC6 21 SER B2102  THR B2103  ARG B2243  LYS B2303                    
+SITE     4 AC6 21 HIS B2307  HOH B7252  HOH B7258  HOH B7267                    
+SITE     5 AC6 21 HOH B7268  HOH B7293  HOH B7383  HOH B7502                    
+SITE     6 AC6 21 HOH B7781                                                     
+SITE     1 AC7 20 ASN C3043  LEU C3046  VAL C3097  ALA C3098                    
+SITE     2 AC7 20 VAL C3099  GLY C3100  LYS C3101  SER C3102                    
+SITE     3 AC7 20 THR C3103  ARG C3243  LYS C3303  HIS C3307                    
+SITE     4 AC7 20 HOH C7253  HOH C7273  HOH C7279  HOH C7291                    
+SITE     5 AC7 20 HOH C7300  HOH C7331  HOH C7494  HOH C7670                    
+SITE     1 AC8 19 ASN D4043  ASP D4045  LEU D4046  SER D4096                    
+SITE     2 AC8 19 ALA D4098  VAL D4099  GLY D4100  LYS D4101                    
+SITE     3 AC8 19 SER D4102  THR D4103  ARG D4243  LYS D4303                    
+SITE     4 AC8 19 HIS D4307  HOH D7254  HOH D7323  HOH D7391                    
+SITE     5 AC8 19 HOH D7446  HOH D7600  HOH D7766                               
+CRYST1  181.203  181.655   47.418  90.00 104.79  90.00 C 1 2 1      16          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.005519  0.000000  0.001457        0.00000                         
+SCALE2      0.000000  0.005505  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.021812        0.00000                         
+ATOM      1  N   MET A1009      55.316 -22.357  30.823  1.00 42.18           N  
+ATOM      2  CA  MET A1009      56.516 -21.519  30.545  1.00 41.23           C  
+ATOM      3  C   MET A1009      56.453 -21.007  29.112  1.00 39.93           C  
+ATOM      4  O   MET A1009      55.690 -21.517  28.297  1.00 41.41           O  
+ATOM      5  CB  MET A1009      57.793 -22.342  30.723  1.00 42.37           C  
+ATOM      6  CG  MET A1009      57.874 -23.089  32.033  1.00 44.70           C  
+ATOM      7  SD  MET A1009      59.303 -24.182  32.072  1.00 46.63           S  
+ATOM      8  CE  MET A1009      60.578 -23.030  32.644  1.00 45.72           C  
+ATOM      9  N   THR A1010      57.264 -20.003  28.802  1.00 37.54           N  
+ATOM     10  CA  THR A1010      57.288 -19.447  27.455  1.00 34.86           C  
+ATOM     11  C   THR A1010      58.716 -19.403  26.922  1.00 33.09           C  
+ATOM     12  O   THR A1010      59.675 -19.566  27.674  1.00 33.12           O  
+ATOM     13  CB  THR A1010      56.708 -18.019  27.427  1.00 34.92           C  
+ATOM     14  OG1 THR A1010      57.506 -17.163  28.252  1.00 36.47           O  
+ATOM     15  CG2 THR A1010      55.278 -18.014  27.940  1.00 34.77           C  
+ATOM     16  N   PRO A1011      58.871 -19.192  25.605  1.00 31.64           N  
+ATOM     17  CA  PRO A1011      60.183 -19.122  24.951  1.00 29.11           C  
+ATOM     18  C   PRO A1011      60.960 -17.871  25.348  1.00 27.95           C  
+ATOM     19  O   PRO A1011      62.038 -17.611  24.809  1.00 24.90           O  
+ATOM     20  CB  PRO A1011      59.825 -19.097  23.462  1.00 29.15           C  
+ATOM     21  CG  PRO A1011      58.515 -19.817  23.408  1.00 29.92           C  
+ATOM     22  CD  PRO A1011      57.797 -19.236  24.598  1.00 30.05           C  
+ATOM     23  N   TYR A1012      60.422 -17.103  26.294  1.00 26.08           N  
+ATOM     24  CA  TYR A1012      61.074 -15.861  26.689  1.00 26.17           C  
+ATOM     25  C   TYR A1012      61.485 -15.685  28.144  1.00 26.55           C  
+ATOM     26  O   TYR A1012      60.770 -16.085  29.062  1.00 26.79           O  
+ATOM     27  CB  TYR A1012      60.180 -14.660  26.333  1.00 26.03           C  
+ATOM     28  CG  TYR A1012      59.963 -14.398  24.857  1.00 24.55           C  
+ATOM     29  CD1 TYR A1012      58.886 -14.966  24.172  1.00 25.64           C  
+ATOM     30  CD2 TYR A1012      60.810 -13.540  24.154  1.00 25.36           C  
+ATOM     31  CE1 TYR A1012      58.657 -14.675  22.814  1.00 24.96           C  
+ATOM     32  CE2 TYR A1012      60.592 -13.245  22.811  1.00 24.64           C  
+ATOM     33  CZ  TYR A1012      59.516 -13.813  22.150  1.00 24.82           C  
+ATOM     34  OH  TYR A1012      59.301 -13.496  20.833  1.00 26.64           O  
+ATOM     35  N   LEU A1013      62.646 -15.066  28.337  1.00 25.73           N  
+ATOM     36  CA  LEU A1013      63.125 -14.734  29.672  1.00 26.56           C  
+ATOM     37  C   LEU A1013      62.396 -13.412  29.879  1.00 27.70           C  
+ATOM     38  O   LEU A1013      62.234 -12.651  28.924  1.00 28.00           O  
+ATOM     39  CB  LEU A1013      64.633 -14.469  29.683  1.00 23.87           C  
+ATOM     40  CG  LEU A1013      65.620 -15.609  29.457  1.00 25.26           C  
+ATOM     41  CD1 LEU A1013      67.029 -15.030  29.441  1.00 24.90           C  
+ATOM     42  CD2 LEU A1013      65.479 -16.661  30.550  1.00 21.84           C  
+ATOM     43  N   GLN A1014      61.951 -13.125  31.096  1.00 28.79           N  
+ATOM     44  CA  GLN A1014      61.233 -11.875  31.321  1.00 29.72           C  
+ATOM     45  C   GLN A1014      61.857 -10.992  32.390  1.00 28.55           C  
+ATOM     46  O   GLN A1014      62.314 -11.483  33.417  1.00 29.68           O  
+ATOM     47  CB  GLN A1014      59.789 -12.171  31.694  1.00 32.48           C  
+ATOM     48  CG  GLN A1014      58.927 -10.936  31.747  1.00 39.28           C  
+ATOM     49  CD  GLN A1014      57.531 -11.233  32.227  1.00 44.29           C  
+ATOM     50  OE1 GLN A1014      56.830 -12.078  31.660  1.00 47.72           O  
+ATOM     51  NE2 GLN A1014      57.110 -10.539  33.283  1.00 46.49           N  
+ATOM     52  N   PHE A1015      61.870  -9.687  32.142  1.00 27.69           N  
+ATOM     53  CA  PHE A1015      62.431  -8.725  33.085  1.00 27.50           C  
+ATOM     54  C   PHE A1015      61.537  -7.490  33.202  1.00 29.92           C  
+ATOM     55  O   PHE A1015      61.170  -6.898  32.184  1.00 29.94           O  
+ATOM     56  CB  PHE A1015      63.817  -8.241  32.631  1.00 25.74           C  
+ATOM     57  CG  PHE A1015      64.779  -9.338  32.303  1.00 26.06           C  
+ATOM     58  CD1 PHE A1015      64.741  -9.968  31.064  1.00 26.49           C  
+ATOM     59  CD2 PHE A1015      65.736  -9.742  33.233  1.00 27.98           C  
+ATOM     60  CE1 PHE A1015      65.646 -10.989  30.753  1.00 26.42           C  
+ATOM     61  CE2 PHE A1015      66.643 -10.761  32.936  1.00 27.26           C  
+ATOM     62  CZ  PHE A1015      66.595 -11.384  31.690  1.00 28.12           C  
+ATOM     63  N   ASP A1016      61.171  -7.103  34.425  1.00 29.96           N  
+ATOM     64  CA  ASP A1016      60.381  -5.891  34.588  1.00 29.89           C  
+ATOM     65  C   ASP A1016      61.424  -4.786  34.593  1.00 28.73           C  
+ATOM     66  O   ASP A1016      62.618  -5.075  34.591  1.00 29.86           O  
+ATOM     67  CB  ASP A1016      59.576  -5.885  35.897  1.00 31.84           C  
+ATOM     68  CG  ASP A1016      60.443  -6.025  37.133  1.00 32.64           C  
+ATOM     69  OD1 ASP A1016      61.529  -5.412  37.195  1.00 33.95           O  
+ATOM     70  OD2 ASP A1016      60.018  -6.745  38.058  1.00 35.05           O  
+ATOM     71  N   ARG A1017      60.997  -3.530  34.607  1.00 28.71           N  
+ATOM     72  CA  ARG A1017      61.957  -2.435  34.569  1.00 29.37           C  
+ATOM     73  C   ARG A1017      63.111  -2.529  35.561  1.00 29.22           C  
+ATOM     74  O   ARG A1017      64.274  -2.366  35.181  1.00 29.43           O  
+ATOM     75  CB  ARG A1017      61.268  -1.086  34.762  1.00 28.07           C  
+ATOM     76  CG  ARG A1017      62.189   0.052  34.376  1.00 30.04           C  
+ATOM     77  CD  ARG A1017      61.754   1.371  34.942  1.00 31.99           C  
+ATOM     78  NE  ARG A1017      62.664   2.440  34.532  1.00 35.45           N  
+ATOM     79  CZ  ARG A1017      62.689   2.989  33.318  1.00 36.18           C  
+ATOM     80  NH1 ARG A1017      61.854   2.575  32.372  1.00 35.70           N  
+ATOM     81  NH2 ARG A1017      63.544   3.966  33.052  1.00 36.91           N  
+ATOM     82  N   ASN A1018      62.800  -2.770  36.832  1.00 28.64           N  
+ATOM     83  CA  ASN A1018      63.841  -2.851  37.854  1.00 30.31           C  
+ATOM     84  C   ASN A1018      64.843  -3.967  37.611  1.00 28.90           C  
+ATOM     85  O   ASN A1018      66.048  -3.762  37.752  1.00 28.84           O  
+ATOM     86  CB  ASN A1018      63.222  -3.018  39.246  1.00 33.12           C  
+ATOM     87  CG  ASN A1018      62.403  -1.814  39.661  1.00 36.09           C  
+ATOM     88  OD1 ASN A1018      62.825  -0.668  39.472  1.00 39.53           O  
+ATOM     89  ND2 ASN A1018      61.230  -2.062  40.235  1.00 37.10           N  
+ATOM     90  N   GLN A1019      64.342  -5.145  37.256  1.00 28.81           N  
+ATOM     91  CA  GLN A1019      65.212  -6.278  36.989  1.00 30.45           C  
+ATOM     92  C   GLN A1019      66.138  -5.917  35.838  1.00 30.35           C  
+ATOM     93  O   GLN A1019      67.348  -6.130  35.913  1.00 30.81           O  
+ATOM     94  CB  GLN A1019      64.397  -7.506  36.598  1.00 32.93           C  
+ATOM     95  CG  GLN A1019      63.318  -7.906  37.575  1.00 36.37           C  
+ATOM     96  CD  GLN A1019      62.590  -9.148  37.118  1.00 37.10           C  
+ATOM     97  OE1 GLN A1019      63.140 -10.248  37.155  1.00 42.32           O  
+ATOM     98  NE2 GLN A1019      61.352  -8.982  36.669  1.00 38.33           N  
+ATOM     99  N   TRP A1020      65.562  -5.359  34.777  1.00 29.32           N  
+ATOM    100  CA  TRP A1020      66.346  -4.977  33.610  1.00 29.03           C  
+ATOM    101  C   TRP A1020      67.372  -3.897  33.922  1.00 28.89           C  
+ATOM    102  O   TRP A1020      68.511  -3.973  33.467  1.00 29.50           O  
+ATOM    103  CB  TRP A1020      65.426  -4.511  32.476  1.00 26.74           C  
+ATOM    104  CG  TRP A1020      66.163  -4.226  31.205  1.00 24.70           C  
+ATOM    105  CD1 TRP A1020      66.605  -3.019  30.768  1.00 25.79           C  
+ATOM    106  CD2 TRP A1020      66.580  -5.186  30.228  1.00 25.17           C  
+ATOM    107  NE1 TRP A1020      67.277  -3.160  29.577  1.00 25.99           N  
+ATOM    108  CE2 TRP A1020      67.277  -4.482  29.223  1.00 25.30           C  
+ATOM    109  CE3 TRP A1020      66.436  -6.577  30.107  1.00 23.57           C  
+ATOM    110  CZ2 TRP A1020      67.830  -5.120  28.100  1.00 25.89           C  
+ATOM    111  CZ3 TRP A1020      66.985  -7.212  28.994  1.00 26.63           C  
+ATOM    112  CH2 TRP A1020      67.675  -6.478  28.003  1.00 25.61           C  
+ATOM    113  N   ALA A1021      66.982  -2.891  34.698  1.00 29.73           N  
+ATOM    114  CA  ALA A1021      67.914  -1.822  35.034  1.00 31.23           C  
+ATOM    115  C   ALA A1021      69.017  -2.343  35.962  1.00 33.21           C  
+ATOM    116  O   ALA A1021      70.134  -1.817  35.968  1.00 33.05           O  
+ATOM    117  CB  ALA A1021      67.170  -0.652  35.688  1.00 30.92           C  
+ATOM    118  N   ALA A1022      68.701  -3.386  36.729  1.00 34.15           N  
+ATOM    119  CA  ALA A1022      69.657  -3.978  37.659  1.00 36.72           C  
+ATOM    120  C   ALA A1022      70.873  -4.564  36.937  1.00 39.32           C  
+ATOM    121  O   ALA A1022      71.936  -4.755  37.540  1.00 39.16           O  
+ATOM    122  CB  ALA A1022      68.977  -5.056  38.486  1.00 34.88           C  
+ATOM    123  N   LEU A1023      70.714  -4.842  35.646  1.00 40.91           N  
+ATOM    124  CA  LEU A1023      71.789  -5.404  34.836  1.00 42.22           C  
+ATOM    125  C   LEU A1023      73.040  -4.526  34.760  1.00 43.67           C  
+ATOM    126  O   LEU A1023      74.143  -5.031  34.547  1.00 44.76           O  
+ATOM    127  CB  LEU A1023      71.265  -5.702  33.428  1.00 40.56           C  
+ATOM    128  CG  LEU A1023      70.565  -7.056  33.245  1.00 39.91           C  
+ATOM    129  CD1 LEU A1023      69.585  -7.326  34.379  1.00 39.80           C  
+ATOM    130  CD2 LEU A1023      69.865  -7.073  31.899  1.00 37.54           C  
+ATOM    131  N   ARG A1024      72.875  -3.219  34.932  1.00 46.19           N  
+ATOM    132  CA  ARG A1024      74.012  -2.299  34.895  1.00 49.11           C  
+ATOM    133  C   ARG A1024      74.971  -2.621  36.041  1.00 50.93           C  
+ATOM    134  O   ARG A1024      74.591  -3.286  37.007  1.00 50.83           O  
+ATOM    135  CB  ARG A1024      73.521  -0.858  35.027  1.00 48.82           C  
+ATOM    136  CG  ARG A1024      72.452  -0.485  34.016  1.00 50.05           C  
+ATOM    137  CD  ARG A1024      71.410   0.435  34.637  1.00 50.70           C  
+ATOM    138  NE  ARG A1024      71.956   1.747  34.961  1.00 50.61           N  
+ATOM    139  CZ  ARG A1024      71.376   2.614  35.784  1.00 51.80           C  
+ATOM    140  NH1 ARG A1024      70.229   2.302  36.373  1.00 51.57           N  
+ATOM    141  NH2 ARG A1024      71.938   3.798  36.011  1.00 53.12           N  
+ATOM    142  N   ASP A1025      76.210  -2.151  35.933  1.00 53.27           N  
+ATOM    143  CA  ASP A1025      77.210  -2.394  36.972  1.00 56.30           C  
+ATOM    144  C   ASP A1025      77.018  -1.479  38.182  1.00 56.85           C  
+ATOM    145  O   ASP A1025      76.276  -0.494  38.128  1.00 57.23           O  
+ATOM    146  CB  ASP A1025      78.621  -2.206  36.406  1.00 58.55           C  
+ATOM    147  CG  ASP A1025      78.998  -3.287  35.407  1.00 60.91           C  
+ATOM    148  OD1 ASP A1025      78.927  -4.479  35.776  1.00 61.54           O  
+ATOM    149  OD2 ASP A1025      79.365  -2.947  34.258  1.00 61.96           O  
+ATOM    150  N   MET A1029      77.677   2.790  32.711  1.00 61.46           N  
+ATOM    151  CA  MET A1029      78.771   3.073  31.792  1.00 62.27           C  
+ATOM    152  C   MET A1029      79.020   4.578  31.701  1.00 62.29           C  
+ATOM    153  O   MET A1029      80.087   5.019  31.269  1.00 63.21           O  
+ATOM    154  CB  MET A1029      78.458   2.518  30.395  1.00 62.81           C  
+ATOM    155  CG  MET A1029      78.236   1.004  30.338  1.00 63.46           C  
+ATOM    156  SD  MET A1029      78.160   0.322  28.647  1.00 62.98           S  
+ATOM    157  CE  MET A1029      79.742  -0.459  28.537  1.00 62.90           C  
+ATOM    158  N   LEU A1031      77.797   8.131  29.875  1.00 51.40           N  
+ATOM    159  CA  LEU A1031      77.769   8.798  28.575  1.00 51.12           C  
+ATOM    160  C   LEU A1031      78.527  10.126  28.646  1.00 50.60           C  
+ATOM    161  O   LEU A1031      78.466  10.827  29.657  1.00 49.94           O  
+ATOM    162  CB  LEU A1031      76.325   9.036  28.139  1.00 50.96           C  
+ATOM    163  N   SER A1032      79.240  10.461  27.572  1.00 50.41           N  
+ATOM    164  CA  SER A1032      80.019  11.694  27.516  1.00 50.55           C  
+ATOM    165  C   SER A1032      79.163  12.900  27.162  1.00 51.03           C  
+ATOM    166  O   SER A1032      77.957  12.785  26.960  1.00 51.98           O  
+ATOM    167  CB  SER A1032      81.140  11.567  26.486  1.00 50.69           C  
+ATOM    168  OG  SER A1032      80.623  11.548  25.168  1.00 51.41           O  
+ATOM    169  N   GLU A1033      79.799  14.063  27.088  1.00 51.08           N  
+ATOM    170  CA  GLU A1033      79.103  15.300  26.756  1.00 50.48           C  
+ATOM    171  C   GLU A1033      78.631  15.253  25.306  1.00 50.34           C  
+ATOM    172  O   GLU A1033      77.519  15.662  24.990  1.00 48.16           O  
+ATOM    173  CB  GLU A1033      80.030  16.492  26.971  1.00 49.86           C  
+ATOM    174  N   ASP A1034      79.487  14.745  24.428  1.00 51.61           N  
+ATOM    175  CA  ASP A1034      79.158  14.635  23.014  1.00 53.84           C  
+ATOM    176  C   ASP A1034      78.009  13.645  22.836  1.00 54.56           C  
+ATOM    177  O   ASP A1034      77.051  13.908  22.106  1.00 55.29           O  
+ATOM    178  CB  ASP A1034      80.371  14.135  22.221  1.00 54.81           C  
+ATOM    179  CG  ASP A1034      81.631  14.937  22.500  1.00 57.78           C  
+ATOM    180  OD1 ASP A1034      81.991  15.095  23.690  1.00 58.92           O  
+ATOM    181  OD2 ASP A1034      82.271  15.398  21.527  1.00 58.06           O  
+ATOM    182  N   GLU A1035      78.111  12.509  23.517  1.00 53.49           N  
+ATOM    183  CA  GLU A1035      77.104  11.463  23.426  1.00 53.12           C  
+ATOM    184  C   GLU A1035      75.727  11.866  23.952  1.00 51.89           C  
+ATOM    185  O   GLU A1035      74.705  11.445  23.405  1.00 51.53           O  
+ATOM    186  CB  GLU A1035      77.595  10.212  24.158  1.00 54.32           C  
+ATOM    187  CG  GLU A1035      78.967   9.750  23.700  1.00 57.38           C  
+ATOM    188  CD  GLU A1035      79.422   8.480  24.393  1.00 60.39           C  
+ATOM    189  OE1 GLU A1035      79.339   8.420  25.641  1.00 62.37           O  
+ATOM    190  OE2 GLU A1035      79.870   7.544  23.690  1.00 60.69           O  
+ATOM    191  N   ILE A1036      75.693  12.669  25.013  1.00 50.29           N  
+ATOM    192  CA  ILE A1036      74.415  13.101  25.578  1.00 48.79           C  
+ATOM    193  C   ILE A1036      73.749  14.115  24.653  1.00 47.25           C  
+ATOM    194  O   ILE A1036      72.524  14.163  24.539  1.00 46.80           O  
+ATOM    195  CB  ILE A1036      74.593  13.753  26.965  1.00 48.19           C  
+ATOM    196  CG1 ILE A1036      75.196  12.746  27.946  1.00 48.69           C  
+ATOM    197  CG2 ILE A1036      73.243  14.239  27.484  1.00 48.13           C  
+ATOM    198  CD1 ILE A1036      75.421  13.304  29.339  1.00 46.07           C  
+ATOM    199  N   ALA A1037      74.570  14.925  23.997  1.00 45.45           N  
+ATOM    200  CA  ALA A1037      74.071  15.937  23.084  1.00 44.60           C  
+ATOM    201  C   ALA A1037      73.539  15.267  21.824  1.00 43.41           C  
+ATOM    202  O   ALA A1037      72.573  15.733  21.221  1.00 41.22           O  
+ATOM    203  CB  ALA A1037      75.187  16.908  22.730  1.00 44.95           C  
+ATOM    204  N   ARG A1038      74.180  14.170  21.433  1.00 42.52           N  
+ATOM    205  CA  ARG A1038      73.774  13.438  20.244  1.00 42.15           C  
+ATOM    206  C   ARG A1038      72.428  12.764  20.468  1.00 40.86           C  
+ATOM    207  O   ARG A1038      71.585  12.725  19.571  1.00 40.92           O  
+ATOM    208  CB  ARG A1038      74.821  12.389  19.877  1.00 43.17           C  
+ATOM    209  CG  ARG A1038      74.539  11.726  18.545  1.00 46.70           C  
+ATOM    210  CD  ARG A1038      75.560  10.664  18.202  1.00 48.75           C  
+ATOM    211  NE  ARG A1038      75.179   9.968  16.976  1.00 50.39           N  
+ATOM    212  CZ  ARG A1038      75.869   8.973  16.430  1.00 51.80           C  
+ATOM    213  NH1 ARG A1038      76.989   8.549  17.004  1.00 52.13           N  
+ATOM    214  NH2 ARG A1038      75.441   8.405  15.306  1.00 51.29           N  
+ATOM    215  N   LEU A1039      72.234  12.231  21.670  1.00 38.95           N  
+ATOM    216  CA  LEU A1039      70.986  11.570  22.015  1.00 38.45           C  
+ATOM    217  C   LEU A1039      69.835  12.575  22.075  1.00 39.59           C  
+ATOM    218  O   LEU A1039      68.705  12.260  21.690  1.00 39.35           O  
+ATOM    219  CB  LEU A1039      71.125  10.839  23.353  1.00 37.25           C  
+ATOM    220  CG  LEU A1039      71.937   9.540  23.324  1.00 37.58           C  
+ATOM    221  CD1 LEU A1039      72.070   8.979  24.734  1.00 36.34           C  
+ATOM    222  CD2 LEU A1039      71.248   8.527  22.411  1.00 35.12           C  
+ATOM    223  N   LYS A1040      70.113  13.783  22.559  1.00 38.99           N  
+ATOM    224  CA  LYS A1040      69.074  14.794  22.622  1.00 39.31           C  
+ATOM    225  C   LYS A1040      68.792  15.270  21.205  1.00 38.65           C  
+ATOM    226  O   LYS A1040      67.655  15.583  20.859  1.00 38.41           O  
+ATOM    227  CB  LYS A1040      69.505  15.960  23.508  1.00 42.55           C  
+ATOM    228  CG  LYS A1040      69.384  15.666  24.997  1.00 46.28           C  
+ATOM    229  CD  LYS A1040      68.577  16.746  25.718  1.00 48.97           C  
+ATOM    230  CE  LYS A1040      68.270  16.334  27.158  1.00 51.77           C  
+ATOM    231  NZ  LYS A1040      67.515  17.373  27.920  1.00 53.23           N  
+ATOM    232  N   GLY A1041      69.836  15.309  20.382  1.00 38.47           N  
+ATOM    233  CA  GLY A1041      69.671  15.716  18.998  1.00 37.83           C  
+ATOM    234  C   GLY A1041      68.774  14.717  18.281  1.00 37.90           C  
+ATOM    235  O   GLY A1041      68.055  15.063  17.336  1.00 37.79           O  
+ATOM    236  N   ILE A1042      68.822  13.468  18.735  1.00 36.44           N  
+ATOM    237  CA  ILE A1042      68.011  12.411  18.154  1.00 36.23           C  
+ATOM    238  C   ILE A1042      66.531  12.656  18.462  1.00 36.53           C  
+ATOM    239  O   ILE A1042      65.687  12.628  17.565  1.00 37.11           O  
+ATOM    240  CB  ILE A1042      68.452  11.017  18.696  1.00 36.12           C  
+ATOM    241  CG1 ILE A1042      69.756  10.579  18.015  1.00 35.09           C  
+ATOM    242  CG2 ILE A1042      67.361   9.988  18.461  1.00 35.94           C  
+ATOM    243  CD1 ILE A1042      70.376   9.314  18.597  1.00 32.26           C  
+ATOM    244  N   ASN A1043      66.225  12.907  19.730  1.00 36.08           N  
+ATOM    245  CA  ASN A1043      64.853  13.157  20.153  1.00 36.64           C  
+ATOM    246  C   ASN A1043      64.883  13.968  21.448  1.00 37.16           C  
+ATOM    247  O   ASN A1043      65.207  13.442  22.517  1.00 35.22           O  
+ATOM    248  CB  ASN A1043      64.129  11.828  20.389  1.00 36.88           C  
+ATOM    249  CG  ASN A1043      62.639  12.005  20.642  1.00 34.44           C  
+ATOM    250  OD1 ASN A1043      62.214  12.950  21.303  1.00 35.31           O  
+ATOM    251  ND2 ASN A1043      61.842  11.078  20.131  1.00 35.09           N  
+ATOM    252  N   GLU A1044      64.535  15.247  21.342  1.00 37.80           N  
+ATOM    253  CA  GLU A1044      64.539  16.155  22.487  1.00 38.48           C  
+ATOM    254  C   GLU A1044      63.691  15.658  23.651  1.00 37.78           C  
+ATOM    255  O   GLU A1044      63.904  16.067  24.791  1.00 37.56           O  
+ATOM    256  CB  GLU A1044      64.067  17.543  22.056  1.00 39.40           C  
+ATOM    257  N   ASP A1045      62.740  14.773  23.366  1.00 37.49           N  
+ATOM    258  CA  ASP A1045      61.871  14.230  24.405  1.00 37.96           C  
+ATOM    259  C   ASP A1045      62.405  12.936  25.005  1.00 36.98           C  
+ATOM    260  O   ASP A1045      61.784  12.365  25.902  1.00 37.06           O  
+ATOM    261  CB  ASP A1045      60.465  13.989  23.848  1.00 40.26           C  
+ATOM    262  CG  ASP A1045      59.755  15.280  23.483  1.00 43.63           C  
+ATOM    263  OD1 ASP A1045      59.544  16.115  24.390  1.00 44.98           O  
+ATOM    264  OD2 ASP A1045      59.410  15.462  22.295  1.00 44.69           O  
+ATOM    265  N   LEU A1046      63.550  12.471  24.512  1.00 35.97           N  
+ATOM    266  CA  LEU A1046      64.153  11.236  25.015  1.00 35.84           C  
+ATOM    267  C   LEU A1046      64.768  11.446  26.398  1.00 35.24           C  
+ATOM    268  O   LEU A1046      65.638  12.295  26.578  1.00 35.60           O  
+ATOM    269  CB  LEU A1046      65.230  10.736  24.046  1.00 35.63           C  
+ATOM    270  CG  LEU A1046      65.927   9.413  24.384  1.00 35.41           C  
+ATOM    271  CD1 LEU A1046      64.915   8.275  24.461  1.00 35.56           C  
+ATOM    272  CD2 LEU A1046      66.968   9.121  23.320  1.00 35.29           C  
+ATOM    273  N   SER A1047      64.310  10.658  27.364  1.00 34.78           N  
+ATOM    274  CA  SER A1047      64.783  10.730  28.744  1.00 35.22           C  
+ATOM    275  C   SER A1047      66.178  10.137  28.930  1.00 35.58           C  
+ATOM    276  O   SER A1047      66.425   8.983  28.580  1.00 35.59           O  
+ATOM    277  CB  SER A1047      63.794   9.999  29.658  1.00 35.52           C  
+ATOM    278  OG  SER A1047      64.377   9.707  30.913  1.00 34.80           O  
+ATOM    279  N   LEU A1048      67.086  10.926  29.495  1.00 36.03           N  
+ATOM    280  CA  LEU A1048      68.452  10.467  29.720  1.00 36.09           C  
+ATOM    281  C   LEU A1048      68.504   9.342  30.743  1.00 36.13           C  
+ATOM    282  O   LEU A1048      69.386   8.486  30.694  1.00 35.51           O  
+ATOM    283  CB  LEU A1048      69.326  11.639  30.163  1.00 36.52           C  
+ATOM    284  CG  LEU A1048      69.473  12.700  29.069  1.00 37.84           C  
+ATOM    285  CD1 LEU A1048      70.201  13.929  29.600  1.00 39.22           C  
+ATOM    286  CD2 LEU A1048      70.228  12.091  27.895  1.00 39.62           C  
+ATOM    287  N   GLU A1049      67.546   9.338  31.663  1.00 35.32           N  
+ATOM    288  CA  GLU A1049      67.480   8.301  32.681  1.00 35.73           C  
+ATOM    289  C   GLU A1049      66.969   7.016  32.033  1.00 34.47           C  
+ATOM    290  O   GLU A1049      67.361   5.917  32.417  1.00 34.28           O  
+ATOM    291  CB  GLU A1049      66.539   8.726  33.804  1.00 39.28           C  
+ATOM    292  CG  GLU A1049      66.556   7.794  34.997  1.00 46.16           C  
+ATOM    293  CD  GLU A1049      65.537   8.185  36.052  1.00 49.87           C  
+ATOM    294  OE1 GLU A1049      65.535   9.364  36.468  1.00 50.26           O  
+ATOM    295  OE2 GLU A1049      64.741   7.309  36.465  1.00 53.61           O  
+ATOM    296  N   GLU A1050      66.077   7.163  31.057  1.00 33.22           N  
+ATOM    297  CA  GLU A1050      65.535   6.017  30.333  1.00 32.31           C  
+ATOM    298  C   GLU A1050      66.697   5.386  29.556  1.00 30.42           C  
+ATOM    299  O   GLU A1050      66.866   4.165  29.538  1.00 29.86           O  
+ATOM    300  CB  GLU A1050      64.434   6.477  29.361  1.00 33.82           C  
+ATOM    301  CG  GLU A1050      63.751   5.360  28.572  1.00 34.29           C  
+ATOM    302  CD  GLU A1050      62.743   4.576  29.396  1.00 36.59           C  
+ATOM    303  OE1 GLU A1050      62.138   3.627  28.855  1.00 36.55           O  
+ATOM    304  OE2 GLU A1050      62.549   4.910  30.584  1.00 39.77           O  
+ATOM    305  N   VAL A1051      67.508   6.229  28.926  1.00 28.97           N  
+ATOM    306  CA  VAL A1051      68.648   5.744  28.163  1.00 28.20           C  
+ATOM    307  C   VAL A1051      69.606   4.984  29.064  1.00 29.64           C  
+ATOM    308  O   VAL A1051      70.025   3.867  28.748  1.00 29.05           O  
+ATOM    309  CB  VAL A1051      69.406   6.905  27.493  1.00 28.00           C  
+ATOM    310  CG1 VAL A1051      70.725   6.406  26.923  1.00 28.20           C  
+ATOM    311  CG2 VAL A1051      68.551   7.508  26.383  1.00 26.49           C  
+ATOM    312  N   ALA A1052      69.939   5.586  30.200  1.00 30.69           N  
+ATOM    313  CA  ALA A1052      70.865   4.969  31.142  1.00 31.41           C  
+ATOM    314  C   ALA A1052      70.361   3.660  31.761  1.00 31.46           C  
+ATOM    315  O   ALA A1052      71.145   2.732  31.972  1.00 31.72           O  
+ATOM    316  CB  ALA A1052      71.221   5.968  32.249  1.00 30.32           C  
+ATOM    317  N   GLU A1053      69.064   3.573  32.045  1.00 31.75           N  
+ATOM    318  CA  GLU A1053      68.520   2.368  32.669  1.00 31.98           C  
+ATOM    319  C   GLU A1053      67.994   1.307  31.712  1.00 30.63           C  
+ATOM    320  O   GLU A1053      67.921   0.134  32.075  1.00 31.20           O  
+ATOM    321  CB  GLU A1053      67.394   2.727  33.642  1.00 33.89           C  
+ATOM    322  CG  GLU A1053      67.746   3.802  34.653  1.00 38.47           C  
+ATOM    323  CD  GLU A1053      66.645   4.015  35.685  1.00 42.02           C  
+ATOM    324  OE1 GLU A1053      65.449   3.869  35.338  1.00 43.40           O  
+ATOM    325  OE2 GLU A1053      66.979   4.344  36.843  1.00 44.57           O  
+ATOM    326  N   ILE A1054      67.622   1.704  30.502  1.00 28.69           N  
+ATOM    327  CA  ILE A1054      67.072   0.743  29.553  1.00 28.05           C  
+ATOM    328  C   ILE A1054      67.916   0.481  28.306  1.00 27.39           C  
+ATOM    329  O   ILE A1054      68.294  -0.659  28.031  1.00 27.86           O  
+ATOM    330  CB  ILE A1054      65.665   1.184  29.070  1.00 28.83           C  
+ATOM    331  CG1 ILE A1054      64.745   1.437  30.272  1.00 28.93           C  
+ATOM    332  CG2 ILE A1054      65.078   0.125  28.149  1.00 26.45           C  
+ATOM    333  CD1 ILE A1054      64.594   0.260  31.207  1.00 27.47           C  
+ATOM    334  N   TYR A1055      68.206   1.535  27.555  1.00 25.15           N  
+ATOM    335  CA  TYR A1055      68.954   1.389  26.317  1.00 26.02           C  
+ATOM    336  C   TYR A1055      70.445   1.080  26.405  1.00 26.09           C  
+ATOM    337  O   TYR A1055      70.981   0.428  25.514  1.00 27.58           O  
+ATOM    338  CB  TYR A1055      68.700   2.607  25.425  1.00 25.43           C  
+ATOM    339  CG  TYR A1055      67.231   2.739  25.084  1.00 26.67           C  
+ATOM    340  CD1 TYR A1055      66.393   3.597  25.807  1.00 26.32           C  
+ATOM    341  CD2 TYR A1055      66.651   1.921  24.115  1.00 27.44           C  
+ATOM    342  CE1 TYR A1055      65.014   3.626  25.577  1.00 26.04           C  
+ATOM    343  CE2 TYR A1055      65.281   1.941  23.876  1.00 26.58           C  
+ATOM    344  CZ  TYR A1055      64.466   2.792  24.609  1.00 27.97           C  
+ATOM    345  OH  TYR A1055      63.107   2.789  24.383  1.00 27.50           O  
+ATOM    346  N   LEU A1056      71.128   1.535  27.448  1.00 26.62           N  
+ATOM    347  CA  LEU A1056      72.545   1.208  27.569  1.00 25.71           C  
+ATOM    348  C   LEU A1056      72.661  -0.302  27.792  1.00 24.60           C  
+ATOM    349  O   LEU A1056      73.450  -0.973  27.123  1.00 25.24           O  
+ATOM    350  CB  LEU A1056      73.200   1.985  28.717  1.00 27.83           C  
+ATOM    351  CG  LEU A1056      73.816   3.313  28.277  1.00 27.90           C  
+ATOM    352  CD1 LEU A1056      74.283   4.086  29.491  1.00 30.08           C  
+ATOM    353  CD2 LEU A1056      74.976   3.046  27.327  1.00 28.13           C  
+ATOM    354  N   PRO A1057      71.883  -0.854  28.741  1.00 22.14           N  
+ATOM    355  CA  PRO A1057      71.927  -2.295  29.001  1.00 21.47           C  
+ATOM    356  C   PRO A1057      71.532  -3.092  27.747  1.00 20.35           C  
+ATOM    357  O   PRO A1057      72.087  -4.164  27.486  1.00 19.41           O  
+ATOM    358  CB  PRO A1057      70.917  -2.470  30.133  1.00 21.55           C  
+ATOM    359  CG  PRO A1057      71.055  -1.187  30.886  1.00 22.83           C  
+ATOM    360  CD  PRO A1057      71.086  -0.167  29.775  1.00 23.86           C  
+ATOM    361  N   LEU A1058      70.571  -2.564  26.987  1.00 18.35           N  
+ATOM    362  CA  LEU A1058      70.118  -3.212  25.758  1.00 18.30           C  
+ATOM    363  C   LEU A1058      71.258  -3.224  24.733  1.00 16.64           C  
+ATOM    364  O   LEU A1058      71.453  -4.206  24.033  1.00 16.56           O  
+ATOM    365  CB  LEU A1058      68.900  -2.476  25.173  1.00 17.15           C  
+ATOM    366  CG  LEU A1058      68.334  -3.012  23.843  1.00 18.12           C  
+ATOM    367  CD1 LEU A1058      67.847  -4.441  24.026  1.00 15.74           C  
+ATOM    368  CD2 LEU A1058      67.193  -2.138  23.366  1.00 16.61           C  
+ATOM    369  N   SER A1059      72.011  -2.132  24.648  1.00 18.14           N  
+ATOM    370  CA  SER A1059      73.115  -2.073  23.697  1.00 18.68           C  
+ATOM    371  C   SER A1059      74.209  -3.034  24.145  1.00 19.71           C  
+ATOM    372  O   SER A1059      74.908  -3.609  23.315  1.00 19.44           O  
+ATOM    373  CB  SER A1059      73.658  -0.644  23.570  1.00 19.79           C  
+ATOM    374  OG  SER A1059      74.323  -0.226  24.746  1.00 25.63           O  
+ATOM    375  N   ARG A1060      74.350  -3.222  25.456  1.00 21.26           N  
+ATOM    376  CA  ARG A1060      75.352  -4.152  25.967  1.00 22.13           C  
+ATOM    377  C   ARG A1060      74.940  -5.559  25.551  1.00 20.97           C  
+ATOM    378  O   ARG A1060      75.757  -6.327  25.046  1.00 20.66           O  
+ATOM    379  CB  ARG A1060      75.461  -4.090  27.497  1.00 26.13           C  
+ATOM    380  CG  ARG A1060      76.219  -2.879  28.049  1.00 32.56           C  
+ATOM    381  CD  ARG A1060      76.515  -3.052  29.542  1.00 35.13           C  
+ATOM    382  NE  ARG A1060      77.366  -4.215  29.800  1.00 39.55           N  
+ATOM    383  CZ  ARG A1060      77.617  -4.713  31.009  1.00 41.67           C  
+ATOM    384  NH1 ARG A1060      77.082  -4.151  32.086  1.00 42.89           N  
+ATOM    385  NH2 ARG A1060      78.399  -5.780  31.144  1.00 41.44           N  
+ATOM    386  N   LEU A1061      73.668  -5.891  25.765  1.00 19.38           N  
+ATOM    387  CA  LEU A1061      73.153  -7.207  25.397  1.00 18.96           C  
+ATOM    388  C   LEU A1061      73.420  -7.488  23.918  1.00 17.60           C  
+ATOM    389  O   LEU A1061      73.911  -8.546  23.553  1.00 18.23           O  
+ATOM    390  CB  LEU A1061      71.645  -7.300  25.639  1.00 18.47           C  
+ATOM    391  CG  LEU A1061      71.069  -8.663  25.244  1.00 17.38           C  
+ATOM    392  CD1 LEU A1061      71.237  -9.633  26.396  1.00 18.70           C  
+ATOM    393  CD2 LEU A1061      69.609  -8.541  24.887  1.00 19.78           C  
+ATOM    394  N   LEU A1062      73.080  -6.529  23.073  1.00 18.25           N  
+ATOM    395  CA  LEU A1062      73.287  -6.677  21.646  1.00 18.49           C  
+ATOM    396  C   LEU A1062      74.752  -6.915  21.332  1.00 19.82           C  
+ATOM    397  O   LEU A1062      75.076  -7.764  20.501  1.00 21.18           O  
+ATOM    398  CB  LEU A1062      72.774  -5.436  20.913  1.00 17.50           C  
+ATOM    399  CG  LEU A1062      71.246  -5.319  20.921  1.00 19.25           C  
+ATOM    400  CD1 LEU A1062      70.821  -3.986  20.318  1.00 17.64           C  
+ATOM    401  CD2 LEU A1062      70.641  -6.487  20.158  1.00 15.99           C  
+ATOM    402  N   ASN A1063      75.636  -6.181  22.006  1.00 18.90           N  
+ATOM    403  CA  ASN A1063      77.066  -6.335  21.787  1.00 19.57           C  
+ATOM    404  C   ASN A1063      77.535  -7.749  22.122  1.00 19.91           C  
+ATOM    405  O   ASN A1063      78.433  -8.285  21.468  1.00 19.32           O  
+ATOM    406  CB  ASN A1063      77.862  -5.316  22.612  1.00 19.28           C  
+ATOM    407  CG  ASN A1063      79.360  -5.475  22.425  1.00 23.04           C  
+ATOM    408  OD1 ASN A1063      80.041  -6.117  23.230  1.00 23.75           O  
+ATOM    409  ND2 ASN A1063      79.879  -4.911  21.344  1.00 23.53           N  
+ATOM    410  N   PHE A1064      76.937  -8.357  23.140  1.00 17.93           N  
+ATOM    411  CA  PHE A1064      77.311  -9.719  23.492  1.00 19.77           C  
+ATOM    412  C   PHE A1064      76.951 -10.674  22.343  1.00 19.08           C  
+ATOM    413  O   PHE A1064      77.718 -11.579  22.017  1.00 17.78           O  
+ATOM    414  CB  PHE A1064      76.609 -10.166  24.789  1.00 21.51           C  
+ATOM    415  CG  PHE A1064      77.261  -9.651  26.045  1.00 22.24           C  
+ATOM    416  CD1 PHE A1064      76.510  -8.989  27.018  1.00 23.49           C  
+ATOM    417  CD2 PHE A1064      78.624  -9.848  26.267  1.00 23.63           C  
+ATOM    418  CE1 PHE A1064      77.110  -8.530  28.201  1.00 24.01           C  
+ATOM    419  CE2 PHE A1064      79.236  -9.397  27.443  1.00 25.34           C  
+ATOM    420  CZ  PHE A1064      78.476  -8.736  28.413  1.00 24.94           C  
+ATOM    421  N   TYR A1065      75.780 -10.478  21.739  1.00 18.34           N  
+ATOM    422  CA  TYR A1065      75.369 -11.335  20.628  1.00 17.89           C  
+ATOM    423  C   TYR A1065      76.277 -11.088  19.430  1.00 18.25           C  
+ATOM    424  O   TYR A1065      76.679 -12.018  18.746  1.00 18.89           O  
+ATOM    425  CB  TYR A1065      73.917 -11.059  20.223  1.00 17.44           C  
+ATOM    426  CG  TYR A1065      72.895 -11.759  21.079  1.00 16.59           C  
+ATOM    427  CD1 TYR A1065      72.606 -11.314  22.368  1.00 19.06           C  
+ATOM    428  CD2 TYR A1065      72.246 -12.899  20.612  1.00 17.30           C  
+ATOM    429  CE1 TYR A1065      71.687 -12.001  23.181  1.00 20.97           C  
+ATOM    430  CE2 TYR A1065      71.334 -13.591  21.404  1.00 19.98           C  
+ATOM    431  CZ  TYR A1065      71.059 -13.141  22.689  1.00 21.11           C  
+ATOM    432  OH  TYR A1065      70.186 -13.856  23.475  1.00 22.17           O  
+ATOM    433  N   ILE A1066      76.606  -9.827  19.185  1.00 18.48           N  
+ATOM    434  CA  ILE A1066      77.458  -9.475  18.061  1.00 19.24           C  
+ATOM    435  C   ILE A1066      78.864 -10.024  18.254  1.00 20.21           C  
+ATOM    436  O   ILE A1066      79.438 -10.599  17.325  1.00 20.97           O  
+ATOM    437  CB  ILE A1066      77.515  -7.944  17.875  1.00 17.68           C  
+ATOM    438  CG1 ILE A1066      76.102  -7.417  17.607  1.00 15.77           C  
+ATOM    439  CG2 ILE A1066      78.474  -7.584  16.737  1.00 14.81           C  
+ATOM    440  CD1 ILE A1066      75.979  -5.909  17.659  1.00 15.81           C  
+ATOM    441  N   SER A1067      79.414  -9.844  19.454  1.00 21.25           N  
+ATOM    442  CA  SER A1067      80.756 -10.333  19.769  1.00 21.28           C  
+ATOM    443  C   SER A1067      80.790 -11.832  19.570  1.00 20.57           C  
+ATOM    444  O   SER A1067      81.678 -12.367  18.917  1.00 18.69           O  
+ATOM    445  CB  SER A1067      81.133 -10.028  21.222  1.00 21.87           C  
+ATOM    446  OG  SER A1067      81.290  -8.643  21.439  1.00 29.20           O  
+ATOM    447  N   SER A1068      79.814 -12.511  20.155  1.00 21.08           N  
+ATOM    448  CA  SER A1068      79.740 -13.960  20.025  1.00 22.51           C  
+ATOM    449  C   SER A1068      79.766 -14.363  18.548  1.00 22.87           C  
+ATOM    450  O   SER A1068      80.425 -15.326  18.165  1.00 22.09           O  
+ATOM    451  CB  SER A1068      78.460 -14.483  20.677  1.00 20.13           C  
+ATOM    452  OG  SER A1068      78.390 -15.891  20.571  1.00 21.75           O  
+ATOM    453  N   ASN A1069      79.046 -13.610  17.726  1.00 24.43           N  
+ATOM    454  CA  ASN A1069      78.971 -13.885  16.299  1.00 27.01           C  
+ATOM    455  C   ASN A1069      80.340 -13.680  15.643  1.00 25.30           C  
+ATOM    456  O   ASN A1069      80.783 -14.506  14.849  1.00 27.97           O  
+ATOM    457  CB  ASN A1069      77.900 -12.981  15.665  1.00 30.13           C  
+ATOM    458  CG  ASN A1069      77.681 -13.266  14.186  1.00 33.30           C  
+ATOM    459  OD1 ASN A1069      78.389 -12.739  13.326  1.00 34.59           O  
+ATOM    460  ND2 ASN A1069      76.696 -14.109  13.884  1.00 35.48           N  
+ATOM    461  N   LEU A1070      81.019 -12.598  15.995  1.00 24.40           N  
+ATOM    462  CA  LEU A1070      82.337 -12.323  15.435  1.00 24.37           C  
+ATOM    463  C   LEU A1070      83.365 -13.389  15.795  1.00 24.61           C  
+ATOM    464  O   LEU A1070      84.156 -13.805  14.945  1.00 25.93           O  
+ATOM    465  CB  LEU A1070      82.839 -10.957  15.895  1.00 22.53           C  
+ATOM    466  CG  LEU A1070      82.129  -9.761  15.255  1.00 26.14           C  
+ATOM    467  CD1 LEU A1070      82.558  -8.474  15.942  1.00 24.47           C  
+ATOM    468  CD2 LEU A1070      82.458  -9.714  13.763  1.00 26.87           C  
+ATOM    469  N   ARG A1071      83.354 -13.837  17.047  1.00 22.53           N  
+ATOM    470  CA  ARG A1071      84.300 -14.849  17.479  1.00 22.76           C  
+ATOM    471  C   ARG A1071      84.013 -16.168  16.771  1.00 22.08           C  
+ATOM    472  O   ARG A1071      84.933 -16.865  16.365  1.00 21.07           O  
+ATOM    473  CB  ARG A1071      84.236 -15.028  19.001  1.00 22.35           C  
+ATOM    474  N   ARG A1072      82.732 -16.504  16.641  1.00 22.93           N  
+ATOM    475  CA  ARG A1072      82.305 -17.732  15.966  1.00 22.13           C  
+ATOM    476  C   ARG A1072      82.916 -17.707  14.565  1.00 21.83           C  
+ATOM    477  O   ARG A1072      83.552 -18.669  14.120  1.00 20.10           O  
+ATOM    478  CB  ARG A1072      80.775 -17.752  15.828  1.00 21.60           C  
+ATOM    479  CG  ARG A1072      80.103 -19.092  16.048  1.00 22.82           C  
+ATOM    480  CD  ARG A1072      79.309 -19.617  14.851  1.00 22.79           C  
+ATOM    481  NE  ARG A1072      78.476 -18.634  14.149  1.00 25.16           N  
+ATOM    482  CZ  ARG A1072      77.163 -18.474  14.307  1.00 24.77           C  
+ATOM    483  NH1 ARG A1072      76.486 -19.220  15.165  1.00 25.69           N  
+ATOM    484  NH2 ARG A1072      76.514 -17.591  13.558  1.00 25.94           N  
+ATOM    485  N   GLN A1073      82.697 -16.583  13.885  1.00 22.46           N  
+ATOM    486  CA  GLN A1073      83.176 -16.371  12.525  1.00 25.83           C  
+ATOM    487  C   GLN A1073      84.673 -16.678  12.402  1.00 23.51           C  
+ATOM    488  O   GLN A1073      85.088 -17.390  11.494  1.00 23.63           O  
+ATOM    489  CB  GLN A1073      82.870 -14.932  12.100  1.00 26.79           C  
+ATOM    490  CG  GLN A1073      82.815 -14.677  10.601  1.00 32.61           C  
+ATOM    491  CD  GLN A1073      84.156 -14.270  10.030  1.00 38.79           C  
+ATOM    492  OE1 GLN A1073      84.898 -13.500  10.652  1.00 42.90           O  
+ATOM    493  NE2 GLN A1073      84.474 -14.768   8.837  1.00 40.83           N  
+ATOM    494  N   ALA A1074      85.474 -16.169  13.331  1.00 22.89           N  
+ATOM    495  CA  ALA A1074      86.908 -16.412  13.290  1.00 22.90           C  
+ATOM    496  C   ALA A1074      87.208 -17.909  13.427  1.00 23.18           C  
+ATOM    497  O   ALA A1074      88.038 -18.447  12.690  1.00 19.81           O  
+ATOM    498  CB  ALA A1074      87.609 -15.633  14.394  1.00 23.26           C  
+ATOM    499  N   VAL A1075      86.537 -18.573  14.368  1.00 21.11           N  
+ATOM    500  CA  VAL A1075      86.751 -20.000  14.574  1.00 21.56           C  
+ATOM    501  C   VAL A1075      86.389 -20.765  13.308  1.00 22.62           C  
+ATOM    502  O   VAL A1075      87.099 -21.689  12.903  1.00 23.73           O  
+ATOM    503  CB  VAL A1075      85.887 -20.544  15.731  1.00 22.36           C  
+ATOM    504  CG1 VAL A1075      85.904 -22.071  15.733  1.00 20.85           C  
+ATOM    505  CG2 VAL A1075      86.406 -20.019  17.059  1.00 23.20           C  
+ATOM    506  N   LEU A1076      85.280 -20.383  12.687  1.00 21.98           N  
+ATOM    507  CA  LEU A1076      84.832 -21.066  11.482  1.00 22.53           C  
+ATOM    508  C   LEU A1076      85.731 -20.744  10.295  1.00 23.12           C  
+ATOM    509  O   LEU A1076      85.939 -21.580   9.429  1.00 21.52           O  
+ATOM    510  CB  LEU A1076      83.374 -20.696  11.165  1.00 22.00           C  
+ATOM    511  CG  LEU A1076      82.328 -21.279  12.129  1.00 22.04           C  
+ATOM    512  CD1 LEU A1076      80.951 -20.695  11.814  1.00 23.51           C  
+ATOM    513  CD2 LEU A1076      82.315 -22.796  12.028  1.00 17.47           C  
+ATOM    514  N   GLU A1077      86.283 -19.537  10.273  1.00 25.38           N  
+ATOM    515  CA  GLU A1077      87.154 -19.136   9.179  1.00 27.66           C  
+ATOM    516  C   GLU A1077      88.392 -20.012   9.142  1.00 27.70           C  
+ATOM    517  O   GLU A1077      88.876 -20.381   8.070  1.00 28.94           O  
+ATOM    518  CB  GLU A1077      87.558 -17.680   9.336  1.00 28.52           C  
+ATOM    519  CG  GLU A1077      88.535 -17.190   8.290  1.00 33.27           C  
+ATOM    520  CD  GLU A1077      88.758 -15.700   8.396  1.00 35.83           C  
+ATOM    521  OE1 GLU A1077      87.794 -14.944   8.140  1.00 36.48           O  
+ATOM    522  OE2 GLU A1077      89.887 -15.285   8.745  1.00 36.24           O  
+ATOM    523  N   GLN A1078      88.898 -20.340  10.325  1.00 26.10           N  
+ATOM    524  CA  GLN A1078      90.070 -21.185  10.453  1.00 25.52           C  
+ATOM    525  C   GLN A1078      89.735 -22.609  10.002  1.00 25.32           C  
+ATOM    526  O   GLN A1078      90.466 -23.213   9.220  1.00 24.14           O  
+ATOM    527  CB  GLN A1078      90.532 -21.186  11.908  1.00 26.37           C  
+ATOM    528  CG  GLN A1078      91.719 -22.071  12.196  1.00 25.95           C  
+ATOM    529  CD  GLN A1078      92.100 -22.030  13.659  1.00 26.92           C  
+ATOM    530  OE1 GLN A1078      91.354 -22.507  14.521  1.00 25.59           O  
+ATOM    531  NE2 GLN A1078      93.262 -21.449  13.953  1.00 23.89           N  
+ATOM    532  N   PHE A1079      88.621 -23.135  10.502  1.00 24.36           N  
+ATOM    533  CA  PHE A1079      88.173 -24.484  10.165  1.00 24.69           C  
+ATOM    534  C   PHE A1079      87.849 -24.656   8.681  1.00 23.97           C  
+ATOM    535  O   PHE A1079      88.289 -25.619   8.058  1.00 23.21           O  
+ATOM    536  CB  PHE A1079      86.933 -24.833  10.998  1.00 24.41           C  
+ATOM    537  CG  PHE A1079      86.294 -26.141  10.629  1.00 24.93           C  
+ATOM    538  CD1 PHE A1079      86.960 -27.342  10.839  1.00 26.47           C  
+ATOM    539  CD2 PHE A1079      85.004 -26.173  10.102  1.00 25.17           C  
+ATOM    540  CE1 PHE A1079      86.348 -28.566  10.534  1.00 26.55           C  
+ATOM    541  CE2 PHE A1079      84.382 -27.380   9.794  1.00 25.99           C  
+ATOM    542  CZ  PHE A1079      85.054 -28.583  10.011  1.00 27.44           C  
+ATOM    543  N   LEU A1080      87.075 -23.719   8.133  1.00 24.01           N  
+ATOM    544  CA  LEU A1080      86.649 -23.763   6.735  1.00 25.01           C  
+ATOM    545  C   LEU A1080      87.724 -23.286   5.774  1.00 27.08           C  
+ATOM    546  O   LEU A1080      87.605 -23.467   4.568  1.00 24.75           O  
+ATOM    547  CB  LEU A1080      85.398 -22.902   6.535  1.00 21.39           C  
+ATOM    548  CG  LEU A1080      84.161 -23.273   7.355  1.00 21.21           C  
+ATOM    549  CD1 LEU A1080      83.096 -22.197   7.203  1.00 20.20           C  
+ATOM    550  CD2 LEU A1080      83.630 -24.638   6.898  1.00 21.54           C  
+ATOM    551  N   GLY A1081      88.764 -22.662   6.315  1.00 30.36           N  
+ATOM    552  CA  GLY A1081      89.839 -22.163   5.480  1.00 33.86           C  
+ATOM    553  C   GLY A1081      89.422 -21.104   4.474  1.00 36.79           C  
+ATOM    554  O   GLY A1081      90.054 -20.969   3.426  1.00 38.10           O  
+ATOM    555  N   THR A1082      88.369 -20.347   4.773  1.00 38.41           N  
+ATOM    556  CA  THR A1082      87.915 -19.305   3.851  1.00 39.97           C  
+ATOM    557  C   THR A1082      88.764 -18.044   3.987  1.00 42.18           C  
+ATOM    558  O   THR A1082      89.685 -17.985   4.808  1.00 42.08           O  
+ATOM    559  CB  THR A1082      86.436 -18.912   4.088  1.00 39.62           C  
+ATOM    560  OG1 THR A1082      86.285 -18.375   5.410  1.00 38.67           O  
+ATOM    561  CG2 THR A1082      85.514 -20.119   3.901  1.00 37.99           C  
+ATOM    562  N   ASN A1083      88.440 -17.039   3.175  1.00 43.91           N  
+ATOM    563  CA  ASN A1083      89.156 -15.765   3.178  1.00 45.30           C  
+ATOM    564  C   ASN A1083      88.322 -14.650   3.809  1.00 44.46           C  
+ATOM    565  O   ASN A1083      87.699 -14.840   4.851  1.00 44.23           O  
+ATOM    566  CB  ASN A1083      89.534 -15.381   1.754  1.00 45.96           C  
+ATOM    567  N   GLN A1085      85.650 -13.279   4.125  1.00 48.61           N  
+ATOM    568  CA  GLN A1085      84.803 -12.160   3.728  1.00 48.52           C  
+ATOM    569  C   GLN A1085      83.995 -11.644   4.924  1.00 48.10           C  
+ATOM    570  O   GLN A1085      83.523 -12.430   5.755  1.00 48.49           O  
+ATOM    571  CB  GLN A1085      83.855 -12.600   2.610  1.00 49.07           C  
+ATOM    572  CG  GLN A1085      83.101 -11.463   1.937  1.00 50.43           C  
+ATOM    573  CD  GLN A1085      82.110 -11.959   0.892  1.00 51.58           C  
+ATOM    574  OE1 GLN A1085      81.555 -11.171   0.122  1.00 52.93           O  
+ATOM    575  NE2 GLN A1085      81.878 -13.270   0.866  1.00 49.78           N  
+ATOM    576  N   ARG A1086      83.843 -10.325   5.012  1.00 45.42           N  
+ATOM    577  CA  ARG A1086      83.094  -9.716   6.104  1.00 42.73           C  
+ATOM    578  C   ARG A1086      81.624  -9.586   5.722  1.00 40.78           C  
+ATOM    579  O   ARG A1086      81.298  -9.080   4.643  1.00 42.65           O  
+ATOM    580  CB  ARG A1086      83.673  -8.335   6.435  1.00 42.12           C  
+ATOM    581  N   ILE A1087      80.746 -10.059   6.604  1.00 35.92           N  
+ATOM    582  CA  ILE A1087      79.303  -9.982   6.391  1.00 30.63           C  
+ATOM    583  C   ILE A1087      78.690  -9.201   7.552  1.00 27.81           C  
+ATOM    584  O   ILE A1087      78.912  -9.523   8.716  1.00 24.91           O  
+ATOM    585  CB  ILE A1087      78.658 -11.402   6.312  1.00 31.92           C  
+ATOM    586  CG1 ILE A1087      78.778 -11.962   4.889  1.00 32.15           C  
+ATOM    587  CG2 ILE A1087      77.189 -11.342   6.701  1.00 29.20           C  
+ATOM    588  CD1 ILE A1087      80.179 -12.200   4.436  1.00 33.26           C  
+ATOM    589  N   PRO A1088      77.912  -8.159   7.244  1.00 25.60           N  
+ATOM    590  CA  PRO A1088      77.260  -7.314   8.247  1.00 24.36           C  
+ATOM    591  C   PRO A1088      76.348  -8.061   9.204  1.00 21.76           C  
+ATOM    592  O   PRO A1088      75.599  -8.946   8.797  1.00 22.07           O  
+ATOM    593  CB  PRO A1088      76.455  -6.325   7.403  1.00 24.39           C  
+ATOM    594  CG  PRO A1088      77.206  -6.261   6.133  1.00 26.52           C  
+ATOM    595  CD  PRO A1088      77.594  -7.690   5.886  1.00 25.72           C  
+ATOM    596  N   TYR A1089      76.417  -7.700  10.479  1.00 19.16           N  
+ATOM    597  CA  TYR A1089      75.537  -8.288  11.476  1.00 16.76           C  
+ATOM    598  C   TYR A1089      74.282  -7.437  11.292  1.00 16.67           C  
+ATOM    599  O   TYR A1089      74.377  -6.216  11.191  1.00 16.42           O  
+ATOM    600  CB  TYR A1089      76.101  -8.093  12.881  1.00 15.91           C  
+ATOM    601  CG  TYR A1089      75.294  -8.790  13.946  1.00 14.83           C  
+ATOM    602  CD1 TYR A1089      75.538 -10.122  14.279  1.00 16.08           C  
+ATOM    603  CD2 TYR A1089      74.284  -8.123  14.616  1.00 14.80           C  
+ATOM    604  CE1 TYR A1089      74.788 -10.766  15.265  1.00 17.17           C  
+ATOM    605  CE2 TYR A1089      73.527  -8.757  15.603  1.00 16.88           C  
+ATOM    606  CZ  TYR A1089      73.782 -10.074  15.921  1.00 14.90           C  
+ATOM    607  OH  TYR A1089      73.018 -10.693  16.879  1.00 14.90           O  
+ATOM    608  N   ILE A1090      73.112  -8.056  11.240  1.00 17.04           N  
+ATOM    609  CA  ILE A1090      71.910  -7.269  11.011  1.00 17.15           C  
+ATOM    610  C   ILE A1090      70.867  -7.352  12.110  1.00 17.28           C  
+ATOM    611  O   ILE A1090      70.474  -8.436  12.528  1.00 19.58           O  
+ATOM    612  CB  ILE A1090      71.247  -7.671   9.689  1.00 15.82           C  
+ATOM    613  CG1 ILE A1090      72.226  -7.455   8.538  1.00 15.53           C  
+ATOM    614  CG2 ILE A1090      69.983  -6.860   9.468  1.00 13.47           C  
+ATOM    615  CD1 ILE A1090      71.647  -7.854   7.198  1.00 17.56           C  
+ATOM    616  N   ILE A1091      70.408  -6.186  12.548  1.00 17.53           N  
+ATOM    617  CA  ILE A1091      69.401  -6.070  13.604  1.00 17.48           C  
+ATOM    618  C   ILE A1091      68.159  -5.385  13.036  1.00 17.33           C  
+ATOM    619  O   ILE A1091      68.257  -4.316  12.438  1.00 17.04           O  
+ATOM    620  CB  ILE A1091      69.925  -5.205  14.784  1.00 15.02           C  
+ATOM    621  CG1 ILE A1091      71.173  -5.842  15.403  1.00 13.89           C  
+ATOM    622  CG2 ILE A1091      68.828  -5.044  15.832  1.00 16.81           C  
+ATOM    623  CD1 ILE A1091      71.971  -4.891  16.297  1.00 11.73           C  
+ATOM    624  N   SER A1092      66.997  -6.004  13.207  1.00 16.64           N  
+ATOM    625  CA  SER A1092      65.763  -5.407  12.712  1.00 16.48           C  
+ATOM    626  C   SER A1092      64.915  -4.955  13.900  1.00 17.21           C  
+ATOM    627  O   SER A1092      65.034  -5.490  15.003  1.00 17.01           O  
+ATOM    628  CB  SER A1092      64.982  -6.395  11.834  1.00 13.77           C  
+ATOM    629  OG  SER A1092      64.450  -7.467  12.584  1.00 16.48           O  
+ATOM    630  N   ILE A1093      64.079  -3.952  13.667  1.00 16.05           N  
+ATOM    631  CA  ILE A1093      63.222  -3.408  14.703  1.00 16.73           C  
+ATOM    632  C   ILE A1093      61.819  -3.263  14.139  1.00 16.89           C  
+ATOM    633  O   ILE A1093      61.598  -2.508  13.192  1.00 16.09           O  
+ATOM    634  CB  ILE A1093      63.760  -2.041  15.185  1.00 17.04           C  
+ATOM    635  CG1 ILE A1093      65.170  -2.228  15.763  1.00 17.22           C  
+ATOM    636  CG2 ILE A1093      62.825  -1.451  16.225  1.00 16.06           C  
+ATOM    637  CD1 ILE A1093      65.880  -0.951  16.112  1.00 17.36           C  
+ATOM    638  N   ALA A1094      60.885  -4.009  14.726  1.00 15.45           N  
+ATOM    639  CA  ALA A1094      59.498  -4.020  14.297  1.00 15.55           C  
+ATOM    640  C   ALA A1094      58.563  -3.412  15.333  1.00 17.99           C  
+ATOM    641  O   ALA A1094      58.974  -3.058  16.443  1.00 17.76           O  
+ATOM    642  CB  ALA A1094      59.066  -5.454  13.991  1.00 14.89           C  
+ATOM    643  N   GLY A1095      57.292  -3.307  14.958  1.00 18.63           N  
+ATOM    644  CA  GLY A1095      56.298  -2.735  15.845  1.00 18.40           C  
+ATOM    645  C   GLY A1095      55.341  -1.798  15.128  1.00 18.70           C  
+ATOM    646  O   GLY A1095      55.538  -1.427  13.963  1.00 16.13           O  
+ATOM    647  N   SER A1096      54.295  -1.410  15.844  1.00 17.87           N  
+ATOM    648  CA  SER A1096      53.276  -0.513  15.319  1.00 18.76           C  
+ATOM    649  C   SER A1096      53.802   0.824  14.838  1.00 20.10           C  
+ATOM    650  O   SER A1096      54.856   1.295  15.282  1.00 20.39           O  
+ATOM    651  CB  SER A1096      52.214  -0.234  16.387  1.00 20.60           C  
+ATOM    652  OG  SER A1096      51.356   0.822  15.979  1.00 18.61           O  
+ATOM    653  N   VAL A1097      53.050   1.434  13.927  1.00 19.37           N  
+ATOM    654  CA  VAL A1097      53.398   2.751  13.436  1.00 18.98           C  
+ATOM    655  C   VAL A1097      53.297   3.622  14.696  1.00 19.55           C  
+ATOM    656  O   VAL A1097      52.370   3.460  15.498  1.00 18.84           O  
+ATOM    657  CB  VAL A1097      52.367   3.239  12.368  1.00 19.74           C  
+ATOM    658  CG1 VAL A1097      52.530   4.740  12.107  1.00 16.70           C  
+ATOM    659  CG2 VAL A1097      52.546   2.453  11.077  1.00 16.83           C  
+ATOM    660  N   ALA A1098      54.271   4.504  14.878  1.00 19.63           N  
+ATOM    661  CA  ALA A1098      54.313   5.415  16.011  1.00 21.07           C  
+ATOM    662  C   ALA A1098      54.658   4.817  17.374  1.00 20.65           C  
+ATOM    663  O   ALA A1098      54.493   5.493  18.388  1.00 19.76           O  
+ATOM    664  CB  ALA A1098      52.997   6.169  16.111  1.00 22.28           C  
+ATOM    665  N   VAL A1099      55.141   3.577  17.423  1.00 20.21           N  
+ATOM    666  CA  VAL A1099      55.489   3.007  18.721  1.00 18.90           C  
+ATOM    667  C   VAL A1099      56.848   3.525  19.186  1.00 20.23           C  
+ATOM    668  O   VAL A1099      57.142   3.526  20.384  1.00 20.62           O  
+ATOM    669  CB  VAL A1099      55.527   1.463  18.695  1.00 19.22           C  
+ATOM    670  CG1 VAL A1099      56.689   0.972  17.840  1.00 18.23           C  
+ATOM    671  CG2 VAL A1099      55.639   0.935  20.117  1.00 18.20           C  
+ATOM    672  N   GLY A1100      57.672   3.969  18.235  1.00 19.52           N  
+ATOM    673  CA  GLY A1100      58.990   4.488  18.564  1.00 18.99           C  
+ATOM    674  C   GLY A1100      60.154   3.723  17.953  1.00 20.76           C  
+ATOM    675  O   GLY A1100      61.263   3.732  18.502  1.00 20.70           O  
+ATOM    676  N   LYS A1101      59.913   3.064  16.820  1.00 20.41           N  
+ATOM    677  CA  LYS A1101      60.952   2.288  16.144  1.00 20.17           C  
+ATOM    678  C   LYS A1101      62.103   3.163  15.687  1.00 21.37           C  
+ATOM    679  O   LYS A1101      63.264   2.834  15.890  1.00 22.63           O  
+ATOM    680  CB  LYS A1101      60.383   1.564  14.920  1.00 19.12           C  
+ATOM    681  CG  LYS A1101      59.345   0.490  15.223  1.00 17.20           C  
+ATOM    682  CD  LYS A1101      58.903  -0.238  13.952  1.00 17.04           C  
+ATOM    683  CE  LYS A1101      58.290   0.721  12.920  1.00 15.85           C  
+ATOM    684  NZ  LYS A1101      57.108   1.456  13.462  1.00 16.03           N  
+ATOM    685  N   SER A1102      61.773   4.286  15.064  1.00 23.86           N  
+ATOM    686  CA  SER A1102      62.789   5.192  14.555  1.00 25.09           C  
+ATOM    687  C   SER A1102      63.675   5.745  15.657  1.00 24.43           C  
+ATOM    688  O   SER A1102      64.894   5.841  15.496  1.00 26.03           O  
+ATOM    689  CB  SER A1102      62.134   6.337  13.788  1.00 25.17           C  
+ATOM    690  OG  SER A1102      63.127   7.167  13.219  1.00 29.11           O  
+ATOM    691  N   THR A1103      63.065   6.118  16.774  1.00 24.06           N  
+ATOM    692  CA  THR A1103      63.824   6.639  17.898  1.00 23.80           C  
+ATOM    693  C   THR A1103      64.692   5.524  18.498  1.00 22.81           C  
+ATOM    694  O   THR A1103      65.880   5.718  18.762  1.00 22.78           O  
+ATOM    695  CB  THR A1103      62.879   7.212  18.982  1.00 24.04           C  
+ATOM    696  OG1 THR A1103      62.235   8.385  18.471  1.00 27.04           O  
+ATOM    697  CG2 THR A1103      63.654   7.588  20.232  1.00 24.46           C  
+ATOM    698  N   THR A1104      64.096   4.354  18.699  1.00 22.34           N  
+ATOM    699  CA  THR A1104      64.820   3.221  19.266  1.00 21.26           C  
+ATOM    700  C   THR A1104      66.026   2.858  18.395  1.00 21.22           C  
+ATOM    701  O   THR A1104      67.131   2.652  18.897  1.00 20.18           O  
+ATOM    702  CB  THR A1104      63.898   1.997  19.392  1.00 19.82           C  
+ATOM    703  OG1 THR A1104      62.786   2.333  20.224  1.00 23.93           O  
+ATOM    704  CG2 THR A1104      64.632   0.823  20.002  1.00 19.67           C  
+ATOM    705  N   ALA A1105      65.801   2.782  17.089  1.00 20.60           N  
+ATOM    706  CA  ALA A1105      66.856   2.448  16.142  1.00 19.63           C  
+ATOM    707  C   ALA A1105      68.014   3.432  16.225  1.00 20.55           C  
+ATOM    708  O   ALA A1105      69.176   3.035  16.359  1.00 21.33           O  
+ATOM    709  CB  ALA A1105      66.295   2.434  14.719  1.00 17.90           C  
+ATOM    710  N   ARG A1106      67.692   4.719  16.142  1.00 20.47           N  
+ATOM    711  CA  ARG A1106      68.710   5.756  16.181  1.00 21.66           C  
+ATOM    712  C   ARG A1106      69.457   5.787  17.508  1.00 21.50           C  
+ATOM    713  O   ARG A1106      70.655   6.059  17.540  1.00 20.89           O  
+ATOM    714  CB  ARG A1106      68.077   7.118  15.861  1.00 22.79           C  
+ATOM    715  CG  ARG A1106      67.633   7.209  14.401  1.00 27.28           C  
+ATOM    716  CD  ARG A1106      66.633   8.321  14.178  1.00 29.40           C  
+ATOM    717  NE  ARG A1106      67.253   9.624  14.334  1.00 35.22           N  
+ATOM    718  CZ  ARG A1106      66.582  10.741  14.580  1.00 37.51           C  
+ATOM    719  NH1 ARG A1106      65.261  10.710  14.703  1.00 39.06           N  
+ATOM    720  NH2 ARG A1106      67.236  11.890  14.699  1.00 40.15           N  
+ATOM    721  N   VAL A1107      68.757   5.506  18.603  1.00 20.95           N  
+ATOM    722  CA  VAL A1107      69.414   5.476  19.906  1.00 21.02           C  
+ATOM    723  C   VAL A1107      70.406   4.308  19.914  1.00 20.70           C  
+ATOM    724  O   VAL A1107      71.561   4.474  20.310  1.00 21.71           O  
+ATOM    725  CB  VAL A1107      68.395   5.282  21.070  1.00 20.82           C  
+ATOM    726  CG1 VAL A1107      69.136   4.944  22.355  1.00 18.08           C  
+ATOM    727  CG2 VAL A1107      67.574   6.551  21.269  1.00 18.12           C  
+ATOM    728  N   LEU A1108      69.951   3.140  19.457  1.00 19.43           N  
+ATOM    729  CA  LEU A1108      70.797   1.952  19.412  1.00 19.59           C  
+ATOM    730  C   LEU A1108      71.975   2.136  18.470  1.00 19.89           C  
+ATOM    731  O   LEU A1108      73.057   1.610  18.723  1.00 21.69           O  
+ATOM    732  CB  LEU A1108      69.985   0.725  18.988  1.00 18.41           C  
+ATOM    733  CG  LEU A1108      68.990   0.227  20.039  1.00 19.00           C  
+ATOM    734  CD1 LEU A1108      68.273  -1.019  19.529  1.00 16.33           C  
+ATOM    735  CD2 LEU A1108      69.734  -0.074  21.333  1.00 15.15           C  
+ATOM    736  N   GLN A1109      71.769   2.877  17.384  1.00 19.93           N  
+ATOM    737  CA  GLN A1109      72.844   3.135  16.433  1.00 21.24           C  
+ATOM    738  C   GLN A1109      73.949   3.934  17.118  1.00 22.69           C  
+ATOM    739  O   GLN A1109      75.134   3.652  16.950  1.00 21.73           O  
+ATOM    740  CB  GLN A1109      72.319   3.919  15.233  1.00 21.99           C  
+ATOM    741  CG  GLN A1109      73.405   4.491  14.339  1.00 22.76           C  
+ATOM    742  CD  GLN A1109      72.831   5.175  13.109  1.00 26.36           C  
+ATOM    743  OE1 GLN A1109      71.939   6.022  13.216  1.00 25.47           O  
+ATOM    744  NE2 GLN A1109      73.341   4.812  11.930  1.00 25.23           N  
+ATOM    745  N   ALA A1110      73.537   4.930  17.895  1.00 24.54           N  
+ATOM    746  CA  ALA A1110      74.461   5.788  18.623  1.00 25.72           C  
+ATOM    747  C   ALA A1110      75.213   5.004  19.695  1.00 26.34           C  
+ATOM    748  O   ALA A1110      76.438   5.082  19.779  1.00 27.76           O  
+ATOM    749  CB  ALA A1110      73.693   6.945  19.265  1.00 24.65           C  
+ATOM    750  N   LEU A1111      74.485   4.243  20.508  1.00 25.30           N  
+ATOM    751  CA  LEU A1111      75.125   3.468  21.567  1.00 26.71           C  
+ATOM    752  C   LEU A1111      76.058   2.360  21.058  1.00 27.84           C  
+ATOM    753  O   LEU A1111      77.153   2.174  21.590  1.00 28.92           O  
+ATOM    754  CB  LEU A1111      74.066   2.875  22.501  1.00 22.88           C  
+ATOM    755  CG  LEU A1111      73.169   3.934  23.152  1.00 24.87           C  
+ATOM    756  CD1 LEU A1111      72.130   3.268  24.034  1.00 23.32           C  
+ATOM    757  CD2 LEU A1111      74.027   4.905  23.965  1.00 23.84           C  
+ATOM    758  N   LEU A1112      75.642   1.627  20.031  1.00 28.34           N  
+ATOM    759  CA  LEU A1112      76.483   0.553  19.510  1.00 28.44           C  
+ATOM    760  C   LEU A1112      77.782   1.102  18.940  1.00 27.96           C  
+ATOM    761  O   LEU A1112      78.769   0.376  18.826  1.00 26.36           O  
+ATOM    762  CB  LEU A1112      75.731  -0.258  18.450  1.00 27.36           C  
+ATOM    763  CG  LEU A1112      74.648  -1.185  19.015  1.00 25.54           C  
+ATOM    764  CD1 LEU A1112      73.744  -1.698  17.904  1.00 25.44           C  
+ATOM    765  CD2 LEU A1112      75.321  -2.345  19.743  1.00 25.25           C  
+ATOM    766  N   SER A1113      77.780   2.389  18.600  1.00 29.29           N  
+ATOM    767  CA  SER A1113      78.970   3.041  18.053  1.00 31.51           C  
+ATOM    768  C   SER A1113      80.063   3.222  19.105  1.00 30.92           C  
+ATOM    769  O   SER A1113      81.208   3.520  18.767  1.00 30.83           O  
+ATOM    770  CB  SER A1113      78.610   4.413  17.461  1.00 32.68           C  
+ATOM    771  OG  SER A1113      77.954   4.277  16.211  1.00 36.56           O  
+ATOM    772  N   ARG A1114      79.705   3.039  20.375  1.00 30.78           N  
+ATOM    773  CA  ARG A1114      80.652   3.190  21.479  1.00 30.29           C  
+ATOM    774  C   ARG A1114      81.789   2.166  21.460  1.00 29.80           C  
+ATOM    775  O   ARG A1114      82.898   2.448  21.930  1.00 29.14           O  
+ATOM    776  CB  ARG A1114      79.903   3.111  22.812  1.00 30.73           C  
+ATOM    777  CG  ARG A1114      79.077   4.347  23.112  1.00 34.34           C  
+ATOM    778  CD  ARG A1114      77.953   4.059  24.098  1.00 37.38           C  
+ATOM    779  NE  ARG A1114      78.414   3.398  25.315  1.00 39.86           N  
+ATOM    780  CZ  ARG A1114      79.253   3.940  26.191  1.00 42.45           C  
+ATOM    781  NH1 ARG A1114      79.733   5.161  25.991  1.00 43.03           N  
+ATOM    782  NH2 ARG A1114      79.608   3.262  27.272  1.00 43.92           N  
+ATOM    783  N   TRP A1115      81.516   0.979  20.931  1.00 27.26           N  
+ATOM    784  CA  TRP A1115      82.527  -0.064  20.855  1.00 27.21           C  
+ATOM    785  C   TRP A1115      83.443   0.170  19.662  1.00 29.44           C  
+ATOM    786  O   TRP A1115      82.978   0.444  18.561  1.00 30.38           O  
+ATOM    787  CB  TRP A1115      81.869  -1.432  20.715  1.00 25.28           C  
+ATOM    788  CG  TRP A1115      81.353  -1.996  21.998  1.00 23.30           C  
+ATOM    789  CD1 TRP A1115      81.999  -2.860  22.831  1.00 20.99           C  
+ATOM    790  CD2 TRP A1115      80.085  -1.728  22.601  1.00 21.61           C  
+ATOM    791  NE1 TRP A1115      81.207  -3.150  23.915  1.00 20.61           N  
+ATOM    792  CE2 TRP A1115      80.027  -2.466  23.798  1.00 20.35           C  
+ATOM    793  CE3 TRP A1115      78.987  -0.933  22.244  1.00 21.73           C  
+ATOM    794  CZ2 TRP A1115      78.917  -2.433  24.646  1.00 21.29           C  
+ATOM    795  CZ3 TRP A1115      77.882  -0.903  23.088  1.00 22.20           C  
+ATOM    796  CH2 TRP A1115      77.858  -1.648  24.273  1.00 20.17           C  
+ATOM    797  N   PRO A1116      84.762   0.072  19.871  1.00 31.24           N  
+ATOM    798  CA  PRO A1116      85.742   0.274  18.797  1.00 32.95           C  
+ATOM    799  C   PRO A1116      85.515  -0.670  17.616  1.00 34.91           C  
+ATOM    800  O   PRO A1116      85.855  -0.341  16.485  1.00 37.00           O  
+ATOM    801  CB  PRO A1116      87.077   0.009  19.494  1.00 32.37           C  
+ATOM    802  CG  PRO A1116      86.812   0.459  20.898  1.00 32.26           C  
+ATOM    803  CD  PRO A1116      85.437  -0.117  21.169  1.00 30.38           C  
+ATOM    804  N   GLU A1117      84.952  -1.846  17.889  1.00 37.15           N  
+ATOM    805  CA  GLU A1117      84.687  -2.841  16.848  1.00 38.74           C  
+ATOM    806  C   GLU A1117      83.577  -2.427  15.889  1.00 38.86           C  
+ATOM    807  O   GLU A1117      83.622  -2.764  14.707  1.00 40.42           O  
+ATOM    808  CB  GLU A1117      84.284  -4.186  17.456  1.00 40.66           C  
+ATOM    809  CG  GLU A1117      85.370  -4.925  18.200  1.00 43.79           C  
+ATOM    810  CD  GLU A1117      85.788  -4.225  19.470  1.00 45.15           C  
+ATOM    811  OE1 GLU A1117      84.891  -3.813  20.247  1.00 42.57           O  
+ATOM    812  OE2 GLU A1117      87.015  -4.100  19.689  1.00 45.54           O  
+ATOM    813  N   HIS A1118      82.565  -1.730  16.400  1.00 36.70           N  
+ATOM    814  CA  HIS A1118      81.456  -1.309  15.555  1.00 35.43           C  
+ATOM    815  C   HIS A1118      81.733   0.064  14.950  1.00 35.88           C  
+ATOM    816  O   HIS A1118      81.044   1.038  15.231  1.00 36.30           O  
+ATOM    817  CB  HIS A1118      80.148  -1.312  16.363  1.00 31.09           C  
+ATOM    818  CG  HIS A1118      79.994  -2.512  17.254  1.00 25.95           C  
+ATOM    819  ND1 HIS A1118      80.455  -3.764  16.899  1.00 23.63           N  
+ATOM    820  CD2 HIS A1118      79.479  -2.638  18.498  1.00 21.60           C  
+ATOM    821  CE1 HIS A1118      80.237  -4.605  17.894  1.00 21.07           C  
+ATOM    822  NE2 HIS A1118      79.648  -3.951  18.877  1.00 21.23           N  
+ATOM    823  N   ARG A1119      82.758   0.123  14.107  1.00 37.37           N  
+ATOM    824  CA  ARG A1119      83.152   1.364  13.453  1.00 37.65           C  
+ATOM    825  C   ARG A1119      82.063   1.907  12.531  1.00 37.56           C  
+ATOM    826  O   ARG A1119      81.936   3.117  12.355  1.00 37.89           O  
+ATOM    827  CB  ARG A1119      84.438   1.145  12.663  1.00 37.95           C  
+ATOM    828  N   ARG A1120      81.276   1.020  11.936  1.00 35.47           N  
+ATOM    829  CA  ARG A1120      80.230   1.475  11.039  1.00 33.75           C  
+ATOM    830  C   ARG A1120      78.882   0.832  11.310  1.00 30.37           C  
+ATOM    831  O   ARG A1120      78.693  -0.371  11.098  1.00 30.10           O  
+ATOM    832  CB  ARG A1120      80.640   1.235   9.583  1.00 37.75           C  
+ATOM    833  CG  ARG A1120      81.834   2.068   9.130  1.00 43.68           C  
+ATOM    834  CD  ARG A1120      82.069   1.929   7.627  1.00 48.86           C  
+ATOM    835  NE  ARG A1120      83.080   2.870   7.143  1.00 54.59           N  
+ATOM    836  CZ  ARG A1120      83.467   2.974   5.874  1.00 56.85           C  
+ATOM    837  NH1 ARG A1120      82.929   2.194   4.943  1.00 57.89           N  
+ATOM    838  NH2 ARG A1120      84.392   3.862   5.534  1.00 57.94           N  
+ATOM    839  N   VAL A1121      77.951   1.655  11.783  1.00 27.30           N  
+ATOM    840  CA  VAL A1121      76.597   1.220  12.094  1.00 25.02           C  
+ATOM    841  C   VAL A1121      75.636   1.967  11.191  1.00 26.09           C  
+ATOM    842  O   VAL A1121      75.445   3.174  11.331  1.00 26.82           O  
+ATOM    843  CB  VAL A1121      76.252   1.508  13.567  1.00 24.38           C  
+ATOM    844  CG1 VAL A1121      74.833   1.062  13.876  1.00 22.21           C  
+ATOM    845  CG2 VAL A1121      77.247   0.793  14.466  1.00 20.85           C  
+ATOM    846  N   GLU A1122      75.042   1.235  10.255  1.00 26.93           N  
+ATOM    847  CA  GLU A1122      74.109   1.800   9.291  1.00 27.43           C  
+ATOM    848  C   GLU A1122      72.659   1.621   9.711  1.00 26.33           C  
+ATOM    849  O   GLU A1122      72.318   0.668  10.402  1.00 27.60           O  
+ATOM    850  CB  GLU A1122      74.327   1.141   7.926  1.00 30.24           C  
+ATOM    851  CG  GLU A1122      75.449   1.759   7.109  1.00 34.83           C  
+ATOM    852  CD  GLU A1122      75.061   3.117   6.552  1.00 38.00           C  
+ATOM    853  OE1 GLU A1122      75.937   3.806   5.995  1.00 39.20           O  
+ATOM    854  OE2 GLU A1122      73.873   3.493   6.667  1.00 40.29           O  
+ATOM    855  N   LEU A1123      71.801   2.536   9.279  1.00 24.91           N  
+ATOM    856  CA  LEU A1123      70.383   2.458   9.608  1.00 24.62           C  
+ATOM    857  C   LEU A1123      69.560   2.618   8.335  1.00 23.35           C  
+ATOM    858  O   LEU A1123      69.703   3.607   7.625  1.00 22.65           O  
+ATOM    859  CB  LEU A1123      70.003   3.565  10.587  1.00 27.45           C  
+ATOM    860  CG  LEU A1123      68.811   3.348  11.522  1.00 29.06           C  
+ATOM    861  CD1 LEU A1123      68.270   4.712  11.933  1.00 29.62           C  
+ATOM    862  CD2 LEU A1123      67.724   2.550  10.850  1.00 30.56           C  
+ATOM    863  N   ILE A1124      68.711   1.638   8.044  1.00 22.36           N  
+ATOM    864  CA  ILE A1124      67.860   1.684   6.856  1.00 21.30           C  
+ATOM    865  C   ILE A1124      66.432   1.418   7.311  1.00 20.84           C  
+ATOM    866  O   ILE A1124      66.204   0.523   8.115  1.00 20.89           O  
+ATOM    867  CB  ILE A1124      68.248   0.588   5.829  1.00 19.70           C  
+ATOM    868  CG1 ILE A1124      69.713   0.738   5.400  1.00 19.26           C  
+ATOM    869  CG2 ILE A1124      67.330   0.662   4.630  1.00 20.02           C  
+ATOM    870  CD1 ILE A1124      70.026   2.032   4.673  1.00 17.27           C  
+ATOM    871  N   THR A1125      65.475   2.203   6.828  1.00 20.97           N  
+ATOM    872  CA  THR A1125      64.088   1.977   7.208  1.00 22.55           C  
+ATOM    873  C   THR A1125      63.395   1.323   6.021  1.00 21.94           C  
+ATOM    874  O   THR A1125      63.820   1.498   4.878  1.00 21.46           O  
+ATOM    875  CB  THR A1125      63.369   3.292   7.570  1.00 25.51           C  
+ATOM    876  OG1 THR A1125      63.292   4.136   6.416  1.00 27.65           O  
+ATOM    877  CG2 THR A1125      64.132   4.017   8.672  1.00 27.32           C  
+ATOM    878  N   THR A1126      62.347   0.552   6.281  1.00 19.22           N  
+ATOM    879  CA  THR A1126      61.648  -0.110   5.188  1.00 21.22           C  
+ATOM    880  C   THR A1126      60.696   0.824   4.442  1.00 20.50           C  
+ATOM    881  O   THR A1126      60.205   0.477   3.361  1.00 20.25           O  
+ATOM    882  CB  THR A1126      60.860  -1.342   5.682  1.00 20.93           C  
+ATOM    883  OG1 THR A1126      59.803  -0.925   6.555  1.00 21.11           O  
+ATOM    884  CG2 THR A1126      61.790  -2.297   6.433  1.00 21.18           C  
+ATOM    885  N   ASP A1127      60.446   2.004   5.013  1.00 19.87           N  
+ATOM    886  CA  ASP A1127      59.565   2.992   4.391  1.00 20.30           C  
+ATOM    887  C   ASP A1127      59.958   3.189   2.937  1.00 19.21           C  
+ATOM    888  O   ASP A1127      59.103   3.268   2.060  1.00 21.33           O  
+ATOM    889  CB  ASP A1127      59.655   4.360   5.085  1.00 21.53           C  
+ATOM    890  CG  ASP A1127      59.127   4.343   6.505  1.00 25.12           C  
+ATOM    891  OD1 ASP A1127      58.333   3.445   6.848  1.00 25.23           O  
+ATOM    892  OD2 ASP A1127      59.502   5.246   7.277  1.00 28.93           O  
+ATOM    893  N   GLY A1128      61.261   3.275   2.698  1.00 18.53           N  
+ATOM    894  CA  GLY A1128      61.771   3.492   1.359  1.00 20.00           C  
+ATOM    895  C   GLY A1128      61.370   2.455   0.331  1.00 21.39           C  
+ATOM    896  O   GLY A1128      61.278   2.774  -0.853  1.00 23.47           O  
+ATOM    897  N   PHE A1129      61.126   1.225   0.775  1.00 19.10           N  
+ATOM    898  CA  PHE A1129      60.744   0.154  -0.131  1.00 19.25           C  
+ATOM    899  C   PHE A1129      59.245   0.122  -0.447  1.00 19.30           C  
+ATOM    900  O   PHE A1129      58.747  -0.822  -1.058  1.00 19.48           O  
+ATOM    901  CB  PHE A1129      61.209  -1.197   0.432  1.00 19.11           C  
+ATOM    902  CG  PHE A1129      62.708  -1.302   0.597  1.00 18.50           C  
+ATOM    903  CD1 PHE A1129      63.349  -0.712   1.690  1.00 17.70           C  
+ATOM    904  CD2 PHE A1129      63.482  -1.962  -0.359  1.00 17.99           C  
+ATOM    905  CE1 PHE A1129      64.745  -0.779   1.828  1.00 19.70           C  
+ATOM    906  CE2 PHE A1129      64.882  -2.035  -0.235  1.00 18.89           C  
+ATOM    907  CZ  PHE A1129      65.514  -1.443   0.861  1.00 18.72           C  
+ATOM    908  N   LEU A1130      58.519   1.146  -0.019  1.00 20.51           N  
+ATOM    909  CA  LEU A1130      57.094   1.221  -0.329  1.00 19.94           C  
+ATOM    910  C   LEU A1130      56.999   1.514  -1.824  1.00 21.80           C  
+ATOM    911  O   LEU A1130      57.935   2.063  -2.410  1.00 20.66           O  
+ATOM    912  CB  LEU A1130      56.432   2.379   0.421  1.00 19.42           C  
+ATOM    913  CG  LEU A1130      55.997   2.200   1.876  1.00 18.79           C  
+ATOM    914  CD1 LEU A1130      55.735   3.565   2.478  1.00 20.67           C  
+ATOM    915  CD2 LEU A1130      54.762   1.319   1.952  1.00 16.98           C  
+ATOM    916  N   HIS A1131      55.886   1.142  -2.449  1.00 23.13           N  
+ATOM    917  CA  HIS A1131      55.712   1.453  -3.863  1.00 24.18           C  
+ATOM    918  C   HIS A1131      55.463   2.960  -3.913  1.00 25.01           C  
+ATOM    919  O   HIS A1131      54.756   3.500  -3.058  1.00 25.97           O  
+ATOM    920  CB  HIS A1131      54.492   0.728  -4.445  1.00 24.00           C  
+ATOM    921  CG  HIS A1131      54.711  -0.732  -4.706  1.00 24.85           C  
+ATOM    922  ND1 HIS A1131      55.662  -1.195  -5.595  1.00 26.02           N  
+ATOM    923  CD2 HIS A1131      54.092  -1.826  -4.211  1.00 22.30           C  
+ATOM    924  CE1 HIS A1131      55.613  -2.514  -5.635  1.00 22.93           C  
+ATOM    925  NE2 HIS A1131      54.670  -2.922  -4.806  1.00 24.74           N  
+ATOM    926  N   PRO A1132      56.044   3.662  -4.899  1.00 24.90           N  
+ATOM    927  CA  PRO A1132      55.823   5.109  -4.985  1.00 25.45           C  
+ATOM    928  C   PRO A1132      54.319   5.405  -5.046  1.00 25.37           C  
+ATOM    929  O   PRO A1132      53.522   4.528  -5.415  1.00 24.75           O  
+ATOM    930  CB  PRO A1132      56.537   5.492  -6.286  1.00 25.65           C  
+ATOM    931  CG  PRO A1132      57.641   4.476  -6.374  1.00 25.89           C  
+ATOM    932  CD  PRO A1132      56.929   3.197  -5.981  1.00 24.95           C  
+ATOM    933  N   ASN A1133      53.930   6.626  -4.686  1.00 25.02           N  
+ATOM    934  CA  ASN A1133      52.516   6.994  -4.708  1.00 28.64           C  
+ATOM    935  C   ASN A1133      51.873   6.754  -6.080  1.00 30.68           C  
+ATOM    936  O   ASN A1133      50.706   6.354  -6.162  1.00 30.32           O  
+ATOM    937  CB  ASN A1133      52.329   8.460  -4.296  1.00 27.20           C  
+ATOM    938  CG  ASN A1133      52.641   8.699  -2.833  1.00 28.47           C  
+ATOM    939  OD1 ASN A1133      52.749   7.756  -2.043  1.00 26.53           O  
+ATOM    940  ND2 ASN A1133      52.768   9.966  -2.458  1.00 28.31           N  
+ATOM    941  N   GLN A1134      52.631   6.986  -7.150  1.00 31.71           N  
+ATOM    942  CA  GLN A1134      52.107   6.779  -8.498  1.00 34.92           C  
+ATOM    943  C   GLN A1134      51.592   5.353  -8.610  1.00 34.39           C  
+ATOM    944  O   GLN A1134      50.431   5.117  -8.966  1.00 34.28           O  
+ATOM    945  CB  GLN A1134      53.196   7.002  -9.546  1.00 37.80           C  
+ATOM    946  CG  GLN A1134      52.682   6.933 -10.976  1.00 44.52           C  
+ATOM    947  CD  GLN A1134      53.794   7.099 -12.002  1.00 48.60           C  
+ATOM    948  OE1 GLN A1134      54.566   8.063 -11.952  1.00 51.59           O  
+ATOM    949  NE2 GLN A1134      53.881   6.159 -12.939  1.00 48.74           N  
+ATOM    950  N   VAL A1135      52.469   4.406  -8.291  1.00 32.30           N  
+ATOM    951  CA  VAL A1135      52.121   3.004  -8.347  1.00 28.20           C  
+ATOM    952  C   VAL A1135      51.006   2.646  -7.372  1.00 27.96           C  
+ATOM    953  O   VAL A1135      50.118   1.873  -7.720  1.00 29.52           O  
+ATOM    954  CB  VAL A1135      53.342   2.122  -8.068  1.00 26.83           C  
+ATOM    955  CG1 VAL A1135      52.929   0.671  -8.001  1.00 22.88           C  
+ATOM    956  CG2 VAL A1135      54.379   2.321  -9.166  1.00 26.71           C  
+ATOM    957  N   LEU A1136      51.028   3.194  -6.160  1.00 26.39           N  
+ATOM    958  CA  LEU A1136      49.964   2.862  -5.207  1.00 25.45           C  
+ATOM    959  C   LEU A1136      48.588   3.340  -5.687  1.00 27.02           C  
+ATOM    960  O   LEU A1136      47.585   2.641  -5.519  1.00 26.31           O  
+ATOM    961  CB  LEU A1136      50.253   3.453  -3.821  1.00 22.60           C  
+ATOM    962  CG  LEU A1136      51.459   2.925  -3.036  1.00 23.05           C  
+ATOM    963  CD1 LEU A1136      51.656   3.782  -1.782  1.00 22.89           C  
+ATOM    964  CD2 LEU A1136      51.252   1.459  -2.668  1.00 16.61           C  
+ATOM    965  N   LYS A1137      48.544   4.534  -6.271  1.00 27.94           N  
+ATOM    966  CA  LYS A1137      47.299   5.097  -6.775  1.00 28.80           C  
+ATOM    967  C   LYS A1137      46.744   4.156  -7.837  1.00 30.39           C  
+ATOM    968  O   LYS A1137      45.548   3.852  -7.848  1.00 30.69           O  
+ATOM    969  CB  LYS A1137      47.567   6.478  -7.367  1.00 30.24           C  
+ATOM    970  CG  LYS A1137      46.349   7.220  -7.900  1.00 32.53           C  
+ATOM    971  CD  LYS A1137      46.799   8.543  -8.518  1.00 34.62           C  
+ATOM    972  CE  LYS A1137      45.653   9.339  -9.111  1.00 37.39           C  
+ATOM    973  NZ  LYS A1137      46.137  10.643  -9.662  1.00 38.40           N  
+ATOM    974  N   GLU A1138      47.620   3.687  -8.721  1.00 30.64           N  
+ATOM    975  CA  GLU A1138      47.228   2.759  -9.781  1.00 31.33           C  
+ATOM    976  C   GLU A1138      46.541   1.523  -9.215  1.00 30.99           C  
+ATOM    977  O   GLU A1138      45.551   1.038  -9.763  1.00 29.07           O  
+ATOM    978  CB  GLU A1138      48.456   2.303 -10.565  1.00 33.37           C  
+ATOM    979  CG  GLU A1138      48.824   3.176 -11.737  1.00 39.42           C  
+ATOM    980  CD  GLU A1138      50.230   2.898 -12.236  1.00 43.76           C  
+ATOM    981  OE1 GLU A1138      50.673   1.727 -12.167  1.00 45.55           O  
+ATOM    982  OE2 GLU A1138      50.890   3.853 -12.704  1.00 46.44           O  
+ATOM    983  N   ARG A1139      47.076   1.015  -8.111  1.00 29.97           N  
+ATOM    984  CA  ARG A1139      46.534  -0.183  -7.497  1.00 29.04           C  
+ATOM    985  C   ARG A1139      45.441   0.123  -6.490  1.00 30.31           C  
+ATOM    986  O   ARG A1139      44.870  -0.788  -5.884  1.00 31.94           O  
+ATOM    987  CB  ARG A1139      47.675  -0.966  -6.846  1.00 29.35           C  
+ATOM    988  CG  ARG A1139      48.855  -1.149  -7.806  1.00 29.94           C  
+ATOM    989  CD  ARG A1139      49.949  -2.073  -7.286  1.00 28.59           C  
+ATOM    990  NE  ARG A1139      51.014  -2.210  -8.275  1.00 28.37           N  
+ATOM    991  CZ  ARG A1139      52.078  -2.998  -8.141  1.00 31.20           C  
+ATOM    992  NH1 ARG A1139      52.234  -3.735  -7.047  1.00 27.53           N  
+ATOM    993  NH2 ARG A1139      52.989  -3.052  -9.111  1.00 29.42           N  
+ATOM    994  N   GLY A1140      45.134   1.406  -6.325  1.00 29.25           N  
+ATOM    995  CA  GLY A1140      44.101   1.791  -5.384  1.00 30.02           C  
+ATOM    996  C   GLY A1140      44.528   1.497  -3.962  1.00 31.76           C  
+ATOM    997  O   GLY A1140      43.709   1.108  -3.126  1.00 30.49           O  
+ATOM    998  N   LEU A1141      45.815   1.698  -3.686  1.00 32.84           N  
+ATOM    999  CA  LEU A1141      46.378   1.441  -2.362  1.00 33.85           C  
+ATOM   1000  C   LEU A1141      46.901   2.701  -1.659  1.00 34.63           C  
+ATOM   1001  O   LEU A1141      47.702   2.607  -0.722  1.00 33.21           O  
+ATOM   1002  CB  LEU A1141      47.517   0.425  -2.480  1.00 34.00           C  
+ATOM   1003  CG  LEU A1141      47.188  -0.933  -3.104  1.00 34.38           C  
+ATOM   1004  CD1 LEU A1141      48.430  -1.803  -3.102  1.00 35.06           C  
+ATOM   1005  CD2 LEU A1141      46.083  -1.608  -2.317  1.00 34.54           C  
+ATOM   1006  N   MET A1142      46.447   3.874  -2.094  1.00 35.32           N  
+ATOM   1007  CA  MET A1142      46.918   5.119  -1.493  1.00 36.82           C  
+ATOM   1008  C   MET A1142      46.438   5.285  -0.051  1.00 36.10           C  
+ATOM   1009  O   MET A1142      46.953   6.128   0.684  1.00 36.07           O  
+ATOM   1010  CB  MET A1142      46.485   6.321  -2.337  1.00 38.94           C  
+ATOM   1011  CG  MET A1142      47.415   7.526  -2.198  1.00 44.11           C  
+ATOM   1012  SD  MET A1142      49.071   7.251  -2.898  1.00 45.87           S  
+ATOM   1013  CE  MET A1142      48.874   8.020  -4.503  1.00 48.22           C  
+ATOM   1014  N   LYS A1143      45.456   4.480   0.348  1.00 34.39           N  
+ATOM   1015  CA  LYS A1143      44.925   4.522   1.709  1.00 34.29           C  
+ATOM   1016  C   LYS A1143      45.365   3.261   2.443  1.00 32.92           C  
+ATOM   1017  O   LYS A1143      44.792   2.890   3.465  1.00 32.03           O  
+ATOM   1018  CB  LYS A1143      43.398   4.576   1.689  1.00 36.48           C  
+ATOM   1019  CG  LYS A1143      42.821   5.836   1.067  1.00 42.47           C  
+ATOM   1020  CD  LYS A1143      42.728   6.964   2.080  1.00 45.38           C  
+ATOM   1021  CE  LYS A1143      41.732   6.616   3.180  1.00 49.04           C  
+ATOM   1022  NZ  LYS A1143      41.582   7.717   4.172  1.00 51.03           N  
+ATOM   1023  N   LYS A1144      46.389   2.605   1.907  1.00 31.37           N  
+ATOM   1024  CA  LYS A1144      46.903   1.375   2.492  1.00 28.70           C  
+ATOM   1025  C   LYS A1144      48.410   1.374   2.706  1.00 26.54           C  
+ATOM   1026  O   LYS A1144      49.025   0.306   2.731  1.00 27.86           O  
+ATOM   1027  CB  LYS A1144      46.518   0.180   1.615  1.00 29.13           C  
+ATOM   1028  CG  LYS A1144      45.036  -0.174   1.662  1.00 31.50           C  
+ATOM   1029  CD  LYS A1144      44.646  -0.683   3.036  1.00 32.15           C  
+ATOM   1030  CE  LYS A1144      43.186  -1.109   3.083  1.00 33.75           C  
+ATOM   1031  NZ  LYS A1144      42.807  -1.655   4.415  1.00 34.58           N  
+ATOM   1032  N   LYS A1145      49.015   2.550   2.848  1.00 23.67           N  
+ATOM   1033  CA  LYS A1145      50.451   2.591   3.089  1.00 22.12           C  
+ATOM   1034  C   LYS A1145      50.748   1.871   4.400  1.00 21.01           C  
+ATOM   1035  O   LYS A1145      50.109   2.138   5.425  1.00 19.16           O  
+ATOM   1036  CB  LYS A1145      50.962   4.027   3.156  1.00 21.98           C  
+ATOM   1037  CG  LYS A1145      51.313   4.611   1.795  1.00 24.96           C  
+ATOM   1038  CD  LYS A1145      51.873   6.020   1.922  1.00 24.64           C  
+ATOM   1039  CE  LYS A1145      52.274   6.576   0.562  1.00 27.51           C  
+ATOM   1040  NZ  LYS A1145      52.762   7.992   0.611  1.00 26.22           N  
+ATOM   1041  N   GLY A1146      51.709   0.952   4.352  1.00 19.21           N  
+ATOM   1042  CA  GLY A1146      52.082   0.186   5.528  1.00 19.51           C  
+ATOM   1043  C   GLY A1146      51.586  -1.246   5.454  1.00 19.80           C  
+ATOM   1044  O   GLY A1146      52.098  -2.134   6.145  1.00 20.87           O  
+ATOM   1045  N   PHE A1147      50.566  -1.471   4.633  1.00 19.20           N  
+ATOM   1046  CA  PHE A1147      50.018  -2.805   4.459  1.00 20.52           C  
+ATOM   1047  C   PHE A1147      50.942  -3.554   3.507  1.00 20.99           C  
+ATOM   1048  O   PHE A1147      51.645  -2.938   2.703  1.00 21.72           O  
+ATOM   1049  CB  PHE A1147      48.595  -2.733   3.896  1.00 20.15           C  
+ATOM   1050  CG  PHE A1147      47.561  -2.323   4.916  1.00 20.66           C  
+ATOM   1051  CD1 PHE A1147      47.578  -1.044   5.474  1.00 18.67           C  
+ATOM   1052  CD2 PHE A1147      46.591  -3.227   5.341  1.00 19.33           C  
+ATOM   1053  CE1 PHE A1147      46.645  -0.679   6.442  1.00 18.88           C  
+ATOM   1054  CE2 PHE A1147      45.653  -2.869   6.311  1.00 20.09           C  
+ATOM   1055  CZ  PHE A1147      45.680  -1.593   6.861  1.00 17.97           C  
+ATOM   1056  N   PRO A1148      50.962  -4.889   3.597  1.00 21.11           N  
+ATOM   1057  CA  PRO A1148      51.810  -5.733   2.751  1.00 22.49           C  
+ATOM   1058  C   PRO A1148      51.827  -5.365   1.272  1.00 23.91           C  
+ATOM   1059  O   PRO A1148      52.888  -5.208   0.670  1.00 23.21           O  
+ATOM   1060  CB  PRO A1148      51.245  -7.128   2.987  1.00 23.26           C  
+ATOM   1061  CG  PRO A1148      50.809  -7.058   4.435  1.00 23.24           C  
+ATOM   1062  CD  PRO A1148      50.115  -5.708   4.483  1.00 20.38           C  
+ATOM   1063  N   GLU A1149      50.650  -5.211   0.689  1.00 24.79           N  
+ATOM   1064  CA  GLU A1149      50.556  -4.896  -0.729  1.00 27.24           C  
+ATOM   1065  C   GLU A1149      51.151  -3.548  -1.163  1.00 26.06           C  
+ATOM   1066  O   GLU A1149      51.379  -3.319  -2.356  1.00 24.11           O  
+ATOM   1067  CB  GLU A1149      49.093  -5.022  -1.186  1.00 29.42           C  
+ATOM   1068  CG  GLU A1149      48.074  -4.193  -0.394  1.00 33.45           C  
+ATOM   1069  CD  GLU A1149      47.638  -4.815   0.943  1.00 36.07           C  
+ATOM   1070  OE1 GLU A1149      46.566  -4.406   1.450  1.00 37.09           O  
+ATOM   1071  OE2 GLU A1149      48.344  -5.691   1.495  1.00 33.70           O  
+ATOM   1072  N   SER A1150      51.431  -2.667  -0.205  1.00 24.88           N  
+ATOM   1073  CA  SER A1150      51.997  -1.359  -0.543  1.00 22.83           C  
+ATOM   1074  C   SER A1150      53.517  -1.395  -0.609  1.00 21.85           C  
+ATOM   1075  O   SER A1150      54.151  -0.393  -0.947  1.00 22.66           O  
+ATOM   1076  CB  SER A1150      51.563  -0.300   0.479  1.00 22.91           C  
+ATOM   1077  OG  SER A1150      52.283  -0.412   1.699  1.00 23.53           O  
+ATOM   1078  N   TYR A1151      54.101  -2.545  -0.277  1.00 21.34           N  
+ATOM   1079  CA  TYR A1151      55.554  -2.684  -0.285  1.00 20.69           C  
+ATOM   1080  C   TYR A1151      56.093  -3.477  -1.458  1.00 21.52           C  
+ATOM   1081  O   TYR A1151      55.461  -4.418  -1.939  1.00 20.76           O  
+ATOM   1082  CB  TYR A1151      56.059  -3.388   0.987  1.00 20.69           C  
+ATOM   1083  CG  TYR A1151      55.967  -2.596   2.265  1.00 19.87           C  
+ATOM   1084  CD1 TYR A1151      54.876  -2.745   3.121  1.00 19.27           C  
+ATOM   1085  CD2 TYR A1151      56.991  -1.720   2.638  1.00 19.95           C  
+ATOM   1086  CE1 TYR A1151      54.807  -2.047   4.320  1.00 19.71           C  
+ATOM   1087  CE2 TYR A1151      56.932  -1.015   3.835  1.00 18.95           C  
+ATOM   1088  CZ  TYR A1151      55.838  -1.186   4.673  1.00 20.65           C  
+ATOM   1089  OH  TYR A1151      55.786  -0.514   5.871  1.00 21.98           O  
+ATOM   1090  N   ASP A1152      57.280  -3.093  -1.899  1.00 20.77           N  
+ATOM   1091  CA  ASP A1152      57.965  -3.798  -2.963  1.00 22.73           C  
+ATOM   1092  C   ASP A1152      58.827  -4.757  -2.147  1.00 23.34           C  
+ATOM   1093  O   ASP A1152      60.036  -4.570  -2.023  1.00 22.93           O  
+ATOM   1094  CB  ASP A1152      58.837  -2.826  -3.753  1.00 24.51           C  
+ATOM   1095  CG  ASP A1152      59.656  -3.512  -4.831  1.00 27.75           C  
+ATOM   1096  OD1 ASP A1152      59.543  -4.752  -4.972  1.00 27.45           O  
+ATOM   1097  OD2 ASP A1152      60.418  -2.809  -5.536  1.00 28.27           O  
+ATOM   1098  N   MET A1153      58.179  -5.764  -1.564  1.00 25.08           N  
+ATOM   1099  CA  MET A1153      58.846  -6.737  -0.709  1.00 25.95           C  
+ATOM   1100  C   MET A1153      60.001  -7.508  -1.314  1.00 27.01           C  
+ATOM   1101  O   MET A1153      61.001  -7.743  -0.634  1.00 27.92           O  
+ATOM   1102  CB  MET A1153      57.832  -7.729  -0.139  1.00 27.92           C  
+ATOM   1103  CG  MET A1153      57.471  -7.441   1.295  1.00 31.68           C  
+ATOM   1104  SD  MET A1153      58.887  -7.450   2.388  1.00 33.13           S  
+ATOM   1105  CE  MET A1153      58.143  -7.947   3.952  1.00 34.40           C  
+ATOM   1106  N   HIS A1154      59.869  -7.919  -2.573  1.00 25.31           N  
+ATOM   1107  CA  HIS A1154      60.937  -8.670  -3.215  1.00 23.75           C  
+ATOM   1108  C   HIS A1154      62.216  -7.860  -3.189  1.00 23.00           C  
+ATOM   1109  O   HIS A1154      63.307  -8.409  -3.023  1.00 24.32           O  
+ATOM   1110  CB  HIS A1154      60.556  -9.020  -4.655  1.00 24.04           C  
+ATOM   1111  CG  HIS A1154      59.482 -10.058  -4.751  1.00 25.25           C  
+ATOM   1112  ND1 HIS A1154      59.619 -11.322  -4.219  1.00 27.18           N  
+ATOM   1113  CD2 HIS A1154      58.241 -10.013  -5.295  1.00 26.59           C  
+ATOM   1114  CE1 HIS A1154      58.511 -12.012  -4.427  1.00 26.85           C  
+ATOM   1115  NE2 HIS A1154      57.659 -11.239  -5.078  1.00 26.70           N  
+ATOM   1116  N   ARG A1155      62.080  -6.550  -3.337  1.00 20.47           N  
+ATOM   1117  CA  ARG A1155      63.240  -5.686  -3.328  1.00 21.71           C  
+ATOM   1118  C   ARG A1155      63.849  -5.602  -1.918  1.00 21.78           C  
+ATOM   1119  O   ARG A1155      65.073  -5.606  -1.761  1.00 21.21           O  
+ATOM   1120  CB  ARG A1155      62.864  -4.290  -3.836  1.00 21.70           C  
+ATOM   1121  CG  ARG A1155      64.055  -3.363  -3.932  1.00 24.73           C  
+ATOM   1122  CD  ARG A1155      63.705  -2.029  -4.537  1.00 26.44           C  
+ATOM   1123  NE  ARG A1155      64.895  -1.190  -4.651  1.00 26.99           N  
+ATOM   1124  CZ  ARG A1155      64.908   0.009  -5.221  1.00 27.36           C  
+ATOM   1125  NH1 ARG A1155      63.791   0.513  -5.733  1.00 24.11           N  
+ATOM   1126  NH2 ARG A1155      66.036   0.703  -5.278  1.00 28.93           N  
+ATOM   1127  N   LEU A1156      62.998  -5.527  -0.896  1.00 20.91           N  
+ATOM   1128  CA  LEU A1156      63.488  -5.453   0.481  1.00 20.08           C  
+ATOM   1129  C   LEU A1156      64.237  -6.733   0.826  1.00 20.43           C  
+ATOM   1130  O   LEU A1156      65.307  -6.696   1.433  1.00 21.25           O  
+ATOM   1131  CB  LEU A1156      62.329  -5.256   1.466  1.00 18.65           C  
+ATOM   1132  CG  LEU A1156      62.708  -5.267   2.956  1.00 17.84           C  
+ATOM   1133  CD1 LEU A1156      63.746  -4.186   3.254  1.00 15.40           C  
+ATOM   1134  CD2 LEU A1156      61.454  -5.056   3.793  1.00 16.73           C  
+ATOM   1135  N   VAL A1157      63.667  -7.867   0.438  1.00 20.83           N  
+ATOM   1136  CA  VAL A1157      64.292  -9.156   0.695  1.00 21.58           C  
+ATOM   1137  C   VAL A1157      65.660  -9.229   0.021  1.00 21.50           C  
+ATOM   1138  O   VAL A1157      66.643  -9.653   0.634  1.00 21.35           O  
+ATOM   1139  CB  VAL A1157      63.411 -10.326   0.184  1.00 20.58           C  
+ATOM   1140  CG1 VAL A1157      64.186 -11.631   0.271  1.00 19.58           C  
+ATOM   1141  CG2 VAL A1157      62.142 -10.429   1.028  1.00 22.89           C  
+ATOM   1142  N   LYS A1158      65.723  -8.802  -1.236  1.00 22.09           N  
+ATOM   1143  CA  LYS A1158      66.983  -8.830  -1.969  1.00 22.45           C  
+ATOM   1144  C   LYS A1158      68.026  -7.908  -1.337  1.00 22.14           C  
+ATOM   1145  O   LYS A1158      69.232  -8.172  -1.424  1.00 21.81           O  
+ATOM   1146  CB  LYS A1158      66.765  -8.425  -3.427  1.00 22.41           C  
+ATOM   1147  CG  LYS A1158      68.034  -8.499  -4.260  1.00 24.14           C  
+ATOM   1148  CD  LYS A1158      67.768  -8.201  -5.724  1.00 28.23           C  
+ATOM   1149  CE  LYS A1158      69.015  -8.445  -6.583  1.00 31.41           C  
+ATOM   1150  NZ  LYS A1158      70.120  -7.486  -6.278  1.00 31.77           N  
+ATOM   1151  N   PHE A1159      67.566  -6.830  -0.701  1.00 20.67           N  
+ATOM   1152  CA  PHE A1159      68.487  -5.887  -0.068  1.00 21.93           C  
+ATOM   1153  C   PHE A1159      69.273  -6.578   1.051  1.00 22.22           C  
+ATOM   1154  O   PHE A1159      70.505  -6.564   1.054  1.00 22.26           O  
+ATOM   1155  CB  PHE A1159      67.725  -4.684   0.500  1.00 22.07           C  
+ATOM   1156  CG  PHE A1159      68.600  -3.703   1.219  1.00 22.66           C  
+ATOM   1157  CD1 PHE A1159      69.443  -2.849   0.509  1.00 23.66           C  
+ATOM   1158  CD2 PHE A1159      68.601  -3.645   2.611  1.00 23.81           C  
+ATOM   1159  CE1 PHE A1159      70.282  -1.944   1.181  1.00 23.12           C  
+ATOM   1160  CE2 PHE A1159      69.433  -2.748   3.292  1.00 23.09           C  
+ATOM   1161  CZ  PHE A1159      70.276  -1.896   2.572  1.00 22.71           C  
+ATOM   1162  N   VAL A1160      68.565  -7.182   2.000  1.00 21.10           N  
+ATOM   1163  CA  VAL A1160      69.240  -7.867   3.091  1.00 21.31           C  
+ATOM   1164  C   VAL A1160      69.927  -9.132   2.581  1.00 22.28           C  
+ATOM   1165  O   VAL A1160      70.963  -9.543   3.112  1.00 22.95           O  
+ATOM   1166  CB  VAL A1160      68.262  -8.211   4.233  1.00 19.17           C  
+ATOM   1167  CG1 VAL A1160      67.813  -6.937   4.904  1.00 20.86           C  
+ATOM   1168  CG2 VAL A1160      67.064  -8.968   3.703  1.00 18.48           C  
+ATOM   1169  N   SER A1161      69.363  -9.742   1.541  1.00 22.61           N  
+ATOM   1170  CA  SER A1161      69.971 -10.938   0.968  1.00 23.26           C  
+ATOM   1171  C   SER A1161      71.354 -10.577   0.393  1.00 22.28           C  
+ATOM   1172  O   SER A1161      72.339 -11.279   0.633  1.00 20.26           O  
+ATOM   1173  CB  SER A1161      69.071 -11.523  -0.129  1.00 24.21           C  
+ATOM   1174  OG  SER A1161      69.638 -12.707  -0.663  1.00 27.13           O  
+ATOM   1175  N   ASP A1162      71.426  -9.477  -0.355  1.00 22.75           N  
+ATOM   1176  CA  ASP A1162      72.700  -9.042  -0.935  1.00 22.71           C  
+ATOM   1177  C   ASP A1162      73.719  -8.726   0.155  1.00 22.89           C  
+ATOM   1178  O   ASP A1162      74.890  -9.070   0.023  1.00 22.45           O  
+ATOM   1179  CB  ASP A1162      72.514  -7.802  -1.819  1.00 21.45           C  
+ATOM   1180  CG  ASP A1162      71.795  -8.114  -3.121  1.00 23.26           C  
+ATOM   1181  OD1 ASP A1162      71.819  -9.285  -3.552  1.00 21.73           O  
+ATOM   1182  OD2 ASP A1162      71.218  -7.183  -3.721  1.00 24.09           O  
+ATOM   1183  N   LEU A1163      73.273  -8.060   1.222  1.00 22.11           N  
+ATOM   1184  CA  LEU A1163      74.161  -7.717   2.332  1.00 21.58           C  
+ATOM   1185  C   LEU A1163      74.707  -8.998   2.943  1.00 21.17           C  
+ATOM   1186  O   LEU A1163      75.889  -9.095   3.257  1.00 22.43           O  
+ATOM   1187  CB  LEU A1163      73.407  -6.939   3.411  1.00 21.23           C  
+ATOM   1188  CG  LEU A1163      73.063  -5.477   3.148  1.00 21.80           C  
+ATOM   1189  CD1 LEU A1163      71.971  -5.021   4.108  1.00 21.92           C  
+ATOM   1190  CD2 LEU A1163      74.316  -4.628   3.307  1.00 22.40           C  
+ATOM   1191  N   LYS A1164      73.832  -9.983   3.103  1.00 20.81           N  
+ATOM   1192  CA  LYS A1164      74.227 -11.249   3.682  1.00 21.17           C  
+ATOM   1193  C   LYS A1164      74.945 -12.151   2.677  1.00 22.87           C  
+ATOM   1194  O   LYS A1164      75.304 -13.287   2.995  1.00 21.18           O  
+ATOM   1195  CB  LYS A1164      73.008 -11.960   4.262  1.00 19.16           C  
+ATOM   1196  CG  LYS A1164      73.121 -12.243   5.756  1.00 23.50           C  
+ATOM   1197  CD  LYS A1164      73.076 -10.972   6.573  1.00 22.60           C  
+ATOM   1198  CE  LYS A1164      73.006 -11.255   8.085  1.00 20.12           C  
+ATOM   1199  NZ  LYS A1164      74.321 -11.515   8.726  1.00 18.26           N  
+ATOM   1200  N   SER A1165      75.150 -11.641   1.465  1.00 23.64           N  
+ATOM   1201  CA  SER A1165      75.849 -12.392   0.427  1.00 24.13           C  
+ATOM   1202  C   SER A1165      77.264 -11.848   0.326  1.00 26.28           C  
+ATOM   1203  O   SER A1165      78.119 -12.411  -0.359  1.00 27.05           O  
+ATOM   1204  CB  SER A1165      75.143 -12.243  -0.927  1.00 23.55           C  
+ATOM   1205  OG  SER A1165      73.928 -12.971  -0.971  1.00 21.02           O  
+ATOM   1206  N   GLY A1166      77.502 -10.735   1.013  1.00 28.02           N  
+ATOM   1207  CA  GLY A1166      78.815 -10.127   0.996  1.00 29.27           C  
+ATOM   1208  C   GLY A1166      78.987  -9.037  -0.046  1.00 30.96           C  
+ATOM   1209  O   GLY A1166      80.102  -8.549  -0.245  1.00 30.74           O  
+ATOM   1210  N   VAL A1167      77.903  -8.651  -0.715  1.00 30.62           N  
+ATOM   1211  CA  VAL A1167      77.986  -7.599  -1.723  1.00 30.95           C  
+ATOM   1212  C   VAL A1167      78.516  -6.335  -1.047  1.00 34.02           C  
+ATOM   1213  O   VAL A1167      77.910  -5.812  -0.112  1.00 35.39           O  
+ATOM   1214  CB  VAL A1167      76.617  -7.302  -2.345  1.00 30.37           C  
+ATOM   1215  CG1 VAL A1167      76.754  -6.196  -3.373  1.00 29.54           C  
+ATOM   1216  CG2 VAL A1167      76.042  -8.565  -2.988  1.00 26.12           C  
+ATOM   1217  N   PRO A1168      79.658  -5.822  -1.525  1.00 35.85           N  
+ATOM   1218  CA  PRO A1168      80.295  -4.621  -0.975  1.00 36.82           C  
+ATOM   1219  C   PRO A1168      79.415  -3.378  -0.833  1.00 37.80           C  
+ATOM   1220  O   PRO A1168      79.330  -2.799   0.254  1.00 38.71           O  
+ATOM   1221  CB  PRO A1168      81.489  -4.405  -1.909  1.00 36.58           C  
+ATOM   1222  CG  PRO A1168      81.027  -5.010  -3.207  1.00 38.17           C  
+ATOM   1223  CD  PRO A1168      80.345  -6.269  -2.749  1.00 35.95           C  
+ATOM   1224  N   ASN A1169      78.765  -2.961  -1.913  1.00 37.96           N  
+ATOM   1225  CA  ASN A1169      77.910  -1.783  -1.852  1.00 39.25           C  
+ATOM   1226  C   ASN A1169      76.493  -2.147  -2.247  1.00 39.49           C  
+ATOM   1227  O   ASN A1169      76.261  -2.703  -3.316  1.00 42.15           O  
+ATOM   1228  CB  ASN A1169      78.435  -0.689  -2.780  1.00 42.45           C  
+ATOM   1229  CG  ASN A1169      79.894  -0.360  -2.524  1.00 45.84           C  
+ATOM   1230  OD1 ASN A1169      80.272   0.023  -1.415  1.00 48.35           O  
+ATOM   1231  ND2 ASN A1169      80.723  -0.512  -3.552  1.00 46.28           N  
+ATOM   1232  N   VAL A1170      75.544  -1.836  -1.378  1.00 37.83           N  
+ATOM   1233  CA  VAL A1170      74.149  -2.136  -1.643  1.00 36.17           C  
+ATOM   1234  C   VAL A1170      73.353  -0.841  -1.586  1.00 34.86           C  
+ATOM   1235  O   VAL A1170      73.591   0.008  -0.728  1.00 35.18           O  
+ATOM   1236  CB  VAL A1170      73.597  -3.141  -0.614  1.00 35.96           C  
+ATOM   1237  CG1 VAL A1170      72.243  -3.653  -1.060  1.00 36.76           C  
+ATOM   1238  CG2 VAL A1170      74.563  -4.298  -0.462  1.00 37.47           C  
+ATOM   1239  N   THR A1171      72.408  -0.689  -2.503  1.00 34.02           N  
+ATOM   1240  CA  THR A1171      71.600   0.521  -2.562  1.00 32.49           C  
+ATOM   1241  C   THR A1171      70.165   0.300  -2.092  1.00 31.06           C  
+ATOM   1242  O   THR A1171      69.559  -0.743  -2.355  1.00 29.87           O  
+ATOM   1243  CB  THR A1171      71.583   1.083  -3.998  1.00 33.78           C  
+ATOM   1244  OG1 THR A1171      72.922   1.414  -4.390  1.00 35.05           O  
+ATOM   1245  CG2 THR A1171      70.723   2.330  -4.078  1.00 34.87           C  
+ATOM   1246  N   ALA A1172      69.629   1.292  -1.388  1.00 29.19           N  
+ATOM   1247  CA  ALA A1172      68.264   1.217  -0.884  1.00 28.23           C  
+ATOM   1248  C   ALA A1172      67.487   2.471  -1.245  1.00 27.28           C  
+ATOM   1249  O   ALA A1172      68.029   3.577  -1.233  1.00 24.39           O  
+ATOM   1250  CB  ALA A1172      68.268   1.041   0.626  1.00 29.46           C  
+ATOM   1251  N   PRO A1173      66.203   2.311  -1.593  1.00 27.10           N  
+ATOM   1252  CA  PRO A1173      65.402   3.485  -1.944  1.00 28.13           C  
+ATOM   1253  C   PRO A1173      65.135   4.257  -0.655  1.00 28.56           C  
+ATOM   1254  O   PRO A1173      65.226   3.691   0.440  1.00 28.40           O  
+ATOM   1255  CB  PRO A1173      64.138   2.872  -2.551  1.00 26.26           C  
+ATOM   1256  CG  PRO A1173      64.002   1.587  -1.789  1.00 27.89           C  
+ATOM   1257  CD  PRO A1173      65.423   1.069  -1.743  1.00 27.34           C  
+ATOM   1258  N   VAL A1174      64.827   5.543  -0.776  1.00 27.62           N  
+ATOM   1259  CA  VAL A1174      64.567   6.369   0.393  1.00 27.46           C  
+ATOM   1260  C   VAL A1174      63.200   7.040   0.316  1.00 28.98           C  
+ATOM   1261  O   VAL A1174      62.789   7.524  -0.742  1.00 28.65           O  
+ATOM   1262  CB  VAL A1174      65.650   7.448   0.557  1.00 26.74           C  
+ATOM   1263  CG1 VAL A1174      65.276   8.392   1.691  1.00 26.49           C  
+ATOM   1264  CG2 VAL A1174      66.989   6.795   0.838  1.00 27.78           C  
+ATOM   1265  N   TYR A1175      62.514   7.065   1.456  1.00 28.43           N  
+ATOM   1266  CA  TYR A1175      61.187   7.649   1.579  1.00 29.69           C  
+ATOM   1267  C   TYR A1175      61.275   8.962   2.339  1.00 31.94           C  
+ATOM   1268  O   TYR A1175      62.120   9.125   3.211  1.00 32.16           O  
+ATOM   1269  CB  TYR A1175      60.279   6.683   2.342  1.00 28.20           C  
+ATOM   1270  CG  TYR A1175      58.828   7.095   2.423  1.00 27.02           C  
+ATOM   1271  CD1 TYR A1175      57.974   6.947   1.327  1.00 25.08           C  
+ATOM   1272  CD2 TYR A1175      58.299   7.607   3.606  1.00 26.03           C  
+ATOM   1273  CE1 TYR A1175      56.631   7.296   1.411  1.00 24.13           C  
+ATOM   1274  CE2 TYR A1175      56.960   7.958   3.699  1.00 24.84           C  
+ATOM   1275  CZ  TYR A1175      56.132   7.802   2.603  1.00 24.88           C  
+ATOM   1276  OH  TYR A1175      54.808   8.159   2.704  1.00 24.57           O  
+ATOM   1277  N   SER A1176      60.390   9.893   2.010  1.00 34.47           N  
+ATOM   1278  CA  SER A1176      60.362  11.199   2.661  1.00 37.43           C  
+ATOM   1279  C   SER A1176      58.978  11.492   3.235  1.00 39.26           C  
+ATOM   1280  O   SER A1176      58.024  11.676   2.482  1.00 39.35           O  
+ATOM   1281  CB  SER A1176      60.731  12.289   1.652  1.00 38.09           C  
+ATOM   1282  OG  SER A1176      60.468  13.581   2.172  1.00 41.96           O  
+ATOM   1283  N   HIS A1177      58.854  11.531   4.559  1.00 42.39           N  
+ATOM   1284  CA  HIS A1177      57.555  11.826   5.160  1.00 44.63           C  
+ATOM   1285  C   HIS A1177      57.200  13.293   4.891  1.00 44.32           C  
+ATOM   1286  O   HIS A1177      56.059  13.717   5.086  1.00 44.68           O  
+ATOM   1287  CB  HIS A1177      57.561  11.541   6.675  1.00 46.51           C  
+ATOM   1288  CG  HIS A1177      57.437  10.085   7.022  1.00 49.82           C  
+ATOM   1289  ND1 HIS A1177      58.523   9.237   7.095  1.00 50.83           N  
+ATOM   1290  CD2 HIS A1177      56.349   9.325   7.299  1.00 50.63           C  
+ATOM   1291  CE1 HIS A1177      58.110   8.020   7.404  1.00 50.14           C  
+ATOM   1292  NE2 HIS A1177      56.795   8.046   7.533  1.00 50.83           N  
+ATOM   1293  N   LEU A1178      58.187  14.053   4.424  1.00 43.11           N  
+ATOM   1294  CA  LEU A1178      58.002  15.461   4.111  1.00 42.21           C  
+ATOM   1295  C   LEU A1178      57.179  15.603   2.838  1.00 42.24           C  
+ATOM   1296  O   LEU A1178      56.324  16.485   2.734  1.00 42.83           O  
+ATOM   1297  CB  LEU A1178      59.353  16.135   3.933  1.00 42.52           C  
+ATOM   1298  N   ILE A1179      57.445  14.745   1.859  1.00 40.82           N  
+ATOM   1299  CA  ILE A1179      56.699  14.795   0.613  1.00 39.80           C  
+ATOM   1300  C   ILE A1179      55.725  13.628   0.563  1.00 38.39           C  
+ATOM   1301  O   ILE A1179      54.948  13.492  -0.380  1.00 38.90           O  
+ATOM   1302  CB  ILE A1179      57.631  14.753  -0.611  1.00 40.62           C  
+ATOM   1303  CG1 ILE A1179      58.323  13.397  -0.706  1.00 41.27           C  
+ATOM   1304  CG2 ILE A1179      58.671  15.852  -0.496  1.00 41.31           C  
+ATOM   1305  CD1 ILE A1179      59.287  13.297  -1.867  1.00 42.14           C  
+ATOM   1306  N   TYR A1180      55.784  12.782   1.585  1.00 36.94           N  
+ATOM   1307  CA  TYR A1180      54.876  11.644   1.684  1.00 36.24           C  
+ATOM   1308  C   TYR A1180      55.000  10.722   0.469  1.00 34.46           C  
+ATOM   1309  O   TYR A1180      54.006  10.237  -0.050  1.00 34.48           O  
+ATOM   1310  CB  TYR A1180      53.446  12.188   1.809  1.00 37.44           C  
+ATOM   1311  CG  TYR A1180      52.348  11.178   2.059  1.00 38.37           C  
+ATOM   1312  CD1 TYR A1180      52.199  10.566   3.301  1.00 38.96           C  
+ATOM   1313  CD2 TYR A1180      51.423  10.873   1.059  1.00 39.25           C  
+ATOM   1314  CE1 TYR A1180      51.149   9.677   3.545  1.00 39.75           C  
+ATOM   1315  CE2 TYR A1180      50.375   9.987   1.290  1.00 39.72           C  
+ATOM   1316  CZ  TYR A1180      50.243   9.396   2.533  1.00 40.54           C  
+ATOM   1317  OH  TYR A1180      49.197   8.530   2.761  1.00 42.62           O  
+ATOM   1318  N   ASP A1181      56.223  10.482   0.011  1.00 33.57           N  
+ATOM   1319  CA  ASP A1181      56.424   9.613  -1.144  1.00 33.48           C  
+ATOM   1320  C   ASP A1181      57.875   9.180  -1.245  1.00 32.91           C  
+ATOM   1321  O   ASP A1181      58.736   9.711  -0.555  1.00 32.69           O  
+ATOM   1322  CB  ASP A1181      56.001  10.342  -2.431  1.00 32.98           C  
+ATOM   1323  CG  ASP A1181      55.959   9.419  -3.654  1.00 34.95           C  
+ATOM   1324  OD1 ASP A1181      55.600   8.233  -3.501  1.00 34.52           O  
+ATOM   1325  OD2 ASP A1181      56.267   9.883  -4.778  1.00 34.51           O  
+ATOM   1326  N   VAL A1182      58.142   8.191  -2.086  1.00 34.05           N  
+ATOM   1327  CA  VAL A1182      59.504   7.735  -2.278  1.00 35.22           C  
+ATOM   1328  C   VAL A1182      60.197   8.838  -3.073  1.00 36.40           C  
+ATOM   1329  O   VAL A1182      59.584   9.453  -3.947  1.00 36.46           O  
+ATOM   1330  CB  VAL A1182      59.544   6.420  -3.074  1.00 34.95           C  
+ATOM   1331  CG1 VAL A1182      60.989   5.966  -3.262  1.00 33.73           C  
+ATOM   1332  CG2 VAL A1182      58.737   5.357  -2.345  1.00 34.05           C  
+ATOM   1333  N   ILE A1183      61.458   9.107  -2.751  1.00 38.82           N  
+ATOM   1334  CA  ILE A1183      62.218  10.141  -3.448  1.00 40.98           C  
+ATOM   1335  C   ILE A1183      62.779   9.549  -4.740  1.00 43.40           C  
+ATOM   1336  O   ILE A1183      63.653   8.685  -4.706  1.00 44.67           O  
+ATOM   1337  CB  ILE A1183      63.377  10.666  -2.573  1.00 40.00           C  
+ATOM   1338  CG1 ILE A1183      62.836  11.118  -1.213  1.00 39.63           C  
+ATOM   1339  CG2 ILE A1183      64.071  11.835  -3.271  1.00 39.80           C  
+ATOM   1340  CD1 ILE A1183      63.898  11.581  -0.240  1.00 38.80           C  
+ATOM   1341  N   PRO A1184      62.283  10.016  -5.898  1.00 45.95           N  
+ATOM   1342  CA  PRO A1184      62.701   9.552  -7.227  1.00 48.17           C  
+ATOM   1343  C   PRO A1184      64.170   9.162  -7.424  1.00 49.46           C  
+ATOM   1344  O   PRO A1184      64.466   8.007  -7.733  1.00 51.17           O  
+ATOM   1345  CB  PRO A1184      62.259  10.693  -8.154  1.00 49.02           C  
+ATOM   1346  CG  PRO A1184      62.074  11.880  -7.216  1.00 49.08           C  
+ATOM   1347  CD  PRO A1184      61.463  11.232  -6.017  1.00 46.87           C  
+ATOM   1348  N   ASP A1185      65.089  10.106  -7.248  1.00 49.46           N  
+ATOM   1349  CA  ASP A1185      66.506   9.796  -7.431  1.00 49.98           C  
+ATOM   1350  C   ASP A1185      67.306  10.018  -6.154  1.00 50.43           C  
+ATOM   1351  O   ASP A1185      68.367  10.650  -6.181  1.00 50.41           O  
+ATOM   1352  CB  ASP A1185      67.081  10.647  -8.567  1.00 50.42           C  
+ATOM   1353  N   GLY A1186      66.807   9.483  -5.040  1.00 50.06           N  
+ATOM   1354  CA  GLY A1186      67.495   9.657  -3.771  1.00 48.69           C  
+ATOM   1355  C   GLY A1186      68.007   8.392  -3.106  1.00 46.92           C  
+ATOM   1356  O   GLY A1186      68.300   8.399  -1.914  1.00 47.14           O  
+ATOM   1357  N   ASP A1187      68.123   7.313  -3.872  1.00 45.96           N  
+ATOM   1358  CA  ASP A1187      68.599   6.036  -3.344  1.00 44.02           C  
+ATOM   1359  C   ASP A1187      69.894   6.174  -2.548  1.00 43.16           C  
+ATOM   1360  O   ASP A1187      70.834   6.834  -2.976  1.00 43.37           O  
+ATOM   1361  CB  ASP A1187      68.776   5.042  -4.491  1.00 43.99           C  
+ATOM   1362  CG  ASP A1187      67.448   4.613  -5.092  1.00 45.37           C  
+ATOM   1363  OD1 ASP A1187      66.472   5.385  -4.981  1.00 45.93           O  
+ATOM   1364  OD2 ASP A1187      67.375   3.514  -5.680  1.00 46.21           O  
+ATOM   1365  N   LYS A1188      69.924   5.539  -1.383  1.00 42.17           N  
+ATOM   1366  CA  LYS A1188      71.073   5.586  -0.482  1.00 42.14           C  
+ATOM   1367  C   LYS A1188      71.979   4.362  -0.662  1.00 40.52           C  
+ATOM   1368  O   LYS A1188      71.500   3.235  -0.749  1.00 40.27           O  
+ATOM   1369  CB  LYS A1188      70.548   5.668   0.962  1.00 43.78           C  
+ATOM   1370  CG  LYS A1188      71.581   5.621   2.083  1.00 45.49           C  
+ATOM   1371  CD  LYS A1188      70.874   5.586   3.447  1.00 47.05           C  
+ATOM   1372  CE  LYS A1188      71.851   5.365   4.605  1.00 48.36           C  
+ATOM   1373  NZ  LYS A1188      71.166   5.295   5.939  1.00 46.72           N  
+ATOM   1374  N   THR A1189      73.288   4.591  -0.715  1.00 40.63           N  
+ATOM   1375  CA  THR A1189      74.253   3.504  -0.878  1.00 40.76           C  
+ATOM   1376  C   THR A1189      74.959   3.108   0.419  1.00 40.80           C  
+ATOM   1377  O   THR A1189      75.713   3.886   0.994  1.00 40.27           O  
+ATOM   1378  CB  THR A1189      75.338   3.862  -1.913  1.00 40.74           C  
+ATOM   1379  OG1 THR A1189      74.736   4.017  -3.202  1.00 41.83           O  
+ATOM   1380  CG2 THR A1189      76.382   2.758  -1.988  1.00 40.32           C  
+ATOM   1381  N   VAL A1190      74.713   1.880   0.858  1.00 42.80           N  
+ATOM   1382  CA  VAL A1190      75.310   1.329   2.074  1.00 44.63           C  
+ATOM   1383  C   VAL A1190      76.649   0.663   1.739  1.00 46.24           C  
+ATOM   1384  O   VAL A1190      76.703  -0.242   0.905  1.00 46.31           O  
+ATOM   1385  CB  VAL A1190      74.376   0.270   2.701  1.00 44.94           C  
+ATOM   1386  CG1 VAL A1190      75.007  -0.326   3.951  1.00 44.67           C  
+ATOM   1387  CG2 VAL A1190      73.031   0.901   3.023  1.00 45.88           C  
+ATOM   1388  N   VAL A1191      77.724   1.099   2.389  1.00 46.89           N  
+ATOM   1389  CA  VAL A1191      79.032   0.526   2.118  1.00 48.62           C  
+ATOM   1390  C   VAL A1191      79.573  -0.327   3.266  1.00 49.27           C  
+ATOM   1391  O   VAL A1191      79.814   0.161   4.370  1.00 51.20           O  
+ATOM   1392  CB  VAL A1191      80.050   1.636   1.771  1.00 49.18           C  
+ATOM   1393  CG1 VAL A1191      79.566   2.410   0.552  1.00 50.97           C  
+ATOM   1394  CG2 VAL A1191      80.226   2.578   2.941  1.00 50.29           C  
+ATOM   1395  N   PRO A1193      79.064  -1.997   6.000  1.00 26.55           N  
+ATOM   1396  CA  PRO A1193      78.854  -1.831   7.441  1.00 27.08           C  
+ATOM   1397  C   PRO A1193      79.162  -3.036   8.302  1.00 26.52           C  
+ATOM   1398  O   PRO A1193      79.050  -4.178   7.865  1.00 28.90           O  
+ATOM   1399  CB  PRO A1193      77.376  -1.464   7.544  1.00 25.89           C  
+ATOM   1400  CG  PRO A1193      76.778  -2.235   6.435  1.00 26.29           C  
+ATOM   1401  CD  PRO A1193      77.771  -2.021   5.298  1.00 26.08           C  
+ATOM   1402  N   ASP A1194      79.526  -2.759   9.548  1.00 26.98           N  
+ATOM   1403  CA  ASP A1194      79.798  -3.812  10.511  1.00 25.64           C  
+ATOM   1404  C   ASP A1194      78.444  -4.250  11.040  1.00 23.50           C  
+ATOM   1405  O   ASP A1194      78.207  -5.430  11.289  1.00 23.21           O  
+ATOM   1406  CB  ASP A1194      80.638  -3.283  11.667  1.00 28.02           C  
+ATOM   1407  CG  ASP A1194      82.040  -2.908  11.242  1.00 28.39           C  
+ATOM   1408  OD1 ASP A1194      82.797  -3.812  10.831  1.00 28.71           O  
+ATOM   1409  OD2 ASP A1194      82.378  -1.709  11.314  1.00 29.87           O  
+ATOM   1410  N   ILE A1195      77.556  -3.279  11.201  1.00 21.80           N  
+ATOM   1411  CA  ILE A1195      76.216  -3.537  11.697  1.00 20.19           C  
+ATOM   1412  C   ILE A1195      75.194  -2.756  10.892  1.00 20.09           C  
+ATOM   1413  O   ILE A1195      75.418  -1.589  10.549  1.00 18.58           O  
+ATOM   1414  CB  ILE A1195      76.075  -3.104  13.163  1.00 20.74           C  
+ATOM   1415  CG1 ILE A1195      77.016  -3.932  14.041  1.00 21.40           C  
+ATOM   1416  CG2 ILE A1195      74.615  -3.254  13.618  1.00 18.77           C  
+ATOM   1417  CD1 ILE A1195      77.086  -3.445  15.471  1.00 19.08           C  
+ATOM   1418  N   LEU A1196      74.076  -3.400  10.579  1.00 18.36           N  
+ATOM   1419  CA  LEU A1196      73.016  -2.720   9.859  1.00 18.57           C  
+ATOM   1420  C   LEU A1196      71.743  -2.849  10.677  1.00 19.07           C  
+ATOM   1421  O   LEU A1196      71.349  -3.950  11.055  1.00 19.07           O  
+ATOM   1422  CB  LEU A1196      72.794  -3.322   8.470  1.00 18.11           C  
+ATOM   1423  CG  LEU A1196      71.700  -2.584   7.677  1.00 20.98           C  
+ATOM   1424  CD1 LEU A1196      72.280  -2.004   6.377  1.00 19.98           C  
+ATOM   1425  CD2 LEU A1196      70.565  -3.547   7.362  1.00 22.00           C  
+ATOM   1426  N   ILE A1197      71.123  -1.714  10.978  1.00 17.97           N  
+ATOM   1427  CA  ILE A1197      69.872  -1.718  11.713  1.00 18.82           C  
+ATOM   1428  C   ILE A1197      68.770  -1.491  10.683  1.00 17.11           C  
+ATOM   1429  O   ILE A1197      68.761  -0.480   9.996  1.00 16.07           O  
+ATOM   1430  CB  ILE A1197      69.829  -0.596  12.786  1.00 19.49           C  
+ATOM   1431  CG1 ILE A1197      70.938  -0.830  13.820  1.00 20.50           C  
+ATOM   1432  CG2 ILE A1197      68.457  -0.574  13.468  1.00 16.99           C  
+ATOM   1433  CD1 ILE A1197      71.101   0.306  14.834  1.00 18.67           C  
+ATOM   1434  N   LEU A1198      67.870  -2.462  10.562  1.00 17.56           N  
+ATOM   1435  CA  LEU A1198      66.754  -2.393   9.629  1.00 17.56           C  
+ATOM   1436  C   LEU A1198      65.489  -2.137  10.433  1.00 19.22           C  
+ATOM   1437  O   LEU A1198      65.020  -3.004  11.176  1.00 20.27           O  
+ATOM   1438  CB  LEU A1198      66.620  -3.702   8.847  1.00 16.08           C  
+ATOM   1439  CG  LEU A1198      65.519  -3.716   7.779  1.00 17.14           C  
+ATOM   1440  CD1 LEU A1198      65.866  -2.725   6.679  1.00 17.75           C  
+ATOM   1441  CD2 LEU A1198      65.368  -5.119   7.203  1.00 16.23           C  
+ATOM   1442  N   GLU A1199      64.935  -0.944  10.274  1.00 19.38           N  
+ATOM   1443  CA  GLU A1199      63.747  -0.544  11.007  1.00 21.09           C  
+ATOM   1444  C   GLU A1199      62.500  -0.486  10.122  1.00 20.69           C  
+ATOM   1445  O   GLU A1199      62.502   0.147   9.067  1.00 21.11           O  
+ATOM   1446  CB  GLU A1199      64.012   0.815  11.668  1.00 23.19           C  
+ATOM   1447  CG  GLU A1199      62.824   1.414  12.365  1.00 29.98           C  
+ATOM   1448  CD  GLU A1199      62.128   2.437  11.509  1.00 34.08           C  
+ATOM   1449  OE1 GLU A1199      62.739   3.498  11.254  1.00 36.27           O  
+ATOM   1450  OE2 GLU A1199      60.979   2.176  11.086  1.00 38.05           O  
+ATOM   1451  N   GLY A1200      61.442  -1.167  10.560  1.00 19.88           N  
+ATOM   1452  CA  GLY A1200      60.203  -1.188   9.801  1.00 20.42           C  
+ATOM   1453  C   GLY A1200      59.131  -2.042  10.450  1.00 19.61           C  
+ATOM   1454  O   GLY A1200      59.425  -3.043  11.104  1.00 21.25           O  
+ATOM   1455  N   LEU A1201      57.876  -1.660  10.257  1.00 19.07           N  
+ATOM   1456  CA  LEU A1201      56.765  -2.391  10.845  1.00 18.79           C  
+ATOM   1457  C   LEU A1201      56.616  -3.809  10.294  1.00 17.89           C  
+ATOM   1458  O   LEU A1201      55.994  -4.661  10.920  1.00 15.88           O  
+ATOM   1459  CB  LEU A1201      55.469  -1.617  10.605  1.00 18.18           C  
+ATOM   1460  CG  LEU A1201      55.064  -1.452   9.137  1.00 20.15           C  
+ATOM   1461  CD1 LEU A1201      54.294  -2.689   8.679  1.00 16.37           C  
+ATOM   1462  CD2 LEU A1201      54.191  -0.206   8.971  1.00 19.20           C  
+ATOM   1463  N   ASN A1202      57.210  -4.064   9.136  1.00 17.10           N  
+ATOM   1464  CA  ASN A1202      57.069  -5.365   8.484  1.00 18.55           C  
+ATOM   1465  C   ASN A1202      58.286  -6.291   8.475  1.00 18.07           C  
+ATOM   1466  O   ASN A1202      58.268  -7.300   7.775  1.00 18.82           O  
+ATOM   1467  CB  ASN A1202      56.615  -5.136   7.035  1.00 16.83           C  
+ATOM   1468  CG  ASN A1202      57.619  -4.316   6.239  1.00 19.51           C  
+ATOM   1469  OD1 ASN A1202      58.325  -3.471   6.796  1.00 19.93           O  
+ATOM   1470  ND2 ASN A1202      57.681  -4.554   4.935  1.00 18.13           N  
+ATOM   1471  N   VAL A1203      59.328  -5.979   9.243  1.00 17.72           N  
+ATOM   1472  CA  VAL A1203      60.528  -6.815   9.225  1.00 15.33           C  
+ATOM   1473  C   VAL A1203      60.364  -8.247   9.714  1.00 16.04           C  
+ATOM   1474  O   VAL A1203      61.241  -9.085   9.478  1.00 14.42           O  
+ATOM   1475  CB  VAL A1203      61.696  -6.149   9.991  1.00 14.19           C  
+ATOM   1476  CG1 VAL A1203      62.059  -4.849   9.309  1.00 11.65           C  
+ATOM   1477  CG2 VAL A1203      61.322  -5.920  11.457  1.00 14.26           C  
+ATOM   1478  N   LEU A1204      59.253  -8.535  10.391  1.00 17.03           N  
+ATOM   1479  CA  LEU A1204      59.007  -9.887  10.889  1.00 17.54           C  
+ATOM   1480  C   LEU A1204      57.975 -10.631  10.035  1.00 18.98           C  
+ATOM   1481  O   LEU A1204      57.706 -11.818  10.246  1.00 20.04           O  
+ATOM   1482  CB  LEU A1204      58.548  -9.841  12.350  1.00 17.50           C  
+ATOM   1483  CG  LEU A1204      59.640  -9.468  13.361  1.00 18.70           C  
+ATOM   1484  CD1 LEU A1204      59.022  -9.311  14.746  1.00 19.89           C  
+ATOM   1485  CD2 LEU A1204      60.735 -10.540  13.372  1.00 16.31           C  
+ATOM   1486  N   GLN A1205      57.396  -9.934   9.066  1.00 18.84           N  
+ATOM   1487  CA  GLN A1205      56.409 -10.551   8.197  1.00 20.97           C  
+ATOM   1488  C   GLN A1205      57.091 -11.543   7.256  1.00 21.03           C  
+ATOM   1489  O   GLN A1205      58.315 -11.574   7.158  1.00 19.04           O  
+ATOM   1490  CB  GLN A1205      55.653  -9.472   7.413  1.00 20.88           C  
+ATOM   1491  CG  GLN A1205      54.724  -8.647   8.301  1.00 17.84           C  
+ATOM   1492  CD  GLN A1205      54.069  -7.489   7.574  1.00 20.41           C  
+ATOM   1493  OE1 GLN A1205      54.265  -7.292   6.363  1.00 20.57           O  
+ATOM   1494  NE2 GLN A1205      53.284  -6.712   8.306  1.00 19.12           N  
+ATOM   1495  N   SER A1206      56.289 -12.350   6.573  1.00 22.50           N  
+ATOM   1496  CA  SER A1206      56.813 -13.365   5.673  1.00 23.86           C  
+ATOM   1497  C   SER A1206      55.905 -13.606   4.466  1.00 23.41           C  
+ATOM   1498  O   SER A1206      55.018 -12.805   4.172  1.00 23.95           O  
+ATOM   1499  CB  SER A1206      57.003 -14.666   6.451  1.00 23.32           C  
+ATOM   1500  OG  SER A1206      55.770 -15.091   7.003  1.00 27.33           O  
+ATOM   1501  N   GLY A1207      56.138 -14.720   3.778  1.00 23.07           N  
+ATOM   1502  CA  GLY A1207      55.361 -15.056   2.600  1.00 23.25           C  
+ATOM   1503  C   GLY A1207      53.858 -15.097   2.800  1.00 23.49           C  
+ATOM   1504  O   GLY A1207      53.105 -14.696   1.909  1.00 23.54           O  
+ATOM   1505  N   MET A1208      53.415 -15.586   3.957  1.00 23.27           N  
+ATOM   1506  CA  MET A1208      51.989 -15.680   4.246  1.00 24.71           C  
+ATOM   1507  C   MET A1208      51.307 -14.313   4.241  1.00 25.11           C  
+ATOM   1508  O   MET A1208      50.093 -14.220   4.081  1.00 25.93           O  
+ATOM   1509  CB  MET A1208      51.763 -16.360   5.602  1.00 25.99           C  
+ATOM   1510  CG  MET A1208      52.226 -15.548   6.800  1.00 27.81           C  
+ATOM   1511  SD  MET A1208      52.047 -16.459   8.352  1.00 30.88           S  
+ATOM   1512  CE  MET A1208      50.257 -16.815   8.291  1.00 25.75           C  
+ATOM   1513  N   ASP A1209      52.089 -13.255   4.419  1.00 25.52           N  
+ATOM   1514  CA  ASP A1209      51.542 -11.907   4.435  1.00 28.18           C  
+ATOM   1515  C   ASP A1209      51.422 -11.333   3.034  1.00 29.76           C  
+ATOM   1516  O   ASP A1209      50.858 -10.260   2.854  1.00 30.94           O  
+ATOM   1517  CB  ASP A1209      52.421 -10.985   5.277  1.00 29.07           C  
+ATOM   1518  CG  ASP A1209      52.477 -11.404   6.724  1.00 30.93           C  
+ATOM   1519  OD1 ASP A1209      51.427 -11.333   7.400  1.00 31.96           O  
+ATOM   1520  OD2 ASP A1209      53.566 -11.808   7.179  1.00 28.78           O  
+ATOM   1521  N   TYR A1210      51.956 -12.041   2.041  1.00 31.02           N  
+ATOM   1522  CA  TYR A1210      51.893 -11.566   0.662  1.00 30.94           C  
+ATOM   1523  C   TYR A1210      51.351 -12.647  -0.267  1.00 31.95           C  
+ATOM   1524  O   TYR A1210      52.003 -13.042  -1.229  1.00 31.91           O  
+ATOM   1525  CB  TYR A1210      53.285 -11.109   0.207  1.00 30.13           C  
+ATOM   1526  CG  TYR A1210      53.848  -9.992   1.067  1.00 31.10           C  
+ATOM   1527  CD1 TYR A1210      54.239 -10.234   2.380  1.00 30.62           C  
+ATOM   1528  CD2 TYR A1210      53.919  -8.680   0.590  1.00 30.66           C  
+ATOM   1529  CE1 TYR A1210      54.680  -9.202   3.206  1.00 32.92           C  
+ATOM   1530  CE2 TYR A1210      54.356  -7.638   1.404  1.00 31.50           C  
+ATOM   1531  CZ  TYR A1210      54.735  -7.904   2.716  1.00 35.19           C  
+ATOM   1532  OH  TYR A1210      55.159  -6.880   3.548  1.00 36.67           O  
+ATOM   1533  N   PRO A1211      50.132 -13.131   0.008  1.00 32.89           N  
+ATOM   1534  CA  PRO A1211      49.521 -14.176  -0.821  1.00 34.74           C  
+ATOM   1535  C   PRO A1211      49.356 -13.740  -2.277  1.00 35.82           C  
+ATOM   1536  O   PRO A1211      49.320 -14.574  -3.183  1.00 35.67           O  
+ATOM   1537  CB  PRO A1211      48.183 -14.421  -0.128  1.00 33.18           C  
+ATOM   1538  CG  PRO A1211      47.834 -13.051   0.379  1.00 33.73           C  
+ATOM   1539  CD  PRO A1211      49.152 -12.580   0.962  1.00 33.34           C  
+ATOM   1540  N   HIS A1212      49.265 -12.429  -2.491  1.00 37.20           N  
+ATOM   1541  CA  HIS A1212      49.101 -11.876  -3.831  1.00 37.89           C  
+ATOM   1542  C   HIS A1212      50.385 -11.949  -4.658  1.00 37.75           C  
+ATOM   1543  O   HIS A1212      50.342 -11.925  -5.889  1.00 39.36           O  
+ATOM   1544  CB  HIS A1212      48.633 -10.419  -3.746  1.00 38.62           C  
+ATOM   1545  CG  HIS A1212      49.503  -9.549  -2.887  1.00 40.15           C  
+ATOM   1546  ND1 HIS A1212      49.518  -9.638  -1.510  1.00 39.42           N  
+ATOM   1547  CD2 HIS A1212      50.401  -8.589  -3.212  1.00 39.87           C  
+ATOM   1548  CE1 HIS A1212      50.389  -8.771  -1.026  1.00 38.83           C  
+ATOM   1549  NE2 HIS A1212      50.940  -8.122  -2.035  1.00 39.79           N  
+ATOM   1550  N   ASP A1213      51.520 -12.054  -3.974  1.00 36.63           N  
+ATOM   1551  CA  ASP A1213      52.828 -12.107  -4.621  1.00 34.01           C  
+ATOM   1552  C   ASP A1213      53.808 -12.690  -3.601  1.00 32.71           C  
+ATOM   1553  O   ASP A1213      54.642 -11.980  -3.053  1.00 33.85           O  
+ATOM   1554  CB  ASP A1213      53.243 -10.687  -5.004  1.00 33.91           C  
+ATOM   1555  CG  ASP A1213      54.517 -10.650  -5.799  1.00 33.59           C  
+ATOM   1556  OD1 ASP A1213      55.014  -9.533  -6.056  1.00 35.54           O  
+ATOM   1557  OD2 ASP A1213      55.015 -11.734  -6.164  1.00 34.33           O  
+ATOM   1558  N   PRO A1214      53.728 -14.006  -3.354  1.00 31.85           N  
+ATOM   1559  CA  PRO A1214      54.569 -14.734  -2.397  1.00 31.61           C  
+ATOM   1560  C   PRO A1214      56.081 -14.849  -2.595  1.00 31.05           C  
+ATOM   1561  O   PRO A1214      56.572 -15.016  -3.712  1.00 30.51           O  
+ATOM   1562  CB  PRO A1214      53.906 -16.109  -2.352  1.00 32.10           C  
+ATOM   1563  CG  PRO A1214      53.446 -16.283  -3.766  1.00 32.70           C  
+ATOM   1564  CD  PRO A1214      52.835 -14.935  -4.073  1.00 32.53           C  
+ATOM   1565  N   HIS A1215      56.808 -14.742  -1.481  1.00 28.69           N  
+ATOM   1566  CA  HIS A1215      58.255 -14.915  -1.481  1.00 27.08           C  
+ATOM   1567  C   HIS A1215      58.496 -16.088  -0.532  1.00 25.50           C  
+ATOM   1568  O   HIS A1215      57.736 -16.293   0.412  1.00 26.52           O  
+ATOM   1569  CB  HIS A1215      59.016 -13.638  -1.043  1.00 25.85           C  
+ATOM   1570  CG  HIS A1215      58.586 -13.061   0.273  1.00 27.27           C  
+ATOM   1571  ND1 HIS A1215      57.436 -12.311   0.420  1.00 27.03           N  
+ATOM   1572  CD2 HIS A1215      59.187 -13.068   1.487  1.00 25.97           C  
+ATOM   1573  CE1 HIS A1215      57.352 -11.880   1.667  1.00 27.66           C  
+ATOM   1574  NE2 HIS A1215      58.401 -12.324   2.336  1.00 26.38           N  
+ATOM   1575  N   HIS A1216      59.539 -16.866  -0.792  1.00 25.61           N  
+ATOM   1576  CA  HIS A1216      59.818 -18.055   0.001  1.00 24.91           C  
+ATOM   1577  C   HIS A1216      60.993 -18.002   0.959  1.00 23.72           C  
+ATOM   1578  O   HIS A1216      61.243 -18.961   1.688  1.00 22.36           O  
+ATOM   1579  CB  HIS A1216      59.953 -19.233  -0.953  1.00 26.50           C  
+ATOM   1580  CG  HIS A1216      58.747 -19.416  -1.817  1.00 28.61           C  
+ATOM   1581  ND1 HIS A1216      57.632 -20.111  -1.398  1.00 30.00           N  
+ATOM   1582  CD2 HIS A1216      58.435 -18.898  -3.029  1.00 28.65           C  
+ATOM   1583  CE1 HIS A1216      56.684 -20.009  -2.312  1.00 30.48           C  
+ATOM   1584  NE2 HIS A1216      57.143 -19.277  -3.311  1.00 31.25           N  
+ATOM   1585  N   VAL A1217      61.716 -16.891   0.942  1.00 22.08           N  
+ATOM   1586  CA  VAL A1217      62.824 -16.680   1.859  1.00 23.48           C  
+ATOM   1587  C   VAL A1217      62.458 -15.326   2.445  1.00 23.28           C  
+ATOM   1588  O   VAL A1217      62.245 -14.363   1.707  1.00 24.73           O  
+ATOM   1589  CB  VAL A1217      64.187 -16.602   1.147  1.00 24.05           C  
+ATOM   1590  CG1 VAL A1217      65.297 -16.560   2.189  1.00 27.14           C  
+ATOM   1591  CG2 VAL A1217      64.383 -17.817   0.257  1.00 25.41           C  
+ATOM   1592  N   PHE A1218      62.373 -15.248   3.766  1.00 21.23           N  
+ATOM   1593  CA  PHE A1218      61.954 -14.013   4.410  1.00 18.88           C  
+ATOM   1594  C   PHE A1218      63.064 -13.083   4.889  1.00 19.27           C  
+ATOM   1595  O   PHE A1218      64.237 -13.464   4.980  1.00 19.64           O  
+ATOM   1596  CB  PHE A1218      61.044 -14.372   5.586  1.00 19.98           C  
+ATOM   1597  CG  PHE A1218      60.198 -15.587   5.339  1.00 20.12           C  
+ATOM   1598  CD1 PHE A1218      60.087 -16.581   6.309  1.00 19.76           C  
+ATOM   1599  CD2 PHE A1218      59.531 -15.755   4.125  1.00 22.25           C  
+ATOM   1600  CE1 PHE A1218      59.327 -17.727   6.074  1.00 19.76           C  
+ATOM   1601  CE2 PHE A1218      58.769 -16.898   3.877  1.00 21.18           C  
+ATOM   1602  CZ  PHE A1218      58.667 -17.886   4.853  1.00 22.34           C  
+ATOM   1603  N   VAL A1219      62.672 -11.847   5.186  1.00 19.18           N  
+ATOM   1604  CA  VAL A1219      63.598 -10.848   5.695  1.00 18.57           C  
+ATOM   1605  C   VAL A1219      64.311 -11.421   6.935  1.00 17.74           C  
+ATOM   1606  O   VAL A1219      65.531 -11.304   7.075  1.00 16.89           O  
+ATOM   1607  CB  VAL A1219      62.846  -9.544   6.095  1.00 18.73           C  
+ATOM   1608  CG1 VAL A1219      63.746  -8.658   6.950  1.00 17.04           C  
+ATOM   1609  CG2 VAL A1219      62.403  -8.789   4.845  1.00 15.44           C  
+ATOM   1610  N   SER A1220      63.537 -12.050   7.815  1.00 17.09           N  
+ATOM   1611  CA  SER A1220      64.071 -12.620   9.043  1.00 17.76           C  
+ATOM   1612  C   SER A1220      65.157 -13.665   8.782  1.00 17.83           C  
+ATOM   1613  O   SER A1220      66.014 -13.908   9.629  1.00 17.37           O  
+ATOM   1614  CB  SER A1220      62.942 -13.235   9.879  1.00 16.23           C  
+ATOM   1615  OG  SER A1220      62.358 -14.344   9.209  1.00 21.17           O  
+ATOM   1616  N   ASP A1221      65.122 -14.281   7.605  1.00 20.43           N  
+ATOM   1617  CA  ASP A1221      66.118 -15.285   7.250  1.00 19.76           C  
+ATOM   1618  C   ASP A1221      67.484 -14.661   7.009  1.00 19.22           C  
+ATOM   1619  O   ASP A1221      68.484 -15.366   6.911  1.00 20.25           O  
+ATOM   1620  CB  ASP A1221      65.663 -16.082   6.022  1.00 19.41           C  
+ATOM   1621  CG  ASP A1221      64.466 -16.981   6.327  1.00 21.69           C  
+ATOM   1622  OD1 ASP A1221      64.443 -17.558   7.438  1.00 19.76           O  
+ATOM   1623  OD2 ASP A1221      63.559 -17.117   5.464  1.00 19.97           O  
+ATOM   1624  N   PHE A1222      67.527 -13.333   6.941  1.00 19.12           N  
+ATOM   1625  CA  PHE A1222      68.781 -12.612   6.740  1.00 19.75           C  
+ATOM   1626  C   PHE A1222      69.037 -11.620   7.884  1.00 19.91           C  
+ATOM   1627  O   PHE A1222      69.866 -10.710   7.767  1.00 18.38           O  
+ATOM   1628  CB  PHE A1222      68.763 -11.876   5.396  1.00 20.13           C  
+ATOM   1629  CG  PHE A1222      68.540 -12.781   4.218  1.00 21.59           C  
+ATOM   1630  CD1 PHE A1222      67.302 -12.832   3.585  1.00 21.24           C  
+ATOM   1631  CD2 PHE A1222      69.561 -13.609   3.761  1.00 22.53           C  
+ATOM   1632  CE1 PHE A1222      67.084 -13.697   2.511  1.00 23.61           C  
+ATOM   1633  CE2 PHE A1222      69.359 -14.478   2.693  1.00 23.67           C  
+ATOM   1634  CZ  PHE A1222      68.117 -14.525   2.063  1.00 24.30           C  
+ATOM   1635  N   VAL A1223      68.314 -11.802   8.988  1.00 18.64           N  
+ATOM   1636  CA  VAL A1223      68.460 -10.938  10.157  1.00 17.52           C  
+ATOM   1637  C   VAL A1223      69.009 -11.755  11.330  1.00 17.67           C  
+ATOM   1638  O   VAL A1223      68.526 -12.853  11.615  1.00 17.84           O  
+ATOM   1639  CB  VAL A1223      67.101 -10.299  10.550  1.00 17.70           C  
+ATOM   1640  CG1 VAL A1223      67.225  -9.567  11.879  1.00 15.40           C  
+ATOM   1641  CG2 VAL A1223      66.651  -9.329   9.463  1.00 16.72           C  
+ATOM   1642  N   ASP A1224      70.021 -11.217  12.004  1.00 18.25           N  
+ATOM   1643  CA  ASP A1224      70.629 -11.908  13.133  1.00 19.05           C  
+ATOM   1644  C   ASP A1224      69.856 -11.731  14.430  1.00 19.85           C  
+ATOM   1645  O   ASP A1224      69.676 -12.690  15.179  1.00 21.65           O  
+ATOM   1646  CB  ASP A1224      72.068 -11.440  13.346  1.00 19.05           C  
+ATOM   1647  CG  ASP A1224      72.958 -11.751  12.165  1.00 22.08           C  
+ATOM   1648  OD1 ASP A1224      73.142 -10.863  11.300  1.00 21.10           O  
+ATOM   1649  OD2 ASP A1224      73.459 -12.894  12.100  1.00 23.21           O  
+ATOM   1650  N   PHE A1225      69.405 -10.510  14.702  1.00 19.33           N  
+ATOM   1651  CA  PHE A1225      68.661 -10.237  15.929  1.00 19.36           C  
+ATOM   1652  C   PHE A1225      67.462  -9.340  15.617  1.00 19.44           C  
+ATOM   1653  O   PHE A1225      67.595  -8.351  14.900  1.00 22.76           O  
+ATOM   1654  CB  PHE A1225      69.575  -9.527  16.936  1.00 19.06           C  
+ATOM   1655  CG  PHE A1225      69.075  -9.564  18.361  1.00 18.66           C  
+ATOM   1656  CD1 PHE A1225      69.466 -10.591  19.227  1.00 17.86           C  
+ATOM   1657  CD2 PHE A1225      68.220  -8.573  18.839  1.00 16.90           C  
+ATOM   1658  CE1 PHE A1225      69.013 -10.625  20.551  1.00 17.48           C  
+ATOM   1659  CE2 PHE A1225      67.761  -8.598  20.160  1.00 19.39           C  
+ATOM   1660  CZ  PHE A1225      68.162  -9.630  21.020  1.00 16.87           C  
+ATOM   1661  N   SER A1226      66.295  -9.675  16.153  1.00 18.29           N  
+ATOM   1662  CA  SER A1226      65.120  -8.856  15.903  1.00 18.85           C  
+ATOM   1663  C   SER A1226      64.463  -8.377  17.199  1.00 19.49           C  
+ATOM   1664  O   SER A1226      64.341  -9.125  18.174  1.00 20.00           O  
+ATOM   1665  CB  SER A1226      64.098  -9.613  15.035  1.00 15.47           C  
+ATOM   1666  OG  SER A1226      63.537 -10.715  15.717  1.00 14.75           O  
+ATOM   1667  N   ILE A1227      64.051  -7.113  17.189  1.00 19.60           N  
+ATOM   1668  CA  ILE A1227      63.409  -6.481  18.331  1.00 19.44           C  
+ATOM   1669  C   ILE A1227      62.020  -5.998  17.928  1.00 20.67           C  
+ATOM   1670  O   ILE A1227      61.850  -5.382  16.874  1.00 18.89           O  
+ATOM   1671  CB  ILE A1227      64.195  -5.223  18.800  1.00 20.80           C  
+ATOM   1672  CG1 ILE A1227      65.560  -5.616  19.365  1.00 19.47           C  
+ATOM   1673  CG2 ILE A1227      63.371  -4.443  19.825  1.00 17.47           C  
+ATOM   1674  CD1 ILE A1227      66.529  -4.442  19.426  1.00 20.16           C  
+ATOM   1675  N   TYR A1228      61.031  -6.278  18.767  1.00 19.94           N  
+ATOM   1676  CA  TYR A1228      59.683  -5.808  18.505  1.00 20.50           C  
+ATOM   1677  C   TYR A1228      59.325  -4.806  19.609  1.00 20.58           C  
+ATOM   1678  O   TYR A1228      59.251  -5.173  20.787  1.00 20.20           O  
+ATOM   1679  CB  TYR A1228      58.688  -6.968  18.513  1.00 19.40           C  
+ATOM   1680  CG  TYR A1228      57.276  -6.550  18.168  1.00 20.73           C  
+ATOM   1681  CD1 TYR A1228      56.780  -6.693  16.869  1.00 21.81           C  
+ATOM   1682  CD2 TYR A1228      56.426  -6.019  19.144  1.00 22.67           C  
+ATOM   1683  CE1 TYR A1228      55.468  -6.322  16.552  1.00 21.13           C  
+ATOM   1684  CE2 TYR A1228      55.116  -5.644  18.840  1.00 21.95           C  
+ATOM   1685  CZ  TYR A1228      54.640  -5.801  17.544  1.00 22.53           C  
+ATOM   1686  OH  TYR A1228      53.336  -5.458  17.251  1.00 21.29           O  
+ATOM   1687  N   VAL A1229      59.130  -3.542  19.236  1.00 19.39           N  
+ATOM   1688  CA  VAL A1229      58.766  -2.519  20.211  1.00 20.12           C  
+ATOM   1689  C   VAL A1229      57.251  -2.621  20.366  1.00 20.67           C  
+ATOM   1690  O   VAL A1229      56.513  -2.516  19.392  1.00 20.56           O  
+ATOM   1691  CB  VAL A1229      59.185  -1.120  19.727  1.00 19.59           C  
+ATOM   1692  CG1 VAL A1229      59.123  -0.124  20.880  1.00 17.29           C  
+ATOM   1693  CG2 VAL A1229      60.589  -1.188  19.158  1.00 17.02           C  
+ATOM   1694  N   ASP A1230      56.802  -2.832  21.602  1.00 22.07           N  
+ATOM   1695  CA  ASP A1230      55.386  -3.039  21.901  1.00 21.39           C  
+ATOM   1696  C   ASP A1230      54.772  -1.996  22.834  1.00 22.59           C  
+ATOM   1697  O   ASP A1230      55.443  -1.466  23.716  1.00 21.70           O  
+ATOM   1698  CB  ASP A1230      55.242  -4.438  22.503  1.00 20.86           C  
+ATOM   1699  CG  ASP A1230      53.828  -4.954  22.472  1.00 23.66           C  
+ATOM   1700  OD1 ASP A1230      53.075  -4.635  21.529  1.00 26.11           O  
+ATOM   1701  OD2 ASP A1230      53.466  -5.710  23.391  1.00 27.07           O  
+ATOM   1702  N   ALA A1231      53.489  -1.702  22.624  1.00 22.97           N  
+ATOM   1703  CA  ALA A1231      52.766  -0.733  23.447  1.00 24.03           C  
+ATOM   1704  C   ALA A1231      51.262  -0.852  23.228  1.00 26.18           C  
+ATOM   1705  O   ALA A1231      50.812  -1.293  22.172  1.00 28.02           O  
+ATOM   1706  CB  ALA A1231      53.225   0.685  23.136  1.00 22.06           C  
+ATOM   1707  N   PRO A1232      50.460  -0.467  24.235  1.00 27.80           N  
+ATOM   1708  CA  PRO A1232      48.994  -0.530  24.157  1.00 28.52           C  
+ATOM   1709  C   PRO A1232      48.437   0.399  23.086  1.00 27.02           C  
+ATOM   1710  O   PRO A1232      49.029   1.431  22.782  1.00 25.52           O  
+ATOM   1711  CB  PRO A1232      48.545  -0.098  25.556  1.00 29.81           C  
+ATOM   1712  CG  PRO A1232      49.724  -0.410  26.422  1.00 29.45           C  
+ATOM   1713  CD  PRO A1232      50.888   0.003  25.563  1.00 29.13           C  
+ATOM   1714  N   GLU A1233      47.286   0.034  22.539  1.00 27.87           N  
+ATOM   1715  CA  GLU A1233      46.630   0.820  21.500  1.00 29.81           C  
+ATOM   1716  C   GLU A1233      46.341   2.257  21.941  1.00 29.47           C  
+ATOM   1717  O   GLU A1233      46.508   3.193  21.156  1.00 29.28           O  
+ATOM   1718  CB  GLU A1233      45.329   0.123  21.078  1.00 32.03           C  
+ATOM   1719  CG  GLU A1233      44.607   0.723  19.873  1.00 35.99           C  
+ATOM   1720  CD  GLU A1233      43.878   2.020  20.187  1.00 37.96           C  
+ATOM   1721  OE1 GLU A1233      43.296   2.127  21.291  1.00 39.67           O  
+ATOM   1722  OE2 GLU A1233      43.870   2.925  19.320  1.00 39.08           O  
+ATOM   1723  N   ASP A1234      45.915   2.436  23.192  1.00 29.06           N  
+ATOM   1724  CA  ASP A1234      45.602   3.773  23.688  1.00 29.54           C  
+ATOM   1725  C   ASP A1234      46.820   4.697  23.697  1.00 27.04           C  
+ATOM   1726  O   ASP A1234      46.698   5.897  23.437  1.00 27.12           O  
+ATOM   1727  CB  ASP A1234      44.992   3.706  25.094  1.00 32.55           C  
+ATOM   1728  CG  ASP A1234      45.963   3.167  26.128  1.00 36.42           C  
+ATOM   1729  OD1 ASP A1234      46.335   1.978  26.032  1.00 39.56           O  
+ATOM   1730  OD2 ASP A1234      46.360   3.932  27.033  1.00 37.75           O  
+ATOM   1731  N   LEU A1235      47.991   4.148  24.004  1.00 24.92           N  
+ATOM   1732  CA  LEU A1235      49.207   4.956  24.017  1.00 23.09           C  
+ATOM   1733  C   LEU A1235      49.691   5.219  22.591  1.00 23.04           C  
+ATOM   1734  O   LEU A1235      50.163   6.313  22.279  1.00 24.76           O  
+ATOM   1735  CB  LEU A1235      50.306   4.253  24.818  1.00 23.45           C  
+ATOM   1736  CG  LEU A1235      50.083   4.225  26.336  1.00 21.96           C  
+ATOM   1737  CD1 LEU A1235      51.148   3.382  27.014  1.00 19.58           C  
+ATOM   1738  CD2 LEU A1235      50.114   5.657  26.859  1.00 21.63           C  
+ATOM   1739  N   LEU A1236      49.574   4.211  21.728  1.00 22.06           N  
+ATOM   1740  CA  LEU A1236      49.995   4.343  20.337  1.00 21.13           C  
+ATOM   1741  C   LEU A1236      49.196   5.458  19.655  1.00 22.95           C  
+ATOM   1742  O   LEU A1236      49.750   6.272  18.909  1.00 21.93           O  
+ATOM   1743  CB  LEU A1236      49.792   3.014  19.594  1.00 21.12           C  
+ATOM   1744  CG  LEU A1236      50.711   1.837  19.966  1.00 20.56           C  
+ATOM   1745  CD1 LEU A1236      50.289   0.594  19.213  1.00 20.67           C  
+ATOM   1746  CD2 LEU A1236      52.152   2.172  19.628  1.00 18.10           C  
+ATOM   1747  N   GLN A1237      47.896   5.504  19.931  1.00 22.40           N  
+ATOM   1748  CA  GLN A1237      47.027   6.518  19.344  1.00 25.13           C  
+ATOM   1749  C   GLN A1237      47.480   7.915  19.760  1.00 23.64           C  
+ATOM   1750  O   GLN A1237      47.609   8.814  18.929  1.00 25.50           O  
+ATOM   1751  CB  GLN A1237      45.573   6.280  19.770  1.00 25.86           C  
+ATOM   1752  CG  GLN A1237      44.571   7.187  19.080  1.00 30.12           C  
+ATOM   1753  CD  GLN A1237      43.152   7.003  19.598  1.00 33.87           C  
+ATOM   1754  OE1 GLN A1237      42.594   5.904  19.551  1.00 34.86           O  
+ATOM   1755  NE2 GLN A1237      42.561   8.086  20.093  1.00 36.45           N  
+ATOM   1756  N   THR A1238      47.735   8.089  21.048  1.00 23.99           N  
+ATOM   1757  CA  THR A1238      48.191   9.373  21.572  1.00 23.31           C  
+ATOM   1758  C   THR A1238      49.517   9.797  20.929  1.00 22.94           C  
+ATOM   1759  O   THR A1238      49.673  10.940  20.490  1.00 23.53           O  
+ATOM   1760  CB  THR A1238      48.389   9.303  23.100  1.00 22.78           C  
+ATOM   1761  OG1 THR A1238      47.150   8.940  23.728  1.00 23.57           O  
+ATOM   1762  CG2 THR A1238      48.863  10.645  23.631  1.00 21.85           C  
+ATOM   1763  N   TRP A1239      50.470   8.873  20.878  1.00 22.09           N  
+ATOM   1764  CA  TRP A1239      51.772   9.169  20.296  1.00 22.05           C  
+ATOM   1765  C   TRP A1239      51.646   9.507  18.817  1.00 21.38           C  
+ATOM   1766  O   TRP A1239      52.315  10.411  18.327  1.00 21.54           O  
+ATOM   1767  CB  TRP A1239      52.722   7.984  20.485  1.00 22.47           C  
+ATOM   1768  CG  TRP A1239      52.896   7.611  21.929  1.00 23.41           C  
+ATOM   1769  CD1 TRP A1239      52.598   8.385  23.015  1.00 24.53           C  
+ATOM   1770  CD2 TRP A1239      53.415   6.380  22.447  1.00 22.73           C  
+ATOM   1771  NE1 TRP A1239      52.894   7.713  24.175  1.00 24.02           N  
+ATOM   1772  CE2 TRP A1239      53.396   6.479  23.857  1.00 21.88           C  
+ATOM   1773  CE3 TRP A1239      53.893   5.199  21.856  1.00 20.59           C  
+ATOM   1774  CZ2 TRP A1239      53.838   5.445  24.688  1.00 20.31           C  
+ATOM   1775  CZ3 TRP A1239      54.335   4.172  22.685  1.00 19.06           C  
+ATOM   1776  CH2 TRP A1239      54.301   4.305  24.088  1.00 19.91           C  
+ATOM   1777  N   TYR A1240      50.778   8.785  18.114  1.00 22.05           N  
+ATOM   1778  CA  TYR A1240      50.561   9.022  16.689  1.00 21.90           C  
+ATOM   1779  C   TYR A1240      50.007  10.428  16.465  1.00 21.75           C  
+ATOM   1780  O   TYR A1240      50.522  11.188  15.649  1.00 20.25           O  
+ATOM   1781  CB  TYR A1240      49.564   8.014  16.107  1.00 21.32           C  
+ATOM   1782  CG  TYR A1240      49.270   8.285  14.650  1.00 21.31           C  
+ATOM   1783  CD1 TYR A1240      50.171   7.898  13.657  1.00 21.05           C  
+ATOM   1784  CD2 TYR A1240      48.134   9.012  14.270  1.00 19.61           C  
+ATOM   1785  CE1 TYR A1240      49.954   8.233  12.318  1.00 21.50           C  
+ATOM   1786  CE2 TYR A1240      47.908   9.354  12.944  1.00 20.81           C  
+ATOM   1787  CZ  TYR A1240      48.823   8.964  11.971  1.00 22.51           C  
+ATOM   1788  OH  TYR A1240      48.622   9.318  10.662  1.00 21.58           O  
+ATOM   1789  N   ILE A1241      48.949  10.759  17.199  1.00 22.50           N  
+ATOM   1790  CA  ILE A1241      48.320  12.068  17.083  1.00 23.81           C  
+ATOM   1791  C   ILE A1241      49.283  13.197  17.419  1.00 24.64           C  
+ATOM   1792  O   ILE A1241      49.407  14.152  16.648  1.00 23.89           O  
+ATOM   1793  CB  ILE A1241      47.076  12.165  17.996  1.00 24.61           C  
+ATOM   1794  CG1 ILE A1241      46.008  11.182  17.503  1.00 24.13           C  
+ATOM   1795  CG2 ILE A1241      46.529  13.590  17.997  1.00 24.62           C  
+ATOM   1796  CD1 ILE A1241      44.801  11.075  18.405  1.00 25.42           C  
+ATOM   1797  N   ASN A1242      49.974  13.091  18.554  1.00 25.81           N  
+ATOM   1798  CA  ASN A1242      50.916  14.141  18.943  1.00 25.10           C  
+ATOM   1799  C   ASN A1242      52.032  14.314  17.916  1.00 24.02           C  
+ATOM   1800  O   ASN A1242      52.509  15.425  17.694  1.00 22.58           O  
+ATOM   1801  CB  ASN A1242      51.503  13.864  20.334  1.00 26.67           C  
+ATOM   1802  CG  ASN A1242      50.444  13.936  21.439  1.00 29.14           C  
+ATOM   1803  OD1 ASN A1242      49.461  14.671  21.325  1.00 28.07           O  
+ATOM   1804  ND2 ASN A1242      50.652  13.185  22.517  1.00 28.94           N  
+ATOM   1805  N   ARG A1243      52.443  13.225  17.271  1.00 23.83           N  
+ATOM   1806  CA  ARG A1243      53.488  13.327  16.253  1.00 23.16           C  
+ATOM   1807  C   ARG A1243      52.883  14.028  15.038  1.00 22.61           C  
+ATOM   1808  O   ARG A1243      53.537  14.831  14.382  1.00 22.30           O  
+ATOM   1809  CB  ARG A1243      54.012  11.943  15.846  1.00 22.04           C  
+ATOM   1810  CG  ARG A1243      55.181  12.011  14.858  1.00 23.61           C  
+ATOM   1811  CD  ARG A1243      55.691  10.627  14.474  1.00 21.57           C  
+ATOM   1812  NE  ARG A1243      54.678   9.861  13.758  1.00 21.51           N  
+ATOM   1813  CZ  ARG A1243      54.843   8.618  13.312  1.00 21.62           C  
+ATOM   1814  NH1 ARG A1243      55.995   7.978  13.507  1.00 19.42           N  
+ATOM   1815  NH2 ARG A1243      53.854   8.010  12.668  1.00 19.37           N  
+ATOM   1816  N   PHE A1244      51.621  13.719  14.757  1.00 23.08           N  
+ATOM   1817  CA  PHE A1244      50.901  14.326  13.639  1.00 23.73           C  
+ATOM   1818  C   PHE A1244      50.839  15.837  13.838  1.00 23.09           C  
+ATOM   1819  O   PHE A1244      51.160  16.612  12.939  1.00 23.94           O  
+ATOM   1820  CB  PHE A1244      49.473  13.773  13.567  1.00 23.24           C  
+ATOM   1821  CG  PHE A1244      48.607  14.446  12.534  1.00 24.38           C  
+ATOM   1822  CD1 PHE A1244      48.582  13.991  11.220  1.00 26.42           C  
+ATOM   1823  CD2 PHE A1244      47.811  15.535  12.877  1.00 25.49           C  
+ATOM   1824  CE1 PHE A1244      47.773  14.612  10.259  1.00 27.39           C  
+ATOM   1825  CE2 PHE A1244      47.002  16.161  11.924  1.00 25.81           C  
+ATOM   1826  CZ  PHE A1244      46.985  15.695  10.613  1.00 26.11           C  
+ATOM   1827  N   LEU A1245      50.422  16.248  15.028  1.00 23.99           N  
+ATOM   1828  CA  LEU A1245      50.311  17.668  15.336  1.00 25.43           C  
+ATOM   1829  C   LEU A1245      51.640  18.397  15.146  1.00 25.70           C  
+ATOM   1830  O   LEU A1245      51.669  19.507  14.619  1.00 25.18           O  
+ATOM   1831  CB  LEU A1245      49.789  17.857  16.763  1.00 25.07           C  
+ATOM   1832  CG  LEU A1245      48.365  17.318  16.947  1.00 25.56           C  
+ATOM   1833  CD1 LEU A1245      47.886  17.548  18.363  1.00 26.49           C  
+ATOM   1834  CD2 LEU A1245      47.445  18.021  15.969  1.00 27.27           C  
+ATOM   1835  N   LYS A1246      52.739  17.762  15.548  1.00 24.65           N  
+ATOM   1836  CA  LYS A1246      54.057  18.374  15.408  1.00 25.14           C  
+ATOM   1837  C   LYS A1246      54.393  18.571  13.931  1.00 25.44           C  
+ATOM   1838  O   LYS A1246      54.930  19.607  13.540  1.00 26.19           O  
+ATOM   1839  CB  LYS A1246      55.125  17.507  16.093  1.00 23.67           C  
+ATOM   1840  N   PHE A1247      54.076  17.570  13.115  1.00 25.81           N  
+ATOM   1841  CA  PHE A1247      54.318  17.650  11.681  1.00 25.79           C  
+ATOM   1842  C   PHE A1247      53.473  18.765  11.079  1.00 25.87           C  
+ATOM   1843  O   PHE A1247      53.941  19.518  10.233  1.00 27.03           O  
+ATOM   1844  CB  PHE A1247      53.962  16.324  11.008  1.00 27.41           C  
+ATOM   1845  CG  PHE A1247      55.019  15.267  11.149  1.00 30.78           C  
+ATOM   1846  CD1 PHE A1247      54.670  13.922  11.188  1.00 30.42           C  
+ATOM   1847  CD2 PHE A1247      56.367  15.612  11.195  1.00 32.40           C  
+ATOM   1848  CE1 PHE A1247      55.643  12.934  11.267  1.00 33.49           C  
+ATOM   1849  CE2 PHE A1247      57.351  14.631  11.274  1.00 34.40           C  
+ATOM   1850  CZ  PHE A1247      56.988  13.286  11.309  1.00 33.34           C  
+ATOM   1851  N   ARG A1248      52.221  18.866  11.511  1.00 24.96           N  
+ATOM   1852  CA  ARG A1248      51.337  19.908  10.998  1.00 24.80           C  
+ATOM   1853  C   ARG A1248      51.915  21.286  11.332  1.00 26.98           C  
+ATOM   1854  O   ARG A1248      52.114  22.112  10.439  1.00 26.49           O  
+ATOM   1855  CB  ARG A1248      49.933  19.740  11.594  1.00 23.44           C  
+ATOM   1856  CG  ARG A1248      48.935  20.834  11.244  1.00 21.99           C  
+ATOM   1857  CD  ARG A1248      47.556  20.487  11.778  1.00 21.90           C  
+ATOM   1858  NE  ARG A1248      46.630  21.613  11.721  1.00 24.26           N  
+ATOM   1859  CZ  ARG A1248      46.618  22.627  12.581  1.00 23.53           C  
+ATOM   1860  NH1 ARG A1248      47.488  22.670  13.586  1.00 22.62           N  
+ATOM   1861  NH2 ARG A1248      45.730  23.603  12.434  1.00 23.65           N  
+ATOM   1862  N   GLU A1249      52.190  21.524  12.613  1.00 27.64           N  
+ATOM   1863  CA  GLU A1249      52.760  22.797  13.057  1.00 31.36           C  
+ATOM   1864  C   GLU A1249      54.005  23.138  12.252  1.00 30.91           C  
+ATOM   1865  O   GLU A1249      54.206  24.285  11.855  1.00 33.75           O  
+ATOM   1866  CB  GLU A1249      53.109  22.737  14.554  1.00 31.68           C  
+ATOM   1867  CG  GLU A1249      51.968  23.185  15.455  1.00 38.09           C  
+ATOM   1868  CD  GLU A1249      51.970  22.525  16.829  1.00 41.28           C  
+ATOM   1869  OE1 GLU A1249      53.035  22.509  17.493  1.00 41.35           O  
+ATOM   1870  OE2 GLU A1249      50.889  22.033  17.245  1.00 40.54           O  
+ATOM   1871  N   GLY A1250      54.829  22.131  11.996  1.00 30.11           N  
+ATOM   1872  CA  GLY A1250      56.054  22.347  11.252  1.00 31.12           C  
+ATOM   1873  C   GLY A1250      55.877  22.625   9.773  1.00 31.30           C  
+ATOM   1874  O   GLY A1250      56.860  22.823   9.064  1.00 32.66           O  
+ATOM   1875  N   ALA A1251      54.635  22.651   9.300  1.00 30.53           N  
+ATOM   1876  CA  ALA A1251      54.368  22.898   7.887  1.00 29.08           C  
+ATOM   1877  C   ALA A1251      53.582  24.181   7.648  1.00 28.43           C  
+ATOM   1878  O   ALA A1251      53.200  24.474   6.514  1.00 28.31           O  
+ATOM   1879  CB  ALA A1251      53.606  21.707   7.289  1.00 30.78           C  
+ATOM   1880  N   PHE A1252      53.337  24.937   8.714  1.00 27.56           N  
+ATOM   1881  CA  PHE A1252      52.582  26.183   8.625  1.00 28.23           C  
+ATOM   1882  C   PHE A1252      53.100  27.179   7.590  1.00 30.14           C  
+ATOM   1883  O   PHE A1252      52.314  27.879   6.961  1.00 31.20           O  
+ATOM   1884  CB  PHE A1252      52.512  26.856  10.005  1.00 27.12           C  
+ATOM   1885  CG  PHE A1252      51.520  26.211  10.953  1.00 25.08           C  
+ATOM   1886  CD1 PHE A1252      51.459  26.599  12.287  1.00 23.49           C  
+ATOM   1887  CD2 PHE A1252      50.640  25.227  10.507  1.00 22.47           C  
+ATOM   1888  CE1 PHE A1252      50.537  26.014  13.159  1.00 23.40           C  
+ATOM   1889  CE2 PHE A1252      49.719  24.641  11.371  1.00 20.75           C  
+ATOM   1890  CZ  PHE A1252      49.666  25.032  12.695  1.00 21.37           C  
+ATOM   1891  N   THR A1253      54.413  27.241   7.401  1.00 32.13           N  
+ATOM   1892  CA  THR A1253      54.984  28.174   6.433  1.00 34.47           C  
+ATOM   1893  C   THR A1253      55.731  27.464   5.305  1.00 38.04           C  
+ATOM   1894  O   THR A1253      56.649  28.027   4.707  1.00 39.31           O  
+ATOM   1895  CB  THR A1253      55.953  29.161   7.118  1.00 32.95           C  
+ATOM   1896  OG1 THR A1253      57.051  28.435   7.680  1.00 32.09           O  
+ATOM   1897  CG2 THR A1253      55.242  29.928   8.228  1.00 31.20           C  
+ATOM   1898  N   ASP A1254      55.340  26.227   5.016  1.00 40.61           N  
+ATOM   1899  CA  ASP A1254      55.984  25.466   3.956  1.00 42.42           C  
+ATOM   1900  C   ASP A1254      54.958  24.804   3.049  1.00 44.52           C  
+ATOM   1901  O   ASP A1254      54.619  23.637   3.229  1.00 44.01           O  
+ATOM   1902  CB  ASP A1254      56.898  24.396   4.548  1.00 42.73           C  
+ATOM   1903  CG  ASP A1254      57.717  23.686   3.487  1.00 44.22           C  
+ATOM   1904  OD1 ASP A1254      57.519  23.979   2.286  1.00 42.02           O  
+ATOM   1905  OD2 ASP A1254      58.556  22.835   3.855  1.00 44.66           O  
+ATOM   1906  N   PRO A1255      54.451  25.547   2.055  1.00 47.28           N  
+ATOM   1907  CA  PRO A1255      53.457  25.020   1.116  1.00 49.54           C  
+ATOM   1908  C   PRO A1255      53.961  23.857   0.258  1.00 51.20           C  
+ATOM   1909  O   PRO A1255      53.205  23.292  -0.527  1.00 52.66           O  
+ATOM   1910  CB  PRO A1255      53.079  26.246   0.289  1.00 49.80           C  
+ATOM   1911  CG  PRO A1255      54.324  27.082   0.332  1.00 50.10           C  
+ATOM   1912  CD  PRO A1255      54.742  26.963   1.771  1.00 48.26           C  
+ATOM   1913  N   ASP A1256      55.236  23.506   0.402  1.00 52.02           N  
+ATOM   1914  CA  ASP A1256      55.794  22.382  -0.350  1.00 52.56           C  
+ATOM   1915  C   ASP A1256      55.726  21.127   0.515  1.00 51.04           C  
+ATOM   1916  O   ASP A1256      55.975  20.013   0.049  1.00 52.47           O  
+ATOM   1917  CB  ASP A1256      57.252  22.643  -0.748  1.00 53.86           C  
+ATOM   1918  CG  ASP A1256      57.401  23.826  -1.682  1.00 55.95           C  
+ATOM   1919  OD1 ASP A1256      56.403  24.197  -2.342  1.00 55.24           O  
+ATOM   1920  OD2 ASP A1256      58.524  24.377  -1.762  1.00 57.35           O  
+ATOM   1921  N   SER A1257      55.388  21.318   1.783  1.00 47.77           N  
+ATOM   1922  CA  SER A1257      55.285  20.207   2.711  1.00 44.50           C  
+ATOM   1923  C   SER A1257      53.926  19.540   2.543  1.00 42.23           C  
+ATOM   1924  O   SER A1257      52.906  20.215   2.385  1.00 42.76           O  
+ATOM   1925  CB  SER A1257      55.446  20.706   4.150  1.00 45.01           C  
+ATOM   1926  OG  SER A1257      55.607  19.630   5.059  1.00 42.51           O  
+ATOM   1927  N   TYR A1258      53.919  18.213   2.559  1.00 37.76           N  
+ATOM   1928  CA  TYR A1258      52.681  17.457   2.430  1.00 34.21           C  
+ATOM   1929  C   TYR A1258      51.708  17.845   3.549  1.00 31.07           C  
+ATOM   1930  O   TYR A1258      50.507  17.982   3.318  1.00 28.36           O  
+ATOM   1931  CB  TYR A1258      52.983  15.956   2.499  1.00 34.73           C  
+ATOM   1932  CG  TYR A1258      51.765  15.073   2.591  1.00 32.70           C  
+ATOM   1933  CD1 TYR A1258      51.001  14.793   1.466  1.00 33.71           C  
+ATOM   1934  CD2 TYR A1258      51.383  14.505   3.810  1.00 32.36           C  
+ATOM   1935  CE1 TYR A1258      49.878  13.959   1.548  1.00 33.86           C  
+ATOM   1936  CE2 TYR A1258      50.271  13.676   3.904  1.00 32.15           C  
+ATOM   1937  CZ  TYR A1258      49.523  13.405   2.770  1.00 32.41           C  
+ATOM   1938  OH  TYR A1258      48.428  12.572   2.847  1.00 33.44           O  
+ATOM   1939  N   PHE A1259      52.238  18.026   4.755  1.00 29.05           N  
+ATOM   1940  CA  PHE A1259      51.412  18.389   5.901  1.00 28.11           C  
+ATOM   1941  C   PHE A1259      50.842  19.802   5.867  1.00 28.04           C  
+ATOM   1942  O   PHE A1259      50.030  20.166   6.721  1.00 25.39           O  
+ATOM   1943  CB  PHE A1259      52.182  18.198   7.209  1.00 28.18           C  
+ATOM   1944  CG  PHE A1259      52.149  16.786   7.728  1.00 29.82           C  
+ATOM   1945  CD1 PHE A1259      53.004  15.816   7.212  1.00 29.79           C  
+ATOM   1946  CD2 PHE A1259      51.233  16.419   8.713  1.00 27.68           C  
+ATOM   1947  CE1 PHE A1259      52.944  14.499   7.668  1.00 27.50           C  
+ATOM   1948  CE2 PHE A1259      51.168  15.107   9.172  1.00 27.76           C  
+ATOM   1949  CZ  PHE A1259      52.025  14.149   8.646  1.00 27.88           C  
+ATOM   1950  N   HIS A1260      51.260  20.605   4.898  1.00 27.58           N  
+ATOM   1951  CA  HIS A1260      50.730  21.955   4.811  1.00 30.96           C  
+ATOM   1952  C   HIS A1260      49.233  21.866   4.514  1.00 30.90           C  
+ATOM   1953  O   HIS A1260      48.477  22.797   4.808  1.00 31.26           O  
+ATOM   1954  CB  HIS A1260      51.458  22.751   3.726  1.00 35.09           C  
+ATOM   1955  CG  HIS A1260      51.033  24.185   3.641  1.00 39.30           C  
+ATOM   1956  ND1 HIS A1260      49.844  24.576   3.063  1.00 41.72           N  
+ATOM   1957  CD2 HIS A1260      51.639  25.322   4.062  1.00 40.47           C  
+ATOM   1958  CE1 HIS A1260      49.735  25.892   3.130  1.00 41.86           C  
+ATOM   1959  NE2 HIS A1260      50.812  26.368   3.732  1.00 42.39           N  
+ATOM   1960  N   ASN A1261      48.812  20.732   3.952  1.00 30.28           N  
+ATOM   1961  CA  ASN A1261      47.404  20.489   3.635  1.00 30.67           C  
+ATOM   1962  C   ASN A1261      46.548  20.419   4.911  1.00 29.98           C  
+ATOM   1963  O   ASN A1261      45.333  20.648   4.869  1.00 27.56           O  
+ATOM   1964  CB  ASN A1261      47.242  19.167   2.865  1.00 32.63           C  
+ATOM   1965  CG  ASN A1261      47.781  19.237   1.444  1.00 34.01           C  
+ATOM   1966  OD1 ASN A1261      47.311  20.027   0.622  1.00 35.95           O  
+ATOM   1967  ND2 ASN A1261      48.770  18.404   1.148  1.00 35.18           N  
+ATOM   1968  N   TYR A1262      47.177  20.094   6.040  1.00 28.46           N  
+ATOM   1969  CA  TYR A1262      46.450  19.995   7.303  1.00 27.53           C  
+ATOM   1970  C   TYR A1262      46.435  21.305   8.074  1.00 27.05           C  
+ATOM   1971  O   TYR A1262      45.708  21.446   9.059  1.00 26.61           O  
+ATOM   1972  CB  TYR A1262      47.028  18.873   8.172  1.00 26.47           C  
+ATOM   1973  CG  TYR A1262      46.854  17.499   7.557  1.00 27.23           C  
+ATOM   1974  CD1 TYR A1262      47.948  16.779   7.087  1.00 26.81           C  
+ATOM   1975  CD2 TYR A1262      45.587  16.928   7.427  1.00 25.40           C  
+ATOM   1976  CE1 TYR A1262      47.789  15.522   6.500  1.00 27.51           C  
+ATOM   1977  CE2 TYR A1262      45.417  15.671   6.841  1.00 26.94           C  
+ATOM   1978  CZ  TYR A1262      46.526  14.976   6.376  1.00 27.35           C  
+ATOM   1979  OH  TYR A1262      46.375  13.750   5.759  1.00 28.59           O  
+ATOM   1980  N   ALA A1263      47.225  22.273   7.622  1.00 26.40           N  
+ATOM   1981  CA  ALA A1263      47.248  23.571   8.286  1.00 27.94           C  
+ATOM   1982  C   ALA A1263      45.946  24.333   7.992  1.00 28.15           C  
+ATOM   1983  O   ALA A1263      45.556  25.220   8.756  1.00 27.81           O  
+ATOM   1984  CB  ALA A1263      48.446  24.385   7.814  1.00 28.92           C  
+ATOM   1985  N   LYS A1264      45.279  23.979   6.889  1.00 26.91           N  
+ATOM   1986  CA  LYS A1264      44.022  24.623   6.491  1.00 25.12           C  
+ATOM   1987  C   LYS A1264      42.873  24.215   7.415  1.00 24.38           C  
+ATOM   1988  O   LYS A1264      41.839  24.889   7.486  1.00 23.18           O  
+ATOM   1989  CB  LYS A1264      43.684  24.261   5.053  1.00 23.89           C  
+ATOM   1990  N   LEU A1265      43.067  23.105   8.120  1.00 22.41           N  
+ATOM   1991  CA  LEU A1265      42.069  22.597   9.042  1.00 21.43           C  
+ATOM   1992  C   LEU A1265      42.286  23.203  10.416  1.00 21.85           C  
+ATOM   1993  O   LEU A1265      43.407  23.595  10.760  1.00 21.81           O  
+ATOM   1994  CB  LEU A1265      42.170  21.069   9.140  1.00 21.44           C  
+ATOM   1995  CG  LEU A1265      41.989  20.250   7.849  1.00 21.18           C  
+ATOM   1996  CD1 LEU A1265      42.088  18.761   8.180  1.00 18.88           C  
+ATOM   1997  CD2 LEU A1265      40.637  20.558   7.215  1.00 19.32           C  
+ATOM   1998  N   THR A1266      41.219  23.303  11.201  1.00 20.46           N  
+ATOM   1999  CA  THR A1266      41.374  23.832  12.545  1.00 20.97           C  
+ATOM   2000  C   THR A1266      42.096  22.734  13.324  1.00 23.30           C  
+ATOM   2001  O   THR A1266      42.080  21.563  12.923  1.00 25.35           O  
+ATOM   2002  CB  THR A1266      40.021  24.093  13.226  1.00 19.23           C  
+ATOM   2003  OG1 THR A1266      39.287  22.867  13.298  1.00 19.11           O  
+ATOM   2004  CG2 THR A1266      39.215  25.135  12.460  1.00 19.62           C  
+ATOM   2005  N   LYS A1267      42.730  23.100  14.430  1.00 23.15           N  
+ATOM   2006  CA  LYS A1267      43.438  22.115  15.233  1.00 24.73           C  
+ATOM   2007  C   LYS A1267      42.501  20.958  15.578  1.00 23.43           C  
+ATOM   2008  O   LYS A1267      42.874  19.793  15.462  1.00 22.25           O  
+ATOM   2009  CB  LYS A1267      43.967  22.749  16.523  1.00 23.62           C  
+ATOM   2010  CG  LYS A1267      45.042  21.911  17.206  1.00 28.36           C  
+ATOM   2011  CD  LYS A1267      45.480  22.528  18.524  1.00 33.51           C  
+ATOM   2012  CE  LYS A1267      46.602  21.725  19.162  1.00 35.43           C  
+ATOM   2013  NZ  LYS A1267      47.860  21.757  18.354  1.00 41.17           N  
+ATOM   2014  N   GLU A1268      41.282  21.294  15.993  1.00 22.62           N  
+ATOM   2015  CA  GLU A1268      40.291  20.292  16.374  1.00 23.11           C  
+ATOM   2016  C   GLU A1268      39.953  19.319  15.254  1.00 21.18           C  
+ATOM   2017  O   GLU A1268      39.886  18.114  15.483  1.00 21.26           O  
+ATOM   2018  CB  GLU A1268      39.012  20.976  16.880  1.00 22.82           C  
+ATOM   2019  N   GLU A1269      39.735  19.822  14.043  1.00 22.47           N  
+ATOM   2020  CA  GLU A1269      39.414  18.910  12.948  1.00 22.79           C  
+ATOM   2021  C   GLU A1269      40.656  18.143  12.513  1.00 21.38           C  
+ATOM   2022  O   GLU A1269      40.551  17.031  12.014  1.00 20.64           O  
+ATOM   2023  CB  GLU A1269      38.792  19.655  11.761  1.00 23.11           C  
+ATOM   2024  CG  GLU A1269      38.596  18.772  10.529  1.00 24.64           C  
+ATOM   2025  CD  GLU A1269      37.525  19.280   9.570  1.00 24.75           C  
+ATOM   2026  OE1 GLU A1269      37.508  20.492   9.259  1.00 23.64           O  
+ATOM   2027  OE2 GLU A1269      36.706  18.451   9.114  1.00 25.51           O  
+ATOM   2028  N   ALA A1270      41.830  18.737  12.716  1.00 22.73           N  
+ATOM   2029  CA  ALA A1270      43.088  18.081  12.363  1.00 22.51           C  
+ATOM   2030  C   ALA A1270      43.297  16.884  13.294  1.00 24.14           C  
+ATOM   2031  O   ALA A1270      43.757  15.824  12.869  1.00 23.90           O  
+ATOM   2032  CB  ALA A1270      44.239  19.054  12.502  1.00 21.12           C  
+ATOM   2033  N   ILE A1271      42.959  17.060  14.569  1.00 23.43           N  
+ATOM   2034  CA  ILE A1271      43.096  15.975  15.524  1.00 23.86           C  
+ATOM   2035  C   ILE A1271      42.162  14.821  15.138  1.00 23.97           C  
+ATOM   2036  O   ILE A1271      42.559  13.663  15.205  1.00 22.34           O  
+ATOM   2037  CB  ILE A1271      42.768  16.445  16.955  1.00 24.31           C  
+ATOM   2038  CG1 ILE A1271      43.872  17.393  17.446  1.00 25.81           C  
+ATOM   2039  CG2 ILE A1271      42.612  15.248  17.880  1.00 21.85           C  
+ATOM   2040  CD1 ILE A1271      43.609  18.003  18.812  1.00 22.07           C  
+ATOM   2041  N   LYS A1272      40.931  15.134  14.733  1.00 23.35           N  
+ATOM   2042  CA  LYS A1272      39.989  14.088  14.341  1.00 25.27           C  
+ATOM   2043  C   LYS A1272      40.449  13.398  13.067  1.00 23.76           C  
+ATOM   2044  O   LYS A1272      40.254  12.197  12.897  1.00 24.17           O  
+ATOM   2045  CB  LYS A1272      38.581  14.661  14.140  1.00 28.75           C  
+ATOM   2046  CG  LYS A1272      37.938  15.150  15.430  1.00 35.39           C  
+ATOM   2047  CD  LYS A1272      36.547  15.730  15.182  1.00 38.92           C  
+ATOM   2048  CE  LYS A1272      36.026  16.465  16.411  1.00 38.69           C  
+ATOM   2049  NZ  LYS A1272      34.814  17.264  16.084  1.00 41.54           N  
+ATOM   2050  N   THR A1273      41.059  14.160  12.171  1.00 22.58           N  
+ATOM   2051  CA  THR A1273      41.567  13.601  10.926  1.00 23.46           C  
+ATOM   2052  C   THR A1273      42.672  12.596  11.259  1.00 23.65           C  
+ATOM   2053  O   THR A1273      42.683  11.466  10.757  1.00 22.24           O  
+ATOM   2054  CB  THR A1273      42.129  14.714  10.020  1.00 24.02           C  
+ATOM   2055  OG1 THR A1273      41.103  15.688   9.783  1.00 23.01           O  
+ATOM   2056  CG2 THR A1273      42.593  14.139   8.684  1.00 24.06           C  
+ATOM   2057  N   ALA A1274      43.590  13.009  12.127  1.00 23.77           N  
+ATOM   2058  CA  ALA A1274      44.692  12.148  12.546  1.00 24.60           C  
+ATOM   2059  C   ALA A1274      44.154  10.900  13.222  1.00 24.85           C  
+ATOM   2060  O   ALA A1274      44.648   9.793  12.995  1.00 23.98           O  
+ATOM   2061  CB  ALA A1274      45.604  12.898  13.512  1.00 25.49           C  
+ATOM   2062  N   MET A1275      43.139  11.092  14.059  1.00 24.79           N  
+ATOM   2063  CA  MET A1275      42.529   9.997  14.790  1.00 26.13           C  
+ATOM   2064  C   MET A1275      41.909   8.983  13.832  1.00 26.46           C  
+ATOM   2065  O   MET A1275      41.945   7.780  14.074  1.00 26.68           O  
+ATOM   2066  CB  MET A1275      41.468  10.542  15.744  1.00 28.88           C  
+ATOM   2067  CG  MET A1275      40.985   9.533  16.759  1.00 33.38           C  
+ATOM   2068  SD  MET A1275      39.674  10.210  17.802  1.00 42.48           S  
+ATOM   2069  CE  MET A1275      40.539  11.648  18.549  1.00 36.77           C  
+ATOM   2070  N   THR A1276      41.340   9.476  12.742  1.00 25.66           N  
+ATOM   2071  CA  THR A1276      40.734   8.608  11.748  1.00 24.74           C  
+ATOM   2072  C   THR A1276      41.836   7.868  10.979  1.00 23.70           C  
+ATOM   2073  O   THR A1276      41.692   6.682  10.677  1.00 23.15           O  
+ATOM   2074  CB  THR A1276      39.850   9.433  10.773  1.00 24.93           C  
+ATOM   2075  OG1 THR A1276      38.818  10.092  11.519  1.00 27.56           O  
+ATOM   2076  CG2 THR A1276      39.201   8.538   9.736  1.00 23.08           C  
+ATOM   2077  N   LEU A1277      42.934   8.556  10.672  1.00 21.97           N  
+ATOM   2078  CA  LEU A1277      44.045   7.914   9.951  1.00 22.39           C  
+ATOM   2079  C   LEU A1277      44.577   6.760  10.792  1.00 22.93           C  
+ATOM   2080  O   LEU A1277      44.928   5.699  10.277  1.00 21.78           O  
+ATOM   2081  CB  LEU A1277      45.190   8.896   9.692  1.00 21.27           C  
+ATOM   2082  CG  LEU A1277      44.997  10.061   8.709  1.00 23.74           C  
+ATOM   2083  CD1 LEU A1277      46.283  10.899   8.652  1.00 19.92           C  
+ATOM   2084  CD2 LEU A1277      44.661   9.523   7.312  1.00 23.45           C  
+ATOM   2085  N   TRP A1278      44.621   6.980  12.101  1.00 23.29           N  
+ATOM   2086  CA  TRP A1278      45.109   5.975  13.021  1.00 23.73           C  
+ATOM   2087  C   TRP A1278      44.200   4.753  13.146  1.00 24.87           C  
+ATOM   2088  O   TRP A1278      44.652   3.613  13.017  1.00 23.49           O  
+ATOM   2089  CB  TRP A1278      45.326   6.580  14.410  1.00 22.28           C  
+ATOM   2090  CG  TRP A1278      45.595   5.513  15.399  1.00 22.72           C  
+ATOM   2091  CD1 TRP A1278      44.700   4.949  16.255  1.00 20.83           C  
+ATOM   2092  CD2 TRP A1278      46.790   4.734  15.494  1.00 21.45           C  
+ATOM   2093  NE1 TRP A1278      45.255   3.859  16.868  1.00 19.68           N  
+ATOM   2094  CE2 TRP A1278      46.541   3.702  16.418  1.00 21.87           C  
+ATOM   2095  CE3 TRP A1278      48.048   4.804  14.876  1.00 22.53           C  
+ATOM   2096  CZ2 TRP A1278      47.504   2.735  16.745  1.00 20.77           C  
+ATOM   2097  CZ3 TRP A1278      49.006   3.843  15.200  1.00 21.51           C  
+ATOM   2098  CH2 TRP A1278      48.725   2.823  16.127  1.00 20.87           C  
+ATOM   2099  N   LYS A1279      42.920   4.990  13.397  1.00 26.97           N  
+ATOM   2100  CA  LYS A1279      41.974   3.896  13.568  1.00 28.71           C  
+ATOM   2101  C   LYS A1279      41.676   3.077  12.320  1.00 29.36           C  
+ATOM   2102  O   LYS A1279      41.663   1.846  12.376  1.00 31.69           O  
+ATOM   2103  CB  LYS A1279      40.666   4.427  14.152  1.00 29.76           C  
+ATOM   2104  CG  LYS A1279      40.821   5.004  15.555  1.00 34.37           C  
+ATOM   2105  CD  LYS A1279      39.512   5.604  16.056  1.00 37.60           C  
+ATOM   2106  CE  LYS A1279      39.667   6.186  17.459  1.00 39.36           C  
+ATOM   2107  NZ  LYS A1279      38.418   6.853  17.945  1.00 41.17           N  
+ATOM   2108  N   GLU A1280      41.447   3.743  11.195  1.00 27.71           N  
+ATOM   2109  CA  GLU A1280      41.112   3.037   9.967  1.00 28.56           C  
+ATOM   2110  C   GLU A1280      42.300   2.484   9.184  1.00 27.07           C  
+ATOM   2111  O   GLU A1280      42.145   1.520   8.434  1.00 26.63           O  
+ATOM   2112  CB  GLU A1280      40.256   3.944   9.065  1.00 29.14           C  
+ATOM   2113  CG  GLU A1280      38.909   4.304   9.701  1.00 33.98           C  
+ATOM   2114  CD  GLU A1280      38.089   5.315   8.908  1.00 36.92           C  
+ATOM   2115  OE1 GLU A1280      36.999   5.685   9.401  1.00 37.47           O  
+ATOM   2116  OE2 GLU A1280      38.519   5.739   7.809  1.00 37.17           O  
+ATOM   2117  N   ILE A1281      43.481   3.072   9.351  1.00 25.36           N  
+ATOM   2118  CA  ILE A1281      44.644   2.591   8.608  1.00 22.98           C  
+ATOM   2119  C   ILE A1281      45.727   1.935   9.457  1.00 22.04           C  
+ATOM   2120  O   ILE A1281      45.937   0.733   9.364  1.00 19.98           O  
+ATOM   2121  CB  ILE A1281      45.293   3.721   7.774  1.00 20.95           C  
+ATOM   2122  CG1 ILE A1281      44.254   4.331   6.822  1.00 22.99           C  
+ATOM   2123  CG2 ILE A1281      46.455   3.162   6.958  1.00 19.29           C  
+ATOM   2124  CD1 ILE A1281      44.765   5.522   6.024  1.00 22.61           C  
+ATOM   2125  N   ASN A1282      46.405   2.714  10.295  1.00 22.91           N  
+ATOM   2126  CA  ASN A1282      47.493   2.164  11.102  1.00 23.30           C  
+ATOM   2127  C   ASN A1282      47.117   1.128  12.147  1.00 23.25           C  
+ATOM   2128  O   ASN A1282      47.821   0.133  12.310  1.00 22.44           O  
+ATOM   2129  CB  ASN A1282      48.282   3.286  11.767  1.00 22.09           C  
+ATOM   2130  CG  ASN A1282      48.927   4.207  10.755  1.00 25.07           C  
+ATOM   2131  OD1 ASN A1282      49.521   3.752   9.770  1.00 23.49           O  
+ATOM   2132  ND2 ASN A1282      48.816   5.508  10.987  1.00 24.10           N  
+ATOM   2133  N   TRP A1283      46.016   1.352  12.855  1.00 23.60           N  
+ATOM   2134  CA  TRP A1283      45.598   0.413  13.884  1.00 23.17           C  
+ATOM   2135  C   TRP A1283      45.106  -0.883  13.254  1.00 24.05           C  
+ATOM   2136  O   TRP A1283      45.350  -1.971  13.781  1.00 20.13           O  
+ATOM   2137  CB  TRP A1283      44.502   1.028  14.752  1.00 25.75           C  
+ATOM   2138  CG  TRP A1283      44.034   0.123  15.837  1.00 30.76           C  
+ATOM   2139  CD1 TRP A1283      44.808  -0.685  16.629  1.00 31.13           C  
+ATOM   2140  CD2 TRP A1283      42.685  -0.063  16.272  1.00 33.35           C  
+ATOM   2141  NE1 TRP A1283      44.020  -1.363  17.528  1.00 34.69           N  
+ATOM   2142  CE2 TRP A1283      42.712  -0.999  17.331  1.00 35.17           C  
+ATOM   2143  CE3 TRP A1283      41.452   0.473  15.871  1.00 35.78           C  
+ATOM   2144  CZ2 TRP A1283      41.553  -1.414  17.996  1.00 37.88           C  
+ATOM   2145  CZ3 TRP A1283      40.295   0.063  16.532  1.00 38.64           C  
+ATOM   2146  CH2 TRP A1283      40.355  -0.874  17.585  1.00 38.99           C  
+ATOM   2147  N   LEU A1284      44.416  -0.763  12.123  1.00 23.29           N  
+ATOM   2148  CA  LEU A1284      43.907  -1.933  11.425  1.00 24.81           C  
+ATOM   2149  C   LEU A1284      45.109  -2.737  10.962  1.00 24.24           C  
+ATOM   2150  O   LEU A1284      45.124  -3.967  11.046  1.00 25.11           O  
+ATOM   2151  CB  LEU A1284      43.072  -1.513  10.215  1.00 26.63           C  
+ATOM   2152  CG  LEU A1284      42.307  -2.637   9.513  1.00 31.10           C  
+ATOM   2153  CD1 LEU A1284      41.218  -3.165  10.442  1.00 30.66           C  
+ATOM   2154  CD2 LEU A1284      41.687  -2.112   8.216  1.00 31.44           C  
+ATOM   2155  N   ASN A1285      46.123  -2.029  10.482  1.00 21.98           N  
+ATOM   2156  CA  ASN A1285      47.337  -2.674  10.005  1.00 22.42           C  
+ATOM   2157  C   ASN A1285      48.013  -3.400  11.165  1.00 21.54           C  
+ATOM   2158  O   ASN A1285      48.525  -4.497  11.002  1.00 20.12           O  
+ATOM   2159  CB  ASN A1285      48.291  -1.631   9.401  1.00 19.54           C  
+ATOM   2160  CG  ASN A1285      49.483  -2.264   8.714  1.00 21.02           C  
+ATOM   2161  OD1 ASN A1285      49.486  -3.467   8.450  1.00 19.88           O  
+ATOM   2162  ND2 ASN A1285      50.500  -1.456   8.409  1.00 18.94           N  
+ATOM   2163  N   LEU A1286      48.004  -2.776  12.339  1.00 22.53           N  
+ATOM   2164  CA  LEU A1286      48.617  -3.369  13.519  1.00 22.96           C  
+ATOM   2165  C   LEU A1286      47.959  -4.700  13.868  1.00 23.54           C  
+ATOM   2166  O   LEU A1286      48.637  -5.707  14.062  1.00 23.99           O  
+ATOM   2167  CB  LEU A1286      48.511  -2.413  14.715  1.00 22.97           C  
+ATOM   2168  CG  LEU A1286      48.940  -2.966  16.080  1.00 22.06           C  
+ATOM   2169  CD1 LEU A1286      50.398  -3.403  16.023  1.00 22.62           C  
+ATOM   2170  CD2 LEU A1286      48.753  -1.899  17.152  1.00 21.24           C  
+ATOM   2171  N   LYS A1287      46.633  -4.700  13.946  1.00 25.07           N  
+ATOM   2172  CA  LYS A1287      45.877  -5.899  14.294  1.00 26.24           C  
+ATOM   2173  C   LYS A1287      45.952  -7.017  13.264  1.00 25.40           C  
+ATOM   2174  O   LYS A1287      46.130  -8.179  13.622  1.00 26.18           O  
+ATOM   2175  CB  LYS A1287      44.410  -5.534  14.536  1.00 28.46           C  
+ATOM   2176  CG  LYS A1287      44.174  -4.788  15.833  1.00 30.06           C  
+ATOM   2177  CD  LYS A1287      43.062  -3.772  15.696  1.00 32.45           C  
+ATOM   2178  CE  LYS A1287      41.720  -4.407  15.388  1.00 34.61           C  
+ATOM   2179  NZ  LYS A1287      40.696  -3.350  15.121  1.00 34.98           N  
+ATOM   2180  N   GLN A1288      45.828  -6.675  11.988  1.00 25.16           N  
+ATOM   2181  CA  GLN A1288      45.853  -7.696  10.950  1.00 25.86           C  
+ATOM   2182  C   GLN A1288      47.224  -8.162  10.487  1.00 26.16           C  
+ATOM   2183  O   GLN A1288      47.375  -9.327  10.124  1.00 28.62           O  
+ATOM   2184  CB  GLN A1288      45.093  -7.226   9.711  1.00 27.11           C  
+ATOM   2185  CG  GLN A1288      43.686  -6.755   9.954  1.00 30.79           C  
+ATOM   2186  CD  GLN A1288      42.994  -6.377   8.660  1.00 34.06           C  
+ATOM   2187  OE1 GLN A1288      43.629  -5.889   7.722  1.00 33.46           O  
+ATOM   2188  NE2 GLN A1288      41.683  -6.591   8.603  1.00 35.46           N  
+ATOM   2189  N   ASN A1289      48.221  -7.280  10.507  1.00 24.40           N  
+ATOM   2190  CA  ASN A1289      49.537  -7.649   9.983  1.00 23.94           C  
+ATOM   2191  C   ASN A1289      50.775  -7.509  10.849  1.00 22.46           C  
+ATOM   2192  O   ASN A1289      51.741  -8.257  10.675  1.00 23.01           O  
+ATOM   2193  CB  ASN A1289      49.798  -6.860   8.703  1.00 22.79           C  
+ATOM   2194  CG  ASN A1289      48.636  -6.917   7.741  1.00 25.13           C  
+ATOM   2195  OD1 ASN A1289      48.220  -7.996   7.320  1.00 26.13           O  
+ATOM   2196  ND2 ASN A1289      48.103  -5.753   7.383  1.00 23.46           N  
+ATOM   2197  N   ILE A1290      50.767  -6.548  11.762  1.00 20.66           N  
+ATOM   2198  CA  ILE A1290      51.947  -6.311  12.576  1.00 19.46           C  
+ATOM   2199  C   ILE A1290      52.009  -7.077  13.888  1.00 19.19           C  
+ATOM   2200  O   ILE A1290      52.956  -7.815  14.127  1.00 20.52           O  
+ATOM   2201  CB  ILE A1290      52.114  -4.795  12.845  1.00 18.47           C  
+ATOM   2202  CG1 ILE A1290      52.075  -4.028  11.514  1.00 16.81           C  
+ATOM   2203  CG2 ILE A1290      53.428  -4.541  13.556  1.00 15.50           C  
+ATOM   2204  CD1 ILE A1290      52.123  -2.509  11.649  1.00 18.13           C  
+ATOM   2205  N   LEU A1291      50.997  -6.912  14.731  1.00 19.74           N  
+ATOM   2206  CA  LEU A1291      50.973  -7.568  16.029  1.00 18.51           C  
+ATOM   2207  C   LEU A1291      51.162  -9.086  15.979  1.00 19.27           C  
+ATOM   2208  O   LEU A1291      51.811  -9.666  16.851  1.00 18.26           O  
+ATOM   2209  CB  LEU A1291      49.669  -7.225  16.750  1.00 18.64           C  
+ATOM   2210  CG  LEU A1291      49.542  -7.701  18.199  1.00 19.94           C  
+ATOM   2211  CD1 LEU A1291      50.754  -7.254  19.009  1.00 20.15           C  
+ATOM   2212  CD2 LEU A1291      48.246  -7.137  18.796  1.00 20.55           C  
+ATOM   2213  N   PRO A1292      50.606  -9.755  14.953  1.00 19.49           N  
+ATOM   2214  CA  PRO A1292      50.761 -11.212  14.867  1.00 19.32           C  
+ATOM   2215  C   PRO A1292      52.198 -11.708  14.691  1.00 20.27           C  
+ATOM   2216  O   PRO A1292      52.484 -12.883  14.943  1.00 20.89           O  
+ATOM   2217  CB  PRO A1292      49.874 -11.584  13.679  1.00 19.46           C  
+ATOM   2218  CG  PRO A1292      48.815 -10.547  13.719  1.00 18.25           C  
+ATOM   2219  CD  PRO A1292      49.603  -9.288  13.982  1.00 18.81           C  
+ATOM   2220  N   THR A1293      53.094 -10.826  14.255  1.00 18.88           N  
+ATOM   2221  CA  THR A1293      54.491 -11.197  14.051  1.00 18.37           C  
+ATOM   2222  C   THR A1293      55.338 -10.994  15.303  1.00 18.45           C  
+ATOM   2223  O   THR A1293      56.525 -11.328  15.317  1.00 16.36           O  
+ATOM   2224  CB  THR A1293      55.153 -10.359  12.933  1.00 18.90           C  
+ATOM   2225  OG1 THR A1293      55.323  -9.006  13.386  1.00 16.38           O  
+ATOM   2226  CG2 THR A1293      54.298 -10.375  11.666  1.00 17.16           C  
+ATOM   2227  N   ARG A1294      54.732 -10.444  16.351  1.00 19.43           N  
+ATOM   2228  CA  ARG A1294      55.470 -10.166  17.583  1.00 19.42           C  
+ATOM   2229  C   ARG A1294      56.258 -11.320  18.198  1.00 18.82           C  
+ATOM   2230  O   ARG A1294      57.396 -11.122  18.631  1.00 18.00           O  
+ATOM   2231  CB  ARG A1294      54.536  -9.582  18.651  1.00 20.42           C  
+ATOM   2232  CG  ARG A1294      55.276  -9.130  19.906  1.00 22.90           C  
+ATOM   2233  CD  ARG A1294      54.341  -8.534  20.930  1.00 25.12           C  
+ATOM   2234  NE  ARG A1294      53.325  -9.489  21.361  1.00 28.18           N  
+ATOM   2235  CZ  ARG A1294      52.346  -9.199  22.210  1.00 30.27           C  
+ATOM   2236  NH1 ARG A1294      52.249  -7.980  22.719  1.00 31.86           N  
+ATOM   2237  NH2 ARG A1294      51.464 -10.127  22.554  1.00 32.78           N  
+ATOM   2238  N   GLU A1295      55.665 -12.513  18.254  1.00 17.69           N  
+ATOM   2239  CA  GLU A1295      56.356 -13.653  18.848  1.00 19.89           C  
+ATOM   2240  C   GLU A1295      57.491 -14.224  18.011  1.00 20.54           C  
+ATOM   2241  O   GLU A1295      58.118 -15.208  18.399  1.00 20.73           O  
+ATOM   2242  CB  GLU A1295      55.362 -14.759  19.208  1.00 22.98           C  
+ATOM   2243  CG  GLU A1295      54.538 -14.441  20.458  1.00 25.96           C  
+ATOM   2244  CD  GLU A1295      53.685 -13.195  20.289  1.00 26.98           C  
+ATOM   2245  OE1 GLU A1295      53.515 -12.442  21.272  1.00 28.83           O  
+ATOM   2246  OE2 GLU A1295      53.178 -12.975  19.169  1.00 29.33           O  
+ATOM   2247  N   ARG A1296      57.767 -13.611  16.865  1.00 20.80           N  
+ATOM   2248  CA  ARG A1296      58.877 -14.074  16.037  1.00 20.24           C  
+ATOM   2249  C   ARG A1296      60.139 -13.274  16.381  1.00 19.02           C  
+ATOM   2250  O   ARG A1296      61.222 -13.560  15.872  1.00 17.92           O  
+ATOM   2251  CB  ARG A1296      58.567 -13.902  14.547  1.00 19.62           C  
+ATOM   2252  CG  ARG A1296      57.411 -14.737  14.020  1.00 19.91           C  
+ATOM   2253  CD  ARG A1296      57.536 -14.884  12.507  1.00 17.43           C  
+ATOM   2254  NE  ARG A1296      58.728 -15.654  12.152  1.00 17.02           N  
+ATOM   2255  CZ  ARG A1296      59.558 -15.344  11.160  1.00 17.64           C  
+ATOM   2256  NH1 ARG A1296      59.332 -14.275  10.410  1.00 17.10           N  
+ATOM   2257  NH2 ARG A1296      60.630 -16.091  10.930  1.00 17.42           N  
+ATOM   2258  N   ALA A1297      60.001 -12.273  17.248  1.00 17.76           N  
+ATOM   2259  CA  ALA A1297      61.147 -11.434  17.615  1.00 17.15           C  
+ATOM   2260  C   ALA A1297      62.087 -12.062  18.627  1.00 17.43           C  
+ATOM   2261  O   ALA A1297      61.676 -12.877  19.456  1.00 18.30           O  
+ATOM   2262  CB  ALA A1297      60.666 -10.083  18.136  1.00 16.36           C  
+ATOM   2263  N   SER A1298      63.359 -11.681  18.548  1.00 18.05           N  
+ATOM   2264  CA  SER A1298      64.363 -12.178  19.475  1.00 18.51           C  
+ATOM   2265  C   SER A1298      64.103 -11.513  20.812  1.00 19.66           C  
+ATOM   2266  O   SER A1298      64.272 -12.134  21.861  1.00 20.32           O  
+ATOM   2267  CB  SER A1298      65.770 -11.803  19.016  1.00 17.37           C  
+ATOM   2268  OG  SER A1298      66.046 -12.302  17.723  1.00 22.85           O  
+ATOM   2269  N   LEU A1299      63.690 -10.245  20.761  1.00 19.35           N  
+ATOM   2270  CA  LEU A1299      63.432  -9.475  21.971  1.00 18.36           C  
+ATOM   2271  C   LEU A1299      62.238  -8.546  21.828  1.00 19.94           C  
+ATOM   2272  O   LEU A1299      62.081  -7.870  20.809  1.00 21.16           O  
+ATOM   2273  CB  LEU A1299      64.679  -8.664  22.339  1.00 17.32           C  
+ATOM   2274  CG  LEU A1299      64.630  -7.698  23.529  1.00 17.65           C  
+ATOM   2275  CD1 LEU A1299      66.019  -7.551  24.118  1.00 17.15           C  
+ATOM   2276  CD2 LEU A1299      64.076  -6.351  23.105  1.00 14.79           C  
+ATOM   2277  N   ILE A1300      61.399  -8.519  22.860  1.00 19.76           N  
+ATOM   2278  CA  ILE A1300      60.221  -7.664  22.877  1.00 19.70           C  
+ATOM   2279  C   ILE A1300      60.405  -6.564  23.913  1.00 22.00           C  
+ATOM   2280  O   ILE A1300      60.658  -6.843  25.095  1.00 22.85           O  
+ATOM   2281  CB  ILE A1300      58.952  -8.455  23.233  1.00 19.64           C  
+ATOM   2282  CG1 ILE A1300      58.761  -9.613  22.255  1.00 20.24           C  
+ATOM   2283  CG2 ILE A1300      57.749  -7.534  23.195  1.00 19.38           C  
+ATOM   2284  CD1 ILE A1300      57.635 -10.560  22.631  1.00 23.43           C  
+ATOM   2285  N   LEU A1301      60.270  -5.320  23.456  1.00 22.19           N  
+ATOM   2286  CA  LEU A1301      60.400  -4.125  24.287  1.00 21.55           C  
+ATOM   2287  C   LEU A1301      59.011  -3.542  24.541  1.00 23.29           C  
+ATOM   2288  O   LEU A1301      58.447  -2.894  23.662  1.00 24.45           O  
+ATOM   2289  CB  LEU A1301      61.227  -3.065  23.559  1.00 22.55           C  
+ATOM   2290  CG  LEU A1301      62.659  -2.725  23.953  1.00 22.72           C  
+ATOM   2291  CD1 LEU A1301      62.949  -1.318  23.444  1.00 22.84           C  
+ATOM   2292  CD2 LEU A1301      62.834  -2.768  25.463  1.00 21.42           C  
+ATOM   2293  N   THR A1302      58.463  -3.752  25.732  1.00 24.20           N  
+ATOM   2294  CA  THR A1302      57.135  -3.232  26.043  1.00 24.33           C  
+ATOM   2295  C   THR A1302      57.201  -1.853  26.688  1.00 24.32           C  
+ATOM   2296  O   THR A1302      57.795  -1.683  27.750  1.00 24.60           O  
+ATOM   2297  CB  THR A1302      56.387  -4.178  26.968  1.00 24.89           C  
+ATOM   2298  OG1 THR A1302      56.402  -5.489  26.396  1.00 25.12           O  
+ATOM   2299  CG2 THR A1302      54.941  -3.732  27.139  1.00 25.37           C  
+ATOM   2300  N   LYS A1303      56.586  -0.876  26.025  1.00 23.70           N  
+ATOM   2301  CA  LYS A1303      56.566   0.510  26.490  1.00 24.52           C  
+ATOM   2302  C   LYS A1303      55.304   0.854  27.260  1.00 25.26           C  
+ATOM   2303  O   LYS A1303      54.251   0.255  27.057  1.00 22.55           O  
+ATOM   2304  CB  LYS A1303      56.648   1.484  25.317  1.00 23.44           C  
+ATOM   2305  CG  LYS A1303      58.021   1.773  24.766  1.00 22.74           C  
+ATOM   2306  CD  LYS A1303      57.869   2.868  23.729  1.00 21.26           C  
+ATOM   2307  CE  LYS A1303      59.181   3.424  23.265  1.00 22.95           C  
+ATOM   2308  NZ  LYS A1303      58.905   4.511  22.304  1.00 23.05           N  
+ATOM   2309  N   SER A1304      55.419   1.862  28.114  1.00 26.58           N  
+ATOM   2310  CA  SER A1304      54.297   2.318  28.913  1.00 29.50           C  
+ATOM   2311  C   SER A1304      54.137   3.829  28.736  1.00 29.09           C  
+ATOM   2312  O   SER A1304      54.723   4.417  27.825  1.00 29.32           O  
+ATOM   2313  CB  SER A1304      54.545   1.975  30.382  1.00 30.75           C  
+ATOM   2314  OG  SER A1304      53.448   2.376  31.181  1.00 37.02           O  
+ATOM   2315  N   ALA A1305      53.350   4.452  29.610  1.00 28.16           N  
+ATOM   2316  CA  ALA A1305      53.126   5.890  29.545  1.00 26.77           C  
+ATOM   2317  C   ALA A1305      54.436   6.645  29.388  1.00 25.80           C  
+ATOM   2318  O   ALA A1305      55.465   6.225  29.898  1.00 25.38           O  
+ATOM   2319  CB  ALA A1305      52.401   6.359  30.799  1.00 28.23           C  
+ATOM   2320  N   ASN A1306      54.395   7.761  28.669  1.00 27.56           N  
+ATOM   2321  CA  ASN A1306      55.587   8.574  28.455  1.00 27.01           C  
+ATOM   2322  C   ASN A1306      56.738   7.796  27.827  1.00 26.05           C  
+ATOM   2323  O   ASN A1306      57.897   8.183  27.966  1.00 23.40           O  
+ATOM   2324  CB  ASN A1306      56.045   9.170  29.780  1.00 31.71           C  
+ATOM   2325  CG  ASN A1306      54.946   9.945  30.472  1.00 33.92           C  
+ATOM   2326  OD1 ASN A1306      54.400  10.901  29.917  1.00 34.04           O  
+ATOM   2327  ND2 ASN A1306      54.609   9.531  31.690  1.00 34.77           N  
+ATOM   2328  N   HIS A1307      56.409   6.695  27.154  1.00 25.11           N  
+ATOM   2329  CA  HIS A1307      57.397   5.865  26.472  1.00 25.53           C  
+ATOM   2330  C   HIS A1307      58.334   5.081  27.374  1.00 25.51           C  
+ATOM   2331  O   HIS A1307      59.319   4.516  26.902  1.00 24.58           O  
+ATOM   2332  CB  HIS A1307      58.221   6.731  25.525  1.00 24.54           C  
+ATOM   2333  CG  HIS A1307      57.441   7.249  24.362  1.00 26.21           C  
+ATOM   2334  ND1 HIS A1307      57.202   6.497  23.234  1.00 24.61           N  
+ATOM   2335  CD2 HIS A1307      56.816   8.437  24.162  1.00 28.38           C  
+ATOM   2336  CE1 HIS A1307      56.464   7.195  22.388  1.00 27.21           C  
+ATOM   2337  NE2 HIS A1307      56.216   8.376  22.929  1.00 26.66           N  
+ATOM   2338  N   ALA A1308      58.030   5.045  28.667  1.00 25.50           N  
+ATOM   2339  CA  ALA A1308      58.867   4.328  29.618  1.00 24.81           C  
+ATOM   2340  C   ALA A1308      58.758   2.834  29.386  1.00 23.77           C  
+ATOM   2341  O   ALA A1308      57.661   2.299  29.266  1.00 25.06           O  
+ATOM   2342  CB  ALA A1308      58.445   4.668  31.052  1.00 23.95           C  
+ATOM   2343  N   VAL A1309      59.899   2.160  29.313  1.00 23.96           N  
+ATOM   2344  CA  VAL A1309      59.899   0.716  29.124  1.00 25.02           C  
+ATOM   2345  C   VAL A1309      59.532   0.066  30.458  1.00 26.48           C  
+ATOM   2346  O   VAL A1309      60.096   0.414  31.493  1.00 26.66           O  
+ATOM   2347  CB  VAL A1309      61.280   0.220  28.677  1.00 24.92           C  
+ATOM   2348  CG1 VAL A1309      61.331  -1.301  28.716  1.00 21.85           C  
+ATOM   2349  CG2 VAL A1309      61.571   0.731  27.266  1.00 23.41           C  
+ATOM   2350  N   GLU A1310      58.581  -0.863  30.434  1.00 28.33           N  
+ATOM   2351  CA  GLU A1310      58.149  -1.531  31.656  1.00 30.80           C  
+ATOM   2352  C   GLU A1310      58.465  -3.019  31.660  1.00 31.49           C  
+ATOM   2353  O   GLU A1310      58.413  -3.666  32.709  1.00 32.06           O  
+ATOM   2354  CB  GLU A1310      56.642  -1.344  31.874  1.00 32.59           C  
+ATOM   2355  CG  GLU A1310      55.756  -1.955  30.797  1.00 38.49           C  
+ATOM   2356  CD  GLU A1310      54.303  -2.086  31.242  1.00 41.31           C  
+ATOM   2357  OE1 GLU A1310      53.766  -1.120  31.827  1.00 43.57           O  
+ATOM   2358  OE2 GLU A1310      53.696  -3.155  31.003  1.00 43.95           O  
+ATOM   2359  N   GLU A1311      58.787  -3.564  30.492  1.00 29.73           N  
+ATOM   2360  CA  GLU A1311      59.100  -4.977  30.401  1.00 28.95           C  
+ATOM   2361  C   GLU A1311      60.010  -5.300  29.224  1.00 27.85           C  
+ATOM   2362  O   GLU A1311      59.939  -4.663  28.169  1.00 25.53           O  
+ATOM   2363  CB  GLU A1311      57.810  -5.790  30.282  1.00 29.47           C  
+ATOM   2364  CG  GLU A1311      58.045  -7.287  30.194  1.00 34.50           C  
+ATOM   2365  CD  GLU A1311      56.763  -8.081  30.060  1.00 37.79           C  
+ATOM   2366  OE1 GLU A1311      56.048  -7.922  29.045  1.00 37.99           O  
+ATOM   2367  OE2 GLU A1311      56.469  -8.871  30.980  1.00 41.32           O  
+ATOM   2368  N   VAL A1312      60.875  -6.288  29.422  1.00 25.75           N  
+ATOM   2369  CA  VAL A1312      61.783  -6.729  28.379  1.00 24.41           C  
+ATOM   2370  C   VAL A1312      61.761  -8.244  28.352  1.00 26.07           C  
+ATOM   2371  O   VAL A1312      61.989  -8.892  29.378  1.00 29.14           O  
+ATOM   2372  CB  VAL A1312      63.231  -6.275  28.630  1.00 22.57           C  
+ATOM   2373  CG1 VAL A1312      64.105  -6.693  27.454  1.00 22.86           C  
+ATOM   2374  CG2 VAL A1312      63.291  -4.779  28.813  1.00 18.52           C  
+ATOM   2375  N   ARG A1313      61.458  -8.808  27.187  1.00 25.52           N  
+ATOM   2376  CA  ARG A1313      61.433 -10.253  27.023  1.00 23.05           C  
+ATOM   2377  C   ARG A1313      62.452 -10.680  25.976  1.00 23.14           C  
+ATOM   2378  O   ARG A1313      62.484 -10.148  24.861  1.00 23.55           O  
+ATOM   2379  CB  ARG A1313      60.029 -10.721  26.647  1.00 23.49           C  
+ATOM   2380  CG  ARG A1313      59.115 -10.814  27.856  1.00 24.81           C  
+ATOM   2381  CD  ARG A1313      57.821 -11.499  27.516  1.00 27.64           C  
+ATOM   2382  NE  ARG A1313      56.944 -10.632  26.745  1.00 29.95           N  
+ATOM   2383  CZ  ARG A1313      56.022 -11.080  25.901  1.00 33.50           C  
+ATOM   2384  NH1 ARG A1313      55.876 -12.387  25.723  1.00 31.97           N  
+ATOM   2385  NH2 ARG A1313      55.245 -10.226  25.240  1.00 33.35           N  
+ATOM   2386  N   LEU A1314      63.298 -11.635  26.353  1.00 21.60           N  
+ATOM   2387  CA  LEU A1314      64.355 -12.130  25.477  1.00 19.52           C  
+ATOM   2388  C   LEU A1314      64.249 -13.637  25.274  1.00 18.21           C  
+ATOM   2389  O   LEU A1314      64.083 -14.383  26.236  1.00 18.41           O  
+ATOM   2390  CB  LEU A1314      65.716 -11.774  26.084  1.00 17.82           C  
+ATOM   2391  CG  LEU A1314      66.963 -12.385  25.450  1.00 17.59           C  
+ATOM   2392  CD1 LEU A1314      67.122 -11.854  24.033  1.00 17.26           C  
+ATOM   2393  CD2 LEU A1314      68.185 -12.051  26.292  1.00 16.00           C  
+ATOM   2394  N   ARG A1315      64.343 -14.081  24.023  1.00 16.79           N  
+ATOM   2395  CA  ARG A1315      64.254 -15.506  23.720  1.00 17.81           C  
+ATOM   2396  C   ARG A1315      65.314 -16.281  24.492  1.00 20.13           C  
+ATOM   2397  O   ARG A1315      66.484 -15.887  24.529  1.00 18.83           O  
+ATOM   2398  CB  ARG A1315      64.426 -15.761  22.214  1.00 17.26           C  
+ATOM   2399  CG  ARG A1315      63.150 -15.582  21.370  1.00 18.13           C  
+ATOM   2400  CD  ARG A1315      62.062 -16.597  21.735  1.00 15.73           C  
+ATOM   2401  NE  ARG A1315      62.533 -17.975  21.609  1.00 18.39           N  
+ATOM   2402  CZ  ARG A1315      62.709 -18.610  20.451  1.00 19.01           C  
+ATOM   2403  NH1 ARG A1315      62.443 -18.000  19.308  1.00 17.39           N  
+ATOM   2404  NH2 ARG A1315      63.178 -19.851  20.436  1.00 16.21           N  
+ATOM   2405  N   LYS A1316      64.890 -17.378  25.115  1.00 21.23           N  
+ATOM   2406  CA  LYS A1316      65.784 -18.231  25.886  1.00 24.14           C  
+ATOM   2407  C   LYS A1316      66.705 -18.983  24.930  1.00 26.36           C  
+ATOM   2408  O   LYS A1316      67.894 -19.143  25.261  1.00 28.73           O  
+ATOM   2409  CB  LYS A1316      64.979 -19.234  26.715  1.00 24.24           C  
+ATOM   2410  CG  LYS A1316      63.997 -18.602  27.692  1.00 21.65           C  
+ATOM   2411  CD  LYS A1316      63.153 -19.676  28.361  1.00 22.78           C  
+ATOM   2412  CE  LYS A1316      62.332 -19.097  29.506  1.00 22.53           C  
+ATOM   2413  NZ  LYS A1316      61.398 -20.098  30.084  1.00 21.73           N  
+ATOM   2414  OXT LYS A1316      66.223 -19.422  23.866  1.00 27.74           O  
+TER    2415      LYS A1316                                                      
+ATOM   2416  N   MET B2009      78.068  51.679  43.795  1.00 43.10           N  
+ATOM   2417  CA  MET B2009      77.739  52.562  42.635  1.00 41.89           C  
+ATOM   2418  C   MET B2009      77.838  51.794  41.316  1.00 40.37           C  
+ATOM   2419  O   MET B2009      78.323  50.663  41.270  1.00 39.53           O  
+ATOM   2420  CB  MET B2009      78.691  53.764  42.603  1.00 43.16           C  
+ATOM   2421  CG  MET B2009      78.646  54.611  43.870  1.00 44.98           C  
+ATOM   2422  SD  MET B2009      79.865  55.937  43.885  1.00 46.62           S  
+ATOM   2423  CE  MET B2009      80.933  55.429  45.234  1.00 45.75           C  
+ATOM   2424  N   THR B2010      77.359  52.411  40.243  1.00 37.43           N  
+ATOM   2425  CA  THR B2010      77.397  51.788  38.932  1.00 34.43           C  
+ATOM   2426  C   THR B2010      77.981  52.786  37.947  1.00 31.47           C  
+ATOM   2427  O   THR B2010      78.101  53.969  38.257  1.00 32.52           O  
+ATOM   2428  CB  THR B2010      75.984  51.385  38.455  1.00 35.32           C  
+ATOM   2429  OG1 THR B2010      75.229  52.558  38.137  1.00 36.58           O  
+ATOM   2430  CG2 THR B2010      75.256  50.613  39.541  1.00 37.68           C  
+ATOM   2431  N   PRO B2011      78.362  52.322  36.750  1.00 28.54           N  
+ATOM   2432  CA  PRO B2011      78.935  53.196  35.723  1.00 27.17           C  
+ATOM   2433  C   PRO B2011      77.863  54.046  35.031  1.00 26.39           C  
+ATOM   2434  O   PRO B2011      78.143  54.709  34.033  1.00 24.74           O  
+ATOM   2435  CB  PRO B2011      79.574  52.213  34.739  1.00 27.89           C  
+ATOM   2436  CG  PRO B2011      79.645  50.908  35.488  1.00 28.76           C  
+ATOM   2437  CD  PRO B2011      78.404  50.919  36.313  1.00 27.22           C  
+ATOM   2438  N   TYR B2012      76.639  54.022  35.558  1.00 25.12           N  
+ATOM   2439  CA  TYR B2012      75.542  54.775  34.957  1.00 24.70           C  
+ATOM   2440  C   TYR B2012      74.894  55.824  35.847  1.00 25.44           C  
+ATOM   2441  O   TYR B2012      74.794  55.661  37.061  1.00 27.30           O  
+ATOM   2442  CB  TYR B2012      74.420  53.826  34.492  1.00 24.99           C  
+ATOM   2443  CG  TYR B2012      74.772  52.863  33.368  1.00 25.90           C  
+ATOM   2444  CD1 TYR B2012      75.257  51.578  33.635  1.00 25.09           C  
+ATOM   2445  CD2 TYR B2012      74.590  53.233  32.037  1.00 25.67           C  
+ATOM   2446  CE1 TYR B2012      75.545  50.680  32.587  1.00 24.62           C  
+ATOM   2447  CE2 TYR B2012      74.874  52.358  30.994  1.00 25.41           C  
+ATOM   2448  CZ  TYR B2012      75.345  51.085  31.270  1.00 26.44           C  
+ATOM   2449  OH  TYR B2012      75.575  50.233  30.210  1.00 26.26           O  
+ATOM   2450  N   LEU B2013      74.458  56.907  35.214  1.00 25.37           N  
+ATOM   2451  CA  LEU B2013      73.724  57.983  35.868  1.00 26.16           C  
+ATOM   2452  C   LEU B2013      72.302  57.463  35.683  1.00 26.74           C  
+ATOM   2453  O   LEU B2013      72.013  56.831  34.663  1.00 25.89           O  
+ATOM   2454  CB  LEU B2013      73.867  59.299  35.098  1.00 23.52           C  
+ATOM   2455  CG  LEU B2013      75.200  60.040  35.055  1.00 25.27           C  
+ATOM   2456  CD1 LEU B2013      75.071  61.231  34.123  1.00 23.61           C  
+ATOM   2457  CD2 LEU B2013      75.598  60.487  36.459  1.00 25.18           C  
+ATOM   2458  N   GLN B2014      71.414  57.710  36.638  1.00 28.33           N  
+ATOM   2459  CA  GLN B2014      70.050  57.212  36.498  1.00 28.50           C  
+ATOM   2460  C   GLN B2014      68.987  58.299  36.579  1.00 27.93           C  
+ATOM   2461  O   GLN B2014      69.090  59.218  37.391  1.00 28.31           O  
+ATOM   2462  CB  GLN B2014      69.777  56.161  37.560  1.00 31.64           C  
+ATOM   2463  CG  GLN B2014      68.454  55.459  37.373  1.00 37.73           C  
+ATOM   2464  CD  GLN B2014      68.153  54.497  38.493  1.00 41.86           C  
+ATOM   2465  OE1 GLN B2014      68.949  53.601  38.797  1.00 43.92           O  
+ATOM   2466  NE2 GLN B2014      66.993  54.670  39.116  1.00 44.48           N  
+ATOM   2467  N   PHE B2015      67.965  58.185  35.734  1.00 26.81           N  
+ATOM   2468  CA  PHE B2015      66.869  59.154  35.704  1.00 26.69           C  
+ATOM   2469  C   PHE B2015      65.520  58.447  35.561  1.00 29.33           C  
+ATOM   2470  O   PHE B2015      65.350  57.611  34.670  1.00 29.59           O  
+ATOM   2471  CB  PHE B2015      67.004  60.120  34.517  1.00 24.75           C  
+ATOM   2472  CG  PHE B2015      68.344  60.779  34.401  1.00 23.68           C  
+ATOM   2473  CD1 PHE B2015      69.415  60.114  33.802  1.00 25.45           C  
+ATOM   2474  CD2 PHE B2015      68.541  62.073  34.882  1.00 24.47           C  
+ATOM   2475  CE1 PHE B2015      70.670  60.732  33.683  1.00 23.25           C  
+ATOM   2476  CE2 PHE B2015      69.791  62.698  34.771  1.00 23.37           C  
+ATOM   2477  CZ  PHE B2015      70.854  62.021  34.168  1.00 24.19           C  
+ATOM   2478  N   ASP B2016      64.565  58.760  36.437  1.00 30.30           N  
+ATOM   2479  CA  ASP B2016      63.241  58.165  36.299  1.00 30.16           C  
+ATOM   2480  C   ASP B2016      62.559  59.073  35.285  1.00 30.58           C  
+ATOM   2481  O   ASP B2016      63.129  60.096  34.893  1.00 29.11           O  
+ATOM   2482  CB  ASP B2016      62.464  58.146  37.628  1.00 31.22           C  
+ATOM   2483  CG  ASP B2016      62.283  59.524  38.232  1.00 32.09           C  
+ATOM   2484  OD1 ASP B2016      62.031  60.490  37.481  1.00 32.54           O  
+ATOM   2485  OD2 ASP B2016      62.376  59.636  39.473  1.00 33.96           O  
+ATOM   2486  N   ARG B2017      61.349  58.723  34.861  1.00 30.40           N  
+ATOM   2487  CA  ARG B2017      60.665  59.530  33.859  1.00 30.15           C  
+ATOM   2488  C   ARG B2017      60.609  61.029  34.147  1.00 29.70           C  
+ATOM   2489  O   ARG B2017      60.920  61.841  33.278  1.00 30.76           O  
+ATOM   2490  CB  ARG B2017      59.243  59.032  33.625  1.00 29.88           C  
+ATOM   2491  CG  ARG B2017      58.666  59.630  32.364  1.00 31.83           C  
+ATOM   2492  CD  ARG B2017      57.171  59.559  32.324  1.00 33.92           C  
+ATOM   2493  NE  ARG B2017      56.655  60.128  31.082  1.00 36.60           N  
+ATOM   2494  CZ  ARG B2017      56.714  59.529  29.896  1.00 35.94           C  
+ATOM   2495  NH1 ARG B2017      57.273  58.331  29.777  1.00 35.47           N  
+ATOM   2496  NH2 ARG B2017      56.198  60.124  28.829  1.00 34.30           N  
+ATOM   2497  N   ASN B2018      60.203  61.402  35.355  1.00 29.48           N  
+ATOM   2498  CA  ASN B2018      60.104  62.814  35.696  1.00 30.90           C  
+ATOM   2499  C   ASN B2018      61.429  63.563  35.620  1.00 28.25           C  
+ATOM   2500  O   ASN B2018      61.477  64.675  35.113  1.00 26.05           O  
+ATOM   2501  CB  ASN B2018      59.491  62.989  37.085  1.00 33.97           C  
+ATOM   2502  CG  ASN B2018      58.055  62.502  37.150  1.00 37.70           C  
+ATOM   2503  OD1 ASN B2018      57.251  62.775  36.253  1.00 39.64           O  
+ATOM   2504  ND2 ASN B2018      57.721  61.787  38.220  1.00 40.29           N  
+ATOM   2505  N   GLN B2019      62.499  62.952  36.118  1.00 28.77           N  
+ATOM   2506  CA  GLN B2019      63.819  63.573  36.088  1.00 28.82           C  
+ATOM   2507  C   GLN B2019      64.272  63.781  34.649  1.00 29.36           C  
+ATOM   2508  O   GLN B2019      64.808  64.836  34.305  1.00 29.15           O  
+ATOM   2509  CB  GLN B2019      64.826  62.700  36.831  1.00 29.42           C  
+ATOM   2510  CG  GLN B2019      64.413  62.431  38.259  1.00 30.61           C  
+ATOM   2511  CD  GLN B2019      65.377  61.531  38.977  1.00 30.74           C  
+ATOM   2512  OE1 GLN B2019      65.650  60.418  38.536  1.00 31.34           O  
+ATOM   2513  NE2 GLN B2019      65.903  62.007  40.097  1.00 34.94           N  
+ATOM   2514  N   TRP B2020      64.046  62.779  33.804  1.00 28.64           N  
+ATOM   2515  CA  TRP B2020      64.434  62.887  32.404  1.00 27.72           C  
+ATOM   2516  C   TRP B2020      63.604  63.949  31.694  1.00 28.25           C  
+ATOM   2517  O   TRP B2020      64.139  64.771  30.958  1.00 29.54           O  
+ATOM   2518  CB  TRP B2020      64.255  61.549  31.689  1.00 25.27           C  
+ATOM   2519  CG  TRP B2020      64.780  61.569  30.287  1.00 21.45           C  
+ATOM   2520  CD1 TRP B2020      64.055  61.670  29.138  1.00 21.91           C  
+ATOM   2521  CD2 TRP B2020      66.156  61.508  29.892  1.00 20.19           C  
+ATOM   2522  NE1 TRP B2020      64.892  61.675  28.045  1.00 19.30           N  
+ATOM   2523  CE2 TRP B2020      66.188  61.577  28.480  1.00 19.07           C  
+ATOM   2524  CE3 TRP B2020      67.368  61.404  30.596  1.00 18.84           C  
+ATOM   2525  CZ2 TRP B2020      67.386  61.543  27.755  1.00 16.81           C  
+ATOM   2526  CZ3 TRP B2020      68.561  61.370  29.872  1.00 18.58           C  
+ATOM   2527  CH2 TRP B2020      68.558  61.440  28.468  1.00 18.81           C  
+ATOM   2528  N   ALA B2021      62.293  63.923  31.913  1.00 28.60           N  
+ATOM   2529  CA  ALA B2021      61.396  64.887  31.292  1.00 28.68           C  
+ATOM   2530  C   ALA B2021      61.710  66.302  31.764  1.00 29.84           C  
+ATOM   2531  O   ALA B2021      61.475  67.276  31.043  1.00 28.80           O  
+ATOM   2532  CB  ALA B2021      59.943  64.535  31.616  1.00 29.89           C  
+ATOM   2533  N   ALA B2022      62.244  66.409  32.976  1.00 31.29           N  
+ATOM   2534  CA  ALA B2022      62.590  67.704  33.549  1.00 34.40           C  
+ATOM   2535  C   ALA B2022      63.809  68.318  32.871  1.00 36.14           C  
+ATOM   2536  O   ALA B2022      64.244  69.403  33.243  1.00 38.13           O  
+ATOM   2537  CB  ALA B2022      62.851  67.565  35.037  1.00 33.17           C  
+ATOM   2538  N   LEU B2023      64.360  67.629  31.878  1.00 36.88           N  
+ATOM   2539  CA  LEU B2023      65.533  68.139  31.182  1.00 38.37           C  
+ATOM   2540  C   LEU B2023      65.203  69.233  30.171  1.00 38.94           C  
+ATOM   2541  O   LEU B2023      66.101  69.909  29.664  1.00 38.88           O  
+ATOM   2542  CB  LEU B2023      66.282  66.995  30.495  1.00 37.71           C  
+ATOM   2543  CG  LEU B2023      66.807  65.923  31.453  1.00 38.93           C  
+ATOM   2544  CD1 LEU B2023      67.731  64.989  30.692  1.00 40.93           C  
+ATOM   2545  CD2 LEU B2023      67.547  66.570  32.619  1.00 39.25           C  
+ATOM   2546  N   ARG B2024      63.919  69.416  29.885  1.00 39.63           N  
+ATOM   2547  CA  ARG B2024      63.500  70.450  28.945  1.00 39.85           C  
+ATOM   2548  C   ARG B2024      63.490  71.812  29.637  1.00 39.45           C  
+ATOM   2549  O   ARG B2024      63.597  72.855  28.989  1.00 39.82           O  
+ATOM   2550  CB  ARG B2024      62.112  70.127  28.412  1.00 41.05           C  
+ATOM   2551  CG  ARG B2024      62.025  68.779  27.720  1.00 43.19           C  
+ATOM   2552  CD  ARG B2024      60.577  68.379  27.510  1.00 45.62           C  
+ATOM   2553  NE  ARG B2024      59.868  68.256  28.781  1.00 48.13           N  
+ATOM   2554  CZ  ARG B2024      58.569  67.996  28.891  1.00 49.24           C  
+ATOM   2555  NH1 ARG B2024      57.831  67.829  27.802  1.00 51.54           N  
+ATOM   2556  NH2 ARG B2024      58.004  67.910  30.088  1.00 49.61           N  
+ATOM   2557  N   LEU B2031      57.771  71.304  18.127  1.00 44.07           N  
+ATOM   2558  CA  LEU B2031      57.667  70.533  16.887  1.00 45.10           C  
+ATOM   2559  C   LEU B2031      56.629  71.106  15.925  1.00 45.66           C  
+ATOM   2560  O   LEU B2031      55.504  71.411  16.317  1.00 44.16           O  
+ATOM   2561  CB  LEU B2031      57.326  69.069  17.194  1.00 44.18           C  
+ATOM   2562  CG  LEU B2031      58.431  68.225  17.844  1.00 44.04           C  
+ATOM   2563  CD1 LEU B2031      57.891  66.852  18.226  1.00 42.28           C  
+ATOM   2564  CD2 LEU B2031      59.604  68.091  16.876  1.00 42.97           C  
+ATOM   2565  N   SER B2032      57.018  71.235  14.659  1.00 46.63           N  
+ATOM   2566  CA  SER B2032      56.138  71.778  13.628  1.00 48.53           C  
+ATOM   2567  C   SER B2032      55.091  70.763  13.194  1.00 49.20           C  
+ATOM   2568  O   SER B2032      55.262  69.559  13.386  1.00 49.23           O  
+ATOM   2569  CB  SER B2032      56.952  72.225  12.402  1.00 48.33           C  
+ATOM   2570  OG  SER B2032      57.387  71.121  11.626  1.00 48.76           O  
+ATOM   2571  N   GLU B2033      54.011  71.263  12.602  1.00 50.14           N  
+ATOM   2572  CA  GLU B2033      52.924  70.414  12.131  1.00 50.69           C  
+ATOM   2573  C   GLU B2033      53.446  69.294  11.241  1.00 49.70           C  
+ATOM   2574  O   GLU B2033      52.997  68.155  11.335  1.00 49.31           O  
+ATOM   2575  CB  GLU B2033      51.891  71.247  11.360  1.00 51.45           C  
+ATOM   2576  CG  GLU B2033      51.255  72.361  12.186  1.00 55.92           C  
+ATOM   2577  CD  GLU B2033      50.020  72.971  11.527  1.00 58.64           C  
+ATOM   2578  OE1 GLU B2033      50.113  73.395  10.351  1.00 58.78           O  
+ATOM   2579  OE2 GLU B2033      48.959  73.031  12.192  1.00 58.60           O  
+ATOM   2580  N   ASP B2034      54.401  69.619  10.380  1.00 49.59           N  
+ATOM   2581  CA  ASP B2034      54.958  68.625   9.476  1.00 49.52           C  
+ATOM   2582  C   ASP B2034      55.805  67.614  10.237  1.00 48.56           C  
+ATOM   2583  O   ASP B2034      55.868  66.442   9.862  1.00 47.29           O  
+ATOM   2584  CB  ASP B2034      55.787  69.312   8.389  1.00 51.89           C  
+ATOM   2585  CG  ASP B2034      55.015  70.412   7.683  1.00 54.88           C  
+ATOM   2586  OD1 ASP B2034      53.850  70.167   7.298  1.00 55.11           O  
+ATOM   2587  OD2 ASP B2034      55.568  71.520   7.513  1.00 56.11           O  
+ATOM   2588  N   GLU B2035      56.454  68.072  11.304  1.00 47.28           N  
+ATOM   2589  CA  GLU B2035      57.280  67.191  12.119  1.00 46.39           C  
+ATOM   2590  C   GLU B2035      56.394  66.194  12.848  1.00 45.02           C  
+ATOM   2591  O   GLU B2035      56.707  65.007  12.919  1.00 45.22           O  
+ATOM   2592  CB  GLU B2035      58.079  67.985  13.153  1.00 46.74           C  
+ATOM   2593  CG  GLU B2035      59.149  68.887  12.579  1.00 47.69           C  
+ATOM   2594  CD  GLU B2035      60.023  69.496  13.660  1.00 48.94           C  
+ATOM   2595  OE1 GLU B2035      60.773  68.741  14.321  1.00 50.22           O  
+ATOM   2596  OE2 GLU B2035      59.956  70.727  13.855  1.00 49.52           O  
+ATOM   2597  N   ILE B2036      55.287  66.683  13.395  1.00 43.54           N  
+ATOM   2598  CA  ILE B2036      54.363  65.823  14.123  1.00 42.80           C  
+ATOM   2599  C   ILE B2036      53.725  64.819  13.172  1.00 40.83           C  
+ATOM   2600  O   ILE B2036      53.481  63.670  13.533  1.00 40.38           O  
+ATOM   2601  CB  ILE B2036      53.268  66.664  14.827  1.00 43.71           C  
+ATOM   2602  CG1 ILE B2036      53.910  67.504  15.939  1.00 44.39           C  
+ATOM   2603  CG2 ILE B2036      52.182  65.755  15.392  1.00 43.76           C  
+ATOM   2604  CD1 ILE B2036      52.960  68.448  16.648  1.00 45.24           C  
+ATOM   2605  N   ALA B2037      53.469  65.256  11.948  1.00 39.64           N  
+ATOM   2606  CA  ALA B2037      52.870  64.390  10.949  1.00 39.81           C  
+ATOM   2607  C   ALA B2037      53.834  63.263  10.606  1.00 39.70           C  
+ATOM   2608  O   ALA B2037      53.432  62.101  10.486  1.00 39.45           O  
+ATOM   2609  CB  ALA B2037      52.539  65.188   9.699  1.00 40.20           C  
+ATOM   2610  N   ARG B2038      55.106  63.616  10.441  1.00 38.61           N  
+ATOM   2611  CA  ARG B2038      56.130  62.637  10.107  1.00 37.28           C  
+ATOM   2612  C   ARG B2038      56.232  61.614  11.226  1.00 35.37           C  
+ATOM   2613  O   ARG B2038      56.268  60.413  10.984  1.00 34.05           O  
+ATOM   2614  CB  ARG B2038      57.481  63.324   9.906  1.00 38.17           C  
+ATOM   2615  CG  ARG B2038      58.571  62.374   9.448  1.00 41.32           C  
+ATOM   2616  CD  ARG B2038      59.898  63.084   9.244  1.00 42.87           C  
+ATOM   2617  NE  ARG B2038      60.941  62.136   8.870  1.00 45.39           N  
+ATOM   2618  CZ  ARG B2038      62.228  62.441   8.745  1.00 46.58           C  
+ATOM   2619  NH1 ARG B2038      62.641  63.685   8.965  1.00 46.72           N  
+ATOM   2620  NH2 ARG B2038      63.105  61.500   8.404  1.00 46.50           N  
+ATOM   2621  N   LEU B2039      56.270  62.096  12.459  1.00 34.94           N  
+ATOM   2622  CA  LEU B2039      56.355  61.197  13.598  1.00 35.83           C  
+ATOM   2623  C   LEU B2039      55.145  60.264  13.615  1.00 37.24           C  
+ATOM   2624  O   LEU B2039      55.296  59.050  13.778  1.00 38.28           O  
+ATOM   2625  CB  LEU B2039      56.456  62.002  14.896  1.00 33.43           C  
+ATOM   2626  CG  LEU B2039      57.821  62.683  15.061  1.00 34.57           C  
+ATOM   2627  CD1 LEU B2039      57.816  63.635  16.255  1.00 33.73           C  
+ATOM   2628  CD2 LEU B2039      58.889  61.603  15.232  1.00 32.37           C  
+ATOM   2629  N   LYS B2040      53.951  60.823  13.427  1.00 37.09           N  
+ATOM   2630  CA  LYS B2040      52.737  60.019  13.413  1.00 36.69           C  
+ATOM   2631  C   LYS B2040      52.842  59.007  12.277  1.00 36.39           C  
+ATOM   2632  O   LYS B2040      52.383  57.869  12.395  1.00 35.23           O  
+ATOM   2633  CB  LYS B2040      51.518  60.913  13.218  1.00 37.56           C  
+ATOM   2634  N   GLY B2041      53.458  59.431  11.178  1.00 36.83           N  
+ATOM   2635  CA  GLY B2041      53.639  58.550  10.037  1.00 36.73           C  
+ATOM   2636  C   GLY B2041      54.583  57.403  10.364  1.00 39.32           C  
+ATOM   2637  O   GLY B2041      54.418  56.293   9.854  1.00 39.46           O  
+ATOM   2638  N   ILE B2042      55.575  57.666  11.215  1.00 38.76           N  
+ATOM   2639  CA  ILE B2042      56.540  56.640  11.616  1.00 39.69           C  
+ATOM   2640  C   ILE B2042      55.830  55.507  12.363  1.00 40.60           C  
+ATOM   2641  O   ILE B2042      55.940  54.337  11.998  1.00 40.92           O  
+ATOM   2642  CB  ILE B2042      57.639  57.230  12.541  1.00 38.90           C  
+ATOM   2643  CG1 ILE B2042      58.507  58.222  11.766  1.00 39.21           C  
+ATOM   2644  CG2 ILE B2042      58.498  56.116  13.108  1.00 39.73           C  
+ATOM   2645  CD1 ILE B2042      59.485  58.985  12.642  1.00 39.06           C  
+ATOM   2646  N   ASN B2043      55.105  55.867  13.414  1.00 41.65           N  
+ATOM   2647  CA  ASN B2043      54.376  54.892  14.212  1.00 43.00           C  
+ATOM   2648  C   ASN B2043      53.102  55.541  14.728  1.00 43.38           C  
+ATOM   2649  O   ASN B2043      53.144  56.405  15.603  1.00 43.13           O  
+ATOM   2650  CB  ASN B2043      55.231  54.425  15.392  1.00 44.09           C  
+ATOM   2651  CG  ASN B2043      54.653  53.203  16.087  1.00 44.44           C  
+ATOM   2652  OD1 ASN B2043      53.516  53.217  16.564  1.00 45.66           O  
+ATOM   2653  ND2 ASN B2043      55.441  52.137  16.149  1.00 44.17           N  
+ATOM   2654  N   GLU B2044      51.971  55.121  14.178  1.00 44.44           N  
+ATOM   2655  CA  GLU B2044      50.676  55.667  14.566  1.00 46.73           C  
+ATOM   2656  C   GLU B2044      50.381  55.522  16.057  1.00 45.99           C  
+ATOM   2657  O   GLU B2044      49.616  56.301  16.623  1.00 45.86           O  
+ATOM   2658  CB  GLU B2044      49.576  54.986  13.758  1.00 49.66           C  
+ATOM   2659  CG  GLU B2044      48.169  55.308  14.214  1.00 54.62           C  
+ATOM   2660  CD  GLU B2044      47.135  54.393  13.574  1.00 58.04           C  
+ATOM   2661  OE1 GLU B2044      47.220  53.158  13.777  1.00 59.53           O  
+ATOM   2662  OE2 GLU B2044      46.239  54.908  12.867  1.00 59.05           O  
+ATOM   2663  N   ASP B2045      50.994  54.528  16.690  1.00 45.11           N  
+ATOM   2664  CA  ASP B2045      50.783  54.277  18.114  1.00 45.59           C  
+ATOM   2665  C   ASP B2045      51.715  55.086  19.012  1.00 43.56           C  
+ATOM   2666  O   ASP B2045      51.596  55.043  20.236  1.00 42.55           O  
+ATOM   2667  CB  ASP B2045      50.963  52.783  18.415  1.00 48.15           C  
+ATOM   2668  CG  ASP B2045      49.861  51.922  17.812  1.00 51.46           C  
+ATOM   2669  OD1 ASP B2045      49.674  51.951  16.573  1.00 52.06           O  
+ATOM   2670  OD2 ASP B2045      49.179  51.208  18.584  1.00 54.19           O  
+ATOM   2671  N   LEU B2046      52.639  55.818  18.399  1.00 41.93           N  
+ATOM   2672  CA  LEU B2046      53.607  56.630  19.136  1.00 40.24           C  
+ATOM   2673  C   LEU B2046      52.975  57.877  19.759  1.00 39.95           C  
+ATOM   2674  O   LEU B2046      52.452  58.746  19.053  1.00 39.97           O  
+ATOM   2675  CB  LEU B2046      54.748  57.041  18.201  1.00 38.87           C  
+ATOM   2676  CG  LEU B2046      55.891  57.882  18.759  1.00 38.13           C  
+ATOM   2677  CD1 LEU B2046      56.709  57.072  19.755  1.00 38.10           C  
+ATOM   2678  CD2 LEU B2046      56.765  58.338  17.603  1.00 38.33           C  
+ATOM   2679  N   SER B2047      53.034  57.950  21.085  1.00 38.85           N  
+ATOM   2680  CA  SER B2047      52.487  59.066  21.848  1.00 37.80           C  
+ATOM   2681  C   SER B2047      53.301  60.344  21.662  1.00 38.21           C  
+ATOM   2682  O   SER B2047      54.494  60.380  21.968  1.00 37.78           O  
+ATOM   2683  CB  SER B2047      52.452  58.705  23.340  1.00 38.04           C  
+ATOM   2684  OG  SER B2047      52.225  59.847  24.150  1.00 34.44           O  
+ATOM   2685  N   LEU B2048      52.650  61.392  21.170  1.00 38.67           N  
+ATOM   2686  CA  LEU B2048      53.308  62.675  20.954  1.00 39.33           C  
+ATOM   2687  C   LEU B2048      53.804  63.270  22.271  1.00 38.55           C  
+ATOM   2688  O   LEU B2048      54.712  64.098  22.285  1.00 38.90           O  
+ATOM   2689  CB  LEU B2048      52.345  63.641  20.263  1.00 40.84           C  
+ATOM   2690  CG  LEU B2048      51.923  63.171  18.866  1.00 43.57           C  
+ATOM   2691  CD1 LEU B2048      50.762  64.012  18.341  1.00 44.24           C  
+ATOM   2692  CD2 LEU B2048      53.124  63.247  17.928  1.00 43.22           C  
+ATOM   2693  N   GLU B2049      53.203  62.856  23.379  1.00 37.97           N  
+ATOM   2694  CA  GLU B2049      53.631  63.338  24.687  1.00 38.14           C  
+ATOM   2695  C   GLU B2049      54.909  62.592  25.062  1.00 35.92           C  
+ATOM   2696  O   GLU B2049      55.809  63.144  25.695  1.00 35.90           O  
+ATOM   2697  CB  GLU B2049      52.550  63.080  25.737  1.00 40.67           C  
+ATOM   2698  CG  GLU B2049      53.006  63.348  27.161  1.00 46.90           C  
+ATOM   2699  CD  GLU B2049      51.864  63.287  28.161  1.00 51.68           C  
+ATOM   2700  OE1 GLU B2049      52.133  63.274  29.384  1.00 53.55           O  
+ATOM   2701  OE2 GLU B2049      50.692  63.259  27.722  1.00 53.58           O  
+ATOM   2702  N   GLU B2050      54.976  61.326  24.668  1.00 33.60           N  
+ATOM   2703  CA  GLU B2050      56.149  60.501  24.931  1.00 32.70           C  
+ATOM   2704  C   GLU B2050      57.320  61.128  24.165  1.00 32.49           C  
+ATOM   2705  O   GLU B2050      58.425  61.258  24.693  1.00 32.87           O  
+ATOM   2706  CB  GLU B2050      55.901  59.067  24.443  1.00 31.55           C  
+ATOM   2707  CG  GLU B2050      57.031  58.084  24.705  1.00 32.78           C  
+ATOM   2708  CD  GLU B2050      57.103  57.612  26.151  1.00 32.75           C  
+ATOM   2709  OE1 GLU B2050      58.015  56.823  26.469  1.00 34.03           O  
+ATOM   2710  OE2 GLU B2050      56.255  58.022  26.970  1.00 34.19           O  
+ATOM   2711  N   VAL B2051      57.064  61.525  22.921  1.00 30.45           N  
+ATOM   2712  CA  VAL B2051      58.094  62.137  22.102  1.00 29.07           C  
+ATOM   2713  C   VAL B2051      58.601  63.413  22.759  1.00 30.27           C  
+ATOM   2714  O   VAL B2051      59.806  63.619  22.903  1.00 30.37           O  
+ATOM   2715  CB  VAL B2051      57.563  62.472  20.693  1.00 27.73           C  
+ATOM   2716  CG1 VAL B2051      58.569  63.337  19.949  1.00 27.54           C  
+ATOM   2717  CG2 VAL B2051      57.306  61.185  19.918  1.00 27.90           C  
+ATOM   2718  N   ALA B2052      57.674  64.266  23.173  1.00 30.80           N  
+ATOM   2719  CA  ALA B2052      58.036  65.528  23.796  1.00 31.82           C  
+ATOM   2720  C   ALA B2052      58.776  65.385  25.125  1.00 31.99           C  
+ATOM   2721  O   ALA B2052      59.690  66.153  25.413  1.00 32.24           O  
+ATOM   2722  CB  ALA B2052      56.783  66.393  23.986  1.00 31.05           C  
+ATOM   2723  N   GLU B2053      58.396  64.405  25.937  1.00 32.84           N  
+ATOM   2724  CA  GLU B2053      59.039  64.234  27.237  1.00 32.02           C  
+ATOM   2725  C   GLU B2053      60.241  63.298  27.265  1.00 31.06           C  
+ATOM   2726  O   GLU B2053      61.090  63.411  28.149  1.00 31.77           O  
+ATOM   2727  CB  GLU B2053      58.028  63.744  28.274  1.00 34.66           C  
+ATOM   2728  CG  GLU B2053      56.749  64.556  28.351  1.00 39.21           C  
+ATOM   2729  CD  GLU B2053      55.846  64.112  29.488  1.00 42.03           C  
+ATOM   2730  OE1 GLU B2053      55.839  62.902  29.816  1.00 42.97           O  
+ATOM   2731  OE2 GLU B2053      55.132  64.974  30.044  1.00 45.78           O  
+ATOM   2732  N   ILE B2054      60.325  62.381  26.310  1.00 27.58           N  
+ATOM   2733  CA  ILE B2054      61.430  61.435  26.305  1.00 26.58           C  
+ATOM   2734  C   ILE B2054      62.405  61.557  25.135  1.00 26.42           C  
+ATOM   2735  O   ILE B2054      63.607  61.758  25.328  1.00 27.59           O  
+ATOM   2736  CB  ILE B2054      60.906  59.982  26.320  1.00 26.38           C  
+ATOM   2737  CG1 ILE B2054      59.952  59.774  27.503  1.00 26.73           C  
+ATOM   2738  CG2 ILE B2054      62.074  59.013  26.383  1.00 24.28           C  
+ATOM   2739  CD1 ILE B2054      60.542  60.106  28.848  1.00 24.95           C  
+ATOM   2740  N   TYR B2055      61.888  61.437  23.922  1.00 24.73           N  
+ATOM   2741  CA  TYR B2055      62.740  61.477  22.745  1.00 24.39           C  
+ATOM   2742  C   TYR B2055      63.347  62.813  22.333  1.00 24.09           C  
+ATOM   2743  O   TYR B2055      64.435  62.834  21.758  1.00 24.27           O  
+ATOM   2744  CB  TYR B2055      62.007  60.818  21.575  1.00 23.14           C  
+ATOM   2745  CG  TYR B2055      61.678  59.373  21.891  1.00 25.34           C  
+ATOM   2746  CD1 TYR B2055      60.418  59.009  22.375  1.00 25.06           C  
+ATOM   2747  CD2 TYR B2055      62.660  58.385  21.813  1.00 24.88           C  
+ATOM   2748  CE1 TYR B2055      60.152  57.692  22.782  1.00 26.48           C  
+ATOM   2749  CE2 TYR B2055      62.406  57.073  22.214  1.00 24.91           C  
+ATOM   2750  CZ  TYR B2055      61.156  56.733  22.701  1.00 26.28           C  
+ATOM   2751  OH  TYR B2055      60.924  55.447  23.136  1.00 25.77           O  
+ATOM   2752  N   LEU B2056      62.675  63.925  22.609  1.00 23.37           N  
+ATOM   2753  CA  LEU B2056      63.260  65.211  22.253  1.00 23.99           C  
+ATOM   2754  C   LEU B2056      64.497  65.421  23.125  1.00 22.96           C  
+ATOM   2755  O   LEU B2056      65.569  65.781  22.624  1.00 23.51           O  
+ATOM   2756  CB  LEU B2056      62.252  66.352  22.433  1.00 26.02           C  
+ATOM   2757  CG  LEU B2056      61.440  66.661  21.173  1.00 27.87           C  
+ATOM   2758  CD1 LEU B2056      60.341  67.664  21.486  1.00 30.02           C  
+ATOM   2759  CD2 LEU B2056      62.378  67.202  20.095  1.00 28.39           C  
+ATOM   2760  N   PRO B2057      64.370  65.196  24.444  1.00 21.41           N  
+ATOM   2761  CA  PRO B2057      65.522  65.366  25.337  1.00 20.75           C  
+ATOM   2762  C   PRO B2057      66.657  64.406  24.959  1.00 19.49           C  
+ATOM   2763  O   PRO B2057      67.831  64.752  25.072  1.00 18.45           O  
+ATOM   2764  CB  PRO B2057      64.938  65.060  26.714  1.00 19.74           C  
+ATOM   2765  CG  PRO B2057      63.537  65.565  26.584  1.00 21.25           C  
+ATOM   2766  CD  PRO B2057      63.126  65.048  25.224  1.00 22.82           C  
+ATOM   2767  N   LEU B2058      66.289  63.202  24.520  1.00 18.56           N  
+ATOM   2768  CA  LEU B2058      67.262  62.199  24.104  1.00 18.09           C  
+ATOM   2769  C   LEU B2058      67.989  62.682  22.846  1.00 17.13           C  
+ATOM   2770  O   LEU B2058      69.197  62.506  22.715  1.00 18.39           O  
+ATOM   2771  CB  LEU B2058      66.569  60.855  23.817  1.00 16.73           C  
+ATOM   2772  CG  LEU B2058      67.473  59.712  23.332  1.00 16.22           C  
+ATOM   2773  CD1 LEU B2058      68.525  59.391  24.378  1.00 17.00           C  
+ATOM   2774  CD2 LEU B2058      66.636  58.481  23.043  1.00 17.95           C  
+ATOM   2775  N   SER B2059      67.258  63.296  21.922  1.00 17.07           N  
+ATOM   2776  CA  SER B2059      67.893  63.780  20.709  1.00 19.13           C  
+ATOM   2777  C   SER B2059      68.812  64.953  21.057  1.00 21.48           C  
+ATOM   2778  O   SER B2059      69.845  65.146  20.413  1.00 21.20           O  
+ATOM   2779  CB  SER B2059      66.846  64.201  19.668  1.00 21.03           C  
+ATOM   2780  OG  SER B2059      66.149  65.373  20.065  1.00 24.94           O  
+ATOM   2781  N   ARG B2060      68.451  65.722  22.087  1.00 21.42           N  
+ATOM   2782  CA  ARG B2060      69.288  66.841  22.502  1.00 22.38           C  
+ATOM   2783  C   ARG B2060      70.589  66.274  23.067  1.00 22.06           C  
+ATOM   2784  O   ARG B2060      71.675  66.731  22.713  1.00 21.27           O  
+ATOM   2785  CB  ARG B2060      68.604  67.700  23.576  1.00 25.05           C  
+ATOM   2786  CG  ARG B2060      67.509  68.637  23.067  1.00 30.84           C  
+ATOM   2787  CD  ARG B2060      67.078  69.628  24.157  1.00 32.55           C  
+ATOM   2788  NE  ARG B2060      68.184  70.491  24.565  1.00 36.67           N  
+ATOM   2789  CZ  ARG B2060      68.157  71.300  25.621  1.00 39.72           C  
+ATOM   2790  NH1 ARG B2060      67.075  71.358  26.388  1.00 41.97           N  
+ATOM   2791  NH2 ARG B2060      69.211  72.055  25.912  1.00 40.26           N  
+ATOM   2792  N   LEU B2061      70.472  65.279  23.946  1.00 19.37           N  
+ATOM   2793  CA  LEU B2061      71.645  64.650  24.541  1.00 19.56           C  
+ATOM   2794  C   LEU B2061      72.588  64.153  23.452  1.00 18.45           C  
+ATOM   2795  O   LEU B2061      73.789  64.407  23.495  1.00 19.36           O  
+ATOM   2796  CB  LEU B2061      71.250  63.460  25.410  1.00 18.75           C  
+ATOM   2797  CG  LEU B2061      72.459  62.759  26.045  1.00 19.07           C  
+ATOM   2798  CD1 LEU B2061      72.852  63.489  27.324  1.00 19.07           C  
+ATOM   2799  CD2 LEU B2061      72.135  61.312  26.345  1.00 17.98           C  
+ATOM   2800  N   LEU B2062      72.035  63.435  22.486  1.00 18.61           N  
+ATOM   2801  CA  LEU B2062      72.825  62.903  21.394  1.00 19.28           C  
+ATOM   2802  C   LEU B2062      73.528  64.017  20.632  1.00 19.64           C  
+ATOM   2803  O   LEU B2062      74.691  63.872  20.252  1.00 19.08           O  
+ATOM   2804  CB  LEU B2062      71.936  62.092  20.450  1.00 17.76           C  
+ATOM   2805  CG  LEU B2062      71.451  60.771  21.058  1.00 18.92           C  
+ATOM   2806  CD1 LEU B2062      70.460  60.096  20.116  1.00 16.38           C  
+ATOM   2807  CD2 LEU B2062      72.649  59.865  21.324  1.00 15.08           C  
+ATOM   2808  N   ASN B2063      72.826  65.128  20.419  1.00 20.13           N  
+ATOM   2809  CA  ASN B2063      73.411  66.257  19.706  1.00 20.22           C  
+ATOM   2810  C   ASN B2063      74.608  66.821  20.454  1.00 19.69           C  
+ATOM   2811  O   ASN B2063      75.572  67.269  19.837  1.00 19.38           O  
+ATOM   2812  CB  ASN B2063      72.375  67.360  19.483  1.00 20.33           C  
+ATOM   2813  CG  ASN B2063      72.966  68.568  18.781  1.00 23.98           C  
+ATOM   2814  OD1 ASN B2063      73.300  69.576  19.415  1.00 23.90           O  
+ATOM   2815  ND2 ASN B2063      73.119  68.467  17.465  1.00 23.70           N  
+ATOM   2816  N   PHE B2064      74.552  66.806  21.782  1.00 18.78           N  
+ATOM   2817  CA  PHE B2064      75.670  67.305  22.576  1.00 18.83           C  
+ATOM   2818  C   PHE B2064      76.899  66.420  22.345  1.00 18.10           C  
+ATOM   2819  O   PHE B2064      78.017  66.921  22.242  1.00 18.92           O  
+ATOM   2820  CB  PHE B2064      75.310  67.325  24.073  1.00 20.22           C  
+ATOM   2821  CG  PHE B2064      74.492  68.520  24.488  1.00 21.32           C  
+ATOM   2822  CD1 PHE B2064      73.317  68.356  25.218  1.00 22.89           C  
+ATOM   2823  CD2 PHE B2064      74.914  69.818  24.173  1.00 22.40           C  
+ATOM   2824  CE1 PHE B2064      72.565  69.463  25.632  1.00 21.62           C  
+ATOM   2825  CE2 PHE B2064      74.174  70.937  24.581  1.00 22.00           C  
+ATOM   2826  CZ  PHE B2064      72.995  70.758  25.314  1.00 22.72           C  
+ATOM   2827  N   TYR B2065      76.693  65.106  22.280  1.00 16.76           N  
+ATOM   2828  CA  TYR B2065      77.806  64.196  22.053  1.00 17.94           C  
+ATOM   2829  C   TYR B2065      78.354  64.390  20.637  1.00 18.44           C  
+ATOM   2830  O   TYR B2065      79.560  64.389  20.425  1.00 17.80           O  
+ATOM   2831  CB  TYR B2065      77.375  62.735  22.230  1.00 17.44           C  
+ATOM   2832  CG  TYR B2065      77.369  62.261  23.659  1.00 17.29           C  
+ATOM   2833  CD1 TYR B2065      76.357  62.646  24.541  1.00 18.93           C  
+ATOM   2834  CD2 TYR B2065      78.399  61.464  24.147  1.00 18.36           C  
+ATOM   2835  CE1 TYR B2065      76.379  62.248  25.883  1.00 20.22           C  
+ATOM   2836  CE2 TYR B2065      78.431  61.059  25.487  1.00 19.12           C  
+ATOM   2837  CZ  TYR B2065      77.427  61.455  26.346  1.00 20.29           C  
+ATOM   2838  OH  TYR B2065      77.490  61.083  27.670  1.00 23.19           O  
+ATOM   2839  N   ILE B2066      77.455  64.560  19.677  1.00 18.21           N  
+ATOM   2840  CA  ILE B2066      77.848  64.746  18.288  1.00 18.83           C  
+ATOM   2841  C   ILE B2066      78.591  66.061  18.101  1.00 20.47           C  
+ATOM   2842  O   ILE B2066      79.628  66.095  17.443  1.00 21.23           O  
+ATOM   2843  CB  ILE B2066      76.617  64.712  17.371  1.00 17.90           C  
+ATOM   2844  CG1 ILE B2066      75.933  63.345  17.500  1.00 15.40           C  
+ATOM   2845  CG2 ILE B2066      77.024  65.014  15.925  1.00 14.35           C  
+ATOM   2846  CD1 ILE B2066      74.558  63.276  16.858  1.00 16.83           C  
+ATOM   2847  N   SER B2067      78.063  67.135  18.688  1.00 21.10           N  
+ATOM   2848  CA  SER B2067      78.683  68.457  18.597  1.00 20.96           C  
+ATOM   2849  C   SER B2067      80.071  68.393  19.185  1.00 19.32           C  
+ATOM   2850  O   SER B2067      81.034  68.871  18.593  1.00 16.52           O  
+ATOM   2851  CB  SER B2067      77.878  69.507  19.375  1.00 21.42           C  
+ATOM   2852  OG  SER B2067      76.621  69.749  18.770  1.00 28.93           O  
+ATOM   2853  N   SER B2068      80.164  67.803  20.368  1.00 20.48           N  
+ATOM   2854  CA  SER B2068      81.446  67.677  21.040  1.00 21.70           C  
+ATOM   2855  C   SER B2068      82.441  66.962  20.131  1.00 21.64           C  
+ATOM   2856  O   SER B2068      83.609  67.327  20.067  1.00 21.18           O  
+ATOM   2857  CB  SER B2068      81.288  66.894  22.340  1.00 19.87           C  
+ATOM   2858  OG  SER B2068      82.529  66.786  23.007  1.00 22.79           O  
+ATOM   2859  N   ASN B2069      81.960  65.947  19.423  1.00 22.57           N  
+ATOM   2860  CA  ASN B2069      82.807  65.173  18.532  1.00 24.88           C  
+ATOM   2861  C   ASN B2069      83.251  65.999  17.319  1.00 23.62           C  
+ATOM   2862  O   ASN B2069      84.398  65.914  16.896  1.00 24.72           O  
+ATOM   2863  CB  ASN B2069      82.061  63.902  18.098  1.00 27.12           C  
+ATOM   2864  CG  ASN B2069      82.887  63.020  17.177  1.00 29.34           C  
+ATOM   2865  OD1 ASN B2069      82.856  63.177  15.957  1.00 31.69           O  
+ATOM   2866  ND2 ASN B2069      83.640  62.092  17.760  1.00 28.80           N  
+ATOM   2867  N   LEU B2070      82.352  66.812  16.776  1.00 23.11           N  
+ATOM   2868  CA  LEU B2070      82.689  67.649  15.623  1.00 23.19           C  
+ATOM   2869  C   LEU B2070      83.701  68.743  15.980  1.00 23.06           C  
+ATOM   2870  O   LEU B2070      84.550  69.103  15.164  1.00 23.77           O  
+ATOM   2871  CB  LEU B2070      81.422  68.284  15.031  1.00 21.00           C  
+ATOM   2872  CG  LEU B2070      80.431  67.332  14.353  1.00 22.87           C  
+ATOM   2873  CD1 LEU B2070      79.126  68.064  14.051  1.00 22.55           C  
+ATOM   2874  CD2 LEU B2070      81.041  66.787  13.071  1.00 21.79           C  
+ATOM   2875  N   ARG B2071      83.612  69.270  17.196  1.00 22.64           N  
+ATOM   2876  CA  ARG B2071      84.526  70.314  17.632  1.00 23.66           C  
+ATOM   2877  C   ARG B2071      85.916  69.744  17.887  1.00 21.59           C  
+ATOM   2878  O   ARG B2071      86.917  70.370  17.553  1.00 19.15           O  
+ATOM   2879  CB  ARG B2071      83.992  70.998  18.898  1.00 26.97           C  
+ATOM   2880  CG  ARG B2071      82.818  71.928  18.628  1.00 34.46           C  
+ATOM   2881  CD  ARG B2071      81.916  72.103  19.843  1.00 40.16           C  
+ATOM   2882  NE  ARG B2071      80.790  72.995  19.553  1.00 46.54           N  
+ATOM   2883  CZ  ARG B2071      79.763  73.206  20.374  1.00 49.33           C  
+ATOM   2884  NH1 ARG B2071      79.704  72.588  21.546  1.00 50.25           N  
+ATOM   2885  NH2 ARG B2071      78.794  74.044  20.024  1.00 51.83           N  
+ATOM   2886  N   ARG B2072      85.976  68.561  18.490  1.00 21.41           N  
+ATOM   2887  CA  ARG B2072      87.263  67.929  18.765  1.00 20.64           C  
+ATOM   2888  C   ARG B2072      87.941  67.649  17.424  1.00 20.76           C  
+ATOM   2889  O   ARG B2072      89.146  67.843  17.274  1.00 18.80           O  
+ATOM   2890  CB  ARG B2072      87.078  66.615  19.539  1.00 20.62           C  
+ATOM   2891  CG  ARG B2072      88.397  65.924  19.888  1.00 20.83           C  
+ATOM   2892  CD  ARG B2072      88.188  64.583  20.555  1.00 20.95           C  
+ATOM   2893  NE  ARG B2072      87.654  63.579  19.639  1.00 22.79           N  
+ATOM   2894  CZ  ARG B2072      87.221  62.382  20.022  1.00 24.04           C  
+ATOM   2895  NH1 ARG B2072      87.256  62.045  21.303  1.00 23.49           N  
+ATOM   2896  NH2 ARG B2072      86.762  61.518  19.126  1.00 25.91           N  
+ATOM   2897  N   GLN B2073      87.142  67.200  16.457  1.00 21.12           N  
+ATOM   2898  CA  GLN B2073      87.631  66.891  15.118  1.00 23.33           C  
+ATOM   2899  C   GLN B2073      88.247  68.151  14.516  1.00 21.60           C  
+ATOM   2900  O   GLN B2073      89.270  68.087  13.836  1.00 21.14           O  
+ATOM   2901  CB  GLN B2073      86.473  66.377  14.244  1.00 26.94           C  
+ATOM   2902  CG  GLN B2073      86.877  65.674  12.946  1.00 32.01           C  
+ATOM   2903  CD  GLN B2073      87.281  66.634  11.831  1.00 37.31           C  
+ATOM   2904  OE1 GLN B2073      86.516  67.531  11.458  1.00 40.26           O  
+ATOM   2905  NE2 GLN B2073      88.485  66.441  11.284  1.00 38.29           N  
+ATOM   2906  N   ALA B2074      87.637  69.301  14.784  1.00 20.71           N  
+ATOM   2907  CA  ALA B2074      88.167  70.559  14.270  1.00 21.33           C  
+ATOM   2908  C   ALA B2074      89.534  70.834  14.881  1.00 20.36           C  
+ATOM   2909  O   ALA B2074      90.483  71.174  14.171  1.00 18.83           O  
+ATOM   2910  CB  ALA B2074      87.213  71.712  14.586  1.00 22.55           C  
+ATOM   2911  N   VAL B2075      89.627  70.677  16.200  1.00 19.62           N  
+ATOM   2912  CA  VAL B2075      90.874  70.913  16.922  1.00 17.96           C  
+ATOM   2913  C   VAL B2075      91.966  69.948  16.493  1.00 18.11           C  
+ATOM   2914  O   VAL B2075      93.128  70.337  16.346  1.00 17.50           O  
+ATOM   2915  CB  VAL B2075      90.676  70.780  18.446  1.00 18.04           C  
+ATOM   2916  CG1 VAL B2075      92.020  70.773  19.148  1.00 15.28           C  
+ATOM   2917  CG2 VAL B2075      89.821  71.932  18.964  1.00 18.90           C  
+ATOM   2918  N   LEU B2076      91.603  68.686  16.310  1.00 17.04           N  
+ATOM   2919  CA  LEU B2076      92.582  67.702  15.890  1.00 20.00           C  
+ATOM   2920  C   LEU B2076      93.023  67.956  14.448  1.00 21.34           C  
+ATOM   2921  O   LEU B2076      94.188  67.776  14.113  1.00 22.77           O  
+ATOM   2922  CB  LEU B2076      92.010  66.287  16.028  1.00 18.50           C  
+ATOM   2923  CG  LEU B2076      91.869  65.831  17.488  1.00 21.10           C  
+ATOM   2924  CD1 LEU B2076      91.141  64.503  17.544  1.00 20.90           C  
+ATOM   2925  CD2 LEU B2076      93.242  65.726  18.136  1.00 18.10           C  
+ATOM   2926  N   GLU B2077      92.095  68.390  13.603  1.00 24.58           N  
+ATOM   2927  CA  GLU B2077      92.421  68.643  12.205  1.00 26.78           C  
+ATOM   2928  C   GLU B2077      93.511  69.689  12.108  1.00 26.77           C  
+ATOM   2929  O   GLU B2077      94.418  69.575  11.288  1.00 27.83           O  
+ATOM   2930  CB  GLU B2077      91.187  69.112  11.441  1.00 27.41           C  
+ATOM   2931  CG  GLU B2077      91.446  69.450   9.981  1.00 31.38           C  
+ATOM   2932  CD  GLU B2077      90.163  69.782   9.241  1.00 33.06           C  
+ATOM   2933  OE1 GLU B2077      89.256  68.922   9.235  1.00 34.95           O  
+ATOM   2934  OE2 GLU B2077      90.059  70.893   8.674  1.00 31.14           O  
+ATOM   2935  N   GLN B2078      93.417  70.703  12.960  1.00 26.79           N  
+ATOM   2936  CA  GLN B2078      94.391  71.778  12.983  1.00 26.65           C  
+ATOM   2937  C   GLN B2078      95.738  71.274  13.493  1.00 26.91           C  
+ATOM   2938  O   GLN B2078      96.779  71.551  12.900  1.00 27.23           O  
+ATOM   2939  CB  GLN B2078      93.893  72.916  13.875  1.00 26.66           C  
+ATOM   2940  CG  GLN B2078      94.836  74.100  13.931  1.00 29.40           C  
+ATOM   2941  CD  GLN B2078      94.351  75.187  14.865  1.00 30.80           C  
+ATOM   2942  OE1 GLN B2078      94.310  75.003  16.084  1.00 31.28           O  
+ATOM   2943  NE2 GLN B2078      93.975  76.329  14.299  1.00 29.34           N  
+ATOM   2944  N   PHE B2079      95.716  70.536  14.598  1.00 26.19           N  
+ATOM   2945  CA  PHE B2079      96.943  69.998  15.176  1.00 26.53           C  
+ATOM   2946  C   PHE B2079      97.619  68.985  14.244  1.00 26.81           C  
+ATOM   2947  O   PHE B2079      98.784  69.140  13.886  1.00 24.56           O  
+ATOM   2948  CB  PHE B2079      96.631  69.329  16.518  1.00 25.09           C  
+ATOM   2949  CG  PHE B2079      97.790  68.582  17.110  1.00 23.89           C  
+ATOM   2950  CD1 PHE B2079      98.912  69.261  17.571  1.00 25.59           C  
+ATOM   2951  CD2 PHE B2079      97.751  67.194  17.226  1.00 25.46           C  
+ATOM   2952  CE1 PHE B2079      99.984  68.566  18.147  1.00 25.73           C  
+ATOM   2953  CE2 PHE B2079      98.810  66.491  17.798  1.00 24.53           C  
+ATOM   2954  CZ  PHE B2079      99.930  67.178  18.260  1.00 25.85           C  
+ATOM   2955  N   LEU B2080      96.871  67.950  13.869  1.00 27.95           N  
+ATOM   2956  CA  LEU B2080      97.372  66.890  12.997  1.00 30.15           C  
+ATOM   2957  C   LEU B2080      97.640  67.409  11.595  1.00 32.75           C  
+ATOM   2958  O   LEU B2080      98.405  66.815  10.850  1.00 33.19           O  
+ATOM   2959  CB  LEU B2080      96.360  65.733  12.924  1.00 26.66           C  
+ATOM   2960  CG  LEU B2080      96.104  64.952  14.222  1.00 25.05           C  
+ATOM   2961  CD1 LEU B2080      94.955  63.971  14.042  1.00 22.51           C  
+ATOM   2962  CD2 LEU B2080      97.369  64.219  14.623  1.00 24.54           C  
+ATOM   2963  N   GLY B2081      97.005  68.519  11.242  1.00 36.05           N  
+ATOM   2964  CA  GLY B2081      97.188  69.081   9.918  1.00 38.97           C  
+ATOM   2965  C   GLY B2081      96.753  68.132   8.813  1.00 41.60           C  
+ATOM   2966  O   GLY B2081      97.404  68.045   7.770  1.00 42.33           O  
+ATOM   2967  N   THR B2082      95.655  67.418   9.027  1.00 42.69           N  
+ATOM   2968  CA  THR B2082      95.178  66.481   8.015  1.00 44.93           C  
+ATOM   2969  C   THR B2082      94.179  67.135   7.074  1.00 47.07           C  
+ATOM   2970  O   THR B2082      93.708  68.249   7.313  1.00 47.34           O  
+ATOM   2971  CB  THR B2082      94.488  65.258   8.645  1.00 45.20           C  
+ATOM   2972  OG1 THR B2082      93.315  65.689   9.349  1.00 44.45           O  
+ATOM   2973  CG2 THR B2082      95.432  64.538   9.602  1.00 43.39           C  
+ATOM   2974  N   ASN B2083      93.858  66.428   5.996  1.00 49.62           N  
+ATOM   2975  CA  ASN B2083      92.908  66.922   5.010  1.00 50.84           C  
+ATOM   2976  C   ASN B2083      91.494  66.750   5.550  1.00 51.84           C  
+ATOM   2977  O   ASN B2083      91.290  66.596   6.757  1.00 52.64           O  
+ATOM   2978  CB  ASN B2083      93.067  66.155   3.700  1.00 50.82           C  
+ATOM   2979  N   GLY B2084      90.519  66.775   4.652  1.00 52.10           N  
+ATOM   2980  CA  GLY B2084      89.140  66.617   5.070  1.00 52.57           C  
+ATOM   2981  C   GLY B2084      88.904  65.314   5.812  1.00 52.45           C  
+ATOM   2982  O   GLY B2084      89.174  65.211   7.011  1.00 53.27           O  
+ATOM   2983  N   GLN B2085      88.415  64.311   5.090  1.00 51.58           N  
+ATOM   2984  CA  GLN B2085      88.116  63.017   5.683  1.00 50.55           C  
+ATOM   2985  C   GLN B2085      86.965  63.200   6.672  1.00 49.21           C  
+ATOM   2986  O   GLN B2085      87.170  63.198   7.892  1.00 50.09           O  
+ATOM   2987  CB  GLN B2085      89.350  62.458   6.399  1.00 52.50           C  
+ATOM   2988  N   ARG B2086      85.762  63.385   6.135  1.00 45.66           N  
+ATOM   2989  CA  ARG B2086      84.564  63.560   6.952  1.00 42.65           C  
+ATOM   2990  C   ARG B2086      84.048  62.179   7.346  1.00 39.65           C  
+ATOM   2991  O   ARG B2086      83.439  61.487   6.539  1.00 40.72           O  
+ATOM   2992  CB  ARG B2086      83.490  64.317   6.161  1.00 42.00           C  
+ATOM   2993  N   ILE B2087      84.304  61.782   8.588  1.00 35.35           N  
+ATOM   2994  CA  ILE B2087      83.870  60.482   9.088  1.00 30.35           C  
+ATOM   2995  C   ILE B2087      82.511  60.608   9.779  1.00 26.68           C  
+ATOM   2996  O   ILE B2087      82.327  61.464  10.640  1.00 26.64           O  
+ATOM   2997  CB  ILE B2087      84.901  59.931  10.092  1.00 29.81           C  
+ATOM   2998  CG1 ILE B2087      86.288  59.920   9.443  1.00 30.08           C  
+ATOM   2999  CG2 ILE B2087      84.516  58.536  10.533  1.00 29.80           C  
+ATOM   3000  CD1 ILE B2087      86.349  59.141   8.143  1.00 25.54           C  
+ATOM   3001  N   PRO B2088      81.544  59.753   9.411  1.00 23.39           N  
+ATOM   3002  CA  PRO B2088      80.205  59.785  10.006  1.00 22.68           C  
+ATOM   3003  C   PRO B2088      80.199  59.430  11.490  1.00 21.87           C  
+ATOM   3004  O   PRO B2088      80.995  58.607  11.954  1.00 20.44           O  
+ATOM   3005  CB  PRO B2088      79.430  58.739   9.201  1.00 24.04           C  
+ATOM   3006  CG  PRO B2088      80.213  58.599   7.930  1.00 26.94           C  
+ATOM   3007  CD  PRO B2088      81.631  58.690   8.397  1.00 23.91           C  
+ATOM   3008  N   TYR B2089      79.307  60.069  12.235  1.00 21.73           N  
+ATOM   3009  CA  TYR B2089      79.159  59.769  13.652  1.00 18.94           C  
+ATOM   3010  C   TYR B2089      78.182  58.612  13.597  1.00 19.49           C  
+ATOM   3011  O   TYR B2089      77.150  58.717  12.930  1.00 19.96           O  
+ATOM   3012  CB  TYR B2089      78.509  60.929  14.389  1.00 16.41           C  
+ATOM   3013  CG  TYR B2089      78.462  60.731  15.880  1.00 14.83           C  
+ATOM   3014  CD1 TYR B2089      79.534  61.112  16.689  1.00 16.06           C  
+ATOM   3015  CD2 TYR B2089      77.338  60.185  16.488  1.00 15.41           C  
+ATOM   3016  CE1 TYR B2089      79.479  60.960  18.068  1.00 16.85           C  
+ATOM   3017  CE2 TYR B2089      77.270  60.024  17.866  1.00 15.76           C  
+ATOM   3018  CZ  TYR B2089      78.344  60.413  18.648  1.00 15.76           C  
+ATOM   3019  OH  TYR B2089      78.280  60.237  20.000  1.00 16.95           O  
+ATOM   3020  N   ILE B2090      78.488  57.519  14.286  1.00 19.56           N  
+ATOM   3021  CA  ILE B2090      77.614  56.352  14.249  1.00 18.50           C  
+ATOM   3022  C   ILE B2090      76.936  56.037  15.585  1.00 17.54           C  
+ATOM   3023  O   ILE B2090      77.588  55.952  16.620  1.00 19.16           O  
+ATOM   3024  CB  ILE B2090      78.406  55.109  13.782  1.00 17.92           C  
+ATOM   3025  CG1 ILE B2090      79.024  55.368  12.403  1.00 16.94           C  
+ATOM   3026  CG2 ILE B2090      77.489  53.889  13.721  1.00 16.14           C  
+ATOM   3027  CD1 ILE B2090      79.757  54.163  11.837  1.00 13.88           C  
+ATOM   3028  N   ILE B2091      75.624  55.850  15.536  1.00 17.01           N  
+ATOM   3029  CA  ILE B2091      74.825  55.529  16.715  1.00 17.28           C  
+ATOM   3030  C   ILE B2091      74.173  54.168  16.495  1.00 16.12           C  
+ATOM   3031  O   ILE B2091      73.516  53.959  15.485  1.00 17.77           O  
+ATOM   3032  CB  ILE B2091      73.694  56.558  16.926  1.00 16.35           C  
+ATOM   3033  CG1 ILE B2091      74.285  57.961  17.072  1.00 14.00           C  
+ATOM   3034  CG2 ILE B2091      72.855  56.166  18.145  1.00 17.61           C  
+ATOM   3035  CD1 ILE B2091      73.248  59.065  17.088  1.00 12.50           C  
+ATOM   3036  N   SER B2092      74.356  53.244  17.429  1.00 16.04           N  
+ATOM   3037  CA  SER B2092      73.748  51.924  17.298  1.00 16.37           C  
+ATOM   3038  C   SER B2092      72.622  51.784  18.322  1.00 16.66           C  
+ATOM   3039  O   SER B2092      72.622  52.458  19.358  1.00 16.28           O  
+ATOM   3040  CB  SER B2092      74.785  50.808  17.497  1.00 14.13           C  
+ATOM   3041  OG  SER B2092      75.229  50.734  18.837  1.00 16.92           O  
+ATOM   3042  N   ILE B2093      71.656  50.927  18.012  1.00 15.77           N  
+ATOM   3043  CA  ILE B2093      70.516  50.708  18.885  1.00 16.27           C  
+ATOM   3044  C   ILE B2093      70.285  49.209  18.987  1.00 17.11           C  
+ATOM   3045  O   ILE B2093      70.000  48.546  17.986  1.00 16.53           O  
+ATOM   3046  CB  ILE B2093      69.260  51.408  18.327  1.00 18.31           C  
+ATOM   3047  CG1 ILE B2093      69.519  52.915  18.229  1.00 19.16           C  
+ATOM   3048  CG2 ILE B2093      68.057  51.129  19.219  1.00 14.69           C  
+ATOM   3049  CD1 ILE B2093      68.425  53.697  17.529  1.00 20.08           C  
+ATOM   3050  N   ALA B2094      70.435  48.689  20.202  1.00 16.15           N  
+ATOM   3051  CA  ALA B2094      70.286  47.271  20.478  1.00 16.89           C  
+ATOM   3052  C   ALA B2094      69.069  46.979  21.352  1.00 18.89           C  
+ATOM   3053  O   ALA B2094      68.390  47.891  21.832  1.00 18.50           O  
+ATOM   3054  CB  ALA B2094      71.550  46.746  21.158  1.00 17.37           C  
+ATOM   3055  N   GLY B2095      68.815  45.692  21.559  1.00 19.94           N  
+ATOM   3056  CA  GLY B2095      67.685  45.274  22.362  1.00 19.64           C  
+ATOM   3057  C   GLY B2095      66.949  44.086  21.764  1.00 19.31           C  
+ATOM   3058  O   GLY B2095      67.191  43.673  20.626  1.00 17.30           O  
+ATOM   3059  N   SER B2096      66.032  43.539  22.549  1.00 19.77           N  
+ATOM   3060  CA  SER B2096      65.235  42.395  22.139  1.00 19.86           C  
+ATOM   3061  C   SER B2096      64.435  42.613  20.866  1.00 20.45           C  
+ATOM   3062  O   SER B2096      64.120  43.747  20.481  1.00 19.50           O  
+ATOM   3063  CB  SER B2096      64.247  42.018  23.248  1.00 20.31           C  
+ATOM   3064  OG  SER B2096      63.303  41.072  22.777  1.00 19.30           O  
+ATOM   3065  N   VAL B2097      64.116  41.507  20.210  1.00 20.04           N  
+ATOM   3066  CA  VAL B2097      63.281  41.556  19.026  1.00 21.29           C  
+ATOM   3067  C   VAL B2097      61.953  42.094  19.569  1.00 20.69           C  
+ATOM   3068  O   VAL B2097      61.513  41.685  20.647  1.00 22.30           O  
+ATOM   3069  CB  VAL B2097      63.064  40.127  18.437  1.00 22.11           C  
+ATOM   3070  CG1 VAL B2097      61.921  40.137  17.418  1.00 21.46           C  
+ATOM   3071  CG2 VAL B2097      64.356  39.633  17.778  1.00 20.03           C  
+ATOM   3072  N   ALA B2098      61.353  43.037  18.850  1.00 20.01           N  
+ATOM   3073  CA  ALA B2098      60.073  43.629  19.228  1.00 19.53           C  
+ATOM   3074  C   ALA B2098      60.075  44.607  20.399  1.00 20.02           C  
+ATOM   3075  O   ALA B2098      59.001  44.975  20.880  1.00 18.92           O  
+ATOM   3076  CB  ALA B2098      59.055  42.533  19.498  1.00 20.27           C  
+ATOM   3077  N   VAL B2099      61.246  45.039  20.864  1.00 18.20           N  
+ATOM   3078  CA  VAL B2099      61.262  45.991  21.969  1.00 19.36           C  
+ATOM   3079  C   VAL B2099      60.962  47.404  21.467  1.00 20.68           C  
+ATOM   3080  O   VAL B2099      60.520  48.260  22.238  1.00 21.69           O  
+ATOM   3081  CB  VAL B2099      62.624  46.017  22.715  1.00 20.58           C  
+ATOM   3082  CG1 VAL B2099      63.710  46.608  21.824  1.00 15.74           C  
+ATOM   3083  CG2 VAL B2099      62.482  46.821  24.001  1.00 17.04           C  
+ATOM   3084  N   GLY B2100      61.201  47.640  20.177  1.00 20.34           N  
+ATOM   3085  CA  GLY B2100      60.946  48.950  19.602  1.00 20.84           C  
+ATOM   3086  C   GLY B2100      62.162  49.662  19.033  1.00 21.17           C  
+ATOM   3087  O   GLY B2100      62.178  50.894  18.962  1.00 21.89           O  
+ATOM   3088  N   LYS B2101      63.175  48.895  18.629  1.00 20.56           N  
+ATOM   3089  CA  LYS B2101      64.399  49.460  18.065  1.00 19.84           C  
+ATOM   3090  C   LYS B2101      64.128  50.230  16.785  1.00 21.23           C  
+ATOM   3091  O   LYS B2101      64.612  51.346  16.612  1.00 22.04           O  
+ATOM   3092  CB  LYS B2101      65.419  48.355  17.752  1.00 19.01           C  
+ATOM   3093  CG  LYS B2101      65.930  47.586  18.967  1.00 17.16           C  
+ATOM   3094  CD  LYS B2101      67.004  46.575  18.584  1.00 16.77           C  
+ATOM   3095  CE  LYS B2101      66.482  45.544  17.578  1.00 17.09           C  
+ATOM   3096  NZ  LYS B2101      65.313  44.783  18.110  1.00 17.84           N  
+ATOM   3097  N   SER B2102      63.361  49.622  15.885  1.00 22.57           N  
+ATOM   3098  CA  SER B2102      63.055  50.246  14.608  1.00 24.55           C  
+ATOM   3099  C   SER B2102      62.315  51.564  14.771  1.00 24.08           C  
+ATOM   3100  O   SER B2102      62.618  52.542  14.080  1.00 24.59           O  
+ATOM   3101  CB  SER B2102      62.234  49.297  13.741  1.00 24.76           C  
+ATOM   3102  OG  SER B2102      62.029  49.877  12.470  1.00 29.04           O  
+ATOM   3103  N   THR B2103      61.341  51.588  15.675  1.00 22.27           N  
+ATOM   3104  CA  THR B2103      60.583  52.808  15.928  1.00 22.80           C  
+ATOM   3105  C   THR B2103      61.496  53.858  16.565  1.00 21.77           C  
+ATOM   3106  O   THR B2103      61.495  55.021  16.163  1.00 23.51           O  
+ATOM   3107  CB  THR B2103      59.378  52.540  16.866  1.00 22.39           C  
+ATOM   3108  OG1 THR B2103      58.422  51.720  16.189  1.00 25.92           O  
+ATOM   3109  CG2 THR B2103      58.698  53.842  17.254  1.00 22.71           C  
+ATOM   3110  N   THR B2104      62.282  53.443  17.554  1.00 21.34           N  
+ATOM   3111  CA  THR B2104      63.195  54.356  18.235  1.00 21.13           C  
+ATOM   3112  C   THR B2104      64.199  54.962  17.249  1.00 20.19           C  
+ATOM   3113  O   THR B2104      64.449  56.173  17.248  1.00 20.51           O  
+ATOM   3114  CB  THR B2104      63.960  53.628  19.352  1.00 20.37           C  
+ATOM   3115  OG1 THR B2104      63.020  53.081  20.279  1.00 22.83           O  
+ATOM   3116  CG2 THR B2104      64.895  54.580  20.083  1.00 18.04           C  
+ATOM   3117  N   ALA B2105      64.768  54.113  16.407  1.00 19.99           N  
+ATOM   3118  CA  ALA B2105      65.740  54.559  15.415  1.00 19.24           C  
+ATOM   3119  C   ALA B2105      65.150  55.613  14.491  1.00 19.42           C  
+ATOM   3120  O   ALA B2105      65.718  56.694  14.311  1.00 18.10           O  
+ATOM   3121  CB  ALA B2105      66.223  53.376  14.599  1.00 17.89           C  
+ATOM   3122  N   ARG B2106      63.998  55.293  13.911  1.00 20.13           N  
+ATOM   3123  CA  ARG B2106      63.340  56.200  12.986  1.00 21.23           C  
+ATOM   3124  C   ARG B2106      62.923  57.508  13.643  1.00 20.48           C  
+ATOM   3125  O   ARG B2106      62.972  58.560  13.006  1.00 19.34           O  
+ATOM   3126  CB  ARG B2106      62.147  55.492  12.324  1.00 24.08           C  
+ATOM   3127  CG  ARG B2106      62.599  54.371  11.383  1.00 28.11           C  
+ATOM   3128  CD  ARG B2106      61.489  53.394  11.090  1.00 30.77           C  
+ATOM   3129  NE  ARG B2106      60.447  54.006  10.280  1.00 38.88           N  
+ATOM   3130  CZ  ARG B2106      59.201  53.551  10.193  1.00 39.86           C  
+ATOM   3131  NH1 ARG B2106      58.834  52.471  10.876  1.00 40.38           N  
+ATOM   3132  NH2 ARG B2106      58.323  54.176   9.416  1.00 41.11           N  
+ATOM   3133  N   VAL B2107      62.511  57.450  14.909  1.00 19.33           N  
+ATOM   3134  CA  VAL B2107      62.129  58.663  15.619  1.00 18.47           C  
+ATOM   3135  C   VAL B2107      63.385  59.524  15.797  1.00 19.25           C  
+ATOM   3136  O   VAL B2107      63.365  60.727  15.533  1.00 19.42           O  
+ATOM   3137  CB  VAL B2107      61.519  58.353  17.018  1.00 21.48           C  
+ATOM   3138  CG1 VAL B2107      61.417  59.632  17.833  1.00 19.34           C  
+ATOM   3139  CG2 VAL B2107      60.126  57.737  16.869  1.00 16.86           C  
+ATOM   3140  N   LEU B2108      64.477  58.900  16.234  1.00 18.30           N  
+ATOM   3141  CA  LEU B2108      65.733  59.614  16.435  1.00 19.35           C  
+ATOM   3142  C   LEU B2108      66.283  60.162  15.126  1.00 18.80           C  
+ATOM   3143  O   LEU B2108      66.898  61.223  15.110  1.00 19.05           O  
+ATOM   3144  CB  LEU B2108      66.784  58.708  17.089  1.00 18.17           C  
+ATOM   3145  CG  LEU B2108      66.487  58.363  18.550  1.00 20.53           C  
+ATOM   3146  CD1 LEU B2108      67.605  57.481  19.108  1.00 18.57           C  
+ATOM   3147  CD2 LEU B2108      66.353  59.652  19.360  1.00 18.39           C  
+ATOM   3148  N   GLN B2109      66.071  59.441  14.032  1.00 18.50           N  
+ATOM   3149  CA  GLN B2109      66.540  59.904  12.728  1.00 22.02           C  
+ATOM   3150  C   GLN B2109      65.821  61.205  12.360  1.00 22.72           C  
+ATOM   3151  O   GLN B2109      66.433  62.161  11.878  1.00 21.48           O  
+ATOM   3152  CB  GLN B2109      66.264  58.847  11.660  1.00 22.60           C  
+ATOM   3153  CG  GLN B2109      66.447  59.339  10.238  1.00 24.46           C  
+ATOM   3154  CD  GLN B2109      66.251  58.235   9.219  1.00 25.79           C  
+ATOM   3155  OE1 GLN B2109      65.237  57.530   9.238  1.00 27.51           O  
+ATOM   3156  NE2 GLN B2109      67.218  58.079   8.321  1.00 23.94           N  
+ATOM   3157  N   ALA B2110      64.518  61.231  12.611  1.00 23.31           N  
+ATOM   3158  CA  ALA B2110      63.696  62.400  12.323  1.00 24.65           C  
+ATOM   3159  C   ALA B2110      64.092  63.591  13.198  1.00 25.81           C  
+ATOM   3160  O   ALA B2110      64.289  64.699  12.702  1.00 27.06           O  
+ATOM   3161  CB  ALA B2110      62.225  62.060  12.541  1.00 23.44           C  
+ATOM   3162  N   LEU B2111      64.214  63.366  14.502  1.00 25.43           N  
+ATOM   3163  CA  LEU B2111      64.574  64.440  15.416  1.00 24.84           C  
+ATOM   3164  C   LEU B2111      65.982  64.996  15.197  1.00 26.35           C  
+ATOM   3165  O   LEU B2111      66.184  66.213  15.224  1.00 27.07           O  
+ATOM   3166  CB  LEU B2111      64.413  63.968  16.859  1.00 22.81           C  
+ATOM   3167  CG  LEU B2111      62.982  63.529  17.208  1.00 25.52           C  
+ATOM   3168  CD1 LEU B2111      62.913  63.091  18.661  1.00 22.48           C  
+ATOM   3169  CD2 LEU B2111      62.005  64.681  16.952  1.00 24.26           C  
+ATOM   3170  N   LEU B2112      66.959  64.122  14.982  1.00 26.10           N  
+ATOM   3171  CA  LEU B2112      68.326  64.589  14.766  1.00 26.97           C  
+ATOM   3172  C   LEU B2112      68.430  65.427  13.497  1.00 28.32           C  
+ATOM   3173  O   LEU B2112      69.360  66.218  13.344  1.00 28.51           O  
+ATOM   3174  CB  LEU B2112      69.297  63.406  14.706  1.00 25.86           C  
+ATOM   3175  CG  LEU B2112      69.584  62.750  16.065  1.00 24.83           C  
+ATOM   3176  CD1 LEU B2112      70.278  61.410  15.875  1.00 25.59           C  
+ATOM   3177  CD2 LEU B2112      70.436  63.692  16.910  1.00 22.84           C  
+ATOM   3178  N   SER B2113      67.464  65.264  12.597  1.00 28.84           N  
+ATOM   3179  CA  SER B2113      67.444  66.024  11.350  1.00 31.26           C  
+ATOM   3180  C   SER B2113      67.102  67.496  11.580  1.00 30.96           C  
+ATOM   3181  O   SER B2113      67.291  68.326  10.693  1.00 31.32           O  
+ATOM   3182  CB  SER B2113      66.429  65.420  10.365  1.00 31.63           C  
+ATOM   3183  OG  SER B2113      66.932  64.239   9.764  1.00 35.27           O  
+ATOM   3184  N   ARG B2114      66.605  67.813  12.771  1.00 29.10           N  
+ATOM   3185  CA  ARG B2114      66.231  69.183  13.108  1.00 28.41           C  
+ATOM   3186  C   ARG B2114      67.411  70.164  13.113  1.00 28.27           C  
+ATOM   3187  O   ARG B2114      67.241  71.353  12.824  1.00 27.47           O  
+ATOM   3188  CB  ARG B2114      65.526  69.198  14.469  1.00 28.96           C  
+ATOM   3189  CG  ARG B2114      64.115  68.637  14.425  1.00 31.57           C  
+ATOM   3190  CD  ARG B2114      63.645  68.153  15.790  1.00 36.82           C  
+ATOM   3191  NE  ARG B2114      63.800  69.156  16.839  1.00 38.58           N  
+ATOM   3192  CZ  ARG B2114      63.164  70.320  16.859  1.00 41.19           C  
+ATOM   3193  NH1 ARG B2114      62.325  70.635  15.884  1.00 42.58           N  
+ATOM   3194  NH2 ARG B2114      63.369  71.171  17.854  1.00 43.49           N  
+ATOM   3195  N   TRP B2115      68.598  69.669  13.450  1.00 26.00           N  
+ATOM   3196  CA  TRP B2115      69.789  70.506  13.485  1.00 26.30           C  
+ATOM   3197  C   TRP B2115      70.339  70.700  12.082  1.00 28.28           C  
+ATOM   3198  O   TRP B2115      70.472  69.742  11.326  1.00 28.03           O  
+ATOM   3199  CB  TRP B2115      70.870  69.866  14.357  1.00 24.11           C  
+ATOM   3200  CG  TRP B2115      70.672  70.056  15.824  1.00 24.02           C  
+ATOM   3201  CD1 TRP B2115      71.219  71.033  16.609  1.00 23.15           C  
+ATOM   3202  CD2 TRP B2115      69.854  69.258  16.688  1.00 24.07           C  
+ATOM   3203  NE1 TRP B2115      70.793  70.890  17.906  1.00 23.24           N  
+ATOM   3204  CE2 TRP B2115      69.951  69.812  17.984  1.00 23.37           C  
+ATOM   3205  CE3 TRP B2115      69.044  68.131  16.493  1.00 23.06           C  
+ATOM   3206  CZ2 TRP B2115      69.269  69.274  19.082  1.00 22.99           C  
+ATOM   3207  CZ3 TRP B2115      68.366  67.599  17.585  1.00 23.29           C  
+ATOM   3208  CH2 TRP B2115      68.482  68.172  18.860  1.00 21.97           C  
+ATOM   3209  N   PRO B2116      70.668  71.948  11.718  1.00 30.02           N  
+ATOM   3210  CA  PRO B2116      71.214  72.263  10.393  1.00 32.59           C  
+ATOM   3211  C   PRO B2116      72.489  71.475  10.093  1.00 33.37           C  
+ATOM   3212  O   PRO B2116      72.787  71.189   8.941  1.00 35.24           O  
+ATOM   3213  CB  PRO B2116      71.477  73.766  10.479  1.00 31.99           C  
+ATOM   3214  CG  PRO B2116      70.407  74.233  11.415  1.00 30.74           C  
+ATOM   3215  CD  PRO B2116      70.437  73.180  12.493  1.00 30.01           C  
+ATOM   3216  N   GLU B2117      73.239  71.132  11.136  1.00 35.58           N  
+ATOM   3217  CA  GLU B2117      74.482  70.383  10.972  1.00 37.97           C  
+ATOM   3218  C   GLU B2117      74.268  68.949  10.498  1.00 38.19           C  
+ATOM   3219  O   GLU B2117      75.111  68.393   9.797  1.00 40.67           O  
+ATOM   3220  CB  GLU B2117      75.270  70.331  12.283  1.00 39.49           C  
+ATOM   3221  CG  GLU B2117      75.860  71.648  12.743  1.00 42.70           C  
+ATOM   3222  CD  GLU B2117      74.805  72.644  13.164  1.00 43.92           C  
+ATOM   3223  OE1 GLU B2117      73.886  72.253  13.919  1.00 41.81           O  
+ATOM   3224  OE2 GLU B2117      74.906  73.819  12.745  1.00 45.91           O  
+ATOM   3225  N   HIS B2118      73.149  68.341  10.877  1.00 36.64           N  
+ATOM   3226  CA  HIS B2118      72.891  66.963  10.481  1.00 34.40           C  
+ATOM   3227  C   HIS B2118      72.095  66.852   9.184  1.00 33.96           C  
+ATOM   3228  O   HIS B2118      70.940  66.428   9.169  1.00 33.72           O  
+ATOM   3229  CB  HIS B2118      72.202  66.227  11.633  1.00 30.51           C  
+ATOM   3230  CG  HIS B2118      72.857  66.465  12.962  1.00 26.17           C  
+ATOM   3231  ND1 HIS B2118      74.217  66.673  13.088  1.00 25.24           N  
+ATOM   3232  CD2 HIS B2118      72.341  66.569  14.206  1.00 23.55           C  
+ATOM   3233  CE1 HIS B2118      74.504  66.904  14.356  1.00 22.77           C  
+ATOM   3234  NE2 HIS B2118      73.388  66.847  15.058  1.00 24.11           N  
+ATOM   3235  N   ARG B2119      72.748  67.223   8.088  1.00 34.93           N  
+ATOM   3236  CA  ARG B2119      72.136  67.189   6.764  1.00 34.34           C  
+ATOM   3237  C   ARG B2119      71.785  65.768   6.321  1.00 34.43           C  
+ATOM   3238  O   ARG B2119      70.754  65.548   5.690  1.00 35.51           O  
+ATOM   3239  CB  ARG B2119      73.077  67.840   5.745  1.00 34.83           C  
+ATOM   3240  N   ARG B2120      72.633  64.800   6.654  1.00 32.82           N  
+ATOM   3241  CA  ARG B2120      72.368  63.430   6.252  1.00 30.53           C  
+ATOM   3242  C   ARG B2120      72.413  62.446   7.410  1.00 29.37           C  
+ATOM   3243  O   ARG B2120      73.480  62.181   7.981  1.00 28.03           O  
+ATOM   3244  CB  ARG B2120      73.355  63.009   5.165  1.00 31.26           C  
+ATOM   3245  N   VAL B2121      71.239  61.922   7.754  1.00 26.38           N  
+ATOM   3246  CA  VAL B2121      71.104  60.950   8.824  1.00 25.06           C  
+ATOM   3247  C   VAL B2121      70.608  59.657   8.199  1.00 26.45           C  
+ATOM   3248  O   VAL B2121      69.456  59.562   7.768  1.00 26.24           O  
+ATOM   3249  CB  VAL B2121      70.100  61.421   9.899  1.00 24.65           C  
+ATOM   3250  CG1 VAL B2121      70.048  60.414  11.032  1.00 21.62           C  
+ATOM   3251  CG2 VAL B2121      70.513  62.793  10.433  1.00 22.05           C  
+ATOM   3252  N   GLU B2122      71.486  58.662   8.138  1.00 26.80           N  
+ATOM   3253  CA  GLU B2122      71.140  57.377   7.539  1.00 29.09           C  
+ATOM   3254  C   GLU B2122      70.730  56.330   8.560  1.00 27.94           C  
+ATOM   3255  O   GLU B2122      71.187  56.345   9.703  1.00 27.20           O  
+ATOM   3256  CB  GLU B2122      72.318  56.851   6.716  1.00 31.20           C  
+ATOM   3257  CG  GLU B2122      72.506  57.567   5.390  1.00 37.32           C  
+ATOM   3258  CD  GLU B2122      71.585  57.040   4.299  1.00 41.82           C  
+ATOM   3259  OE1 GLU B2122      71.516  57.680   3.229  1.00 42.61           O  
+ATOM   3260  OE2 GLU B2122      70.943  55.982   4.503  1.00 44.88           O  
+ATOM   3261  N   LEU B2123      69.871  55.412   8.136  1.00 26.62           N  
+ATOM   3262  CA  LEU B2123      69.417  54.352   9.017  1.00 27.13           C  
+ATOM   3263  C   LEU B2123      69.664  53.003   8.361  1.00 26.38           C  
+ATOM   3264  O   LEU B2123      69.203  52.761   7.250  1.00 25.47           O  
+ATOM   3265  CB  LEU B2123      67.929  54.519   9.310  1.00 29.38           C  
+ATOM   3266  CG  LEU B2123      67.387  53.754  10.515  1.00 31.21           C  
+ATOM   3267  CD1 LEU B2123      65.941  54.166  10.758  1.00 33.70           C  
+ATOM   3268  CD2 LEU B2123      67.492  52.270  10.280  1.00 32.46           C  
+ATOM   3269  N   ILE B2124      70.398  52.132   9.047  1.00 25.30           N  
+ATOM   3270  CA  ILE B2124      70.692  50.802   8.524  1.00 24.34           C  
+ATOM   3271  C   ILE B2124      70.381  49.775   9.604  1.00 25.06           C  
+ATOM   3272  O   ILE B2124      70.730  49.964  10.766  1.00 25.18           O  
+ATOM   3273  CB  ILE B2124      72.181  50.666   8.123  1.00 23.32           C  
+ATOM   3274  CG1 ILE B2124      72.505  51.627   6.982  1.00 23.27           C  
+ATOM   3275  CG2 ILE B2124      72.486  49.240   7.707  1.00 20.45           C  
+ATOM   3276  CD1 ILE B2124      71.787  51.315   5.698  1.00 22.78           C  
+ATOM   3277  N   THR B2125      69.706  48.696   9.228  1.00 25.07           N  
+ATOM   3278  CA  THR B2125      69.373  47.652  10.190  1.00 25.80           C  
+ATOM   3279  C   THR B2125      70.282  46.457   9.916  1.00 25.15           C  
+ATOM   3280  O   THR B2125      70.739  46.273   8.786  1.00 23.81           O  
+ATOM   3281  CB  THR B2125      67.897  47.225  10.049  1.00 28.09           C  
+ATOM   3282  OG1 THR B2125      67.701  46.586   8.782  1.00 29.16           O  
+ATOM   3283  CG2 THR B2125      66.985  48.446  10.131  1.00 30.34           C  
+ATOM   3284  N   THR B2126      70.551  45.648  10.934  1.00 23.47           N  
+ATOM   3285  CA  THR B2126      71.423  44.501  10.733  1.00 24.94           C  
+ATOM   3286  C   THR B2126      70.688  43.303  10.133  1.00 24.59           C  
+ATOM   3287  O   THR B2126      71.315  42.299   9.788  1.00 22.77           O  
+ATOM   3288  CB  THR B2126      72.111  44.070  12.051  1.00 24.87           C  
+ATOM   3289  OG1 THR B2126      71.126  43.652  13.003  1.00 25.91           O  
+ATOM   3290  CG2 THR B2126      72.897  45.232  12.632  1.00 25.09           C  
+ATOM   3291  N   ASP B2127      69.366  43.417  10.003  1.00 24.61           N  
+ATOM   3292  CA  ASP B2127      68.555  42.343   9.426  1.00 25.72           C  
+ATOM   3293  C   ASP B2127      69.069  41.979   8.048  1.00 25.23           C  
+ATOM   3294  O   ASP B2127      69.025  40.818   7.649  1.00 25.08           O  
+ATOM   3295  CB  ASP B2127      67.088  42.758   9.278  1.00 28.82           C  
+ATOM   3296  CG  ASP B2127      66.381  42.908  10.607  1.00 30.90           C  
+ATOM   3297  OD1 ASP B2127      66.789  42.240  11.581  1.00 33.69           O  
+ATOM   3298  OD2 ASP B2127      65.408  43.686  10.669  1.00 32.26           O  
+ATOM   3299  N   GLY B2128      69.551  42.987   7.329  1.00 25.31           N  
+ATOM   3300  CA  GLY B2128      70.061  42.777   5.988  1.00 24.68           C  
+ATOM   3301  C   GLY B2128      71.332  41.956   5.923  1.00 25.63           C  
+ATOM   3302  O   GLY B2128      71.655  41.420   4.866  1.00 26.46           O  
+ATOM   3303  N   PHE B2129      72.050  41.847   7.038  1.00 23.66           N  
+ATOM   3304  CA  PHE B2129      73.286  41.082   7.059  1.00 24.29           C  
+ATOM   3305  C   PHE B2129      73.093  39.608   7.408  1.00 24.85           C  
+ATOM   3306  O   PHE B2129      74.061  38.834   7.468  1.00 24.49           O  
+ATOM   3307  CB  PHE B2129      74.300  41.739   8.006  1.00 23.60           C  
+ATOM   3308  CG  PHE B2129      74.772  43.083   7.531  1.00 21.74           C  
+ATOM   3309  CD1 PHE B2129      73.971  44.209   7.681  1.00 22.51           C  
+ATOM   3310  CD2 PHE B2129      75.985  43.211   6.867  1.00 21.56           C  
+ATOM   3311  CE1 PHE B2129      74.368  45.445   7.172  1.00 22.64           C  
+ATOM   3312  CE2 PHE B2129      76.392  44.436   6.355  1.00 21.84           C  
+ATOM   3313  CZ  PHE B2129      75.578  45.558   6.507  1.00 24.08           C  
+ATOM   3314  N   LEU B2130      71.846  39.213   7.644  1.00 24.60           N  
+ATOM   3315  CA  LEU B2130      71.556  37.813   7.930  1.00 23.95           C  
+ATOM   3316  C   LEU B2130      71.900  37.045   6.651  1.00 25.06           C  
+ATOM   3317  O   LEU B2130      71.850  37.612   5.551  1.00 23.40           O  
+ATOM   3318  CB  LEU B2130      70.070  37.618   8.222  1.00 23.26           C  
+ATOM   3319  CG  LEU B2130      69.447  38.088   9.534  1.00 22.18           C  
+ATOM   3320  CD1 LEU B2130      67.933  38.006   9.410  1.00 23.03           C  
+ATOM   3321  CD2 LEU B2130      69.937  37.230  10.689  1.00 20.22           C  
+ATOM   3322  N   HIS B2131      72.263  35.772   6.787  1.00 26.54           N  
+ATOM   3323  CA  HIS B2131      72.559  34.958   5.615  1.00 26.71           C  
+ATOM   3324  C   HIS B2131      71.210  34.742   4.926  1.00 28.15           C  
+ATOM   3325  O   HIS B2131      70.178  34.652   5.593  1.00 27.63           O  
+ATOM   3326  CB  HIS B2131      73.121  33.597   6.026  1.00 26.28           C  
+ATOM   3327  CG  HIS B2131      74.474  33.655   6.666  1.00 27.16           C  
+ATOM   3328  ND1 HIS B2131      75.607  34.044   5.981  1.00 27.04           N  
+ATOM   3329  CD2 HIS B2131      74.882  33.317   7.911  1.00 25.05           C  
+ATOM   3330  CE1 HIS B2131      76.654  33.937   6.778  1.00 25.26           C  
+ATOM   3331  NE2 HIS B2131      76.244  33.498   7.954  1.00 24.72           N  
+ATOM   3332  N   PRO B2132      71.194  34.668   3.586  1.00 29.04           N  
+ATOM   3333  CA  PRO B2132      69.922  34.453   2.887  1.00 30.07           C  
+ATOM   3334  C   PRO B2132      69.295  33.133   3.340  1.00 30.52           C  
+ATOM   3335  O   PRO B2132      69.991  32.260   3.862  1.00 30.12           O  
+ATOM   3336  CB  PRO B2132      70.340  34.414   1.420  1.00 29.96           C  
+ATOM   3337  CG  PRO B2132      71.546  35.313   1.390  1.00 30.54           C  
+ATOM   3338  CD  PRO B2132      72.293  34.891   2.633  1.00 29.31           C  
+ATOM   3339  N   ASN B2133      67.987  32.989   3.149  1.00 31.20           N  
+ATOM   3340  CA  ASN B2133      67.299  31.762   3.548  1.00 32.09           C  
+ATOM   3341  C   ASN B2133      67.949  30.518   2.944  1.00 33.77           C  
+ATOM   3342  O   ASN B2133      67.991  29.462   3.579  1.00 33.95           O  
+ATOM   3343  CB  ASN B2133      65.824  31.809   3.142  1.00 30.71           C  
+ATOM   3344  CG  ASN B2133      65.008  32.732   4.018  1.00 30.30           C  
+ATOM   3345  OD1 ASN B2133      65.473  33.191   5.062  1.00 27.61           O  
+ATOM   3346  ND2 ASN B2133      63.776  33.003   3.601  1.00 30.21           N  
+ATOM   3347  N   GLN B2134      68.456  30.641   1.722  1.00 34.04           N  
+ATOM   3348  CA  GLN B2134      69.094  29.507   1.072  1.00 35.39           C  
+ATOM   3349  C   GLN B2134      70.244  28.983   1.927  1.00 34.97           C  
+ATOM   3350  O   GLN B2134      70.366  27.776   2.158  1.00 33.76           O  
+ATOM   3351  CB  GLN B2134      69.626  29.903  -0.304  1.00 38.69           C  
+ATOM   3352  CG  GLN B2134      69.928  28.697  -1.192  1.00 42.74           C  
+ATOM   3353  CD  GLN B2134      71.265  28.801  -1.899  1.00 45.89           C  
+ATOM   3354  OE1 GLN B2134      72.324  28.708  -1.267  1.00 47.01           O  
+ATOM   3355  NE2 GLN B2134      71.227  29.001  -3.217  1.00 46.54           N  
+ATOM   3356  N   VAL B2135      71.084  29.900   2.400  1.00 33.87           N  
+ATOM   3357  CA  VAL B2135      72.226  29.539   3.231  1.00 31.00           C  
+ATOM   3358  C   VAL B2135      71.794  29.024   4.599  1.00 30.65           C  
+ATOM   3359  O   VAL B2135      72.289  28.005   5.071  1.00 30.90           O  
+ATOM   3360  CB  VAL B2135      73.170  30.739   3.422  1.00 30.03           C  
+ATOM   3361  CG1 VAL B2135      74.339  30.343   4.291  1.00 27.54           C  
+ATOM   3362  CG2 VAL B2135      73.664  31.231   2.067  1.00 30.44           C  
+ATOM   3363  N   LEU B2136      70.862  29.724   5.232  1.00 30.61           N  
+ATOM   3364  CA  LEU B2136      70.385  29.322   6.546  1.00 30.64           C  
+ATOM   3365  C   LEU B2136      69.856  27.894   6.549  1.00 32.82           C  
+ATOM   3366  O   LEU B2136      70.130  27.120   7.472  1.00 32.43           O  
+ATOM   3367  CB  LEU B2136      69.285  30.271   7.018  1.00 28.84           C  
+ATOM   3368  CG  LEU B2136      69.702  31.720   7.271  1.00 28.00           C  
+ATOM   3369  CD1 LEU B2136      68.454  32.549   7.521  1.00 26.69           C  
+ATOM   3370  CD2 LEU B2136      70.662  31.791   8.455  1.00 23.03           C  
+ATOM   3371  N   LYS B2137      69.086  27.556   5.519  1.00 35.53           N  
+ATOM   3372  CA  LYS B2137      68.505  26.227   5.392  1.00 37.06           C  
+ATOM   3373  C   LYS B2137      69.597  25.176   5.251  1.00 39.02           C  
+ATOM   3374  O   LYS B2137      69.528  24.119   5.883  1.00 39.60           O  
+ATOM   3375  CB  LYS B2137      67.576  26.175   4.183  1.00 38.16           C  
+ATOM   3376  CG  LYS B2137      66.818  24.869   4.033  1.00 40.34           C  
+ATOM   3377  CD  LYS B2137      66.042  24.859   2.727  1.00 42.82           C  
+ATOM   3378  CE  LYS B2137      65.431  23.502   2.428  1.00 43.40           C  
+ATOM   3379  NZ  LYS B2137      64.744  23.528   1.103  1.00 44.24           N  
+ATOM   3380  N   GLU B2138      70.603  25.463   4.426  1.00 39.47           N  
+ATOM   3381  CA  GLU B2138      71.709  24.526   4.231  1.00 40.06           C  
+ATOM   3382  C   GLU B2138      72.385  24.257   5.565  1.00 39.17           C  
+ATOM   3383  O   GLU B2138      72.766  23.123   5.864  1.00 40.19           O  
+ATOM   3384  CB  GLU B2138      72.749  25.097   3.265  1.00 41.77           C  
+ATOM   3385  CG  GLU B2138      72.218  25.424   1.880  1.00 46.45           C  
+ATOM   3386  CD  GLU B2138      73.271  26.069   0.990  1.00 50.04           C  
+ATOM   3387  OE1 GLU B2138      73.885  27.076   1.419  1.00 51.35           O  
+ATOM   3388  OE2 GLU B2138      73.483  25.575  -0.140  1.00 51.97           O  
+ATOM   3389  N   ARG B2139      72.525  25.310   6.367  1.00 37.47           N  
+ATOM   3390  CA  ARG B2139      73.179  25.206   7.666  1.00 34.85           C  
+ATOM   3391  C   ARG B2139      72.222  24.846   8.790  1.00 33.64           C  
+ATOM   3392  O   ARG B2139      72.598  24.871   9.955  1.00 34.69           O  
+ATOM   3393  CB  ARG B2139      73.895  26.519   7.990  1.00 34.01           C  
+ATOM   3394  CG  ARG B2139      74.923  26.907   6.944  1.00 34.40           C  
+ATOM   3395  CD  ARG B2139      75.710  28.148   7.325  1.00 32.39           C  
+ATOM   3396  NE  ARG B2139      76.567  28.578   6.225  1.00 31.16           N  
+ATOM   3397  CZ  ARG B2139      77.328  29.666   6.247  1.00 32.26           C  
+ATOM   3398  NH1 ARG B2139      77.345  30.446   7.320  1.00 32.17           N  
+ATOM   3399  NH2 ARG B2139      78.066  29.980   5.192  1.00 31.87           N  
+ATOM   3400  N   GLY B2140      70.987  24.512   8.435  1.00 33.30           N  
+ATOM   3401  CA  GLY B2140      69.999  24.133   9.431  1.00 32.55           C  
+ATOM   3402  C   GLY B2140      69.761  25.206  10.474  1.00 33.40           C  
+ATOM   3403  O   GLY B2140      69.625  24.914  11.667  1.00 32.17           O  
+ATOM   3404  N   LEU B2141      69.684  26.452  10.021  1.00 33.88           N  
+ATOM   3405  CA  LEU B2141      69.480  27.575  10.926  1.00 33.97           C  
+ATOM   3406  C   LEU B2141      68.214  28.370  10.612  1.00 34.95           C  
+ATOM   3407  O   LEU B2141      68.073  29.508  11.060  1.00 35.11           O  
+ATOM   3408  CB  LEU B2141      70.683  28.512  10.847  1.00 32.58           C  
+ATOM   3409  CG  LEU B2141      72.063  27.959  11.193  1.00 31.36           C  
+ATOM   3410  CD1 LEU B2141      73.113  29.046  10.979  1.00 29.08           C  
+ATOM   3411  CD2 LEU B2141      72.066  27.474  12.645  1.00 30.62           C  
+ATOM   3412  N   MET B2142      67.290  27.779   9.859  1.00 35.57           N  
+ATOM   3413  CA  MET B2142      66.067  28.488   9.490  1.00 37.23           C  
+ATOM   3414  C   MET B2142      65.173  28.798  10.692  1.00 36.50           C  
+ATOM   3415  O   MET B2142      64.258  29.619  10.595  1.00 37.59           O  
+ATOM   3416  CB  MET B2142      65.282  27.695   8.442  1.00 39.78           C  
+ATOM   3417  CG  MET B2142      64.424  28.570   7.541  1.00 44.86           C  
+ATOM   3418  SD  MET B2142      65.394  29.657   6.441  1.00 46.24           S  
+ATOM   3419  CE  MET B2142      65.383  28.684   4.930  1.00 48.45           C  
+ATOM   3420  N   LYS B2143      65.444  28.145  11.821  1.00 34.97           N  
+ATOM   3421  CA  LYS B2143      64.683  28.369  13.049  1.00 34.75           C  
+ATOM   3422  C   LYS B2143      65.568  29.117  14.037  1.00 32.87           C  
+ATOM   3423  O   LYS B2143      65.299  29.135  15.236  1.00 32.02           O  
+ATOM   3424  CB  LYS B2143      64.266  27.036  13.672  1.00 37.43           C  
+ATOM   3425  CG  LYS B2143      63.307  26.219  12.824  1.00 41.93           C  
+ATOM   3426  CD  LYS B2143      61.871  26.637  13.062  1.00 45.63           C  
+ATOM   3427  CE  LYS B2143      61.454  26.328  14.495  1.00 48.39           C  
+ATOM   3428  NZ  LYS B2143      60.037  26.690  14.758  1.00 51.93           N  
+ATOM   3429  N   LYS B2144      66.629  29.728  13.519  1.00 30.89           N  
+ATOM   3430  CA  LYS B2144      67.571  30.462  14.353  1.00 29.98           C  
+ATOM   3431  C   LYS B2144      67.862  31.877  13.874  1.00 27.64           C  
+ATOM   3432  O   LYS B2144      68.926  32.422  14.172  1.00 30.22           O  
+ATOM   3433  CB  LYS B2144      68.888  29.684  14.462  1.00 29.93           C  
+ATOM   3434  CG  LYS B2144      68.809  28.438  15.324  1.00 32.31           C  
+ATOM   3435  CD  LYS B2144      68.544  28.795  16.780  1.00 32.46           C  
+ATOM   3436  CE  LYS B2144      68.521  27.555  17.658  1.00 33.49           C  
+ATOM   3437  NZ  LYS B2144      68.304  27.900  19.092  1.00 35.93           N  
+ATOM   3438  N   LYS B2145      66.941  32.474  13.123  1.00 26.32           N  
+ATOM   3439  CA  LYS B2145      67.160  33.839  12.665  1.00 23.94           C  
+ATOM   3440  C   LYS B2145      67.288  34.750  13.884  1.00 21.87           C  
+ATOM   3441  O   LYS B2145      66.448  34.714  14.787  1.00 20.13           O  
+ATOM   3442  CB  LYS B2145      66.012  34.312  11.775  1.00 23.21           C  
+ATOM   3443  CG  LYS B2145      66.177  33.921  10.313  1.00 26.26           C  
+ATOM   3444  CD  LYS B2145      65.038  34.468   9.451  1.00 26.05           C  
+ATOM   3445  CE  LYS B2145      65.274  34.147   7.981  1.00 28.82           C  
+ATOM   3446  NZ  LYS B2145      64.158  34.602   7.090  1.00 29.64           N  
+ATOM   3447  N   GLY B2146      68.350  35.549  13.904  1.00 19.55           N  
+ATOM   3448  CA  GLY B2146      68.580  36.453  15.013  1.00 20.42           C  
+ATOM   3449  C   GLY B2146      69.723  35.993  15.895  1.00 20.72           C  
+ATOM   3450  O   GLY B2146      70.315  36.781  16.643  1.00 20.74           O  
+ATOM   3451  N   PHE B2147      70.029  34.704  15.820  1.00 20.31           N  
+ATOM   3452  CA  PHE B2147      71.121  34.155  16.597  1.00 19.79           C  
+ATOM   3453  C   PHE B2147      72.411  34.478  15.863  1.00 20.76           C  
+ATOM   3454  O   PHE B2147      72.411  34.680  14.644  1.00 20.50           O  
+ATOM   3455  CB  PHE B2147      70.953  32.642  16.761  1.00 20.28           C  
+ATOM   3456  CG  PHE B2147      69.890  32.254  17.754  1.00 20.38           C  
+ATOM   3457  CD1 PHE B2147      68.543  32.536  17.510  1.00 21.04           C  
+ATOM   3458  CD2 PHE B2147      70.236  31.624  18.947  1.00 20.35           C  
+ATOM   3459  CE1 PHE B2147      67.559  32.193  18.451  1.00 19.64           C  
+ATOM   3460  CE2 PHE B2147      69.260  31.280  19.888  1.00 20.50           C  
+ATOM   3461  CZ  PHE B2147      67.922  31.566  19.638  1.00 19.40           C  
+ATOM   3462  N   PRO B2148      73.534  34.530  16.594  1.00 21.40           N  
+ATOM   3463  CA  PRO B2148      74.840  34.839  16.008  1.00 21.50           C  
+ATOM   3464  C   PRO B2148      75.165  34.114  14.704  1.00 24.09           C  
+ATOM   3465  O   PRO B2148      75.555  34.742  13.714  1.00 25.60           O  
+ATOM   3466  CB  PRO B2148      75.805  34.472  17.122  1.00 21.42           C  
+ATOM   3467  CG  PRO B2148      75.006  34.804  18.362  1.00 21.41           C  
+ATOM   3468  CD  PRO B2148      73.658  34.228  18.031  1.00 19.65           C  
+ATOM   3469  N   GLU B2149      74.990  32.798  14.696  1.00 24.84           N  
+ATOM   3470  CA  GLU B2149      75.309  32.006  13.520  1.00 27.01           C  
+ATOM   3471  C   GLU B2149      74.487  32.298  12.261  1.00 26.90           C  
+ATOM   3472  O   GLU B2149      74.868  31.892  11.156  1.00 25.63           O  
+ATOM   3473  CB  GLU B2149      75.250  30.513  13.872  1.00 29.81           C  
+ATOM   3474  CG  GLU B2149      73.936  30.021  14.487  1.00 33.33           C  
+ATOM   3475  CD  GLU B2149      73.777  30.310  15.989  1.00 34.60           C  
+ATOM   3476  OE1 GLU B2149      72.939  29.629  16.621  1.00 34.96           O  
+ATOM   3477  OE2 GLU B2149      74.459  31.202  16.538  1.00 33.57           O  
+ATOM   3478  N   SER B2150      73.379  33.021  12.413  1.00 26.03           N  
+ATOM   3479  CA  SER B2150      72.537  33.346  11.261  1.00 23.90           C  
+ATOM   3480  C   SER B2150      72.978  34.634  10.577  1.00 22.44           C  
+ATOM   3481  O   SER B2150      72.412  35.022   9.549  1.00 22.30           O  
+ATOM   3482  CB  SER B2150      71.068  33.477  11.682  1.00 22.81           C  
+ATOM   3483  OG  SER B2150      70.813  34.715  12.322  1.00 23.70           O  
+ATOM   3484  N   TYR B2151      73.978  35.301  11.148  1.00 21.35           N  
+ATOM   3485  CA  TYR B2151      74.468  36.554  10.580  1.00 21.02           C  
+ATOM   3486  C   TYR B2151      75.791  36.423   9.852  1.00 20.85           C  
+ATOM   3487  O   TYR B2151      76.640  35.604  10.200  1.00 22.00           O  
+ATOM   3488  CB  TYR B2151      74.660  37.621  11.664  1.00 20.11           C  
+ATOM   3489  CG  TYR B2151      73.403  38.197  12.271  1.00 19.69           C  
+ATOM   3490  CD1 TYR B2151      72.890  37.691  13.465  1.00 19.40           C  
+ATOM   3491  CD2 TYR B2151      72.736  39.265  11.661  1.00 18.03           C  
+ATOM   3492  CE1 TYR B2151      71.749  38.232  14.043  1.00 18.62           C  
+ATOM   3493  CE2 TYR B2151      71.593  39.811  12.226  1.00 18.11           C  
+ATOM   3494  CZ  TYR B2151      71.105  39.294  13.415  1.00 20.56           C  
+ATOM   3495  OH  TYR B2151      69.977  39.836  13.988  1.00 20.79           O  
+ATOM   3496  N   ASP B2152      75.959  37.249   8.833  1.00 22.34           N  
+ATOM   3497  CA  ASP B2152      77.207  37.299   8.091  1.00 23.63           C  
+ATOM   3498  C   ASP B2152      77.907  38.450   8.810  1.00 23.63           C  
+ATOM   3499  O   ASP B2152      78.004  39.557   8.282  1.00 24.14           O  
+ATOM   3500  CB  ASP B2152      76.925  37.656   6.633  1.00 25.40           C  
+ATOM   3501  CG  ASP B2152      78.187  37.816   5.817  1.00 28.12           C  
+ATOM   3502  OD1 ASP B2152      79.290  37.663   6.388  1.00 29.15           O  
+ATOM   3503  OD2 ASP B2152      78.076  38.102   4.601  1.00 29.33           O  
+ATOM   3504  N   MET B2153      78.352  38.185  10.039  1.00 25.02           N  
+ATOM   3505  CA  MET B2153      79.001  39.192  10.880  1.00 25.29           C  
+ATOM   3506  C   MET B2153      80.226  39.882  10.317  1.00 25.34           C  
+ATOM   3507  O   MET B2153      80.391  41.083  10.507  1.00 27.19           O  
+ATOM   3508  CB  MET B2153      79.356  38.605  12.239  1.00 27.35           C  
+ATOM   3509  CG  MET B2153      78.370  39.001  13.312  1.00 32.22           C  
+ATOM   3510  SD  MET B2153      78.248  40.787  13.542  1.00 33.67           S  
+ATOM   3511  CE  MET B2153      77.856  40.898  15.287  1.00 31.59           C  
+ATOM   3512  N   HIS B2154      81.093  39.137   9.643  1.00 24.14           N  
+ATOM   3513  CA  HIS B2154      82.284  39.742   9.068  1.00 24.14           C  
+ATOM   3514  C   HIS B2154      81.887  40.859   8.115  1.00 23.70           C  
+ATOM   3515  O   HIS B2154      82.567  41.879   8.027  1.00 25.40           O  
+ATOM   3516  CB  HIS B2154      83.113  38.694   8.331  1.00 23.70           C  
+ATOM   3517  CG  HIS B2154      83.783  37.713   9.242  1.00 26.26           C  
+ATOM   3518  ND1 HIS B2154      84.680  38.100  10.215  1.00 25.89           N  
+ATOM   3519  CD2 HIS B2154      83.681  36.368   9.336  1.00 27.34           C  
+ATOM   3520  CE1 HIS B2154      85.101  37.031  10.869  1.00 27.29           C  
+ATOM   3521  NE2 HIS B2154      84.511  35.967  10.357  1.00 25.86           N  
+ATOM   3522  N   ARG B2155      80.772  40.676   7.418  1.00 22.75           N  
+ATOM   3523  CA  ARG B2155      80.316  41.687   6.484  1.00 22.51           C  
+ATOM   3524  C   ARG B2155      79.790  42.923   7.220  1.00 22.74           C  
+ATOM   3525  O   ARG B2155      80.037  44.059   6.797  1.00 22.18           O  
+ATOM   3526  CB  ARG B2155      79.237  41.114   5.568  1.00 23.24           C  
+ATOM   3527  CG  ARG B2155      78.775  42.099   4.513  1.00 25.09           C  
+ATOM   3528  CD  ARG B2155      77.806  41.483   3.535  1.00 26.62           C  
+ATOM   3529  NE  ARG B2155      77.431  42.456   2.517  1.00 28.02           N  
+ATOM   3530  CZ  ARG B2155      76.648  42.193   1.477  1.00 29.43           C  
+ATOM   3531  NH1 ARG B2155      76.153  40.973   1.305  1.00 28.35           N  
+ATOM   3532  NH2 ARG B2155      76.352  43.156   0.613  1.00 29.20           N  
+ATOM   3533  N   LEU B2156      79.068  42.702   8.319  1.00 21.49           N  
+ATOM   3534  CA  LEU B2156      78.532  43.810   9.105  1.00 19.92           C  
+ATOM   3535  C   LEU B2156      79.684  44.619   9.687  1.00 20.69           C  
+ATOM   3536  O   LEU B2156      79.664  45.847   9.665  1.00 21.42           O  
+ATOM   3537  CB  LEU B2156      77.651  43.295  10.248  1.00 18.80           C  
+ATOM   3538  CG  LEU B2156      77.113  44.366  11.208  1.00 18.15           C  
+ATOM   3539  CD1 LEU B2156      76.305  45.415  10.441  1.00 14.87           C  
+ATOM   3540  CD2 LEU B2156      76.258  43.697  12.283  1.00 16.17           C  
+ATOM   3541  N   VAL B2157      80.689  43.925  10.208  1.00 20.46           N  
+ATOM   3542  CA  VAL B2157      81.847  44.599  10.776  1.00 22.47           C  
+ATOM   3543  C   VAL B2157      82.549  45.443   9.715  1.00 22.43           C  
+ATOM   3544  O   VAL B2157      82.913  46.598   9.965  1.00 22.15           O  
+ATOM   3545  CB  VAL B2157      82.855  43.584  11.370  1.00 22.92           C  
+ATOM   3546  CG1 VAL B2157      84.142  44.291  11.742  1.00 22.27           C  
+ATOM   3547  CG2 VAL B2157      82.259  42.921  12.605  1.00 22.66           C  
+ATOM   3548  N   LYS B2158      82.728  44.873   8.528  1.00 23.15           N  
+ATOM   3549  CA  LYS B2158      83.395  45.600   7.449  1.00 23.67           C  
+ATOM   3550  C   LYS B2158      82.598  46.830   7.016  1.00 22.96           C  
+ATOM   3551  O   LYS B2158      83.175  47.838   6.588  1.00 20.77           O  
+ATOM   3552  CB  LYS B2158      83.616  44.683   6.246  1.00 24.55           C  
+ATOM   3553  CG  LYS B2158      84.361  45.360   5.107  1.00 27.02           C  
+ATOM   3554  CD  LYS B2158      84.684  44.390   3.983  1.00 27.92           C  
+ATOM   3555  CE  LYS B2158      85.585  45.042   2.940  1.00 29.68           C  
+ATOM   3556  NZ  LYS B2158      84.912  46.162   2.229  1.00 29.10           N  
+ATOM   3557  N   PHE B2159      81.273  46.742   7.122  1.00 22.04           N  
+ATOM   3558  CA  PHE B2159      80.411  47.857   6.740  1.00 21.76           C  
+ATOM   3559  C   PHE B2159      80.717  49.095   7.598  1.00 21.25           C  
+ATOM   3560  O   PHE B2159      81.004  50.167   7.071  1.00 20.38           O  
+ATOM   3561  CB  PHE B2159      78.932  47.472   6.891  1.00 21.67           C  
+ATOM   3562  CG  PHE B2159      77.981  48.589   6.567  1.00 22.49           C  
+ATOM   3563  CD1 PHE B2159      77.757  48.972   5.245  1.00 23.08           C  
+ATOM   3564  CD2 PHE B2159      77.335  49.289   7.583  1.00 23.29           C  
+ATOM   3565  CE1 PHE B2159      76.907  50.034   4.942  1.00 23.23           C  
+ATOM   3566  CE2 PHE B2159      76.480  50.362   7.289  1.00 22.35           C  
+ATOM   3567  CZ  PHE B2159      76.268  50.731   5.967  1.00 22.17           C  
+ATOM   3568  N   VAL B2160      80.659  48.948   8.917  1.00 20.79           N  
+ATOM   3569  CA  VAL B2160      80.940  50.081   9.789  1.00 20.55           C  
+ATOM   3570  C   VAL B2160      82.429  50.421   9.745  1.00 20.94           C  
+ATOM   3571  O   VAL B2160      82.814  51.580   9.903  1.00 21.54           O  
+ATOM   3572  CB  VAL B2160      80.502  49.804  11.239  1.00 18.70           C  
+ATOM   3573  CG1 VAL B2160      78.995  49.751  11.307  1.00 21.00           C  
+ATOM   3574  CG2 VAL B2160      81.090  48.501  11.726  1.00 20.87           C  
+ATOM   3575  N   SER B2161      83.266  49.415   9.518  1.00 20.59           N  
+ATOM   3576  CA  SER B2161      84.702  49.657   9.425  1.00 22.61           C  
+ATOM   3577  C   SER B2161      84.988  50.562   8.216  1.00 21.08           C  
+ATOM   3578  O   SER B2161      85.743  51.533   8.322  1.00 20.80           O  
+ATOM   3579  CB  SER B2161      85.463  48.331   9.289  1.00 23.46           C  
+ATOM   3580  OG  SER B2161      86.863  48.556   9.240  1.00 27.16           O  
+ATOM   3581  N   ASP B2162      84.372  50.252   7.077  1.00 21.31           N  
+ATOM   3582  CA  ASP B2162      84.564  51.059   5.868  1.00 23.24           C  
+ATOM   3583  C   ASP B2162      84.084  52.488   6.082  1.00 22.89           C  
+ATOM   3584  O   ASP B2162      84.746  53.431   5.653  1.00 24.23           O  
+ATOM   3585  CB  ASP B2162      83.823  50.456   4.667  1.00 22.36           C  
+ATOM   3586  CG  ASP B2162      84.484  49.195   4.143  1.00 22.34           C  
+ATOM   3587  OD1 ASP B2162      85.687  48.994   4.400  1.00 22.33           O  
+ATOM   3588  OD2 ASP B2162      83.801  48.411   3.459  1.00 25.31           O  
+ATOM   3589  N   LEU B2163      82.934  52.644   6.737  1.00 21.76           N  
+ATOM   3590  CA  LEU B2163      82.388  53.970   7.011  1.00 20.64           C  
+ATOM   3591  C   LEU B2163      83.371  54.745   7.877  1.00 21.08           C  
+ATOM   3592  O   LEU B2163      83.630  55.927   7.646  1.00 22.74           O  
+ATOM   3593  CB  LEU B2163      81.049  53.863   7.747  1.00 20.44           C  
+ATOM   3594  CG  LEU B2163      79.813  53.432   6.963  1.00 21.24           C  
+ATOM   3595  CD1 LEU B2163      78.728  52.969   7.929  1.00 23.55           C  
+ATOM   3596  CD2 LEU B2163      79.313  54.591   6.113  1.00 20.91           C  
+ATOM   3597  N   LYS B2164      83.927  54.067   8.873  1.00 21.50           N  
+ATOM   3598  CA  LYS B2164      84.876  54.696   9.771  1.00 21.52           C  
+ATOM   3599  C   LYS B2164      86.274  54.807   9.160  1.00 22.67           C  
+ATOM   3600  O   LYS B2164      87.212  55.271   9.807  1.00 21.13           O  
+ATOM   3601  CB  LYS B2164      84.927  53.928  11.090  1.00 20.38           C  
+ATOM   3602  CG  LYS B2164      84.551  54.772  12.297  1.00 23.51           C  
+ATOM   3603  CD  LYS B2164      83.096  55.161  12.278  1.00 21.55           C  
+ATOM   3604  CE  LYS B2164      82.661  55.840  13.579  1.00 21.79           C  
+ATOM   3605  NZ  LYS B2164      82.941  57.291  13.636  1.00 20.97           N  
+ATOM   3606  N   SER B2165      86.410  54.379   7.909  1.00 24.30           N  
+ATOM   3607  CA  SER B2165      87.692  54.458   7.207  1.00 24.58           C  
+ATOM   3608  C   SER B2165      87.621  55.631   6.242  1.00 25.70           C  
+ATOM   3609  O   SER B2165      88.617  56.018   5.634  1.00 26.31           O  
+ATOM   3610  CB  SER B2165      87.972  53.172   6.420  1.00 24.01           C  
+ATOM   3611  OG  SER B2165      88.279  52.084   7.276  1.00 24.31           O  
+ATOM   3612  N   GLY B2166      86.424  56.189   6.095  1.00 27.37           N  
+ATOM   3613  CA  GLY B2166      86.250  57.317   5.201  1.00 27.52           C  
+ATOM   3614  C   GLY B2166      85.799  56.936   3.803  1.00 28.88           C  
+ATOM   3615  O   GLY B2166      85.754  57.790   2.920  1.00 28.98           O  
+ATOM   3616  N   VAL B2167      85.478  55.664   3.585  1.00 29.11           N  
+ATOM   3617  CA  VAL B2167      85.017  55.235   2.267  1.00 30.52           C  
+ATOM   3618  C   VAL B2167      83.763  56.036   1.912  1.00 32.89           C  
+ATOM   3619  O   VAL B2167      82.756  55.987   2.620  1.00 31.82           O  
+ATOM   3620  CB  VAL B2167      84.678  53.738   2.239  1.00 30.25           C  
+ATOM   3621  CG1 VAL B2167      84.198  53.350   0.850  1.00 28.58           C  
+ATOM   3622  CG2 VAL B2167      85.898  52.920   2.636  1.00 27.77           C  
+ATOM   3623  N   PRO B2168      83.812  56.782   0.795  1.00 35.09           N  
+ATOM   3624  CA  PRO B2168      82.697  57.614   0.327  1.00 37.08           C  
+ATOM   3625  C   PRO B2168      81.336  56.926   0.187  1.00 38.30           C  
+ATOM   3626  O   PRO B2168      80.341  57.390   0.748  1.00 39.38           O  
+ATOM   3627  CB  PRO B2168      83.223  58.181  -0.994  1.00 37.12           C  
+ATOM   3628  CG  PRO B2168      84.179  57.121  -1.462  1.00 38.26           C  
+ATOM   3629  CD  PRO B2168      84.900  56.757  -0.196  1.00 34.65           C  
+ATOM   3630  N   ASN B2169      81.284  55.827  -0.553  1.00 39.09           N  
+ATOM   3631  CA  ASN B2169      80.024  55.117  -0.729  1.00 40.86           C  
+ATOM   3632  C   ASN B2169      80.144  53.692  -0.232  1.00 40.23           C  
+ATOM   3633  O   ASN B2169      81.013  52.944  -0.674  1.00 41.45           O  
+ATOM   3634  CB  ASN B2169      79.619  55.109  -2.203  1.00 44.37           C  
+ATOM   3635  CG  ASN B2169      79.593  56.500  -2.806  1.00 46.72           C  
+ATOM   3636  OD1 ASN B2169      78.872  57.384  -2.337  1.00 49.09           O  
+ATOM   3637  ND2 ASN B2169      80.385  56.703  -3.855  1.00 47.25           N  
+ATOM   3638  N   VAL B2170      79.266  53.318   0.689  1.00 38.85           N  
+ATOM   3639  CA  VAL B2170      79.284  51.974   1.239  1.00 37.51           C  
+ATOM   3640  C   VAL B2170      77.935  51.310   0.981  1.00 36.67           C  
+ATOM   3641  O   VAL B2170      76.885  51.942   1.110  1.00 36.60           O  
+ATOM   3642  CB  VAL B2170      79.569  52.008   2.750  1.00 37.35           C  
+ATOM   3643  CG1 VAL B2170      79.861  50.606   3.259  1.00 37.73           C  
+ATOM   3644  CG2 VAL B2170      80.745  52.925   3.026  1.00 37.68           C  
+ATOM   3645  N   THR B2171      77.965  50.036   0.616  1.00 34.99           N  
+ATOM   3646  CA  THR B2171      76.738  49.313   0.321  1.00 34.46           C  
+ATOM   3647  C   THR B2171      76.368  48.306   1.401  1.00 32.61           C  
+ATOM   3648  O   THR B2171      77.233  47.644   1.971  1.00 32.39           O  
+ATOM   3649  CB  THR B2171      76.866  48.585  -1.028  1.00 35.20           C  
+ATOM   3650  OG1 THR B2171      77.082  49.552  -2.063  1.00 37.27           O  
+ATOM   3651  CG2 THR B2171      75.603  47.797  -1.337  1.00 37.14           C  
+ATOM   3652  N   ALA B2172      75.072  48.193   1.672  1.00 32.53           N  
+ATOM   3653  CA  ALA B2172      74.574  47.261   2.680  1.00 31.22           C  
+ATOM   3654  C   ALA B2172      73.444  46.406   2.120  1.00 29.67           C  
+ATOM   3655  O   ALA B2172      72.604  46.883   1.361  1.00 29.22           O  
+ATOM   3656  CB  ALA B2172      74.079  48.023   3.900  1.00 29.82           C  
+ATOM   3657  N   PRO B2173      73.417  45.119   2.482  1.00 28.51           N  
+ATOM   3658  CA  PRO B2173      72.347  44.257   1.978  1.00 29.22           C  
+ATOM   3659  C   PRO B2173      71.055  44.673   2.673  1.00 29.31           C  
+ATOM   3660  O   PRO B2173      71.094  45.290   3.739  1.00 29.97           O  
+ATOM   3661  CB  PRO B2173      72.814  42.859   2.379  1.00 28.39           C  
+ATOM   3662  CG  PRO B2173      73.578  43.124   3.656  1.00 28.72           C  
+ATOM   3663  CD  PRO B2173      74.363  44.368   3.326  1.00 28.51           C  
+ATOM   3664  N   VAL B2174      69.918  44.356   2.068  1.00 29.33           N  
+ATOM   3665  CA  VAL B2174      68.629  44.714   2.645  1.00 29.50           C  
+ATOM   3666  C   VAL B2174      67.739  43.491   2.837  1.00 30.85           C  
+ATOM   3667  O   VAL B2174      67.676  42.607   1.974  1.00 31.52           O  
+ATOM   3668  CB  VAL B2174      67.889  45.740   1.756  1.00 29.00           C  
+ATOM   3669  CG1 VAL B2174      66.493  45.993   2.296  1.00 27.32           C  
+ATOM   3670  CG2 VAL B2174      68.673  47.042   1.716  1.00 28.92           C  
+ATOM   3671  N   TYR B2175      67.043  43.468   3.971  1.00 31.08           N  
+ATOM   3672  CA  TYR B2175      66.152  42.378   4.345  1.00 31.11           C  
+ATOM   3673  C   TYR B2175      64.710  42.838   4.219  1.00 33.45           C  
+ATOM   3674  O   TYR B2175      64.404  44.008   4.436  1.00 34.24           O  
+ATOM   3675  CB  TYR B2175      66.428  41.975   5.795  1.00 29.57           C  
+ATOM   3676  CG  TYR B2175      65.666  40.761   6.281  1.00 28.63           C  
+ATOM   3677  CD1 TYR B2175      66.050  39.472   5.902  1.00 26.20           C  
+ATOM   3678  CD2 TYR B2175      64.577  40.899   7.140  1.00 26.91           C  
+ATOM   3679  CE1 TYR B2175      65.373  38.354   6.369  1.00 25.97           C  
+ATOM   3680  CE2 TYR B2175      63.890  39.785   7.612  1.00 25.32           C  
+ATOM   3681  CZ  TYR B2175      64.293  38.516   7.223  1.00 26.11           C  
+ATOM   3682  OH  TYR B2175      63.605  37.413   7.673  1.00 24.31           O  
+ATOM   3683  N   SER B2176      63.822  41.911   3.885  1.00 36.34           N  
+ATOM   3684  CA  SER B2176      62.402  42.216   3.733  1.00 39.06           C  
+ATOM   3685  C   SER B2176      61.557  41.315   4.626  1.00 40.57           C  
+ATOM   3686  O   SER B2176      61.480  40.108   4.390  1.00 40.57           O  
+ATOM   3687  CB  SER B2176      61.983  42.018   2.275  1.00 39.94           C  
+ATOM   3688  OG  SER B2176      60.572  42.048   2.133  1.00 42.49           O  
+ATOM   3689  N   HIS B2177      60.935  41.887   5.654  1.00 42.93           N  
+ATOM   3690  CA  HIS B2177      60.093  41.085   6.534  1.00 45.53           C  
+ATOM   3691  C   HIS B2177      58.870  40.608   5.748  1.00 46.12           C  
+ATOM   3692  O   HIS B2177      58.193  39.662   6.153  1.00 46.33           O  
+ATOM   3693  CB  HIS B2177      59.643  41.884   7.767  1.00 47.78           C  
+ATOM   3694  CG  HIS B2177      60.725  42.090   8.786  1.00 50.49           C  
+ATOM   3695  ND1 HIS B2177      61.576  43.177   8.766  1.00 51.57           N  
+ATOM   3696  CD2 HIS B2177      61.117  41.329   9.836  1.00 51.30           C  
+ATOM   3697  CE1 HIS B2177      62.443  43.074   9.758  1.00 52.01           C  
+ATOM   3698  NE2 HIS B2177      62.188  41.962  10.423  1.00 52.04           N  
+ATOM   3699  N   LEU B2178      58.608  41.262   4.616  1.00 45.12           N  
+ATOM   3700  CA  LEU B2178      57.480  40.914   3.756  1.00 43.99           C  
+ATOM   3701  C   LEU B2178      57.727  39.558   3.113  1.00 43.83           C  
+ATOM   3702  O   LEU B2178      56.856  38.682   3.130  1.00 43.89           O  
+ATOM   3703  CB  LEU B2178      57.289  41.973   2.675  1.00 43.91           C  
+ATOM   3704  N   ILE B2179      58.914  39.385   2.538  1.00 42.05           N  
+ATOM   3705  CA  ILE B2179      59.246  38.114   1.915  1.00 40.88           C  
+ATOM   3706  C   ILE B2179      60.006  37.242   2.903  1.00 38.81           C  
+ATOM   3707  O   ILE B2179      60.340  36.097   2.605  1.00 37.97           O  
+ATOM   3708  CB  ILE B2179      60.089  38.297   0.636  1.00 42.27           C  
+ATOM   3709  CG1 ILE B2179      61.493  38.784   0.983  1.00 43.07           C  
+ATOM   3710  CG2 ILE B2179      59.392  39.284  -0.298  1.00 43.97           C  
+ATOM   3711  CD1 ILE B2179      62.440  38.770  -0.205  1.00 44.68           C  
+ATOM   3712  N   TYR B2180      60.274  37.797   4.081  1.00 37.68           N  
+ATOM   3713  CA  TYR B2180      60.969  37.065   5.134  1.00 37.85           C  
+ATOM   3714  C   TYR B2180      62.317  36.550   4.626  1.00 36.31           C  
+ATOM   3715  O   TYR B2180      62.676  35.401   4.860  1.00 36.64           O  
+ATOM   3716  CB  TYR B2180      60.085  35.895   5.576  1.00 40.70           C  
+ATOM   3717  CG  TYR B2180      60.568  35.091   6.762  1.00 43.19           C  
+ATOM   3718  CD1 TYR B2180      60.523  35.615   8.052  1.00 45.18           C  
+ATOM   3719  CD2 TYR B2180      61.015  33.780   6.599  1.00 45.53           C  
+ATOM   3720  CE1 TYR B2180      60.903  34.851   9.154  1.00 46.06           C  
+ATOM   3721  CE2 TYR B2180      61.398  33.008   7.692  1.00 46.85           C  
+ATOM   3722  CZ  TYR B2180      61.337  33.548   8.965  1.00 47.25           C  
+ATOM   3723  OH  TYR B2180      61.698  32.779  10.045  1.00 48.92           O  
+ATOM   3724  N   ASP B2181      63.062  37.395   3.925  1.00 34.65           N  
+ATOM   3725  CA  ASP B2181      64.354  36.976   3.402  1.00 34.38           C  
+ATOM   3726  C   ASP B2181      65.164  38.155   2.877  1.00 33.12           C  
+ATOM   3727  O   ASP B2181      64.638  39.243   2.671  1.00 30.59           O  
+ATOM   3728  CB  ASP B2181      64.145  35.928   2.295  1.00 34.59           C  
+ATOM   3729  CG  ASP B2181      65.446  35.293   1.821  1.00 35.46           C  
+ATOM   3730  OD1 ASP B2181      66.313  34.986   2.665  1.00 37.32           O  
+ATOM   3731  OD2 ASP B2181      65.600  35.084   0.597  1.00 38.54           O  
+ATOM   3732  N   VAL B2182      66.458  37.931   2.690  1.00 34.17           N  
+ATOM   3733  CA  VAL B2182      67.352  38.951   2.169  1.00 34.88           C  
+ATOM   3734  C   VAL B2182      66.990  39.191   0.704  1.00 36.76           C  
+ATOM   3735  O   VAL B2182      66.846  38.243  -0.065  1.00 35.26           O  
+ATOM   3736  CB  VAL B2182      68.825  38.485   2.254  1.00 34.06           C  
+ATOM   3737  CG1 VAL B2182      69.739  39.505   1.599  1.00 32.35           C  
+ATOM   3738  CG2 VAL B2182      69.213  38.269   3.712  1.00 33.53           C  
+ATOM   3739  N   ILE B2183      66.829  40.456   0.329  1.00 38.59           N  
+ATOM   3740  CA  ILE B2183      66.495  40.814  -1.046  1.00 40.56           C  
+ATOM   3741  C   ILE B2183      67.740  40.638  -1.915  1.00 43.51           C  
+ATOM   3742  O   ILE B2183      68.714  41.376  -1.774  1.00 43.25           O  
+ATOM   3743  CB  ILE B2183      66.019  42.270  -1.129  1.00 40.23           C  
+ATOM   3744  CG1 ILE B2183      64.816  42.466  -0.209  1.00 39.14           C  
+ATOM   3745  CG2 ILE B2183      65.671  42.627  -2.569  1.00 42.25           C  
+ATOM   3746  CD1 ILE B2183      64.251  43.860  -0.223  1.00 39.53           C  
+ATOM   3747  N   PRO B2184      67.715  39.658  -2.834  1.00 45.88           N  
+ATOM   3748  CA  PRO B2184      68.826  39.341  -3.745  1.00 47.54           C  
+ATOM   3749  C   PRO B2184      69.568  40.507  -4.403  1.00 49.43           C  
+ATOM   3750  O   PRO B2184      70.784  40.652  -4.230  1.00 49.44           O  
+ATOM   3751  CB  PRO B2184      68.181  38.402  -4.770  1.00 47.34           C  
+ATOM   3752  CG  PRO B2184      66.716  38.741  -4.694  1.00 47.65           C  
+ATOM   3753  CD  PRO B2184      66.504  38.916  -3.220  1.00 46.29           C  
+ATOM   3754  N   ASP B2185      68.851  41.327  -5.166  1.00 49.70           N  
+ATOM   3755  CA  ASP B2185      69.480  42.460  -5.836  1.00 50.55           C  
+ATOM   3756  C   ASP B2185      68.863  43.769  -5.373  1.00 50.69           C  
+ATOM   3757  O   ASP B2185      68.288  44.507  -6.174  1.00 51.87           O  
+ATOM   3758  CB  ASP B2185      69.335  42.319  -7.349  1.00 50.49           C  
+ATOM   3759  N   GLY B2186      68.977  44.051  -4.079  1.00 49.18           N  
+ATOM   3760  CA  GLY B2186      68.415  45.278  -3.543  1.00 47.30           C  
+ATOM   3761  C   GLY B2186      69.305  45.918  -2.496  1.00 45.71           C  
+ATOM   3762  O   GLY B2186      68.826  46.426  -1.487  1.00 44.63           O  
+ATOM   3763  N   ASP B2187      70.608  45.898  -2.738  1.00 45.49           N  
+ATOM   3764  CA  ASP B2187      71.558  46.478  -1.800  1.00 45.64           C  
+ATOM   3765  C   ASP B2187      71.441  47.998  -1.763  1.00 45.28           C  
+ATOM   3766  O   ASP B2187      71.413  48.654  -2.802  1.00 46.50           O  
+ATOM   3767  CB  ASP B2187      72.980  46.051  -2.176  1.00 45.62           C  
+ATOM   3768  CG  ASP B2187      73.227  44.569  -1.929  1.00 47.03           C  
+ATOM   3769  OD1 ASP B2187      72.241  43.802  -1.888  1.00 47.71           O  
+ATOM   3770  OD2 ASP B2187      74.403  44.166  -1.786  1.00 47.34           O  
+ATOM   3771  N   LYS B2188      71.359  48.544  -0.554  1.00 44.68           N  
+ATOM   3772  CA  LYS B2188      71.237  49.983  -0.329  1.00 44.56           C  
+ATOM   3773  C   LYS B2188      72.616  50.640  -0.197  1.00 44.56           C  
+ATOM   3774  O   LYS B2188      73.453  50.189   0.586  1.00 43.49           O  
+ATOM   3775  CB  LYS B2188      70.420  50.224   0.945  1.00 45.29           C  
+ATOM   3776  CG  LYS B2188      70.307  51.670   1.393  1.00 46.53           C  
+ATOM   3777  CD  LYS B2188      69.546  51.756   2.718  1.00 47.58           C  
+ATOM   3778  CE  LYS B2188      69.526  53.181   3.260  1.00 48.36           C  
+ATOM   3779  NZ  LYS B2188      68.911  53.274   4.616  1.00 46.29           N  
+ATOM   3780  N   THR B2189      72.840  51.704  -0.967  1.00 44.76           N  
+ATOM   3781  CA  THR B2189      74.111  52.425  -0.941  1.00 45.24           C  
+ATOM   3782  C   THR B2189      74.063  53.669  -0.061  1.00 45.22           C  
+ATOM   3783  O   THR B2189      73.238  54.561  -0.265  1.00 46.38           O  
+ATOM   3784  CB  THR B2189      74.544  52.852  -2.356  1.00 45.83           C  
+ATOM   3785  OG1 THR B2189      74.786  51.686  -3.150  1.00 47.77           O  
+ATOM   3786  CG2 THR B2189      75.819  53.688  -2.298  1.00 46.10           C  
+ATOM   3787  N   VAL B2190      74.961  53.712   0.917  1.00 44.57           N  
+ATOM   3788  CA  VAL B2190      75.064  54.824   1.851  1.00 44.39           C  
+ATOM   3789  C   VAL B2190      76.117  55.809   1.365  1.00 44.66           C  
+ATOM   3790  O   VAL B2190      77.271  55.431   1.141  1.00 44.88           O  
+ATOM   3791  CB  VAL B2190      75.462  54.322   3.250  1.00 43.40           C  
+ATOM   3792  CG1 VAL B2190      75.667  55.488   4.190  1.00 43.62           C  
+ATOM   3793  CG2 VAL B2190      74.391  53.400   3.780  1.00 43.47           C  
+ATOM   3794  N   VAL B2191      75.719  57.069   1.210  1.00 45.67           N  
+ATOM   3795  CA  VAL B2191      76.641  58.098   0.741  1.00 46.56           C  
+ATOM   3796  C   VAL B2191      76.930  59.206   1.758  1.00 45.95           C  
+ATOM   3797  O   VAL B2191      76.048  59.972   2.148  1.00 47.47           O  
+ATOM   3798  CB  VAL B2191      76.135  58.745  -0.587  1.00 46.84           C  
+ATOM   3799  CG1 VAL B2191      75.904  57.665  -1.627  1.00 46.87           C  
+ATOM   3800  CG2 VAL B2191      74.854  59.524  -0.351  1.00 48.23           C  
+ATOM   3801  N   GLN B2192      78.184  59.266   2.188  1.00 44.76           N  
+ATOM   3802  CA  GLN B2192      78.660  60.271   3.135  1.00 43.31           C  
+ATOM   3803  C   GLN B2192      77.665  60.775   4.172  1.00 40.27           C  
+ATOM   3804  O   GLN B2192      77.413  61.978   4.242  1.00 41.47           O  
+ATOM   3805  CB  GLN B2192      79.173  61.497   2.380  1.00 46.03           C  
+ATOM   3806  CG  GLN B2192      80.239  61.237   1.337  1.00 50.12           C  
+ATOM   3807  CD  GLN B2192      80.667  62.522   0.648  1.00 51.73           C  
+ATOM   3808  OE1 GLN B2192      79.834  63.257   0.110  1.00 54.25           O  
+ATOM   3809  NE2 GLN B2192      81.967  62.802   0.667  1.00 51.22           N  
+ATOM   3810  N   PRO B2193      77.082  59.888   4.992  1.00 37.16           N  
+ATOM   3811  CA  PRO B2193      76.153  60.489   5.953  1.00 34.53           C  
+ATOM   3812  C   PRO B2193      76.912  61.211   7.063  1.00 32.13           C  
+ATOM   3813  O   PRO B2193      78.064  60.880   7.353  1.00 32.35           O  
+ATOM   3814  CB  PRO B2193      75.380  59.290   6.492  1.00 33.28           C  
+ATOM   3815  CG  PRO B2193      76.381  58.175   6.415  1.00 34.19           C  
+ATOM   3816  CD  PRO B2193      77.066  58.415   5.079  1.00 36.55           C  
+ATOM   3817  N   ASP B2194      76.274  62.205   7.669  1.00 29.81           N  
+ATOM   3818  CA  ASP B2194      76.883  62.925   8.781  1.00 27.06           C  
+ATOM   3819  C   ASP B2194      76.683  62.044  10.010  1.00 25.65           C  
+ATOM   3820  O   ASP B2194      77.520  61.998  10.912  1.00 24.29           O  
+ATOM   3821  CB  ASP B2194      76.183  64.261   9.004  1.00 27.75           C  
+ATOM   3822  CG  ASP B2194      76.369  65.208   7.851  1.00 28.42           C  
+ATOM   3823  OD1 ASP B2194      77.521  65.614   7.604  1.00 29.43           O  
+ATOM   3824  OD2 ASP B2194      75.365  65.541   7.187  1.00 30.23           O  
+ATOM   3825  N   ILE B2195      75.551  61.350  10.028  1.00 24.10           N  
+ATOM   3826  CA  ILE B2195      75.209  60.455  11.115  1.00 22.75           C  
+ATOM   3827  C   ILE B2195      74.615  59.173  10.561  1.00 22.05           C  
+ATOM   3828  O   ILE B2195      73.801  59.195   9.636  1.00 20.60           O  
+ATOM   3829  CB  ILE B2195      74.159  61.078  12.056  1.00 23.38           C  
+ATOM   3830  CG1 ILE B2195      74.737  62.317  12.736  1.00 23.25           C  
+ATOM   3831  CG2 ILE B2195      73.709  60.042  13.092  1.00 22.72           C  
+ATOM   3832  CD1 ILE B2195      73.715  63.106  13.545  1.00 21.68           C  
+ATOM   3833  N   LEU B2196      75.039  58.046  11.116  1.00 20.86           N  
+ATOM   3834  CA  LEU B2196      74.491  56.767  10.693  1.00 19.95           C  
+ATOM   3835  C   LEU B2196      73.930  56.066  11.918  1.00 18.58           C  
+ATOM   3836  O   LEU B2196      74.616  55.907  12.922  1.00 18.94           O  
+ATOM   3837  CB  LEU B2196      75.560  55.883  10.048  1.00 20.40           C  
+ATOM   3838  CG  LEU B2196      75.000  54.533   9.559  1.00 22.38           C  
+ATOM   3839  CD1 LEU B2196      75.183  54.383   8.045  1.00 20.57           C  
+ATOM   3840  CD2 LEU B2196      75.693  53.410  10.303  1.00 20.42           C  
+ATOM   3841  N   ILE B2197      72.663  55.686  11.843  1.00 18.96           N  
+ATOM   3842  CA  ILE B2197      72.029  54.974  12.937  1.00 18.51           C  
+ATOM   3843  C   ILE B2197      72.005  53.506  12.518  1.00 17.56           C  
+ATOM   3844  O   ILE B2197      71.442  53.161  11.485  1.00 16.00           O  
+ATOM   3845  CB  ILE B2197      70.587  55.474  13.189  1.00 19.61           C  
+ATOM   3846  CG1 ILE B2197      70.619  56.950  13.602  1.00 20.15           C  
+ATOM   3847  CG2 ILE B2197      69.925  54.633  14.288  1.00 18.97           C  
+ATOM   3848  CD1 ILE B2197      69.238  57.584  13.763  1.00 20.34           C  
+ATOM   3849  N   LEU B2198      72.658  52.662  13.312  1.00 17.56           N  
+ATOM   3850  CA  LEU B2198      72.728  51.226  13.055  1.00 17.11           C  
+ATOM   3851  C   LEU B2198      71.841  50.525  14.076  1.00 17.68           C  
+ATOM   3852  O   LEU B2198      72.144  50.492  15.269  1.00 16.93           O  
+ATOM   3853  CB  LEU B2198      74.165  50.727  13.182  1.00 14.12           C  
+ATOM   3854  CG  LEU B2198      74.366  49.245  12.852  1.00 18.04           C  
+ATOM   3855  CD1 LEU B2198      74.089  49.009  11.371  1.00 16.54           C  
+ATOM   3856  CD2 LEU B2198      75.794  48.818  13.197  1.00 17.33           C  
+ATOM   3857  N   GLU B2199      70.742  49.968  13.590  1.00 18.86           N  
+ATOM   3858  CA  GLU B2199      69.775  49.298  14.441  1.00 21.52           C  
+ATOM   3859  C   GLU B2199      69.790  47.776  14.288  1.00 20.75           C  
+ATOM   3860  O   GLU B2199      69.687  47.250  13.180  1.00 21.26           O  
+ATOM   3861  CB  GLU B2199      68.380  49.862  14.143  1.00 24.15           C  
+ATOM   3862  CG  GLU B2199      67.260  49.174  14.878  1.00 31.13           C  
+ATOM   3863  CD  GLU B2199      66.572  48.145  14.017  1.00 35.09           C  
+ATOM   3864  OE1 GLU B2199      65.917  48.548  13.031  1.00 38.33           O  
+ATOM   3865  OE2 GLU B2199      66.691  46.938  14.317  1.00 38.41           O  
+ATOM   3866  N   GLY B2200      69.926  47.078  15.413  1.00 20.03           N  
+ATOM   3867  CA  GLY B2200      69.955  45.626  15.385  1.00 20.70           C  
+ATOM   3868  C   GLY B2200      70.145  45.024  16.765  1.00 19.86           C  
+ATOM   3869  O   GLY B2200      70.805  45.606  17.622  1.00 21.21           O  
+ATOM   3870  N   LEU B2201      69.580  43.844  16.978  1.00 18.96           N  
+ATOM   3871  CA  LEU B2201      69.676  43.172  18.265  1.00 18.65           C  
+ATOM   3872  C   LEU B2201      71.105  42.771  18.617  1.00 19.04           C  
+ATOM   3873  O   LEU B2201      71.420  42.558  19.783  1.00 18.65           O  
+ATOM   3874  CB  LEU B2201      68.790  41.926  18.260  1.00 17.13           C  
+ATOM   3875  CG  LEU B2201      69.178  40.843  17.245  1.00 18.95           C  
+ATOM   3876  CD1 LEU B2201      70.246  39.942  17.847  1.00 16.98           C  
+ATOM   3877  CD2 LEU B2201      67.956  40.002  16.870  1.00 18.08           C  
+ATOM   3878  N   ASN B2202      71.974  42.697  17.616  1.00 19.39           N  
+ATOM   3879  CA  ASN B2202      73.348  42.253  17.841  1.00 19.67           C  
+ATOM   3880  C   ASN B2202      74.459  43.298  17.782  1.00 19.26           C  
+ATOM   3881  O   ASN B2202      75.633  42.930  17.765  1.00 21.54           O  
+ATOM   3882  CB  ASN B2202      73.669  41.148  16.836  1.00 18.66           C  
+ATOM   3883  CG  ASN B2202      73.557  41.629  15.403  1.00 19.71           C  
+ATOM   3884  OD1 ASN B2202      72.750  42.508  15.094  1.00 19.93           O  
+ATOM   3885  ND2 ASN B2202      74.354  41.052  14.519  1.00 19.79           N  
+ATOM   3886  N   VAL B2203      74.118  44.583  17.761  1.00 18.11           N  
+ATOM   3887  CA  VAL B2203      75.151  45.616  17.656  1.00 18.57           C  
+ATOM   3888  C   VAL B2203      76.134  45.715  18.813  1.00 18.32           C  
+ATOM   3889  O   VAL B2203      77.184  46.350  18.680  1.00 18.83           O  
+ATOM   3890  CB  VAL B2203      74.535  47.012  17.397  1.00 17.40           C  
+ATOM   3891  CG1 VAL B2203      73.771  46.984  16.075  1.00 14.51           C  
+ATOM   3892  CG2 VAL B2203      73.616  47.419  18.556  1.00 17.60           C  
+ATOM   3893  N   LEU B2204      75.806  45.090  19.942  1.00 19.32           N  
+ATOM   3894  CA  LEU B2204      76.697  45.121  21.099  1.00 19.40           C  
+ATOM   3895  C   LEU B2204      77.446  43.805  21.281  1.00 19.68           C  
+ATOM   3896  O   LEU B2204      78.300  43.677  22.166  1.00 23.30           O  
+ATOM   3897  CB  LEU B2204      75.912  45.453  22.370  1.00 18.08           C  
+ATOM   3898  CG  LEU B2204      75.425  46.905  22.475  1.00 18.53           C  
+ATOM   3899  CD1 LEU B2204      74.529  47.066  23.700  1.00 17.23           C  
+ATOM   3900  CD2 LEU B2204      76.631  47.849  22.564  1.00 18.54           C  
+ATOM   3901  N   GLN B2205      77.138  42.825  20.442  1.00 19.25           N  
+ATOM   3902  CA  GLN B2205      77.801  41.530  20.531  1.00 20.21           C  
+ATOM   3903  C   GLN B2205      79.240  41.648  20.036  1.00 22.29           C  
+ATOM   3904  O   GLN B2205      79.625  42.661  19.439  1.00 20.53           O  
+ATOM   3905  CB  GLN B2205      77.024  40.481  19.719  1.00 18.91           C  
+ATOM   3906  CG  GLN B2205      75.695  40.113  20.373  1.00 18.08           C  
+ATOM   3907  CD  GLN B2205      74.841  39.195  19.531  1.00 20.92           C  
+ATOM   3908  OE1 GLN B2205      75.235  38.772  18.435  1.00 20.89           O  
+ATOM   3909  NE2 GLN B2205      73.654  38.879  20.038  1.00 22.39           N  
+ATOM   3910  N   SER B2206      80.029  40.609  20.284  1.00 22.85           N  
+ATOM   3911  CA  SER B2206      81.427  40.604  19.889  1.00 23.89           C  
+ATOM   3912  C   SER B2206      81.929  39.213  19.491  1.00 23.71           C  
+ATOM   3913  O   SER B2206      81.144  38.297  19.235  1.00 23.52           O  
+ATOM   3914  CB  SER B2206      82.273  41.152  21.038  1.00 23.77           C  
+ATOM   3915  OG  SER B2206      82.083  40.378  22.207  1.00 26.35           O  
+ATOM   3916  N   GLY B2207      83.249  39.071  19.446  1.00 23.92           N  
+ATOM   3917  CA  GLY B2207      83.859  37.812  19.061  1.00 23.84           C  
+ATOM   3918  C   GLY B2207      83.424  36.613  19.867  1.00 23.61           C  
+ATOM   3919  O   GLY B2207      83.253  35.523  19.315  1.00 23.98           O  
+ATOM   3920  N   MET B2208      83.238  36.804  21.169  1.00 24.09           N  
+ATOM   3921  CA  MET B2208      82.834  35.711  22.045  1.00 26.10           C  
+ATOM   3922  C   MET B2208      81.486  35.118  21.638  1.00 26.65           C  
+ATOM   3923  O   MET B2208      81.176  33.979  21.975  1.00 26.91           O  
+ATOM   3924  CB  MET B2208      82.773  36.193  23.500  1.00 26.09           C  
+ATOM   3925  CG  MET B2208      81.667  37.206  23.789  1.00 29.14           C  
+ATOM   3926  SD  MET B2208      81.741  37.820  25.499  1.00 32.19           S  
+ATOM   3927  CE  MET B2208      81.605  36.230  26.395  1.00 28.76           C  
+ATOM   3928  N   ASP B2209      80.688  35.890  20.911  1.00 27.51           N  
+ATOM   3929  CA  ASP B2209      79.375  35.423  20.482  1.00 29.42           C  
+ATOM   3930  C   ASP B2209      79.459  34.626  19.194  1.00 29.91           C  
+ATOM   3931  O   ASP B2209      78.470  34.047  18.761  1.00 30.97           O  
+ATOM   3932  CB  ASP B2209      78.430  36.606  20.278  1.00 31.35           C  
+ATOM   3933  CG  ASP B2209      78.178  37.371  21.553  1.00 31.35           C  
+ATOM   3934  OD1 ASP B2209      77.534  36.799  22.460  1.00 31.20           O  
+ATOM   3935  OD2 ASP B2209      78.628  38.536  21.648  1.00 30.26           O  
+ATOM   3936  N   TYR B2210      80.637  34.596  18.580  1.00 30.29           N  
+ATOM   3937  CA  TYR B2210      80.811  33.862  17.335  1.00 31.12           C  
+ATOM   3938  C   TYR B2210      82.010  32.927  17.413  1.00 32.46           C  
+ATOM   3939  O   TYR B2210      82.934  33.013  16.606  1.00 32.75           O  
+ATOM   3940  CB  TYR B2210      80.967  34.845  16.164  1.00 31.03           C  
+ATOM   3941  CG  TYR B2210      79.768  35.762  16.000  1.00 32.12           C  
+ATOM   3942  CD1 TYR B2210      79.501  36.759  16.935  1.00 31.47           C  
+ATOM   3943  CD2 TYR B2210      78.855  35.577  14.957  1.00 32.47           C  
+ATOM   3944  CE1 TYR B2210      78.357  37.543  16.848  1.00 32.96           C  
+ATOM   3945  CE2 TYR B2210      77.703  36.359  14.858  1.00 31.93           C  
+ATOM   3946  CZ  TYR B2210      77.458  37.338  15.807  1.00 34.14           C  
+ATOM   3947  OH  TYR B2210      76.315  38.110  15.721  1.00 35.43           O  
+ATOM   3948  N   PRO B2211      81.997  32.001  18.382  1.00 33.92           N  
+ATOM   3949  CA  PRO B2211      83.104  31.052  18.548  1.00 35.68           C  
+ATOM   3950  C   PRO B2211      83.317  30.187  17.309  1.00 37.37           C  
+ATOM   3951  O   PRO B2211      84.421  29.705  17.060  1.00 38.68           O  
+ATOM   3952  CB  PRO B2211      82.675  30.233  19.764  1.00 34.39           C  
+ATOM   3953  CG  PRO B2211      81.177  30.196  19.615  1.00 34.93           C  
+ATOM   3954  CD  PRO B2211      80.857  31.637  19.246  1.00 34.12           C  
+ATOM   3955  N   HIS B2212      82.255  30.002  16.532  1.00 38.09           N  
+ATOM   3956  CA  HIS B2212      82.325  29.194  15.319  1.00 38.90           C  
+ATOM   3957  C   HIS B2212      83.070  29.896  14.184  1.00 39.11           C  
+ATOM   3958  O   HIS B2212      83.566  29.243  13.263  1.00 39.17           O  
+ATOM   3959  CB  HIS B2212      80.912  28.834  14.848  1.00 39.06           C  
+ATOM   3960  CG  HIS B2212      80.009  30.019  14.682  1.00 39.72           C  
+ATOM   3961  ND1 HIS B2212      79.493  30.718  15.753  1.00 38.94           N  
+ATOM   3962  CD2 HIS B2212      79.548  30.640  13.569  1.00 39.20           C  
+ATOM   3963  CE1 HIS B2212      78.754  31.718  15.308  1.00 38.38           C  
+ATOM   3964  NE2 HIS B2212      78.771  31.695  13.987  1.00 38.80           N  
+ATOM   3965  N   ASP B2213      83.153  31.223  14.263  1.00 37.61           N  
+ATOM   3966  CA  ASP B2213      83.810  32.036  13.237  1.00 35.67           C  
+ATOM   3967  C   ASP B2213      84.119  33.394  13.872  1.00 34.67           C  
+ATOM   3968  O   ASP B2213      83.484  34.396  13.559  1.00 34.75           O  
+ATOM   3969  CB  ASP B2213      82.850  32.217  12.064  1.00 36.03           C  
+ATOM   3970  CG  ASP B2213      83.490  32.904  10.890  1.00 37.20           C  
+ATOM   3971  OD1 ASP B2213      82.765  33.200   9.914  1.00 39.72           O  
+ATOM   3972  OD2 ASP B2213      84.714  33.144  10.939  1.00 38.29           O  
+ATOM   3973  N   PRO B2214      85.120  33.439  14.762  1.00 33.56           N  
+ATOM   3974  CA  PRO B2214      85.546  34.643  15.485  1.00 32.86           C  
+ATOM   3975  C   PRO B2214      86.113  35.853  14.745  1.00 31.34           C  
+ATOM   3976  O   PRO B2214      86.874  35.716  13.789  1.00 33.24           O  
+ATOM   3977  CB  PRO B2214      86.547  34.086  16.495  1.00 34.45           C  
+ATOM   3978  CG  PRO B2214      87.195  32.978  15.715  1.00 35.41           C  
+ATOM   3979  CD  PRO B2214      86.003  32.301  15.078  1.00 33.42           C  
+ATOM   3980  N   HIS B2215      85.716  37.040  15.201  1.00 28.74           N  
+ATOM   3981  CA  HIS B2215      86.235  38.297  14.669  1.00 26.69           C  
+ATOM   3982  C   HIS B2215      86.893  38.983  15.864  1.00 26.12           C  
+ATOM   3983  O   HIS B2215      86.456  38.807  17.008  1.00 25.53           O  
+ATOM   3984  CB  HIS B2215      85.136  39.177  14.037  1.00 27.10           C  
+ATOM   3985  CG  HIS B2215      83.961  39.454  14.922  1.00 26.21           C  
+ATOM   3986  ND1 HIS B2215      82.960  38.535  15.148  1.00 27.65           N  
+ATOM   3987  CD2 HIS B2215      83.591  40.578  15.588  1.00 26.58           C  
+ATOM   3988  CE1 HIS B2215      82.022  39.075  15.908  1.00 25.64           C  
+ATOM   3989  NE2 HIS B2215      82.384  40.316  16.188  1.00 26.68           N  
+ATOM   3990  N   HIS B2216      87.948  39.749  15.610  1.00 25.16           N  
+ATOM   3991  CA  HIS B2216      88.695  40.382  16.690  1.00 25.15           C  
+ATOM   3992  C   HIS B2216      88.524  41.876  16.889  1.00 23.86           C  
+ATOM   3993  O   HIS B2216      89.076  42.450  17.829  1.00 23.39           O  
+ATOM   3994  CB  HIS B2216      90.165  40.020  16.523  1.00 26.59           C  
+ATOM   3995  CG  HIS B2216      90.395  38.543  16.477  1.00 30.09           C  
+ATOM   3996  ND1 HIS B2216      90.516  37.775  17.616  1.00 30.35           N  
+ATOM   3997  CD2 HIS B2216      90.406  37.675  15.435  1.00 30.01           C  
+ATOM   3998  CE1 HIS B2216      90.585  36.500  17.280  1.00 30.57           C  
+ATOM   3999  NE2 HIS B2216      90.519  36.411  15.963  1.00 31.59           N  
+ATOM   4000  N   VAL B2217      87.775  42.504  15.994  1.00 23.46           N  
+ATOM   4001  CA  VAL B2217      87.472  43.926  16.106  1.00 24.52           C  
+ATOM   4002  C   VAL B2217      85.953  43.909  16.014  1.00 23.19           C  
+ATOM   4003  O   VAL B2217      85.392  43.371  15.054  1.00 22.96           O  
+ATOM   4004  CB  VAL B2217      88.069  44.762  14.954  1.00 25.31           C  
+ATOM   4005  CG1 VAL B2217      87.859  46.245  15.244  1.00 25.66           C  
+ATOM   4006  CG2 VAL B2217      89.559  44.482  14.822  1.00 25.11           C  
+ATOM   4007  N   PHE B2218      85.288  44.484  17.009  1.00 21.12           N  
+ATOM   4008  CA  PHE B2218      83.830  44.448  17.055  1.00 19.84           C  
+ATOM   4009  C   PHE B2218      83.099  45.651  16.463  1.00 20.02           C  
+ATOM   4010  O   PHE B2218      83.695  46.703  16.209  1.00 18.90           O  
+ATOM   4011  CB  PHE B2218      83.397  44.245  18.508  1.00 18.26           C  
+ATOM   4012  CG  PHE B2218      84.342  43.385  19.298  1.00 19.46           C  
+ATOM   4013  CD1 PHE B2218      84.739  43.759  20.576  1.00 18.20           C  
+ATOM   4014  CD2 PHE B2218      84.855  42.204  18.754  1.00 21.08           C  
+ATOM   4015  CE1 PHE B2218      85.633  42.972  21.301  1.00 19.46           C  
+ATOM   4016  CE2 PHE B2218      85.752  41.408  19.471  1.00 19.08           C  
+ATOM   4017  CZ  PHE B2218      86.141  41.793  20.744  1.00 21.14           C  
+ATOM   4018  N   VAL B2219      81.798  45.468  16.241  1.00 19.30           N  
+ATOM   4019  CA  VAL B2219      80.946  46.523  15.720  1.00 17.65           C  
+ATOM   4020  C   VAL B2219      81.087  47.747  16.629  1.00 17.65           C  
+ATOM   4021  O   VAL B2219      81.256  48.875  16.148  1.00 17.03           O  
+ATOM   4022  CB  VAL B2219      79.460  46.065  15.686  1.00 17.41           C  
+ATOM   4023  CG1 VAL B2219      78.540  47.262  15.501  1.00 16.71           C  
+ATOM   4024  CG2 VAL B2219      79.245  45.073  14.545  1.00 15.77           C  
+ATOM   4025  N   SER B2220      81.032  47.511  17.941  1.00 16.05           N  
+ATOM   4026  CA  SER B2220      81.136  48.580  18.919  1.00 17.87           C  
+ATOM   4027  C   SER B2220      82.425  49.396  18.775  1.00 17.96           C  
+ATOM   4028  O   SER B2220      82.465  50.563  19.147  1.00 18.20           O  
+ATOM   4029  CB  SER B2220      81.035  48.015  20.341  1.00 18.70           C  
+ATOM   4030  OG  SER B2220      82.137  47.166  20.642  1.00 21.16           O  
+ATOM   4031  N   ASP B2221      83.472  48.778  18.237  1.00 20.07           N  
+ATOM   4032  CA  ASP B2221      84.741  49.472  18.043  1.00 20.65           C  
+ATOM   4033  C   ASP B2221      84.642  50.542  16.953  1.00 21.08           C  
+ATOM   4034  O   ASP B2221      85.551  51.361  16.791  1.00 20.66           O  
+ATOM   4035  CB  ASP B2221      85.856  48.471  17.705  1.00 20.30           C  
+ATOM   4036  CG  ASP B2221      86.206  47.580  18.884  1.00 21.28           C  
+ATOM   4037  OD1 ASP B2221      86.254  48.109  20.022  1.00 20.48           O  
+ATOM   4038  OD2 ASP B2221      86.438  46.365  18.679  1.00 20.74           O  
+ATOM   4039  N   PHE B2222      83.532  50.539  16.215  1.00 20.22           N  
+ATOM   4040  CA  PHE B2222      83.316  51.526  15.161  1.00 20.70           C  
+ATOM   4041  C   PHE B2222      82.020  52.310  15.412  1.00 20.95           C  
+ATOM   4042  O   PHE B2222      81.473  52.961  14.507  1.00 20.10           O  
+ATOM   4043  CB  PHE B2222      83.268  50.836  13.791  1.00 21.34           C  
+ATOM   4044  CG  PHE B2222      84.509  50.059  13.469  1.00 23.07           C  
+ATOM   4045  CD1 PHE B2222      84.520  48.669  13.554  1.00 21.55           C  
+ATOM   4046  CD2 PHE B2222      85.679  50.719  13.100  1.00 23.66           C  
+ATOM   4047  CE1 PHE B2222      85.682  47.946  13.276  1.00 23.79           C  
+ATOM   4048  CE2 PHE B2222      86.848  50.006  12.820  1.00 24.00           C  
+ATOM   4049  CZ  PHE B2222      86.848  48.615  12.908  1.00 24.71           C  
+ATOM   4050  N   VAL B2223      81.530  52.243  16.647  1.00 19.41           N  
+ATOM   4051  CA  VAL B2223      80.310  52.947  17.025  1.00 17.65           C  
+ATOM   4052  C   VAL B2223      80.640  54.005  18.080  1.00 17.33           C  
+ATOM   4053  O   VAL B2223      81.329  53.725  19.055  1.00 17.64           O  
+ATOM   4054  CB  VAL B2223      79.242  51.968  17.574  1.00 17.03           C  
+ATOM   4055  CG1 VAL B2223      78.054  52.742  18.155  1.00 13.83           C  
+ATOM   4056  CG2 VAL B2223      78.764  51.057  16.463  1.00 15.80           C  
+ATOM   4057  N   ASP B2224      80.157  55.225  17.870  1.00 17.79           N  
+ATOM   4058  CA  ASP B2224      80.418  56.313  18.806  1.00 19.74           C  
+ATOM   4059  C   ASP B2224      79.501  56.287  20.024  1.00 18.84           C  
+ATOM   4060  O   ASP B2224      79.953  56.504  21.140  1.00 20.23           O  
+ATOM   4061  CB  ASP B2224      80.273  57.670  18.112  1.00 20.09           C  
+ATOM   4062  CG  ASP B2224      81.276  57.862  16.987  1.00 23.50           C  
+ATOM   4063  OD1 ASP B2224      80.918  57.605  15.814  1.00 20.51           O  
+ATOM   4064  OD2 ASP B2224      82.424  58.266  17.282  1.00 25.48           O  
+ATOM   4065  N   PHE B2225      78.215  56.033  19.807  1.00 19.28           N  
+ATOM   4066  CA  PHE B2225      77.249  56.005  20.905  1.00 20.17           C  
+ATOM   4067  C   PHE B2225      76.304  54.816  20.727  1.00 19.20           C  
+ATOM   4068  O   PHE B2225      75.779  54.599  19.628  1.00 21.32           O  
+ATOM   4069  CB  PHE B2225      76.429  57.308  20.910  1.00 19.18           C  
+ATOM   4070  CG  PHE B2225      75.712  57.585  22.214  1.00 19.39           C  
+ATOM   4071  CD1 PHE B2225      76.315  58.359  23.208  1.00 17.80           C  
+ATOM   4072  CD2 PHE B2225      74.436  57.081  22.443  1.00 17.60           C  
+ATOM   4073  CE1 PHE B2225      75.651  58.625  24.410  1.00 19.13           C  
+ATOM   4074  CE2 PHE B2225      73.764  57.344  23.640  1.00 18.56           C  
+ATOM   4075  CZ  PHE B2225      74.376  58.117  24.625  1.00 18.72           C  
+ATOM   4076  N   SER B2226      76.080  54.053  21.792  1.00 16.86           N  
+ATOM   4077  CA  SER B2226      75.176  52.918  21.703  1.00 16.94           C  
+ATOM   4078  C   SER B2226      74.025  53.007  22.715  1.00 17.62           C  
+ATOM   4079  O   SER B2226      74.212  53.392  23.876  1.00 18.08           O  
+ATOM   4080  CB  SER B2226      75.948  51.601  21.886  1.00 16.89           C  
+ATOM   4081  OG  SER B2226      76.447  51.464  23.199  1.00 15.18           O  
+ATOM   4082  N   ILE B2227      72.836  52.637  22.253  1.00 17.30           N  
+ATOM   4083  CA  ILE B2227      71.632  52.654  23.070  1.00 18.14           C  
+ATOM   4084  C   ILE B2227      71.037  51.252  23.126  1.00 19.38           C  
+ATOM   4085  O   ILE B2227      70.926  50.577  22.103  1.00 19.11           O  
+ATOM   4086  CB  ILE B2227      70.542  53.576  22.454  1.00 19.74           C  
+ATOM   4087  CG1 ILE B2227      70.982  55.038  22.502  1.00 18.93           C  
+ATOM   4088  CG2 ILE B2227      69.210  53.377  23.181  1.00 16.96           C  
+ATOM   4089  CD1 ILE B2227      70.190  55.927  21.541  1.00 22.15           C  
+ATOM   4090  N   TYR B2228      70.658  50.814  24.320  1.00 19.40           N  
+ATOM   4091  CA  TYR B2228      70.023  49.516  24.463  1.00 18.53           C  
+ATOM   4092  C   TYR B2228      68.592  49.769  24.941  1.00 18.80           C  
+ATOM   4093  O   TYR B2228      68.376  50.309  26.030  1.00 18.22           O  
+ATOM   4094  CB  TYR B2228      70.773  48.651  25.480  1.00 17.66           C  
+ATOM   4095  CG  TYR B2228      70.212  47.252  25.618  1.00 20.22           C  
+ATOM   4096  CD1 TYR B2228      70.781  46.173  24.934  1.00 19.66           C  
+ATOM   4097  CD2 TYR B2228      69.105  47.003  26.438  1.00 21.49           C  
+ATOM   4098  CE1 TYR B2228      70.263  44.883  25.068  1.00 20.08           C  
+ATOM   4099  CE2 TYR B2228      68.582  45.724  26.577  1.00 19.30           C  
+ATOM   4100  CZ  TYR B2228      69.165  44.668  25.893  1.00 20.45           C  
+ATOM   4101  OH  TYR B2228      68.654  43.399  26.052  1.00 20.09           O  
+ATOM   4102  N   VAL B2229      67.613  49.410  24.115  1.00 20.44           N  
+ATOM   4103  CA  VAL B2229      66.212  49.587  24.488  1.00 19.61           C  
+ATOM   4104  C   VAL B2229      65.858  48.348  25.310  1.00 21.61           C  
+ATOM   4105  O   VAL B2229      66.032  47.210  24.857  1.00 21.57           O  
+ATOM   4106  CB  VAL B2229      65.326  49.700  23.239  1.00 19.03           C  
+ATOM   4107  CG1 VAL B2229      63.941  50.213  23.615  1.00 16.75           C  
+ATOM   4108  CG2 VAL B2229      65.987  50.642  22.244  1.00 18.23           C  
+ATOM   4109  N   ASP B2230      65.374  48.574  26.525  1.00 21.84           N  
+ATOM   4110  CA  ASP B2230      65.070  47.490  27.451  1.00 21.62           C  
+ATOM   4111  C   ASP B2230      63.612  47.425  27.894  1.00 23.24           C  
+ATOM   4112  O   ASP B2230      62.945  48.460  28.022  1.00 22.70           O  
+ATOM   4113  CB  ASP B2230      65.984  47.655  28.666  1.00 22.48           C  
+ATOM   4114  CG  ASP B2230      66.067  46.416  29.523  1.00 23.64           C  
+ATOM   4115  OD1 ASP B2230      66.007  45.292  28.989  1.00 25.89           O  
+ATOM   4116  OD2 ASP B2230      66.223  46.572  30.745  1.00 27.30           O  
+ATOM   4117  N   ALA B2231      63.121  46.204  28.119  1.00 23.15           N  
+ATOM   4118  CA  ALA B2231      61.745  45.987  28.573  1.00 24.95           C  
+ATOM   4119  C   ALA B2231      61.568  44.578  29.133  1.00 26.39           C  
+ATOM   4120  O   ALA B2231      62.308  43.663  28.776  1.00 28.48           O  
+ATOM   4121  CB  ALA B2231      60.772  46.220  27.434  1.00 22.94           C  
+ATOM   4122  N   PRO B2232      60.585  44.387  30.028  1.00 27.95           N  
+ATOM   4123  CA  PRO B2232      60.314  43.079  30.640  1.00 28.69           C  
+ATOM   4124  C   PRO B2232      59.845  42.058  29.609  1.00 28.24           C  
+ATOM   4125  O   PRO B2232      59.263  42.419  28.597  1.00 29.09           O  
+ATOM   4126  CB  PRO B2232      59.216  43.389  31.659  1.00 30.23           C  
+ATOM   4127  CG  PRO B2232      59.409  44.839  31.960  1.00 28.74           C  
+ATOM   4128  CD  PRO B2232      59.719  45.424  30.614  1.00 28.17           C  
+ATOM   4129  N   GLU B2233      60.091  40.783  29.886  1.00 29.21           N  
+ATOM   4130  CA  GLU B2233      59.705  39.701  28.989  1.00 29.78           C  
+ATOM   4131  C   GLU B2233      58.202  39.668  28.718  1.00 29.09           C  
+ATOM   4132  O   GLU B2233      57.783  39.404  27.591  1.00 28.20           O  
+ATOM   4133  CB  GLU B2233      60.157  38.363  29.580  1.00 30.75           C  
+ATOM   4134  CG  GLU B2233      59.990  37.146  28.675  1.00 35.36           C  
+ATOM   4135  CD  GLU B2233      58.555  36.653  28.579  1.00 38.71           C  
+ATOM   4136  OE1 GLU B2233      57.841  36.695  29.608  1.00 40.24           O  
+ATOM   4137  OE2 GLU B2233      58.150  36.206  27.479  1.00 37.99           O  
+ATOM   4138  N   ASP B2234      57.393  39.938  29.741  1.00 27.25           N  
+ATOM   4139  CA  ASP B2234      55.943  39.915  29.573  1.00 28.23           C  
+ATOM   4140  C   ASP B2234      55.450  40.981  28.601  1.00 26.58           C  
+ATOM   4141  O   ASP B2234      54.492  40.755  27.864  1.00 26.90           O  
+ATOM   4142  CB  ASP B2234      55.233  40.074  30.924  1.00 31.76           C  
+ATOM   4143  CG  ASP B2234      55.481  41.423  31.561  1.00 34.99           C  
+ATOM   4144  OD1 ASP B2234      56.639  41.701  31.938  1.00 38.18           O  
+ATOM   4145  OD2 ASP B2234      54.515  42.209  31.681  1.00 38.36           O  
+ATOM   4146  N   LEU B2235      56.096  42.144  28.598  1.00 24.35           N  
+ATOM   4147  CA  LEU B2235      55.697  43.213  27.683  1.00 23.20           C  
+ATOM   4148  C   LEU B2235      56.208  42.925  26.275  1.00 22.77           C  
+ATOM   4149  O   LEU B2235      55.516  43.183  25.293  1.00 23.08           O  
+ATOM   4150  CB  LEU B2235      56.227  44.564  28.162  1.00 21.66           C  
+ATOM   4151  CG  LEU B2235      55.528  45.123  29.399  1.00 21.54           C  
+ATOM   4152  CD1 LEU B2235      56.231  46.385  29.879  1.00 22.63           C  
+ATOM   4153  CD2 LEU B2235      54.078  45.412  29.062  1.00 21.63           C  
+ATOM   4154  N   LEU B2236      57.417  42.379  26.188  1.00 22.60           N  
+ATOM   4155  CA  LEU B2236      58.014  42.046  24.899  1.00 22.45           C  
+ATOM   4156  C   LEU B2236      57.151  41.017  24.164  1.00 24.39           C  
+ATOM   4157  O   LEU B2236      56.930  41.121  22.952  1.00 23.85           O  
+ATOM   4158  CB  LEU B2236      59.433  41.493  25.099  1.00 22.09           C  
+ATOM   4159  CG  LEU B2236      60.518  42.478  25.574  1.00 20.76           C  
+ATOM   4160  CD1 LEU B2236      61.812  41.746  25.817  1.00 19.88           C  
+ATOM   4161  CD2 LEU B2236      60.726  43.561  24.538  1.00 16.07           C  
+ATOM   4162  N   GLN B2237      56.654  40.030  24.904  1.00 23.92           N  
+ATOM   4163  CA  GLN B2237      55.812  38.986  24.325  1.00 25.72           C  
+ATOM   4164  C   GLN B2237      54.539  39.595  23.732  1.00 24.62           C  
+ATOM   4165  O   GLN B2237      54.170  39.313  22.593  1.00 25.62           O  
+ATOM   4166  CB  GLN B2237      55.456  37.944  25.391  1.00 26.44           C  
+ATOM   4167  CG  GLN B2237      54.715  36.735  24.844  1.00 29.96           C  
+ATOM   4168  CD  GLN B2237      54.304  35.753  25.930  1.00 32.77           C  
+ATOM   4169  OE1 GLN B2237      55.142  35.241  26.672  1.00 33.72           O  
+ATOM   4170  NE2 GLN B2237      53.005  35.482  26.023  1.00 35.61           N  
+ATOM   4171  N   THR B2238      53.881  40.447  24.505  1.00 24.06           N  
+ATOM   4172  CA  THR B2238      52.663  41.112  24.056  1.00 23.85           C  
+ATOM   4173  C   THR B2238      52.910  41.946  22.793  1.00 24.62           C  
+ATOM   4174  O   THR B2238      52.147  41.866  21.824  1.00 23.41           O  
+ATOM   4175  CB  THR B2238      52.115  42.041  25.157  1.00 24.12           C  
+ATOM   4176  OG1 THR B2238      51.846  41.272  26.340  1.00 25.43           O  
+ATOM   4177  CG2 THR B2238      50.848  42.727  24.695  1.00 23.86           C  
+ATOM   4178  N   TRP B2239      53.972  42.749  22.807  1.00 23.77           N  
+ATOM   4179  CA  TRP B2239      54.302  43.588  21.660  1.00 22.08           C  
+ATOM   4180  C   TRP B2239      54.625  42.739  20.435  1.00 22.29           C  
+ATOM   4181  O   TRP B2239      54.226  43.075  19.321  1.00 22.28           O  
+ATOM   4182  CB  TRP B2239      55.486  44.503  21.993  1.00 21.27           C  
+ATOM   4183  CG  TRP B2239      55.225  45.366  23.192  1.00 21.20           C  
+ATOM   4184  CD1 TRP B2239      54.009  45.647  23.746  1.00 21.40           C  
+ATOM   4185  CD2 TRP B2239      56.196  46.065  23.982  1.00 21.22           C  
+ATOM   4186  NE1 TRP B2239      54.160  46.473  24.834  1.00 21.81           N  
+ATOM   4187  CE2 TRP B2239      55.492  46.746  25.003  1.00 21.43           C  
+ATOM   4188  CE3 TRP B2239      57.593  46.181  23.932  1.00 20.52           C  
+ATOM   4189  CZ2 TRP B2239      56.137  47.534  25.966  1.00 19.37           C  
+ATOM   4190  CZ3 TRP B2239      58.236  46.967  24.894  1.00 18.01           C  
+ATOM   4191  CH2 TRP B2239      57.506  47.629  25.894  1.00 19.36           C  
+ATOM   4192  N   TYR B2240      55.339  41.635  20.649  1.00 22.33           N  
+ATOM   4193  CA  TYR B2240      55.698  40.734  19.560  1.00 21.68           C  
+ATOM   4194  C   TYR B2240      54.435  40.147  18.922  1.00 22.64           C  
+ATOM   4195  O   TYR B2240      54.259  40.183  17.700  1.00 19.89           O  
+ATOM   4196  CB  TYR B2240      56.574  39.578  20.067  1.00 19.63           C  
+ATOM   4197  CG  TYR B2240      56.899  38.592  18.965  1.00 21.26           C  
+ATOM   4198  CD1 TYR B2240      57.897  38.869  18.024  1.00 19.94           C  
+ATOM   4199  CD2 TYR B2240      56.140  37.430  18.797  1.00 21.49           C  
+ATOM   4200  CE1 TYR B2240      58.127  38.020  16.941  1.00 21.16           C  
+ATOM   4201  CE2 TYR B2240      56.357  36.577  17.716  1.00 21.81           C  
+ATOM   4202  CZ  TYR B2240      57.348  36.879  16.793  1.00 21.13           C  
+ATOM   4203  OH  TYR B2240      57.534  36.058  15.717  1.00 20.66           O  
+ATOM   4204  N   ILE B2241      53.562  39.598  19.763  1.00 23.56           N  
+ATOM   4205  CA  ILE B2241      52.322  38.994  19.290  1.00 24.73           C  
+ATOM   4206  C   ILE B2241      51.438  40.007  18.561  1.00 26.17           C  
+ATOM   4207  O   ILE B2241      50.969  39.741  17.450  1.00 25.87           O  
+ATOM   4208  CB  ILE B2241      51.531  38.364  20.467  1.00 26.73           C  
+ATOM   4209  CG1 ILE B2241      52.327  37.192  21.050  1.00 25.88           C  
+ATOM   4210  CG2 ILE B2241      50.156  37.885  19.990  1.00 27.11           C  
+ATOM   4211  CD1 ILE B2241      51.731  36.595  22.306  1.00 26.54           C  
+ATOM   4212  N   ASN B2242      51.214  41.169  19.172  1.00 26.06           N  
+ATOM   4213  CA  ASN B2242      50.380  42.178  18.529  1.00 26.71           C  
+ATOM   4214  C   ASN B2242      50.965  42.623  17.190  1.00 25.74           C  
+ATOM   4215  O   ASN B2242      50.221  42.911  16.256  1.00 26.06           O  
+ATOM   4216  CB  ASN B2242      50.167  43.381  19.453  1.00 27.35           C  
+ATOM   4217  CG  ASN B2242      49.353  43.024  20.690  1.00 28.97           C  
+ATOM   4218  OD1 ASN B2242      48.515  42.123  20.652  1.00 29.79           O  
+ATOM   4219  ND2 ASN B2242      49.584  43.738  21.787  1.00 29.20           N  
+ATOM   4220  N   ARG B2243      52.291  42.666  17.084  1.00 24.22           N  
+ATOM   4221  CA  ARG B2243      52.911  43.055  15.819  1.00 24.60           C  
+ATOM   4222  C   ARG B2243      52.681  41.932  14.810  1.00 22.50           C  
+ATOM   4223  O   ARG B2243      52.440  42.178  13.633  1.00 21.67           O  
+ATOM   4224  CB  ARG B2243      54.418  43.305  15.989  1.00 24.95           C  
+ATOM   4225  CG  ARG B2243      55.083  43.845  14.714  1.00 24.36           C  
+ATOM   4226  CD  ARG B2243      56.572  44.085  14.912  1.00 21.27           C  
+ATOM   4227  NE  ARG B2243      57.286  42.843  15.185  1.00 19.87           N  
+ATOM   4228  CZ  ARG B2243      58.592  42.760  15.412  1.00 20.13           C  
+ATOM   4229  NH1 ARG B2243      59.345  43.855  15.402  1.00 21.29           N  
+ATOM   4230  NH2 ARG B2243      59.143  41.582  15.649  1.00 18.86           N  
+ATOM   4231  N   PHE B2244      52.755  40.697  15.294  1.00 23.24           N  
+ATOM   4232  CA  PHE B2244      52.534  39.521  14.457  1.00 23.57           C  
+ATOM   4233  C   PHE B2244      51.129  39.579  13.866  1.00 23.09           C  
+ATOM   4234  O   PHE B2244      50.942  39.425  12.656  1.00 23.43           O  
+ATOM   4235  CB  PHE B2244      52.676  38.246  15.296  1.00 23.55           C  
+ATOM   4236  CG  PHE B2244      52.335  36.979  14.552  1.00 24.41           C  
+ATOM   4237  CD1 PHE B2244      53.298  36.309  13.806  1.00 26.19           C  
+ATOM   4238  CD2 PHE B2244      51.046  36.455  14.603  1.00 25.44           C  
+ATOM   4239  CE1 PHE B2244      52.978  35.127  13.120  1.00 27.21           C  
+ATOM   4240  CE2 PHE B2244      50.718  35.285  13.927  1.00 25.49           C  
+ATOM   4241  CZ  PHE B2244      51.686  34.617  13.183  1.00 26.33           C  
+ATOM   4242  N   LEU B2245      50.145  39.805  14.730  1.00 23.10           N  
+ATOM   4243  CA  LEU B2245      48.758  39.875  14.303  1.00 23.97           C  
+ATOM   4244  C   LEU B2245      48.534  40.929  13.230  1.00 25.07           C  
+ATOM   4245  O   LEU B2245      47.849  40.669  12.236  1.00 26.28           O  
+ATOM   4246  CB  LEU B2245      47.843  40.134  15.507  1.00 23.26           C  
+ATOM   4247  CG  LEU B2245      47.864  38.988  16.522  1.00 24.29           C  
+ATOM   4248  CD1 LEU B2245      46.933  39.276  17.682  1.00 22.97           C  
+ATOM   4249  CD2 LEU B2245      47.451  37.703  15.819  1.00 26.17           C  
+ATOM   4250  N   LYS B2246      49.110  42.116  13.407  1.00 25.39           N  
+ATOM   4251  CA  LYS B2246      48.935  43.166  12.405  1.00 25.04           C  
+ATOM   4252  C   LYS B2246      49.545  42.693  11.094  1.00 25.45           C  
+ATOM   4253  O   LYS B2246      48.994  42.939  10.020  1.00 25.18           O  
+ATOM   4254  CB  LYS B2246      49.590  44.474  12.862  1.00 24.88           C  
+ATOM   4255  N   PHE B2247      50.680  42.001  11.181  1.00 25.65           N  
+ATOM   4256  CA  PHE B2247      51.331  41.481   9.982  1.00 27.08           C  
+ATOM   4257  C   PHE B2247      50.466  40.424   9.298  1.00 26.84           C  
+ATOM   4258  O   PHE B2247      50.437  40.353   8.074  1.00 28.12           O  
+ATOM   4259  CB  PHE B2247      52.699  40.886  10.322  1.00 29.09           C  
+ATOM   4260  CG  PHE B2247      53.793  41.908  10.451  1.00 30.72           C  
+ATOM   4261  CD1 PHE B2247      54.850  41.704  11.331  1.00 31.57           C  
+ATOM   4262  CD2 PHE B2247      53.785  43.063   9.671  1.00 33.95           C  
+ATOM   4263  CE1 PHE B2247      55.886  42.632  11.437  1.00 32.26           C  
+ATOM   4264  CE2 PHE B2247      54.818  44.000   9.768  1.00 35.20           C  
+ATOM   4265  CZ  PHE B2247      55.871  43.781  10.656  1.00 32.80           C  
+ATOM   4266  N   ARG B2248      49.765  39.601  10.073  1.00 26.82           N  
+ATOM   4267  CA  ARG B2248      48.908  38.583   9.462  1.00 29.10           C  
+ATOM   4268  C   ARG B2248      47.744  39.255   8.722  1.00 29.28           C  
+ATOM   4269  O   ARG B2248      47.468  38.931   7.568  1.00 28.67           O  
+ATOM   4270  CB  ARG B2248      48.353  37.608  10.517  1.00 29.33           C  
+ATOM   4271  CG  ARG B2248      47.779  36.318   9.905  1.00 31.15           C  
+ATOM   4272  CD  ARG B2248      47.210  35.375  10.960  1.00 30.24           C  
+ATOM   4273  NE  ARG B2248      46.080  35.990  11.636  1.00 34.25           N  
+ATOM   4274  CZ  ARG B2248      44.811  35.629  11.473  1.00 33.84           C  
+ATOM   4275  NH1 ARG B2248      44.485  34.637  10.656  1.00 34.12           N  
+ATOM   4276  NH2 ARG B2248      43.864  36.288  12.116  1.00 35.15           N  
+ATOM   4277  N   GLU B2249      47.070  40.189   9.393  1.00 30.13           N  
+ATOM   4278  CA  GLU B2249      45.949  40.918   8.801  1.00 32.50           C  
+ATOM   4279  C   GLU B2249      46.353  41.536   7.472  1.00 31.53           C  
+ATOM   4280  O   GLU B2249      45.637  41.418   6.481  1.00 31.77           O  
+ATOM   4281  CB  GLU B2249      45.476  42.037   9.736  1.00 35.72           C  
+ATOM   4282  CG  GLU B2249      44.768  41.556  10.990  1.00 41.77           C  
+ATOM   4283  CD  GLU B2249      44.480  42.683  11.967  1.00 44.66           C  
+ATOM   4284  OE1 GLU B2249      43.962  43.734  11.530  1.00 48.54           O  
+ATOM   4285  OE2 GLU B2249      44.763  42.517  13.174  1.00 46.99           O  
+ATOM   4286  N   GLY B2250      47.507  42.191   7.461  1.00 30.93           N  
+ATOM   4287  CA  GLY B2250      47.982  42.833   6.250  1.00 30.37           C  
+ATOM   4288  C   GLY B2250      48.295  41.910   5.089  1.00 31.16           C  
+ATOM   4289  O   GLY B2250      48.508  42.378   3.972  1.00 33.80           O  
+ATOM   4290  N   ALA B2251      48.319  40.605   5.333  1.00 29.87           N  
+ATOM   4291  CA  ALA B2251      48.632  39.651   4.277  1.00 29.54           C  
+ATOM   4292  C   ALA B2251      47.441  38.818   3.822  1.00 29.24           C  
+ATOM   4293  O   ALA B2251      47.595  37.902   3.013  1.00 29.71           O  
+ATOM   4294  CB  ALA B2251      49.769  38.725   4.737  1.00 32.21           C  
+ATOM   4295  N   PHE B2252      46.257  39.135   4.334  1.00 29.17           N  
+ATOM   4296  CA  PHE B2252      45.046  38.402   3.976  1.00 28.92           C  
+ATOM   4297  C   PHE B2252      44.834  38.250   2.471  1.00 30.35           C  
+ATOM   4298  O   PHE B2252      44.447  37.182   2.001  1.00 30.71           O  
+ATOM   4299  CB  PHE B2252      43.812  39.067   4.606  1.00 26.07           C  
+ATOM   4300  CG  PHE B2252      43.618  38.741   6.071  1.00 23.90           C  
+ATOM   4301  CD1 PHE B2252      42.669  39.421   6.828  1.00 22.54           C  
+ATOM   4302  CD2 PHE B2252      44.383  37.751   6.694  1.00 22.94           C  
+ATOM   4303  CE1 PHE B2252      42.484  39.125   8.185  1.00 21.89           C  
+ATOM   4304  CE2 PHE B2252      44.204  37.450   8.050  1.00 21.83           C  
+ATOM   4305  CZ  PHE B2252      43.251  38.141   8.796  1.00 19.64           C  
+ATOM   4306  N   THR B2253      45.096  39.305   1.710  1.00 32.02           N  
+ATOM   4307  CA  THR B2253      44.894  39.237   0.268  1.00 33.78           C  
+ATOM   4308  C   THR B2253      46.187  39.328  -0.552  1.00 37.26           C  
+ATOM   4309  O   THR B2253      46.149  39.657  -1.742  1.00 37.92           O  
+ATOM   4310  CB  THR B2253      43.948  40.357  -0.194  1.00 32.94           C  
+ATOM   4311  OG1 THR B2253      44.577  41.623   0.030  1.00 31.64           O  
+ATOM   4312  CG2 THR B2253      42.645  40.311   0.589  1.00 32.47           C  
+ATOM   4313  N   ASP B2254      47.326  39.032   0.072  1.00 39.67           N  
+ATOM   4314  CA  ASP B2254      48.604  39.099  -0.627  1.00 41.73           C  
+ATOM   4315  C   ASP B2254      49.401  37.798  -0.543  1.00 43.56           C  
+ATOM   4316  O   ASP B2254      50.229  37.617   0.348  1.00 43.62           O  
+ATOM   4317  CB  ASP B2254      49.430  40.263  -0.079  1.00 42.95           C  
+ATOM   4318  CG  ASP B2254      50.719  40.470  -0.843  1.00 43.49           C  
+ATOM   4319  OD1 ASP B2254      50.795  40.029  -2.007  1.00 44.61           O  
+ATOM   4320  OD2 ASP B2254      51.650  41.085  -0.287  1.00 44.11           O  
+ATOM   4321  N   PRO B2255      49.147  36.868  -1.476  1.00 45.23           N  
+ATOM   4322  CA  PRO B2255      49.831  35.571  -1.527  1.00 47.05           C  
+ATOM   4323  C   PRO B2255      51.330  35.679  -1.812  1.00 48.33           C  
+ATOM   4324  O   PRO B2255      52.048  34.684  -1.746  1.00 49.38           O  
+ATOM   4325  CB  PRO B2255      49.085  34.834  -2.631  1.00 47.11           C  
+ATOM   4326  CG  PRO B2255      47.702  35.413  -2.542  1.00 46.62           C  
+ATOM   4327  CD  PRO B2255      47.999  36.881  -2.398  1.00 46.14           C  
+ATOM   4328  N   ASP B2256      51.800  36.879  -2.147  1.00 49.46           N  
+ATOM   4329  CA  ASP B2256      53.229  37.076  -2.398  1.00 49.63           C  
+ATOM   4330  C   ASP B2256      53.898  37.336  -1.055  1.00 48.78           C  
+ATOM   4331  O   ASP B2256      55.126  37.440  -0.964  1.00 49.57           O  
+ATOM   4332  CB  ASP B2256      53.485  38.281  -3.313  1.00 51.25           C  
+ATOM   4333  CG  ASP B2256      52.920  38.093  -4.706  1.00 52.91           C  
+ATOM   4334  OD1 ASP B2256      53.073  36.983  -5.264  1.00 53.99           O  
+ATOM   4335  OD2 ASP B2256      52.337  39.060  -5.245  1.00 52.45           O  
+ATOM   4336  N   SER B2257      53.076  37.438  -0.014  1.00 46.38           N  
+ATOM   4337  CA  SER B2257      53.563  37.706   1.328  1.00 43.65           C  
+ATOM   4338  C   SER B2257      53.790  36.432   2.132  1.00 42.46           C  
+ATOM   4339  O   SER B2257      53.042  35.457   2.014  1.00 43.51           O  
+ATOM   4340  CB  SER B2257      52.575  38.617   2.062  1.00 43.99           C  
+ATOM   4341  OG  SER B2257      53.103  39.067   3.297  1.00 43.53           O  
+ATOM   4342  N   TYR B2258      54.843  36.454   2.943  1.00 39.99           N  
+ATOM   4343  CA  TYR B2258      55.213  35.333   3.801  1.00 36.73           C  
+ATOM   4344  C   TYR B2258      54.141  35.118   4.865  1.00 35.06           C  
+ATOM   4345  O   TYR B2258      53.851  33.988   5.249  1.00 34.53           O  
+ATOM   4346  CB  TYR B2258      56.561  35.635   4.471  1.00 38.07           C  
+ATOM   4347  CG  TYR B2258      56.962  34.684   5.577  1.00 36.36           C  
+ATOM   4348  CD1 TYR B2258      57.403  33.398   5.289  1.00 37.76           C  
+ATOM   4349  CD2 TYR B2258      56.906  35.077   6.914  1.00 36.68           C  
+ATOM   4350  CE1 TYR B2258      57.784  32.518   6.309  1.00 39.30           C  
+ATOM   4351  CE2 TYR B2258      57.281  34.209   7.942  1.00 37.66           C  
+ATOM   4352  CZ  TYR B2258      57.720  32.931   7.633  1.00 37.82           C  
+ATOM   4353  OH  TYR B2258      58.092  32.058   8.636  1.00 38.15           O  
+ATOM   4354  N   PHE B2259      53.555  36.209   5.342  1.00 33.12           N  
+ATOM   4355  CA  PHE B2259      52.525  36.121   6.368  1.00 32.79           C  
+ATOM   4356  C   PHE B2259      51.167  35.613   5.893  1.00 32.31           C  
+ATOM   4357  O   PHE B2259      50.244  35.470   6.697  1.00 31.05           O  
+ATOM   4358  CB  PHE B2259      52.349  37.474   7.069  1.00 33.24           C  
+ATOM   4359  CG  PHE B2259      53.250  37.655   8.259  1.00 33.65           C  
+ATOM   4360  CD1 PHE B2259      54.565  38.075   8.098  1.00 33.63           C  
+ATOM   4361  CD2 PHE B2259      52.795  37.352   9.542  1.00 33.39           C  
+ATOM   4362  CE1 PHE B2259      55.420  38.189   9.200  1.00 33.10           C  
+ATOM   4363  CE2 PHE B2259      53.642  37.461  10.647  1.00 33.76           C  
+ATOM   4364  CZ  PHE B2259      54.957  37.880  10.473  1.00 32.12           C  
+ATOM   4365  N   HIS B2260      51.030  35.339   4.602  1.00 32.24           N  
+ATOM   4366  CA  HIS B2260      49.757  34.829   4.106  1.00 33.63           C  
+ATOM   4367  C   HIS B2260      49.593  33.409   4.640  1.00 33.54           C  
+ATOM   4368  O   HIS B2260      48.473  32.931   4.832  1.00 33.47           O  
+ATOM   4369  CB  HIS B2260      49.730  34.839   2.574  1.00 36.00           C  
+ATOM   4370  CG  HIS B2260      48.390  34.513   1.987  1.00 38.52           C  
+ATOM   4371  ND1 HIS B2260      47.883  33.230   1.949  1.00 39.98           N  
+ATOM   4372  CD2 HIS B2260      47.446  35.307   1.425  1.00 38.38           C  
+ATOM   4373  CE1 HIS B2260      46.685  33.249   1.390  1.00 39.82           C  
+ATOM   4374  NE2 HIS B2260      46.397  34.497   1.063  1.00 39.84           N  
+ATOM   4375  N   ASN B2261      50.720  32.746   4.900  1.00 31.57           N  
+ATOM   4376  CA  ASN B2261      50.702  31.392   5.430  1.00 30.47           C  
+ATOM   4377  C   ASN B2261      49.931  31.343   6.754  1.00 30.30           C  
+ATOM   4378  O   ASN B2261      49.318  30.327   7.080  1.00 29.77           O  
+ATOM   4379  CB  ASN B2261      52.130  30.881   5.675  1.00 32.22           C  
+ATOM   4380  CG  ASN B2261      52.902  30.633   4.391  1.00 33.75           C  
+ATOM   4381  OD1 ASN B2261      52.471  29.868   3.525  1.00 34.93           O  
+ATOM   4382  ND2 ASN B2261      54.058  31.273   4.269  1.00 32.96           N  
+ATOM   4383  N   TYR B2262      49.974  32.430   7.522  1.00 28.10           N  
+ATOM   4384  CA  TYR B2262      49.278  32.477   8.811  1.00 28.15           C  
+ATOM   4385  C   TYR B2262      47.793  32.839   8.722  1.00 27.55           C  
+ATOM   4386  O   TYR B2262      47.054  32.705   9.701  1.00 27.21           O  
+ATOM   4387  CB  TYR B2262      50.002  33.443   9.764  1.00 27.82           C  
+ATOM   4388  CG  TYR B2262      51.392  32.976  10.138  1.00 27.96           C  
+ATOM   4389  CD1 TYR B2262      52.506  33.799   9.959  1.00 30.62           C  
+ATOM   4390  CD2 TYR B2262      51.600  31.691  10.630  1.00 29.32           C  
+ATOM   4391  CE1 TYR B2262      53.802  33.345  10.262  1.00 30.35           C  
+ATOM   4392  CE2 TYR B2262      52.882  31.228  10.931  1.00 30.88           C  
+ATOM   4393  CZ  TYR B2262      53.975  32.056  10.745  1.00 31.18           C  
+ATOM   4394  OH  TYR B2262      55.231  31.578  11.041  1.00 32.49           O  
+ATOM   4395  N   ALA B2263      47.343  33.281   7.553  1.00 27.90           N  
+ATOM   4396  CA  ALA B2263      45.934  33.629   7.401  1.00 30.01           C  
+ATOM   4397  C   ALA B2263      45.092  32.351   7.447  1.00 30.68           C  
+ATOM   4398  O   ALA B2263      43.940  32.367   7.897  1.00 30.12           O  
+ATOM   4399  CB  ALA B2263      45.706  34.357   6.086  1.00 30.09           C  
+ATOM   4400  N   LYS B2264      45.680  31.246   6.992  1.00 29.26           N  
+ATOM   4401  CA  LYS B2264      45.002  29.953   6.972  1.00 28.32           C  
+ATOM   4402  C   LYS B2264      44.682  29.457   8.379  1.00 26.12           C  
+ATOM   4403  O   LYS B2264      43.882  28.546   8.554  1.00 25.59           O  
+ATOM   4404  CB  LYS B2264      45.869  28.918   6.253  1.00 30.94           C  
+ATOM   4405  CG  LYS B2264      46.471  29.440   4.961  1.00 35.81           C  
+ATOM   4406  CD  LYS B2264      47.006  28.320   4.086  1.00 38.64           C  
+ATOM   4407  CE  LYS B2264      47.600  28.886   2.800  1.00 41.56           C  
+ATOM   4408  NZ  LYS B2264      47.892  27.831   1.783  1.00 45.04           N  
+ATOM   4409  N   LEU B2265      45.312  30.059   9.379  1.00 23.50           N  
+ATOM   4410  CA  LEU B2265      45.086  29.661  10.760  1.00 22.71           C  
+ATOM   4411  C   LEU B2265      44.039  30.546  11.415  1.00 22.35           C  
+ATOM   4412  O   LEU B2265      43.899  31.713  11.054  1.00 22.06           O  
+ATOM   4413  CB  LEU B2265      46.393  29.757  11.556  1.00 23.27           C  
+ATOM   4414  CG  LEU B2265      47.628  29.002  11.041  1.00 25.38           C  
+ATOM   4415  CD1 LEU B2265      48.818  29.389  11.905  1.00 24.10           C  
+ATOM   4416  CD2 LEU B2265      47.405  27.480  11.072  1.00 24.18           C  
+ATOM   4417  N   THR B2266      43.291  30.000  12.369  1.00 21.91           N  
+ATOM   4418  CA  THR B2266      42.302  30.809  13.063  1.00 21.96           C  
+ATOM   4419  C   THR B2266      43.109  31.811  13.893  1.00 24.74           C  
+ATOM   4420  O   THR B2266      44.304  31.605  14.145  1.00 24.43           O  
+ATOM   4421  CB  THR B2266      41.434  29.971  14.023  1.00 21.43           C  
+ATOM   4422  OG1 THR B2266      42.265  29.413  15.050  1.00 23.07           O  
+ATOM   4423  CG2 THR B2266      40.712  28.853  13.270  1.00 18.55           C  
+ATOM   4424  N   LYS B2267      42.470  32.893  14.322  1.00 24.26           N  
+ATOM   4425  CA  LYS B2267      43.171  33.891  15.115  1.00 24.27           C  
+ATOM   4426  C   LYS B2267      43.760  33.242  16.363  1.00 22.86           C  
+ATOM   4427  O   LYS B2267      44.909  33.494  16.720  1.00 19.72           O  
+ATOM   4428  CB  LYS B2267      42.211  35.021  15.506  1.00 26.49           C  
+ATOM   4429  CG  LYS B2267      42.897  36.257  16.082  1.00 27.42           C  
+ATOM   4430  CD  LYS B2267      41.976  37.468  15.975  1.00 32.85           C  
+ATOM   4431  CE  LYS B2267      42.513  38.673  16.737  1.00 35.69           C  
+ATOM   4432  NZ  LYS B2267      42.384  38.498  18.218  1.00 37.24           N  
+ATOM   4433  N   GLU B2268      42.967  32.392  17.009  1.00 23.05           N  
+ATOM   4434  CA  GLU B2268      43.397  31.713  18.223  1.00 25.29           C  
+ATOM   4435  C   GLU B2268      44.697  30.940  18.022  1.00 25.08           C  
+ATOM   4436  O   GLU B2268      45.650  31.113  18.785  1.00 24.72           O  
+ATOM   4437  CB  GLU B2268      42.293  30.771  18.720  1.00 25.60           C  
+ATOM   4438  N   GLU B2269      44.744  30.092  16.998  1.00 25.81           N  
+ATOM   4439  CA  GLU B2269      45.952  29.308  16.755  1.00 25.61           C  
+ATOM   4440  C   GLU B2269      47.120  30.167  16.270  1.00 23.19           C  
+ATOM   4441  O   GLU B2269      48.277  29.847  16.535  1.00 24.38           O  
+ATOM   4442  CB  GLU B2269      45.671  28.173  15.759  1.00 23.61           C  
+ATOM   4443  CG  GLU B2269      46.875  27.257  15.556  1.00 24.54           C  
+ATOM   4444  CD  GLU B2269      46.527  25.921  14.929  1.00 25.19           C  
+ATOM   4445  OE1 GLU B2269      45.559  25.852  14.136  1.00 25.66           O  
+ATOM   4446  OE2 GLU B2269      47.243  24.939  15.217  1.00 22.55           O  
+ATOM   4447  N   ALA B2270      46.814  31.256  15.569  1.00 24.15           N  
+ATOM   4448  CA  ALA B2270      47.838  32.173  15.055  1.00 23.72           C  
+ATOM   4449  C   ALA B2270      48.537  32.859  16.224  1.00 23.57           C  
+ATOM   4450  O   ALA B2270      49.726  33.143  16.169  1.00 23.75           O  
+ATOM   4451  CB  ALA B2270      47.203  33.215  14.152  1.00 21.78           C  
+ATOM   4452  N   ILE B2271      47.778  33.133  17.277  1.00 23.74           N  
+ATOM   4453  CA  ILE B2271      48.327  33.758  18.464  1.00 23.91           C  
+ATOM   4454  C   ILE B2271      49.233  32.750  19.169  1.00 25.01           C  
+ATOM   4455  O   ILE B2271      50.326  33.097  19.611  1.00 25.14           O  
+ATOM   4456  CB  ILE B2271      47.211  34.202  19.430  1.00 24.29           C  
+ATOM   4457  CG1 ILE B2271      46.423  35.365  18.825  1.00 22.35           C  
+ATOM   4458  CG2 ILE B2271      47.808  34.620  20.764  1.00 24.87           C  
+ATOM   4459  CD1 ILE B2271      45.176  35.706  19.615  1.00 20.25           C  
+ATOM   4460  N   LYS B2272      48.784  31.500  19.273  1.00 24.50           N  
+ATOM   4461  CA  LYS B2272      49.595  30.482  19.923  1.00 25.22           C  
+ATOM   4462  C   LYS B2272      50.864  30.257  19.116  1.00 24.54           C  
+ATOM   4463  O   LYS B2272      51.944  30.069  19.673  1.00 24.12           O  
+ATOM   4464  CB  LYS B2272      48.816  29.177  20.065  1.00 28.12           C  
+ATOM   4465  CG  LYS B2272      47.604  29.305  20.983  1.00 34.20           C  
+ATOM   4466  CD  LYS B2272      46.990  27.943  21.296  1.00 38.22           C  
+ATOM   4467  CE  LYS B2272      45.695  28.080  22.088  1.00 39.99           C  
+ATOM   4468  NZ  LYS B2272      45.096  26.751  22.435  1.00 43.37           N  
+ATOM   4469  N   THR B2273      50.731  30.290  17.797  1.00 24.44           N  
+ATOM   4470  CA  THR B2273      51.881  30.111  16.926  1.00 24.81           C  
+ATOM   4471  C   THR B2273      52.902  31.231  17.172  1.00 25.17           C  
+ATOM   4472  O   THR B2273      54.098  30.970  17.313  1.00 26.23           O  
+ATOM   4473  CB  THR B2273      51.448  30.127  15.450  1.00 24.85           C  
+ATOM   4474  OG1 THR B2273      50.488  29.088  15.234  1.00 24.24           O  
+ATOM   4475  CG2 THR B2273      52.650  29.911  14.531  1.00 23.65           C  
+ATOM   4476  N   ALA B2274      52.426  32.473  17.224  1.00 23.41           N  
+ATOM   4477  CA  ALA B2274      53.302  33.617  17.454  1.00 23.89           C  
+ATOM   4478  C   ALA B2274      53.966  33.500  18.817  1.00 23.31           C  
+ATOM   4479  O   ALA B2274      55.152  33.785  18.978  1.00 22.20           O  
+ATOM   4480  CB  ALA B2274      52.504  34.915  17.378  1.00 22.17           C  
+ATOM   4481  N   MET B2275      53.175  33.088  19.799  1.00 24.83           N  
+ATOM   4482  CA  MET B2275      53.645  32.916  21.162  1.00 26.43           C  
+ATOM   4483  C   MET B2275      54.797  31.905  21.211  1.00 26.78           C  
+ATOM   4484  O   MET B2275      55.711  32.023  22.029  1.00 25.53           O  
+ATOM   4485  CB  MET B2275      52.486  32.436  22.031  1.00 29.07           C  
+ATOM   4486  CG  MET B2275      52.723  32.547  23.520  1.00 35.86           C  
+ATOM   4487  SD  MET B2275      51.230  32.131  24.461  1.00 42.62           S  
+ATOM   4488  CE  MET B2275      50.101  33.372  23.859  1.00 37.83           C  
+ATOM   4489  N   THR B2276      54.755  30.916  20.323  1.00 25.00           N  
+ATOM   4490  CA  THR B2276      55.793  29.895  20.285  1.00 23.96           C  
+ATOM   4491  C   THR B2276      57.041  30.412  19.580  1.00 23.59           C  
+ATOM   4492  O   THR B2276      58.167  30.074  19.960  1.00 23.16           O  
+ATOM   4493  CB  THR B2276      55.284  28.607  19.590  1.00 22.91           C  
+ATOM   4494  OG1 THR B2276      54.273  27.999  20.403  1.00 20.74           O  
+ATOM   4495  CG2 THR B2276      56.412  27.622  19.401  1.00 21.66           C  
+ATOM   4496  N   LEU B2277      56.844  31.225  18.550  1.00 23.07           N  
+ATOM   4497  CA  LEU B2277      57.975  31.802  17.835  1.00 22.98           C  
+ATOM   4498  C   LEU B2277      58.710  32.670  18.851  1.00 23.01           C  
+ATOM   4499  O   LEU B2277      59.941  32.714  18.887  1.00 20.65           O  
+ATOM   4500  CB  LEU B2277      57.498  32.674  16.666  1.00 21.73           C  
+ATOM   4501  CG  LEU B2277      56.900  31.976  15.438  1.00 23.64           C  
+ATOM   4502  CD1 LEU B2277      56.415  33.006  14.410  1.00 18.89           C  
+ATOM   4503  CD2 LEU B2277      57.963  31.070  14.821  1.00 21.82           C  
+ATOM   4504  N   TRP B2278      57.931  33.343  19.693  1.00 22.96           N  
+ATOM   4505  CA  TRP B2278      58.493  34.216  20.703  1.00 24.38           C  
+ATOM   4506  C   TRP B2278      59.291  33.467  21.758  1.00 25.61           C  
+ATOM   4507  O   TRP B2278      60.483  33.724  21.955  1.00 26.62           O  
+ATOM   4508  CB  TRP B2278      57.390  35.032  21.390  1.00 23.94           C  
+ATOM   4509  CG  TRP B2278      57.906  35.733  22.605  1.00 24.48           C  
+ATOM   4510  CD1 TRP B2278      57.708  35.367  23.905  1.00 21.80           C  
+ATOM   4511  CD2 TRP B2278      58.865  36.799  22.629  1.00 21.42           C  
+ATOM   4512  NE1 TRP B2278      58.500  36.124  24.735  1.00 20.98           N  
+ATOM   4513  CE2 TRP B2278      59.225  37.008  23.980  1.00 22.15           C  
+ATOM   4514  CE3 TRP B2278      59.475  37.584  21.639  1.00 23.05           C  
+ATOM   4515  CZ2 TRP B2278      60.162  37.978  24.369  1.00 21.73           C  
+ATOM   4516  CZ3 TRP B2278      60.413  38.549  22.023  1.00 20.47           C  
+ATOM   4517  CH2 TRP B2278      60.749  38.731  23.378  1.00 22.07           C  
+ATOM   4518  N   LYS B2279      58.631  32.543  22.439  1.00 26.36           N  
+ATOM   4519  CA  LYS B2279      59.275  31.786  23.502  1.00 26.85           C  
+ATOM   4520  C   LYS B2279      60.448  30.917  23.081  1.00 26.44           C  
+ATOM   4521  O   LYS B2279      61.513  30.967  23.688  1.00 27.54           O  
+ATOM   4522  CB  LYS B2279      58.244  30.919  24.217  1.00 26.11           C  
+ATOM   4523  CG  LYS B2279      57.213  31.715  24.990  1.00 27.87           C  
+ATOM   4524  CD  LYS B2279      56.124  30.797  25.539  1.00 32.36           C  
+ATOM   4525  CE  LYS B2279      55.119  31.559  26.395  1.00 31.19           C  
+ATOM   4526  NZ  LYS B2279      54.005  30.680  26.869  1.00 36.65           N  
+ATOM   4527  N   GLU B2280      60.267  30.131  22.031  1.00 27.09           N  
+ATOM   4528  CA  GLU B2280      61.321  29.221  21.605  1.00 27.65           C  
+ATOM   4529  C   GLU B2280      62.465  29.817  20.805  1.00 26.59           C  
+ATOM   4530  O   GLU B2280      63.566  29.268  20.790  1.00 26.17           O  
+ATOM   4531  CB  GLU B2280      60.694  28.060  20.838  1.00 29.26           C  
+ATOM   4532  CG  GLU B2280      59.706  27.278  21.690  1.00 34.04           C  
+ATOM   4533  CD  GLU B2280      59.042  26.149  20.937  1.00 37.37           C  
+ATOM   4534  OE1 GLU B2280      58.291  25.385  21.584  1.00 37.49           O  
+ATOM   4535  OE2 GLU B2280      59.267  26.028  19.706  1.00 38.72           O  
+ATOM   4536  N   ILE B2281      62.218  30.941  20.145  1.00 26.30           N  
+ATOM   4537  CA  ILE B2281      63.258  31.559  19.335  1.00 24.98           C  
+ATOM   4538  C   ILE B2281      63.731  32.920  19.832  1.00 24.63           C  
+ATOM   4539  O   ILE B2281      64.873  33.057  20.259  1.00 25.02           O  
+ATOM   4540  CB  ILE B2281      62.801  31.703  17.867  1.00 23.30           C  
+ATOM   4541  CG1 ILE B2281      62.402  30.332  17.310  1.00 24.53           C  
+ATOM   4542  CG2 ILE B2281      63.925  32.310  17.029  1.00 20.74           C  
+ATOM   4543  CD1 ILE B2281      61.853  30.379  15.895  1.00 24.56           C  
+ATOM   4544  N   ASN B2282      62.857  33.921  19.793  1.00 23.35           N  
+ATOM   4545  CA  ASN B2282      63.245  35.266  20.206  1.00 24.88           C  
+ATOM   4546  C   ASN B2282      63.597  35.463  21.668  1.00 25.14           C  
+ATOM   4547  O   ASN B2282      64.555  36.164  21.981  1.00 25.69           O  
+ATOM   4548  CB  ASN B2282      62.168  36.272  19.806  1.00 24.85           C  
+ATOM   4549  CG  ASN B2282      61.992  36.348  18.315  1.00 24.45           C  
+ATOM   4550  OD1 ASN B2282      62.970  36.393  17.575  1.00 22.85           O  
+ATOM   4551  ND2 ASN B2282      60.750  36.364  17.862  1.00 25.38           N  
+ATOM   4552  N   TRP B2283      62.823  34.864  22.564  1.00 24.83           N  
+ATOM   4553  CA  TRP B2283      63.097  35.007  23.983  1.00 24.62           C  
+ATOM   4554  C   TRP B2283      64.372  34.266  24.362  1.00 24.81           C  
+ATOM   4555  O   TRP B2283      65.149  34.736  25.188  1.00 24.56           O  
+ATOM   4556  CB  TRP B2283      61.924  34.480  24.804  1.00 26.83           C  
+ATOM   4557  CG  TRP B2283      62.128  34.610  26.274  1.00 31.56           C  
+ATOM   4558  CD1 TRP B2283      62.675  35.672  26.938  1.00 32.61           C  
+ATOM   4559  CD2 TRP B2283      61.766  33.657  27.275  1.00 33.99           C  
+ATOM   4560  NE1 TRP B2283      62.680  35.437  28.290  1.00 34.92           N  
+ATOM   4561  CE2 TRP B2283      62.126  34.206  28.524  1.00 35.13           C  
+ATOM   4562  CE3 TRP B2283      61.172  32.388  27.236  1.00 36.38           C  
+ATOM   4563  CZ2 TRP B2283      61.911  33.532  29.729  1.00 37.18           C  
+ATOM   4564  CZ3 TRP B2283      60.956  31.713  28.436  1.00 38.67           C  
+ATOM   4565  CH2 TRP B2283      61.327  32.289  29.667  1.00 38.32           C  
+ATOM   4566  N   LEU B2284      64.583  33.105  23.755  1.00 24.90           N  
+ATOM   4567  CA  LEU B2284      65.778  32.317  24.033  1.00 26.03           C  
+ATOM   4568  C   LEU B2284      66.981  33.131  23.572  1.00 24.48           C  
+ATOM   4569  O   LEU B2284      68.010  33.178  24.244  1.00 23.18           O  
+ATOM   4570  CB  LEU B2284      65.732  30.993  23.265  1.00 27.91           C  
+ATOM   4571  CG  LEU B2284      66.821  29.982  23.621  1.00 29.80           C  
+ATOM   4572  CD1 LEU B2284      66.602  29.499  25.054  1.00 31.97           C  
+ATOM   4573  CD2 LEU B2284      66.777  28.806  22.648  1.00 31.38           C  
+ATOM   4574  N   ASN B2285      66.829  33.777  22.420  1.00 22.89           N  
+ATOM   4575  CA  ASN B2285      67.893  34.589  21.849  1.00 22.09           C  
+ATOM   4576  C   ASN B2285      68.183  35.755  22.787  1.00 22.18           C  
+ATOM   4577  O   ASN B2285      69.332  36.125  22.992  1.00 19.15           O  
+ATOM   4578  CB  ASN B2285      67.482  35.109  20.466  1.00 20.65           C  
+ATOM   4579  CG  ASN B2285      68.617  35.804  19.741  1.00 21.47           C  
+ATOM   4580  OD1 ASN B2285      69.784  35.673  20.119  1.00 21.82           O  
+ATOM   4581  ND2 ASN B2285      68.286  36.536  18.685  1.00 18.83           N  
+ATOM   4582  N   LEU B2286      67.131  36.316  23.371  1.00 22.68           N  
+ATOM   4583  CA  LEU B2286      67.286  37.435  24.288  1.00 23.63           C  
+ATOM   4584  C   LEU B2286      68.129  37.035  25.493  1.00 24.14           C  
+ATOM   4585  O   LEU B2286      69.095  37.714  25.843  1.00 23.80           O  
+ATOM   4586  CB  LEU B2286      65.911  37.934  24.760  1.00 23.30           C  
+ATOM   4587  CG  LEU B2286      65.910  38.990  25.877  1.00 24.34           C  
+ATOM   4588  CD1 LEU B2286      66.685  40.227  25.427  1.00 23.78           C  
+ATOM   4589  CD2 LEU B2286      64.481  39.363  26.232  1.00 22.31           C  
+ATOM   4590  N   LYS B2287      67.766  35.920  26.116  1.00 25.64           N  
+ATOM   4591  CA  LYS B2287      68.468  35.431  27.301  1.00 27.14           C  
+ATOM   4592  C   LYS B2287      69.912  34.993  27.062  1.00 26.43           C  
+ATOM   4593  O   LYS B2287      70.809  35.335  27.837  1.00 24.64           O  
+ATOM   4594  CB  LYS B2287      67.683  34.274  27.922  1.00 26.50           C  
+ATOM   4595  CG  LYS B2287      66.434  34.708  28.644  1.00 29.87           C  
+ATOM   4596  CD  LYS B2287      65.328  33.684  28.517  1.00 32.88           C  
+ATOM   4597  CE  LYS B2287      65.671  32.375  29.186  1.00 34.88           C  
+ATOM   4598  NZ  LYS B2287      64.621  31.351  28.906  1.00 35.92           N  
+ATOM   4599  N   GLN B2288      70.141  34.245  25.989  1.00 26.58           N  
+ATOM   4600  CA  GLN B2288      71.479  33.754  25.705  1.00 26.59           C  
+ATOM   4601  C   GLN B2288      72.425  34.717  24.999  1.00 27.14           C  
+ATOM   4602  O   GLN B2288      73.631  34.666  25.235  1.00 28.91           O  
+ATOM   4603  CB  GLN B2288      71.415  32.479  24.864  1.00 27.33           C  
+ATOM   4604  CG  GLN B2288      70.531  31.387  25.409  1.00 30.61           C  
+ATOM   4605  CD  GLN B2288      70.590  30.136  24.554  1.00 33.47           C  
+ATOM   4606  OE1 GLN B2288      70.724  30.211  23.329  1.00 32.95           O  
+ATOM   4607  NE2 GLN B2288      70.482  28.975  25.194  1.00 34.35           N  
+ATOM   4608  N   ASN B2289      71.898  35.593  24.144  1.00 26.97           N  
+ATOM   4609  CA  ASN B2289      72.769  36.475  23.363  1.00 25.11           C  
+ATOM   4610  C   ASN B2289      72.576  37.979  23.409  1.00 23.92           C  
+ATOM   4611  O   ASN B2289      73.540  38.728  23.230  1.00 24.24           O  
+ATOM   4612  CB  ASN B2289      72.704  36.060  21.896  1.00 23.29           C  
+ATOM   4613  CG  ASN B2289      72.871  34.568  21.709  1.00 25.36           C  
+ATOM   4614  OD1 ASN B2289      73.879  33.992  22.123  1.00 23.36           O  
+ATOM   4615  ND2 ASN B2289      71.882  33.930  21.076  1.00 22.11           N  
+ATOM   4616  N   ILE B2290      71.348  38.425  23.627  1.00 21.07           N  
+ATOM   4617  CA  ILE B2290      71.077  39.849  23.616  1.00 20.04           C  
+ATOM   4618  C   ILE B2290      71.193  40.560  24.962  1.00 19.30           C  
+ATOM   4619  O   ILE B2290      71.967  41.504  25.105  1.00 19.83           O  
+ATOM   4620  CB  ILE B2290      69.680  40.120  22.995  1.00 19.15           C  
+ATOM   4621  CG1 ILE B2290      69.580  39.429  21.629  1.00 17.93           C  
+ATOM   4622  CG2 ILE B2290      69.460  41.618  22.846  1.00 17.67           C  
+ATOM   4623  CD1 ILE B2290      68.202  39.533  20.963  1.00 17.62           C  
+ATOM   4624  N   LEU B2291      70.431  40.101  25.947  1.00 18.25           N  
+ATOM   4625  CA  LEU B2291      70.439  40.713  27.262  1.00 17.47           C  
+ATOM   4626  C   LEU B2291      71.821  40.850  27.903  1.00 18.33           C  
+ATOM   4627  O   LEU B2291      72.103  41.840  28.581  1.00 18.99           O  
+ATOM   4628  CB  LEU B2291      69.510  39.937  28.189  1.00 16.65           C  
+ATOM   4629  CG  LEU B2291      69.270  40.547  29.569  1.00 20.15           C  
+ATOM   4630  CD1 LEU B2291      68.825  42.011  29.426  1.00 18.83           C  
+ATOM   4631  CD2 LEU B2291      68.218  39.718  30.303  1.00 19.56           C  
+ATOM   4632  N   PRO B2292      72.704  39.861  27.707  1.00 19.58           N  
+ATOM   4633  CA  PRO B2292      74.041  39.954  28.307  1.00 20.67           C  
+ATOM   4634  C   PRO B2292      74.902  41.121  27.801  1.00 20.24           C  
+ATOM   4635  O   PRO B2292      75.871  41.502  28.460  1.00 20.73           O  
+ATOM   4636  CB  PRO B2292      74.665  38.598  27.971  1.00 20.33           C  
+ATOM   4637  CG  PRO B2292      73.479  37.688  27.923  1.00 19.62           C  
+ATOM   4638  CD  PRO B2292      72.480  38.516  27.152  1.00 18.63           C  
+ATOM   4639  N   THR B2293      74.555  41.673  26.641  1.00 17.66           N  
+ATOM   4640  CA  THR B2293      75.315  42.784  26.070  1.00 18.17           C  
+ATOM   4641  C   THR B2293      74.810  44.143  26.546  1.00 19.43           C  
+ATOM   4642  O   THR B2293      75.402  45.178  26.225  1.00 19.72           O  
+ATOM   4643  CB  THR B2293      75.238  42.808  24.521  1.00 19.39           C  
+ATOM   4644  OG1 THR B2293      73.910  43.173  24.115  1.00 18.18           O  
+ATOM   4645  CG2 THR B2293      75.603  41.440  23.937  1.00 16.90           C  
+ATOM   4646  N   ARG B2294      73.724  44.148  27.313  1.00 18.96           N  
+ATOM   4647  CA  ARG B2294      73.139  45.400  27.779  1.00 19.96           C  
+ATOM   4648  C   ARG B2294      74.079  46.380  28.472  1.00 19.54           C  
+ATOM   4649  O   ARG B2294      74.023  47.584  28.196  1.00 20.33           O  
+ATOM   4650  CB  ARG B2294      71.949  45.127  28.702  1.00 21.31           C  
+ATOM   4651  CG  ARG B2294      71.204  46.393  29.112  1.00 24.40           C  
+ATOM   4652  CD  ARG B2294      69.998  46.080  29.976  1.00 26.00           C  
+ATOM   4653  NE  ARG B2294      70.383  45.416  31.214  1.00 29.97           N  
+ATOM   4654  CZ  ARG B2294      69.523  44.982  32.130  1.00 32.15           C  
+ATOM   4655  NH1 ARG B2294      68.220  45.143  31.951  1.00 32.77           N  
+ATOM   4656  NH2 ARG B2294      69.966  44.384  33.227  1.00 35.69           N  
+ATOM   4657  N   GLU B2295      74.935  45.889  29.365  1.00 18.00           N  
+ATOM   4658  CA  GLU B2295      75.837  46.782  30.082  1.00 18.77           C  
+ATOM   4659  C   GLU B2295      76.975  47.353  29.247  1.00 18.80           C  
+ATOM   4660  O   GLU B2295      77.828  48.073  29.768  1.00 17.79           O  
+ATOM   4661  CB  GLU B2295      76.395  46.090  31.328  1.00 21.56           C  
+ATOM   4662  CG  GLU B2295      75.378  46.010  32.465  1.00 25.59           C  
+ATOM   4663  CD  GLU B2295      74.159  45.187  32.090  1.00 26.71           C  
+ATOM   4664  OE1 GLU B2295      73.041  45.539  32.520  1.00 28.65           O  
+ATOM   4665  OE2 GLU B2295      74.325  44.180  31.371  1.00 29.68           O  
+ATOM   4666  N   ARG B2296      76.995  47.039  27.956  1.00 18.46           N  
+ATOM   4667  CA  ARG B2296      78.030  47.584  27.084  1.00 19.27           C  
+ATOM   4668  C   ARG B2296      77.515  48.845  26.396  1.00 18.68           C  
+ATOM   4669  O   ARG B2296      78.258  49.525  25.695  1.00 17.05           O  
+ATOM   4670  CB  ARG B2296      78.444  46.575  26.013  1.00 19.34           C  
+ATOM   4671  CG  ARG B2296      79.123  45.317  26.536  1.00 19.23           C  
+ATOM   4672  CD  ARG B2296      79.923  44.673  25.411  1.00 19.25           C  
+ATOM   4673  NE  ARG B2296      81.048  45.516  25.023  1.00 18.31           N  
+ATOM   4674  CZ  ARG B2296      81.415  45.746  23.766  1.00 20.75           C  
+ATOM   4675  NH1 ARG B2296      80.743  45.192  22.766  1.00 19.73           N  
+ATOM   4676  NH2 ARG B2296      82.442  46.551  23.509  1.00 17.65           N  
+ATOM   4677  N   ALA B2297      76.239  49.159  26.600  1.00 18.82           N  
+ATOM   4678  CA  ALA B2297      75.636  50.335  25.968  1.00 18.26           C  
+ATOM   4679  C   ALA B2297      75.976  51.653  26.646  1.00 19.51           C  
+ATOM   4680  O   ALA B2297      76.222  51.700  27.858  1.00 20.32           O  
+ATOM   4681  CB  ALA B2297      74.116  50.174  25.897  1.00 16.21           C  
+ATOM   4682  N   SER B2298      76.004  52.724  25.852  1.00 19.88           N  
+ATOM   4683  CA  SER B2298      76.283  54.053  26.384  1.00 18.49           C  
+ATOM   4684  C   SER B2298      75.060  54.490  27.178  1.00 18.03           C  
+ATOM   4685  O   SER B2298      75.179  55.146  28.206  1.00 19.69           O  
+ATOM   4686  CB  SER B2298      76.509  55.055  25.257  1.00 16.01           C  
+ATOM   4687  OG  SER B2298      77.518  54.619  24.375  1.00 22.60           O  
+ATOM   4688  N   LEU B2299      73.882  54.116  26.685  1.00 18.81           N  
+ATOM   4689  CA  LEU B2299      72.627  54.487  27.323  1.00 18.54           C  
+ATOM   4690  C   LEU B2299      71.590  53.378  27.261  1.00 19.14           C  
+ATOM   4691  O   LEU B2299      71.405  52.739  26.224  1.00 19.69           O  
+ATOM   4692  CB  LEU B2299      72.070  55.755  26.661  1.00 18.00           C  
+ATOM   4693  CG  LEU B2299      70.704  56.298  27.095  1.00 17.29           C  
+ATOM   4694  CD1 LEU B2299      70.657  57.795  26.868  1.00 19.38           C  
+ATOM   4695  CD2 LEU B2299      69.588  55.606  26.327  1.00 14.53           C  
+ATOM   4696  N   ILE B2300      70.908  53.166  28.382  1.00 19.12           N  
+ATOM   4697  CA  ILE B2300      69.871  52.150  28.477  1.00 19.40           C  
+ATOM   4698  C   ILE B2300      68.525  52.842  28.634  1.00 21.57           C  
+ATOM   4699  O   ILE B2300      68.305  53.604  29.590  1.00 20.85           O  
+ATOM   4700  CB  ILE B2300      70.085  51.227  29.689  1.00 20.02           C  
+ATOM   4701  CG1 ILE B2300      71.455  50.561  29.603  1.00 21.01           C  
+ATOM   4702  CG2 ILE B2300      69.010  50.161  29.723  1.00 20.36           C  
+ATOM   4703  CD1 ILE B2300      71.833  49.793  30.859  1.00 23.49           C  
+ATOM   4704  N   LEU B2301      67.632  52.578  27.685  1.00 22.21           N  
+ATOM   4705  CA  LEU B2301      66.291  53.155  27.677  1.00 22.50           C  
+ATOM   4706  C   LEU B2301      65.339  52.042  28.137  1.00 23.12           C  
+ATOM   4707  O   LEU B2301      65.131  51.075  27.406  1.00 23.83           O  
+ATOM   4708  CB  LEU B2301      65.947  53.595  26.249  1.00 22.04           C  
+ATOM   4709  CG  LEU B2301      64.903  54.697  26.074  1.00 23.74           C  
+ATOM   4710  CD1 LEU B2301      65.487  56.001  26.580  1.00 23.41           C  
+ATOM   4711  CD2 LEU B2301      64.511  54.825  24.615  1.00 25.31           C  
+ATOM   4712  N   THR B2302      64.780  52.165  29.343  1.00 23.29           N  
+ATOM   4713  CA  THR B2302      63.875  51.141  29.884  1.00 21.69           C  
+ATOM   4714  C   THR B2302      62.384  51.475  29.737  1.00 23.29           C  
+ATOM   4715  O   THR B2302      61.896  52.461  30.301  1.00 21.68           O  
+ATOM   4716  CB  THR B2302      64.172  50.872  31.374  1.00 21.33           C  
+ATOM   4717  OG1 THR B2302      65.484  50.320  31.502  1.00 19.94           O  
+ATOM   4718  CG2 THR B2302      63.165  49.884  31.961  1.00 18.86           C  
+ATOM   4719  N   LYS B2303      61.670  50.627  28.996  1.00 23.03           N  
+ATOM   4720  CA  LYS B2303      60.247  50.813  28.733  1.00 23.47           C  
+ATOM   4721  C   LYS B2303      59.314  50.018  29.648  1.00 24.56           C  
+ATOM   4722  O   LYS B2303      59.688  48.983  30.209  1.00 23.53           O  
+ATOM   4723  CB  LYS B2303      59.945  50.465  27.271  1.00 22.15           C  
+ATOM   4724  CG  LYS B2303      60.710  51.326  26.284  1.00 24.75           C  
+ATOM   4725  CD  LYS B2303      60.583  50.835  24.851  1.00 23.37           C  
+ATOM   4726  CE  LYS B2303      59.239  51.147  24.264  1.00 25.14           C  
+ATOM   4727  NZ  LYS B2303      59.225  50.848  22.816  1.00 25.07           N  
+ATOM   4728  N   SER B2304      58.093  50.521  29.787  1.00 24.49           N  
+ATOM   4729  CA  SER B2304      57.083  49.882  30.614  1.00 26.50           C  
+ATOM   4730  C   SER B2304      55.814  49.720  29.771  1.00 27.30           C  
+ATOM   4731  O   SER B2304      55.869  49.802  28.542  1.00 27.63           O  
+ATOM   4732  CB  SER B2304      56.804  50.744  31.844  1.00 27.93           C  
+ATOM   4733  OG  SER B2304      56.204  49.971  32.867  1.00 31.17           O  
+ATOM   4734  N   ALA B2305      54.675  49.497  30.419  1.00 27.01           N  
+ATOM   4735  CA  ALA B2305      53.424  49.312  29.689  1.00 26.60           C  
+ATOM   4736  C   ALA B2305      53.172  50.437  28.691  1.00 27.64           C  
+ATOM   4737  O   ALA B2305      53.525  51.595  28.937  1.00 27.78           O  
+ATOM   4738  CB  ALA B2305      52.254  49.201  30.660  1.00 26.08           C  
+ATOM   4739  N   ASN B2306      52.562  50.077  27.562  1.00 28.23           N  
+ATOM   4740  CA  ASN B2306      52.239  51.024  26.498  1.00 28.62           C  
+ATOM   4741  C   ASN B2306      53.472  51.704  25.916  1.00 28.29           C  
+ATOM   4742  O   ASN B2306      53.366  52.778  25.315  1.00 27.67           O  
+ATOM   4743  CB  ASN B2306      51.268  52.089  27.007  1.00 30.32           C  
+ATOM   4744  CG  ASN B2306      50.011  51.489  27.597  1.00 33.49           C  
+ATOM   4745  OD1 ASN B2306      49.287  50.743  26.928  1.00 33.74           O  
+ATOM   4746  ND2 ASN B2306      49.744  51.806  28.861  1.00 34.04           N  
+ATOM   4747  N   HIS B2307      54.632  51.078  26.103  1.00 26.36           N  
+ATOM   4748  CA  HIS B2307      55.891  51.599  25.580  1.00 27.19           C  
+ATOM   4749  C   HIS B2307      56.410  52.862  26.254  1.00 26.61           C  
+ATOM   4750  O   HIS B2307      57.348  53.493  25.759  1.00 26.76           O  
+ATOM   4751  CB  HIS B2307      55.753  51.847  24.081  1.00 25.70           C  
+ATOM   4752  CG  HIS B2307      55.612  50.593  23.284  1.00 27.04           C  
+ATOM   4753  ND1 HIS B2307      56.694  49.831  22.902  1.00 25.11           N  
+ATOM   4754  CD2 HIS B2307      54.514  49.945  22.824  1.00 27.11           C  
+ATOM   4755  CE1 HIS B2307      56.270  48.769  22.241  1.00 26.64           C  
+ATOM   4756  NE2 HIS B2307      54.951  48.816  22.180  1.00 26.66           N  
+ATOM   4757  N   ALA B2308      55.805  53.232  27.376  1.00 24.72           N  
+ATOM   4758  CA  ALA B2308      56.230  54.425  28.095  1.00 24.65           C  
+ATOM   4759  C   ALA B2308      57.602  54.211  28.713  1.00 24.07           C  
+ATOM   4760  O   ALA B2308      57.840  53.200  29.372  1.00 26.57           O  
+ATOM   4761  CB  ALA B2308      55.213  54.773  29.187  1.00 22.04           C  
+ATOM   4762  N   VAL B2309      58.507  55.157  28.504  1.00 23.50           N  
+ATOM   4763  CA  VAL B2309      59.839  55.051  29.080  1.00 23.33           C  
+ATOM   4764  C   VAL B2309      59.740  55.394  30.562  1.00 25.22           C  
+ATOM   4765  O   VAL B2309      59.145  56.410  30.927  1.00 25.53           O  
+ATOM   4766  CB  VAL B2309      60.814  56.018  28.398  1.00 22.40           C  
+ATOM   4767  CG1 VAL B2309      62.129  56.061  29.160  1.00 22.00           C  
+ATOM   4768  CG2 VAL B2309      61.042  55.580  26.958  1.00 21.18           C  
+ATOM   4769  N   GLU B2310      60.312  54.549  31.416  1.00 27.28           N  
+ATOM   4770  CA  GLU B2310      60.257  54.783  32.857  1.00 29.93           C  
+ATOM   4771  C   GLU B2310      61.622  55.056  33.467  1.00 29.97           C  
+ATOM   4772  O   GLU B2310      61.716  55.545  34.592  1.00 30.58           O  
+ATOM   4773  CB  GLU B2310      59.621  53.586  33.575  1.00 33.38           C  
+ATOM   4774  CG  GLU B2310      60.390  52.273  33.443  1.00 39.18           C  
+ATOM   4775  CD  GLU B2310      59.941  51.232  34.463  1.00 42.17           C  
+ATOM   4776  OE1 GLU B2310      58.715  51.066  34.643  1.00 44.65           O  
+ATOM   4777  OE2 GLU B2310      60.814  50.582  35.077  1.00 44.90           O  
+ATOM   4778  N   GLU B2311      62.679  54.741  32.728  1.00 29.23           N  
+ATOM   4779  CA  GLU B2311      64.021  54.960  33.231  1.00 28.94           C  
+ATOM   4780  C   GLU B2311      65.041  55.160  32.118  1.00 27.43           C  
+ATOM   4781  O   GLU B2311      64.936  54.571  31.042  1.00 26.82           O  
+ATOM   4782  CB  GLU B2311      64.449  53.777  34.104  1.00 30.98           C  
+ATOM   4783  CG  GLU B2311      65.849  53.923  34.678  1.00 35.58           C  
+ATOM   4784  CD  GLU B2311      66.258  52.737  35.526  1.00 39.03           C  
+ATOM   4785  OE1 GLU B2311      66.367  51.618  34.980  1.00 40.38           O  
+ATOM   4786  OE2 GLU B2311      66.470  52.924  36.745  1.00 42.08           O  
+ATOM   4787  N   VAL B2312      66.029  56.001  32.391  1.00 25.86           N  
+ATOM   4788  CA  VAL B2312      67.089  56.264  31.437  1.00 24.51           C  
+ATOM   4789  C   VAL B2312      68.404  56.215  32.190  1.00 25.05           C  
+ATOM   4790  O   VAL B2312      68.576  56.902  33.199  1.00 26.98           O  
+ATOM   4791  CB  VAL B2312      66.950  57.656  30.776  1.00 23.72           C  
+ATOM   4792  CG1 VAL B2312      68.040  57.843  29.734  1.00 20.99           C  
+ATOM   4793  CG2 VAL B2312      65.586  57.792  30.132  1.00 21.14           C  
+ATOM   4794  N   ARG B2313      69.319  55.377  31.714  1.00 23.62           N  
+ATOM   4795  CA  ARG B2313      70.633  55.264  32.320  1.00 22.72           C  
+ATOM   4796  C   ARG B2313      71.714  55.621  31.306  1.00 22.09           C  
+ATOM   4797  O   ARG B2313      71.749  55.081  30.201  1.00 22.79           O  
+ATOM   4798  CB  ARG B2313      70.843  53.860  32.881  1.00 22.79           C  
+ATOM   4799  CG  ARG B2313      70.173  53.673  34.239  1.00 23.20           C  
+ATOM   4800  CD  ARG B2313      70.584  52.377  34.881  1.00 25.60           C  
+ATOM   4801  NE  ARG B2313      69.937  51.235  34.252  1.00 28.52           N  
+ATOM   4802  CZ  ARG B2313      70.466  50.016  34.206  1.00 29.85           C  
+ATOM   4803  NH1 ARG B2313      71.654  49.798  34.753  1.00 28.64           N  
+ATOM   4804  NH2 ARG B2313      69.805  49.021  33.615  1.00 28.96           N  
+ATOM   4805  N   LEU B2314      72.584  56.549  31.694  1.00 20.86           N  
+ATOM   4806  CA  LEU B2314      73.661  57.029  30.837  1.00 18.76           C  
+ATOM   4807  C   LEU B2314      75.031  56.828  31.492  1.00 18.03           C  
+ATOM   4808  O   LEU B2314      75.215  57.167  32.658  1.00 16.45           O  
+ATOM   4809  CB  LEU B2314      73.438  58.516  30.548  1.00 17.89           C  
+ATOM   4810  CG  LEU B2314      74.547  59.284  29.832  1.00 17.84           C  
+ATOM   4811  CD1 LEU B2314      74.747  58.705  28.436  1.00 19.01           C  
+ATOM   4812  CD2 LEU B2314      74.179  60.761  29.752  1.00 18.06           C  
+ATOM   4813  N   ARG B2315      75.984  56.283  30.734  1.00 17.87           N  
+ATOM   4814  CA  ARG B2315      77.331  56.044  31.256  1.00 18.74           C  
+ATOM   4815  C   ARG B2315      77.930  57.340  31.774  1.00 20.06           C  
+ATOM   4816  O   ARG B2315      77.874  58.376  31.102  1.00 20.98           O  
+ATOM   4817  CB  ARG B2315      78.250  55.453  30.172  1.00 18.48           C  
+ATOM   4818  CG  ARG B2315      78.156  53.924  29.992  1.00 17.50           C  
+ATOM   4819  CD  ARG B2315      78.585  53.170  31.250  1.00 14.96           C  
+ATOM   4820  NE  ARG B2315      79.949  53.506  31.648  1.00 16.90           N  
+ATOM   4821  CZ  ARG B2315      81.041  53.064  31.024  1.00 17.86           C  
+ATOM   4822  NH1 ARG B2315      80.930  52.256  29.978  1.00 16.12           N  
+ATOM   4823  NH2 ARG B2315      82.243  53.459  31.426  1.00 14.43           N  
+ATOM   4824  N   LYS B2316      78.488  57.277  32.978  1.00 20.45           N  
+ATOM   4825  CA  LYS B2316      79.095  58.441  33.606  1.00 22.14           C  
+ATOM   4826  C   LYS B2316      80.351  58.847  32.843  1.00 23.91           C  
+ATOM   4827  O   LYS B2316      80.610  60.063  32.723  1.00 24.65           O  
+ATOM   4828  CB  LYS B2316      79.450  58.130  35.058  1.00 21.56           C  
+ATOM   4829  CG  LYS B2316      78.245  57.834  35.945  1.00 22.54           C  
+ATOM   4830  CD  LYS B2316      78.681  57.551  37.374  1.00 23.30           C  
+ATOM   4831  CE  LYS B2316      77.495  57.186  38.256  1.00 24.80           C  
+ATOM   4832  NZ  LYS B2316      77.940  56.914  39.653  1.00 26.05           N  
+ATOM   4833  OXT LYS B2316      81.072  57.935  32.396  1.00 24.00           O  
+TER    4834      LYS B2316                                                      
+ATOM   4835  N   MET C3009      -9.252   4.209  -8.370  1.00 48.00           N  
+ATOM   4836  CA  MET C3009      -8.111   3.423  -7.802  1.00 45.21           C  
+ATOM   4837  C   MET C3009      -6.770   3.952  -8.269  1.00 44.18           C  
+ATOM   4838  O   MET C3009      -6.669   5.093  -8.744  1.00 46.19           O  
+ATOM   4839  CB  MET C3009      -8.245   1.951  -8.172  1.00 46.85           C  
+ATOM   4840  CG  MET C3009      -9.331   1.230  -7.404  1.00 48.85           C  
+ATOM   4841  SD  MET C3009      -9.876  -0.267  -8.234  1.00 50.38           S  
+ATOM   4842  CE  MET C3009      -8.574  -1.425  -7.786  1.00 51.34           C  
+ATOM   4843  N   THR C3010      -5.747   3.115  -8.128  1.00 40.67           N  
+ATOM   4844  CA  THR C3010      -4.377   3.472  -8.503  1.00 37.20           C  
+ATOM   4845  C   THR C3010      -3.833   2.558  -9.604  1.00 33.31           C  
+ATOM   4846  O   THR C3010      -4.191   1.384  -9.676  1.00 32.98           O  
+ATOM   4847  CB  THR C3010      -3.442   3.347  -7.279  1.00 38.22           C  
+ATOM   4848  OG1 THR C3010      -3.894   4.231  -6.252  1.00 41.53           O  
+ATOM   4849  CG2 THR C3010      -2.014   3.687  -7.634  1.00 39.02           C  
+ATOM   4850  N   PRO C3011      -2.950   3.084 -10.470  1.00 30.17           N  
+ATOM   4851  CA  PRO C3011      -2.371   2.278 -11.553  1.00 27.42           C  
+ATOM   4852  C   PRO C3011      -1.208   1.427 -11.032  1.00 24.68           C  
+ATOM   4853  O   PRO C3011      -0.478   0.827 -11.817  1.00 22.19           O  
+ATOM   4854  CB  PRO C3011      -1.878   3.329 -12.554  1.00 27.42           C  
+ATOM   4855  CG  PRO C3011      -2.619   4.575 -12.180  1.00 29.09           C  
+ATOM   4856  CD  PRO C3011      -2.656   4.509 -10.685  1.00 28.08           C  
+ATOM   4857  N   TYR C3012      -1.033   1.382  -9.712  1.00 22.02           N  
+ATOM   4858  CA  TYR C3012       0.074   0.625  -9.132  1.00 22.19           C  
+ATOM   4859  C   TYR C3012      -0.256  -0.482  -8.137  1.00 23.22           C  
+ATOM   4860  O   TYR C3012      -1.145  -0.326  -7.308  1.00 23.63           O  
+ATOM   4861  CB  TYR C3012       1.044   1.566  -8.411  1.00 20.45           C  
+ATOM   4862  CG  TYR C3012       1.764   2.569  -9.278  1.00 22.51           C  
+ATOM   4863  CD1 TYR C3012       1.243   3.845  -9.492  1.00 20.77           C  
+ATOM   4864  CD2 TYR C3012       2.993   2.255  -9.849  1.00 23.60           C  
+ATOM   4865  CE1 TYR C3012       1.939   4.788 -10.249  1.00 22.04           C  
+ATOM   4866  CE2 TYR C3012       3.693   3.182 -10.605  1.00 24.04           C  
+ATOM   4867  CZ  TYR C3012       3.166   4.449 -10.800  1.00 24.79           C  
+ATOM   4868  OH  TYR C3012       3.898   5.370 -11.514  1.00 24.23           O  
+ATOM   4869  N   LEU C3013       0.477  -1.593  -8.222  1.00 23.56           N  
+ATOM   4870  CA  LEU C3013       0.328  -2.664  -7.242  1.00 24.11           C  
+ATOM   4871  C   LEU C3013       1.225  -2.104  -6.137  1.00 25.36           C  
+ATOM   4872  O   LEU C3013       2.241  -1.467  -6.434  1.00 23.87           O  
+ATOM   4873  CB  LEU C3013       0.920  -3.985  -7.728  1.00 20.63           C  
+ATOM   4874  CG  LEU C3013       0.255  -4.769  -8.860  1.00 22.91           C  
+ATOM   4875  CD1 LEU C3013       1.113  -5.997  -9.172  1.00 22.30           C  
+ATOM   4876  CD2 LEU C3013      -1.157  -5.178  -8.467  1.00 18.29           C  
+ATOM   4877  N   GLN C3014       0.864  -2.309  -4.876  1.00 26.63           N  
+ATOM   4878  CA  GLN C3014       1.679  -1.767  -3.797  1.00 27.30           C  
+ATOM   4879  C   GLN C3014       2.152  -2.812  -2.801  1.00 25.46           C  
+ATOM   4880  O   GLN C3014       1.414  -3.713  -2.449  1.00 26.21           O  
+ATOM   4881  CB  GLN C3014       0.906  -0.679  -3.062  1.00 29.72           C  
+ATOM   4882  CG  GLN C3014       1.768   0.077  -2.086  1.00 38.16           C  
+ATOM   4883  CD  GLN C3014       0.990   1.081  -1.285  1.00 43.51           C  
+ATOM   4884  OE1 GLN C3014       0.324   1.970  -1.835  1.00 46.76           O  
+ATOM   4885  NE2 GLN C3014       1.063   0.950   0.035  1.00 45.09           N  
+ATOM   4886  N   PHE C3015       3.393  -2.682  -2.350  1.00 25.39           N  
+ATOM   4887  CA  PHE C3015       3.967  -3.616  -1.386  1.00 24.85           C  
+ATOM   4888  C   PHE C3015       4.789  -2.874  -0.331  1.00 27.42           C  
+ATOM   4889  O   PHE C3015       5.660  -2.067  -0.679  1.00 26.47           O  
+ATOM   4890  CB  PHE C3015       4.909  -4.620  -2.064  1.00 23.09           C  
+ATOM   4891  CG  PHE C3015       4.317  -5.324  -3.254  1.00 24.21           C  
+ATOM   4892  CD1 PHE C3015       4.298  -4.713  -4.511  1.00 22.96           C  
+ATOM   4893  CD2 PHE C3015       3.782  -6.604  -3.123  1.00 23.64           C  
+ATOM   4894  CE1 PHE C3015       3.755  -5.370  -5.615  1.00 19.89           C  
+ATOM   4895  CE2 PHE C3015       3.236  -7.268  -4.224  1.00 23.22           C  
+ATOM   4896  CZ  PHE C3015       3.224  -6.647  -5.471  1.00 23.12           C  
+ATOM   4897  N   ASP C3016       4.513  -3.122   0.953  1.00 27.25           N  
+ATOM   4898  CA  ASP C3016       5.319  -2.491   1.991  1.00 27.09           C  
+ATOM   4899  C   ASP C3016       6.531  -3.404   2.097  1.00 26.79           C  
+ATOM   4900  O   ASP C3016       6.571  -4.458   1.457  1.00 26.49           O  
+ATOM   4901  CB  ASP C3016       4.586  -2.402   3.343  1.00 27.71           C  
+ATOM   4902  CG  ASP C3016       4.135  -3.754   3.872  1.00 27.67           C  
+ATOM   4903  OD1 ASP C3016       4.892  -4.741   3.767  1.00 26.56           O  
+ATOM   4904  OD2 ASP C3016       3.012  -3.822   4.414  1.00 31.93           O  
+ATOM   4905  N   ARG C3017       7.512  -3.025   2.903  1.00 26.92           N  
+ATOM   4906  CA  ARG C3017       8.713  -3.835   3.016  1.00 27.56           C  
+ATOM   4907  C   ARG C3017       8.493  -5.324   3.268  1.00 27.74           C  
+ATOM   4908  O   ARG C3017       9.097  -6.160   2.594  1.00 27.22           O  
+ATOM   4909  CB  ARG C3017       9.642  -3.297   4.101  1.00 27.34           C  
+ATOM   4910  CG  ARG C3017      11.016  -3.916   3.986  1.00 30.08           C  
+ATOM   4911  CD  ARG C3017      11.807  -3.816   5.255  1.00 31.16           C  
+ATOM   4912  NE  ARG C3017      13.134  -4.409   5.090  1.00 35.77           N  
+ATOM   4913  CZ  ARG C3017      14.136  -3.838   4.424  1.00 35.59           C  
+ATOM   4914  NH1 ARG C3017      13.966  -2.649   3.854  1.00 34.71           N  
+ATOM   4915  NH2 ARG C3017      15.310  -4.456   4.340  1.00 35.09           N  
+ATOM   4916  N   ASN C3018       7.654  -5.657   4.245  1.00 27.22           N  
+ATOM   4917  CA  ASN C3018       7.400  -7.058   4.567  1.00 28.66           C  
+ATOM   4918  C   ASN C3018       6.766  -7.840   3.424  1.00 26.42           C  
+ATOM   4919  O   ASN C3018       7.176  -8.959   3.148  1.00 26.50           O  
+ATOM   4920  CB  ASN C3018       6.525  -7.175   5.819  1.00 31.43           C  
+ATOM   4921  CG  ASN C3018       7.207  -6.618   7.053  1.00 35.30           C  
+ATOM   4922  OD1 ASN C3018       8.386  -6.884   7.293  1.00 37.17           O  
+ATOM   4923  ND2 ASN C3018       6.468  -5.847   7.846  1.00 38.67           N  
+ATOM   4924  N   GLN C3019       5.761  -7.260   2.774  1.00 26.24           N  
+ATOM   4925  CA  GLN C3019       5.094  -7.917   1.656  1.00 26.52           C  
+ATOM   4926  C   GLN C3019       6.086  -8.160   0.525  1.00 26.98           C  
+ATOM   4927  O   GLN C3019       6.088  -9.234  -0.080  1.00 27.11           O  
+ATOM   4928  CB  GLN C3019       3.926  -7.071   1.145  1.00 27.09           C  
+ATOM   4929  CG  GLN C3019       2.747  -7.005   2.096  1.00 28.11           C  
+ATOM   4930  CD  GLN C3019       1.720  -5.974   1.683  1.00 28.59           C  
+ATOM   4931  OE1 GLN C3019       2.054  -4.816   1.425  1.00 27.24           O  
+ATOM   4932  NE2 GLN C3019       0.455  -6.385   1.629  1.00 32.46           N  
+ATOM   4933  N   TRP C3020       6.937  -7.173   0.250  1.00 25.75           N  
+ATOM   4934  CA  TRP C3020       7.929  -7.310  -0.816  1.00 24.92           C  
+ATOM   4935  C   TRP C3020       8.942  -8.405  -0.486  1.00 25.98           C  
+ATOM   4936  O   TRP C3020       9.180  -9.302  -1.294  1.00 24.57           O  
+ATOM   4937  CB  TRP C3020       8.656  -5.984  -1.047  1.00 22.34           C  
+ATOM   4938  CG  TRP C3020       9.547  -6.001  -2.259  1.00 21.17           C  
+ATOM   4939  CD1 TRP C3020      10.912  -6.045  -2.280  1.00 20.39           C  
+ATOM   4940  CD2 TRP C3020       9.126  -6.003  -3.627  1.00 18.99           C  
+ATOM   4941  NE1 TRP C3020      11.368  -6.077  -3.579  1.00 19.10           N  
+ATOM   4942  CE2 TRP C3020      10.291  -6.053  -4.426  1.00 20.50           C  
+ATOM   4943  CE3 TRP C3020       7.875  -5.970  -4.258  1.00 17.67           C  
+ATOM   4944  CZ2 TRP C3020      10.241  -6.066  -5.826  1.00 17.99           C  
+ATOM   4945  CZ3 TRP C3020       7.829  -5.981  -5.653  1.00 18.58           C  
+ATOM   4946  CH2 TRP C3020       9.004  -6.031  -6.415  1.00 17.47           C  
+ATOM   4947  N   ALA C3021       9.529  -8.339   0.707  1.00 25.89           N  
+ATOM   4948  CA  ALA C3021      10.504  -9.340   1.118  1.00 26.13           C  
+ATOM   4949  C   ALA C3021       9.877 -10.734   1.206  1.00 26.86           C  
+ATOM   4950  O   ALA C3021      10.567 -11.743   1.091  1.00 25.66           O  
+ATOM   4951  CB  ALA C3021      11.119  -8.952   2.457  1.00 28.80           C  
+ATOM   4952  N   ALA C3022       8.564 -10.788   1.402  1.00 29.26           N  
+ATOM   4953  CA  ALA C3022       7.859 -12.063   1.495  1.00 31.91           C  
+ATOM   4954  C   ALA C3022       7.722 -12.733   0.125  1.00 34.69           C  
+ATOM   4955  O   ALA C3022       7.028 -13.741  -0.011  1.00 36.93           O  
+ATOM   4956  CB  ALA C3022       6.476 -11.853   2.110  1.00 31.23           C  
+ATOM   4957  N   LEU C3023       8.379 -12.177  -0.889  1.00 36.85           N  
+ATOM   4958  CA  LEU C3023       8.309 -12.738  -2.237  1.00 37.05           C  
+ATOM   4959  C   LEU C3023       9.453 -13.715  -2.491  1.00 38.44           C  
+ATOM   4960  O   LEU C3023       9.437 -14.472  -3.464  1.00 39.68           O  
+ATOM   4961  CB  LEU C3023       8.337 -11.618  -3.281  1.00 35.65           C  
+ATOM   4962  CG  LEU C3023       7.224 -10.572  -3.139  1.00 35.99           C  
+ATOM   4963  CD1 LEU C3023       7.369  -9.538  -4.238  1.00 35.45           C  
+ATOM   4964  CD2 LEU C3023       5.851 -11.237  -3.198  1.00 34.27           C  
+ATOM   4965  N   ARG C3024      10.445 -13.701  -1.608  1.00 38.88           N  
+ATOM   4966  CA  ARG C3024      11.583 -14.599  -1.739  1.00 38.99           C  
+ATOM   4967  C   ARG C3024      11.166 -16.055  -1.511  1.00 39.70           C  
+ATOM   4968  O   ARG C3024      10.292 -16.341  -0.691  1.00 39.38           O  
+ATOM   4969  CB  ARG C3024      12.662 -14.212  -0.739  1.00 39.62           C  
+ATOM   4970  CG  ARG C3024      13.267 -12.850  -0.983  1.00 39.95           C  
+ATOM   4971  CD  ARG C3024      14.291 -12.547   0.084  1.00 41.86           C  
+ATOM   4972  NE  ARG C3024      13.670 -12.477   1.402  1.00 43.59           N  
+ATOM   4973  CZ  ARG C3024      14.340 -12.503   2.549  1.00 44.18           C  
+ATOM   4974  NH1 ARG C3024      15.665 -12.601   2.546  1.00 45.12           N  
+ATOM   4975  NH2 ARG C3024      13.685 -12.427   3.701  1.00 44.83           N  
+ATOM   4976  N   MET C3029      17.049 -17.190  -2.228  1.00 56.16           N  
+ATOM   4977  CA  MET C3029      18.387 -17.122  -2.803  1.00 56.58           C  
+ATOM   4978  C   MET C3029      19.393 -16.595  -1.783  1.00 56.52           C  
+ATOM   4979  O   MET C3029      19.017 -15.981  -0.780  1.00 56.78           O  
+ATOM   4980  CB  MET C3029      18.399 -16.212  -4.042  1.00 57.05           C  
+ATOM   4981  CG  MET C3029      17.579 -16.716  -5.232  1.00 57.83           C  
+ATOM   4982  SD  MET C3029      17.652 -15.621  -6.693  1.00 57.59           S  
+ATOM   4983  CE  MET C3029      16.655 -16.546  -7.880  1.00 58.37           C  
+ATOM   4984  N   THR C3030      20.674 -16.848  -2.046  1.00 55.87           N  
+ATOM   4985  CA  THR C3030      21.761 -16.395  -1.175  1.00 54.06           C  
+ATOM   4986  C   THR C3030      22.947 -15.936  -2.022  1.00 52.81           C  
+ATOM   4987  O   THR C3030      23.221 -16.493  -3.091  1.00 52.21           O  
+ATOM   4988  CB  THR C3030      22.236 -17.515  -0.211  1.00 53.87           C  
+ATOM   4989  OG1 THR C3030      22.570 -18.691  -0.962  1.00 53.69           O  
+ATOM   4990  CG2 THR C3030      21.145 -17.842   0.803  1.00 52.83           C  
+ATOM   4991  N   LEU C3031      23.652 -14.921  -1.538  1.00 50.62           N  
+ATOM   4992  CA  LEU C3031      24.792 -14.379  -2.266  1.00 49.27           C  
+ATOM   4993  C   LEU C3031      26.096 -15.098  -1.960  1.00 47.78           C  
+ATOM   4994  O   LEU C3031      26.331 -15.514  -0.831  1.00 46.94           O  
+ATOM   4995  CB  LEU C3031      24.932 -12.890  -1.954  1.00 49.50           C  
+ATOM   4996  CG  LEU C3031      23.726 -12.061  -2.406  1.00 49.37           C  
+ATOM   4997  CD1 LEU C3031      23.874 -10.638  -1.911  1.00 49.15           C  
+ATOM   4998  CD2 LEU C3031      23.614 -12.108  -3.927  1.00 47.86           C  
+ATOM   4999  N   SER C3032      26.941 -15.237  -2.976  1.00 47.07           N  
+ATOM   5000  CA  SER C3032      28.232 -15.899  -2.823  1.00 47.53           C  
+ATOM   5001  C   SER C3032      29.196 -14.955  -2.126  1.00 47.36           C  
+ATOM   5002  O   SER C3032      28.898 -13.779  -1.945  1.00 48.69           O  
+ATOM   5003  CB  SER C3032      28.816 -16.275  -4.185  1.00 47.68           C  
+ATOM   5004  OG  SER C3032      29.389 -15.144  -4.816  1.00 48.07           O  
+ATOM   5005  N   GLU C3033      30.358 -15.471  -1.746  1.00 47.03           N  
+ATOM   5006  CA  GLU C3033      31.360 -14.659  -1.076  1.00 46.60           C  
+ATOM   5007  C   GLU C3033      31.869 -13.559  -2.016  1.00 46.77           C  
+ATOM   5008  O   GLU C3033      32.119 -12.432  -1.585  1.00 45.01           O  
+ATOM   5009  CB  GLU C3033      32.515 -15.541  -0.608  1.00 46.27           C  
+ATOM   5010  N   ASP C3034      32.018 -13.893  -3.297  1.00 47.75           N  
+ATOM   5011  CA  ASP C3034      32.485 -12.932  -4.296  1.00 48.83           C  
+ATOM   5012  C   ASP C3034      31.435 -11.845  -4.497  1.00 48.52           C  
+ATOM   5013  O   ASP C3034      31.760 -10.658  -4.585  1.00 48.24           O  
+ATOM   5014  CB  ASP C3034      32.744 -13.623  -5.641  1.00 50.87           C  
+ATOM   5015  CG  ASP C3034      33.860 -14.649  -5.573  1.00 54.09           C  
+ATOM   5016  OD1 ASP C3034      35.007 -14.267  -5.248  1.00 55.85           O  
+ATOM   5017  OD2 ASP C3034      33.594 -15.840  -5.846  1.00 55.41           O  
+ATOM   5018  N   GLU C3035      30.174 -12.261  -4.578  1.00 47.40           N  
+ATOM   5019  CA  GLU C3035      29.078 -11.324  -4.770  1.00 46.75           C  
+ATOM   5020  C   GLU C3035      28.994 -10.356  -3.600  1.00 44.93           C  
+ATOM   5021  O   GLU C3035      28.785  -9.159  -3.787  1.00 45.51           O  
+ATOM   5022  CB  GLU C3035      27.756 -12.075  -4.925  1.00 48.47           C  
+ATOM   5023  CG  GLU C3035      27.681 -12.924  -6.182  1.00 51.42           C  
+ATOM   5024  CD  GLU C3035      26.339 -13.616  -6.337  1.00 53.62           C  
+ATOM   5025  OE1 GLU C3035      25.303 -12.913  -6.372  1.00 53.61           O  
+ATOM   5026  OE2 GLU C3035      26.319 -14.863  -6.422  1.00 55.40           O  
+ATOM   5027  N   ILE C3036      29.163 -10.876  -2.391  1.00 43.34           N  
+ATOM   5028  CA  ILE C3036      29.113 -10.042  -1.198  1.00 41.74           C  
+ATOM   5029  C   ILE C3036      30.247  -9.017  -1.233  1.00 39.59           C  
+ATOM   5030  O   ILE C3036      30.037  -7.829  -0.981  1.00 38.45           O  
+ATOM   5031  CB  ILE C3036      29.228 -10.911   0.077  1.00 42.33           C  
+ATOM   5032  CG1 ILE C3036      27.914 -11.665   0.297  1.00 42.42           C  
+ATOM   5033  CG2 ILE C3036      29.590 -10.047   1.280  1.00 41.83           C  
+ATOM   5034  CD1 ILE C3036      27.951 -12.671   1.436  1.00 42.90           C  
+ATOM   5035  N   ALA C3037      31.448  -9.481  -1.553  1.00 38.31           N  
+ATOM   5036  CA  ALA C3037      32.602  -8.598  -1.622  1.00 38.24           C  
+ATOM   5037  C   ALA C3037      32.365  -7.518  -2.667  1.00 37.96           C  
+ATOM   5038  O   ALA C3037      32.684  -6.347  -2.451  1.00 37.54           O  
+ATOM   5039  CB  ALA C3037      33.848  -9.392  -1.976  1.00 39.33           C  
+ATOM   5040  N   ARG C3038      31.807  -7.918  -3.805  1.00 37.08           N  
+ATOM   5041  CA  ARG C3038      31.540  -6.974  -4.873  1.00 35.51           C  
+ATOM   5042  C   ARG C3038      30.548  -5.917  -4.400  1.00 33.75           C  
+ATOM   5043  O   ARG C3038      30.673  -4.740  -4.734  1.00 32.33           O  
+ATOM   5044  CB  ARG C3038      30.984  -7.691  -6.107  1.00 37.33           C  
+ATOM   5045  CG  ARG C3038      30.857  -6.745  -7.285  1.00 40.05           C  
+ATOM   5046  CD  ARG C3038      30.197  -7.349  -8.512  1.00 42.89           C  
+ATOM   5047  NE  ARG C3038      30.092  -6.323  -9.551  1.00 43.95           N  
+ATOM   5048  CZ  ARG C3038      29.555  -6.506 -10.751  1.00 44.05           C  
+ATOM   5049  NH1 ARG C3038      29.061  -7.692 -11.081  1.00 45.12           N  
+ATOM   5050  NH2 ARG C3038      29.516  -5.501 -11.619  1.00 42.29           N  
+ATOM   5051  N   LEU C3039      29.559  -6.334  -3.619  1.00 31.51           N  
+ATOM   5052  CA  LEU C3039      28.572  -5.384  -3.119  1.00 31.74           C  
+ATOM   5053  C   LEU C3039      29.208  -4.432  -2.104  1.00 31.80           C  
+ATOM   5054  O   LEU C3039      28.881  -3.241  -2.058  1.00 31.62           O  
+ATOM   5055  CB  LEU C3039      27.380  -6.138  -2.516  1.00 31.26           C  
+ATOM   5056  CG  LEU C3039      26.525  -6.852  -3.576  1.00 31.16           C  
+ATOM   5057  CD1 LEU C3039      25.555  -7.840  -2.930  1.00 31.11           C  
+ATOM   5058  CD2 LEU C3039      25.766  -5.799  -4.391  1.00 30.24           C  
+ATOM   5059  N   LYS C3040      30.128  -4.951  -1.299  1.00 30.72           N  
+ATOM   5060  CA  LYS C3040      30.810  -4.125  -0.315  1.00 30.80           C  
+ATOM   5061  C   LYS C3040      31.679  -3.098  -1.051  1.00 31.06           C  
+ATOM   5062  O   LYS C3040      31.815  -1.955  -0.615  1.00 30.39           O  
+ATOM   5063  CB  LYS C3040      31.665  -5.003   0.595  1.00 32.96           C  
+ATOM   5064  N   GLY C3041      32.264  -3.512  -2.173  1.00 30.90           N  
+ATOM   5065  CA  GLY C3041      33.090  -2.606  -2.954  1.00 29.73           C  
+ATOM   5066  C   GLY C3041      32.256  -1.486  -3.559  1.00 30.79           C  
+ATOM   5067  O   GLY C3041      32.751  -0.377  -3.788  1.00 30.69           O  
+ATOM   5068  N   ILE C3042      30.982  -1.776  -3.822  1.00 30.28           N  
+ATOM   5069  CA  ILE C3042      30.068  -0.789  -4.390  1.00 29.22           C  
+ATOM   5070  C   ILE C3042      29.769   0.307  -3.370  1.00 29.76           C  
+ATOM   5071  O   ILE C3042      29.881   1.488  -3.677  1.00 30.08           O  
+ATOM   5072  CB  ILE C3042      28.736  -1.456  -4.843  1.00 28.01           C  
+ATOM   5073  CG1 ILE C3042      28.974  -2.274  -6.119  1.00 28.45           C  
+ATOM   5074  CG2 ILE C3042      27.654  -0.395  -5.057  1.00 25.67           C  
+ATOM   5075  CD1 ILE C3042      27.783  -3.109  -6.559  1.00 25.38           C  
+ATOM   5076  N   ASN C3043      29.397  -0.089  -2.155  1.00 30.74           N  
+ATOM   5077  CA  ASN C3043      29.079   0.874  -1.105  1.00 32.02           C  
+ATOM   5078  C   ASN C3043      29.273   0.250   0.276  1.00 32.47           C  
+ATOM   5079  O   ASN C3043      28.479  -0.582   0.707  1.00 30.66           O  
+ATOM   5080  CB  ASN C3043      27.629   1.344  -1.258  1.00 32.53           C  
+ATOM   5081  CG  ASN C3043      27.339   2.612  -0.473  1.00 32.08           C  
+ATOM   5082  OD1 ASN C3043      27.902   2.838   0.602  1.00 31.61           O  
+ATOM   5083  ND2 ASN C3043      26.447   3.441  -1.002  1.00 31.92           N  
+ATOM   5084  N   GLU C3044      30.322   0.675   0.971  1.00 35.42           N  
+ATOM   5085  CA  GLU C3044      30.649   0.157   2.300  1.00 37.89           C  
+ATOM   5086  C   GLU C3044      29.509   0.211   3.316  1.00 37.36           C  
+ATOM   5087  O   GLU C3044      29.494  -0.564   4.269  1.00 38.23           O  
+ATOM   5088  CB  GLU C3044      31.853   0.914   2.872  1.00 41.31           C  
+ATOM   5089  CG  GLU C3044      31.600   2.415   3.065  1.00 46.21           C  
+ATOM   5090  CD  GLU C3044      32.804   3.165   3.625  1.00 48.94           C  
+ATOM   5091  OE1 GLU C3044      32.687   4.389   3.851  1.00 52.31           O  
+ATOM   5092  OE2 GLU C3044      33.866   2.540   3.838  1.00 51.08           O  
+ATOM   5093  N   ASP C3045      28.560   1.119   3.114  1.00 36.60           N  
+ATOM   5094  CA  ASP C3045      27.446   1.263   4.047  1.00 36.30           C  
+ATOM   5095  C   ASP C3045      26.167   0.559   3.611  1.00 35.75           C  
+ATOM   5096  O   ASP C3045      25.149   0.620   4.304  1.00 34.07           O  
+ATOM   5097  CB  ASP C3045      27.158   2.749   4.287  1.00 38.85           C  
+ATOM   5098  CG  ASP C3045      28.343   3.479   4.892  1.00 39.56           C  
+ATOM   5099  OD1 ASP C3045      28.927   2.957   5.865  1.00 41.49           O  
+ATOM   5100  OD2 ASP C3045      28.689   4.571   4.403  1.00 42.68           O  
+ATOM   5101  N   LEU C3046      26.214  -0.102   2.461  1.00 34.20           N  
+ATOM   5102  CA  LEU C3046      25.048  -0.814   1.963  1.00 33.43           C  
+ATOM   5103  C   LEU C3046      24.828  -2.047   2.837  1.00 32.85           C  
+ATOM   5104  O   LEU C3046      25.740  -2.858   3.029  1.00 31.83           O  
+ATOM   5105  CB  LEU C3046      25.266  -1.230   0.508  1.00 33.06           C  
+ATOM   5106  CG  LEU C3046      24.179  -2.083  -0.145  1.00 32.44           C  
+ATOM   5107  CD1 LEU C3046      22.891  -1.286  -0.319  1.00 31.81           C  
+ATOM   5108  CD2 LEU C3046      24.698  -2.564  -1.487  1.00 33.88           C  
+ATOM   5109  N   SER C3047      23.619  -2.167   3.376  1.00 32.37           N  
+ATOM   5110  CA  SER C3047      23.246  -3.286   4.234  1.00 31.36           C  
+ATOM   5111  C   SER C3047      23.037  -4.565   3.428  1.00 31.27           C  
+ATOM   5112  O   SER C3047      22.267  -4.578   2.465  1.00 31.57           O  
+ATOM   5113  CB  SER C3047      21.961  -2.942   4.986  1.00 32.06           C  
+ATOM   5114  OG  SER C3047      21.320  -4.111   5.470  1.00 33.55           O  
+ATOM   5115  N   LEU C3048      23.716  -5.638   3.826  1.00 30.90           N  
+ATOM   5116  CA  LEU C3048      23.592  -6.919   3.140  1.00 30.38           C  
+ATOM   5117  C   LEU C3048      22.207  -7.521   3.333  1.00 30.32           C  
+ATOM   5118  O   LEU C3048      21.713  -8.251   2.473  1.00 30.31           O  
+ATOM   5119  CB  LEU C3048      24.648  -7.899   3.647  1.00 31.18           C  
+ATOM   5120  CG  LEU C3048      26.111  -7.526   3.385  1.00 33.46           C  
+ATOM   5121  CD1 LEU C3048      27.023  -8.575   4.025  1.00 33.22           C  
+ATOM   5122  CD2 LEU C3048      26.370  -7.426   1.876  1.00 32.95           C  
+ATOM   5123  N   GLU C3049      21.580  -7.225   4.465  1.00 29.21           N  
+ATOM   5124  CA  GLU C3049      20.248  -7.747   4.720  1.00 29.25           C  
+ATOM   5125  C   GLU C3049      19.289  -7.056   3.763  1.00 28.94           C  
+ATOM   5126  O   GLU C3049      18.358  -7.670   3.243  1.00 29.95           O  
+ATOM   5127  CB  GLU C3049      19.840  -7.482   6.173  1.00 29.62           C  
+ATOM   5128  N   GLU C3050      19.535  -5.771   3.532  1.00 29.81           N  
+ATOM   5129  CA  GLU C3050      18.719  -4.959   2.636  1.00 29.79           C  
+ATOM   5130  C   GLU C3050      18.795  -5.568   1.231  1.00 29.44           C  
+ATOM   5131  O   GLU C3050      17.786  -5.703   0.541  1.00 28.45           O  
+ATOM   5132  CB  GLU C3050      19.251  -3.516   2.623  1.00 31.38           C  
+ATOM   5133  CG  GLU C3050      18.441  -2.528   1.795  1.00 33.17           C  
+ATOM   5134  CD  GLU C3050      17.150  -2.089   2.475  1.00 34.98           C  
+ATOM   5135  OE1 GLU C3050      16.389  -1.306   1.863  1.00 34.79           O  
+ATOM   5136  OE2 GLU C3050      16.896  -2.523   3.620  1.00 35.12           O  
+ATOM   5137  N   VAL C3051      20.000  -5.952   0.820  1.00 28.23           N  
+ATOM   5138  CA  VAL C3051      20.186  -6.542  -0.493  1.00 28.22           C  
+ATOM   5139  C   VAL C3051      19.383  -7.827  -0.614  1.00 29.50           C  
+ATOM   5140  O   VAL C3051      18.651  -8.028  -1.585  1.00 28.65           O  
+ATOM   5141  CB  VAL C3051      21.669  -6.851  -0.764  1.00 27.67           C  
+ATOM   5142  CG1 VAL C3051      21.803  -7.703  -2.019  1.00 28.20           C  
+ATOM   5143  CG2 VAL C3051      22.444  -5.553  -0.931  1.00 25.61           C  
+ATOM   5144  N   ALA C3052      19.510  -8.688   0.388  1.00 29.47           N  
+ATOM   5145  CA  ALA C3052      18.810  -9.959   0.381  1.00 30.52           C  
+ATOM   5146  C   ALA C3052      17.285  -9.837   0.429  1.00 30.87           C  
+ATOM   5147  O   ALA C3052      16.580 -10.622  -0.208  1.00 31.48           O  
+ATOM   5148  CB  ALA C3052      19.303 -10.823   1.544  1.00 30.53           C  
+ATOM   5149  N   GLU C3053      16.769  -8.859   1.168  1.00 30.54           N  
+ATOM   5150  CA  GLU C3053      15.319  -8.718   1.281  1.00 31.36           C  
+ATOM   5151  C   GLU C3053      14.669  -7.789   0.269  1.00 29.39           C  
+ATOM   5152  O   GLU C3053      13.480  -7.926  -0.019  1.00 31.41           O  
+ATOM   5153  CB  GLU C3053      14.933  -8.241   2.686  1.00 33.06           C  
+ATOM   5154  CG  GLU C3053      15.532  -9.051   3.819  1.00 38.00           C  
+ATOM   5155  CD  GLU C3053      15.009  -8.625   5.182  1.00 40.66           C  
+ATOM   5156  OE1 GLU C3053      14.721  -7.418   5.374  1.00 41.17           O  
+ATOM   5157  OE2 GLU C3053      14.898  -9.501   6.067  1.00 44.44           O  
+ATOM   5158  N   ILE C3054      15.429  -6.843  -0.266  1.00 26.16           N  
+ATOM   5159  CA  ILE C3054      14.855  -5.895  -1.207  1.00 24.47           C  
+ATOM   5160  C   ILE C3054      15.356  -6.004  -2.646  1.00 23.88           C  
+ATOM   5161  O   ILE C3054      14.576  -6.227  -3.565  1.00 23.17           O  
+ATOM   5162  CB  ILE C3054      15.094  -4.443  -0.734  1.00 24.93           C  
+ATOM   5163  CG1 ILE C3054      14.565  -4.259   0.698  1.00 26.11           C  
+ATOM   5164  CG2 ILE C3054      14.428  -3.469  -1.687  1.00 24.31           C  
+ATOM   5165  CD1 ILE C3054      13.102  -4.599   0.884  1.00 25.16           C  
+ATOM   5166  N   TYR C3055      16.660  -5.849  -2.831  1.00 22.81           N  
+ATOM   5167  CA  TYR C3055      17.247  -5.874  -4.157  1.00 24.00           C  
+ATOM   5168  C   TYR C3055      17.307  -7.200  -4.900  1.00 23.81           C  
+ATOM   5169  O   TYR C3055      17.234  -7.206  -6.121  1.00 26.20           O  
+ATOM   5170  CB  TYR C3055      18.624  -5.204  -4.112  1.00 24.62           C  
+ATOM   5171  CG  TYR C3055      18.511  -3.765  -3.656  1.00 24.67           C  
+ATOM   5172  CD1 TYR C3055      18.725  -3.412  -2.321  1.00 25.00           C  
+ATOM   5173  CD2 TYR C3055      18.073  -2.775  -4.532  1.00 25.09           C  
+ATOM   5174  CE1 TYR C3055      18.494  -2.109  -1.872  1.00 26.19           C  
+ATOM   5175  CE2 TYR C3055      17.838  -1.472  -4.095  1.00 26.04           C  
+ATOM   5176  CZ  TYR C3055      18.046  -1.145  -2.765  1.00 25.92           C  
+ATOM   5177  OH  TYR C3055      17.785   0.139  -2.336  1.00 28.29           O  
+ATOM   5178  N   LEU C3056      17.440  -8.319  -4.199  1.00 23.47           N  
+ATOM   5179  CA  LEU C3056      17.455  -9.600  -4.895  1.00 22.07           C  
+ATOM   5180  C   LEU C3056      16.075  -9.813  -5.519  1.00 20.93           C  
+ATOM   5181  O   LEU C3056      15.966 -10.157  -6.697  1.00 18.54           O  
+ATOM   5182  CB  LEU C3056      17.814 -10.748  -3.947  1.00 24.07           C  
+ATOM   5183  CG  LEU C3056      19.313 -11.050  -3.890  1.00 27.63           C  
+ATOM   5184  CD1 LEU C3056      19.600 -12.081  -2.810  1.00 30.05           C  
+ATOM   5185  CD2 LEU C3056      19.777 -11.560  -5.248  1.00 29.84           C  
+ATOM   5186  N   PRO C3057      15.002  -9.616  -4.735  1.00 18.99           N  
+ATOM   5187  CA  PRO C3057      13.650  -9.791  -5.271  1.00 18.97           C  
+ATOM   5188  C   PRO C3057      13.387  -8.824  -6.430  1.00 18.00           C  
+ATOM   5189  O   PRO C3057      12.698  -9.166  -7.389  1.00 16.67           O  
+ATOM   5190  CB  PRO C3057      12.767  -9.497  -4.066  1.00 20.06           C  
+ATOM   5191  CG  PRO C3057      13.610  -9.997  -2.924  1.00 19.99           C  
+ATOM   5192  CD  PRO C3057      14.961  -9.454  -3.270  1.00 21.53           C  
+ATOM   5193  N   LEU C3058      13.929  -7.612  -6.319  1.00 16.82           N  
+ATOM   5194  CA  LEU C3058      13.776  -6.600  -7.359  1.00 17.14           C  
+ATOM   5195  C   LEU C3058      14.494  -7.059  -8.634  1.00 16.09           C  
+ATOM   5196  O   LEU C3058      13.990  -6.868  -9.734  1.00 16.17           O  
+ATOM   5197  CB  LEU C3058      14.357  -5.252  -6.894  1.00 17.04           C  
+ATOM   5198  CG  LEU C3058      14.315  -4.098  -7.907  1.00 16.64           C  
+ATOM   5199  CD1 LEU C3058      12.869  -3.783  -8.270  1.00 14.36           C  
+ATOM   5200  CD2 LEU C3058      14.989  -2.868  -7.331  1.00 14.81           C  
+ATOM   5201  N   SER C3059      15.663  -7.675  -8.485  1.00 15.81           N  
+ATOM   5202  CA  SER C3059      16.394  -8.133  -9.653  1.00 18.23           C  
+ATOM   5203  C   SER C3059      15.637  -9.303 -10.277  1.00 19.87           C  
+ATOM   5204  O   SER C3059      15.650  -9.468 -11.497  1.00 20.16           O  
+ATOM   5205  CB  SER C3059      17.833  -8.528  -9.283  1.00 18.91           C  
+ATOM   5206  OG  SER C3059      17.885  -9.718  -8.521  1.00 22.54           O  
+ATOM   5207  N   ARG C3060      14.957 -10.101  -9.449  1.00 19.95           N  
+ATOM   5208  CA  ARG C3060      14.181 -11.220  -9.970  1.00 20.18           C  
+ATOM   5209  C   ARG C3060      13.024 -10.654 -10.790  1.00 18.83           C  
+ATOM   5210  O   ARG C3060      12.768 -11.104 -11.900  1.00 19.23           O  
+ATOM   5211  CB  ARG C3060      13.615 -12.096  -8.846  1.00 24.10           C  
+ATOM   5212  CG  ARG C3060      14.623 -13.031  -8.171  1.00 30.67           C  
+ATOM   5213  CD  ARG C3060      13.918 -14.038  -7.252  1.00 31.18           C  
+ATOM   5214  NE  ARG C3060      13.005 -14.899  -8.003  1.00 35.62           N  
+ATOM   5215  CZ  ARG C3060      12.124 -15.729  -7.449  1.00 37.85           C  
+ATOM   5216  NH1 ARG C3060      12.031 -15.814  -6.127  1.00 38.62           N  
+ATOM   5217  NH2 ARG C3060      11.337 -16.480  -8.215  1.00 38.26           N  
+ATOM   5218  N   LEU C3061      12.332  -9.661 -10.240  1.00 17.85           N  
+ATOM   5219  CA  LEU C3061      11.217  -9.039 -10.939  1.00 18.02           C  
+ATOM   5220  C   LEU C3061      11.670  -8.516 -12.299  1.00 17.24           C  
+ATOM   5221  O   LEU C3061      11.027  -8.749 -13.313  1.00 19.24           O  
+ATOM   5222  CB  LEU C3061      10.652  -7.866 -10.143  1.00 18.70           C  
+ATOM   5223  CG  LEU C3061       9.488  -7.174 -10.861  1.00 17.52           C  
+ATOM   5224  CD1 LEU C3061       8.191  -7.910 -10.571  1.00 17.36           C  
+ATOM   5225  CD2 LEU C3061       9.393  -5.733 -10.408  1.00 19.13           C  
+ATOM   5226  N   LEU C3062      12.775  -7.790 -12.307  1.00 16.94           N  
+ATOM   5227  CA  LEU C3062      13.306  -7.248 -13.545  1.00 17.52           C  
+ATOM   5228  C   LEU C3062      13.613  -8.352 -14.547  1.00 16.84           C  
+ATOM   5229  O   LEU C3062      13.344  -8.204 -15.726  1.00 15.96           O  
+ATOM   5230  CB  LEU C3062      14.563  -6.430 -13.260  1.00 16.01           C  
+ATOM   5231  CG  LEU C3062      14.269  -5.129 -12.514  1.00 17.43           C  
+ATOM   5232  CD1 LEU C3062      15.580  -4.460 -12.125  1.00 15.26           C  
+ATOM   5233  CD2 LEU C3062      13.427  -4.216 -13.393  1.00 14.59           C  
+ATOM   5234  N   ASN C3063      14.161  -9.464 -14.064  1.00 17.81           N  
+ATOM   5235  CA  ASN C3063      14.485 -10.587 -14.932  1.00 19.19           C  
+ATOM   5236  C   ASN C3063      13.235 -11.163 -15.589  1.00 19.48           C  
+ATOM   5237  O   ASN C3063      13.282 -11.597 -16.739  1.00 17.39           O  
+ATOM   5238  CB  ASN C3063      15.211 -11.686 -14.160  1.00 18.24           C  
+ATOM   5239  CG  ASN C3063      15.532 -12.884 -15.033  1.00 22.60           C  
+ATOM   5240  OD1 ASN C3063      14.813 -13.889 -15.025  1.00 22.77           O  
+ATOM   5241  ND2 ASN C3063      16.601 -12.775 -15.816  1.00 23.19           N  
+ATOM   5242  N   PHE C3064      12.119 -11.169 -14.863  1.00 18.25           N  
+ATOM   5243  CA  PHE C3064      10.871 -11.668 -15.432  1.00 17.86           C  
+ATOM   5244  C   PHE C3064      10.434 -10.767 -16.601  1.00 17.41           C  
+ATOM   5245  O   PHE C3064       9.966 -11.254 -17.624  1.00 15.70           O  
+ATOM   5246  CB  PHE C3064       9.766 -11.710 -14.363  1.00 20.17           C  
+ATOM   5247  CG  PHE C3064       9.839 -12.914 -13.454  1.00 22.39           C  
+ATOM   5248  CD1 PHE C3064       9.810 -12.763 -12.067  1.00 23.42           C  
+ATOM   5249  CD2 PHE C3064       9.915 -14.201 -13.985  1.00 22.20           C  
+ATOM   5250  CE1 PHE C3064       9.854 -13.877 -11.217  1.00 21.24           C  
+ATOM   5251  CE2 PHE C3064       9.960 -15.322 -13.150  1.00 23.46           C  
+ATOM   5252  CZ  PHE C3064       9.929 -15.157 -11.758  1.00 21.70           C  
+ATOM   5253  N   TYR C3065      10.577  -9.453 -16.442  1.00 16.82           N  
+ATOM   5254  CA  TYR C3065      10.195  -8.540 -17.513  1.00 16.94           C  
+ATOM   5255  C   TYR C3065      11.143  -8.713 -18.700  1.00 16.73           C  
+ATOM   5256  O   TYR C3065      10.722  -8.687 -19.849  1.00 14.87           O  
+ATOM   5257  CB  TYR C3065      10.248  -7.078 -17.042  1.00 17.51           C  
+ATOM   5258  CG  TYR C3065       9.016  -6.623 -16.295  1.00 18.03           C  
+ATOM   5259  CD1 TYR C3065       8.786  -7.012 -14.972  1.00 17.09           C  
+ATOM   5260  CD2 TYR C3065       8.053  -5.835 -16.929  1.00 17.95           C  
+ATOM   5261  CE1 TYR C3065       7.625  -6.629 -14.305  1.00 17.42           C  
+ATOM   5262  CE2 TYR C3065       6.888  -5.449 -16.271  1.00 15.76           C  
+ATOM   5263  CZ  TYR C3065       6.679  -5.848 -14.963  1.00 17.67           C  
+ATOM   5264  OH  TYR C3065       5.516  -5.474 -14.325  1.00 17.86           O  
+ATOM   5265  N   ILE C3066      12.427  -8.877 -18.408  1.00 16.87           N  
+ATOM   5266  CA  ILE C3066      13.424  -9.042 -19.452  1.00 18.53           C  
+ATOM   5267  C   ILE C3066      13.217 -10.358 -20.198  1.00 20.03           C  
+ATOM   5268  O   ILE C3066      13.242 -10.386 -21.429  1.00 19.64           O  
+ATOM   5269  CB  ILE C3066      14.842  -9.000 -18.863  1.00 16.80           C  
+ATOM   5270  CG1 ILE C3066      15.071  -7.639 -18.204  1.00 15.13           C  
+ATOM   5271  CG2 ILE C3066      15.875  -9.263 -19.955  1.00 14.75           C  
+ATOM   5272  CD1 ILE C3066      16.306  -7.576 -17.344  1.00 18.13           C  
+ATOM   5273  N   SER C3067      13.002 -11.439 -19.452  1.00 20.22           N  
+ATOM   5274  CA  SER C3067      12.785 -12.754 -20.052  1.00 20.45           C  
+ATOM   5275  C   SER C3067      11.572 -12.691 -20.953  1.00 19.50           C  
+ATOM   5276  O   SER C3067      11.605 -13.149 -22.095  1.00 17.17           O  
+ATOM   5277  CB  SER C3067      12.537 -13.824 -18.988  1.00 20.94           C  
+ATOM   5278  OG  SER C3067      13.683 -14.046 -18.201  1.00 26.70           O  
+ATOM   5279  N   SER C3068      10.495 -12.127 -20.425  1.00 18.83           N  
+ATOM   5280  CA  SER C3068       9.265 -12.003 -21.190  1.00 21.29           C  
+ATOM   5281  C   SER C3068       9.542 -11.269 -22.502  1.00 21.21           C  
+ATOM   5282  O   SER C3068       9.033 -11.632 -23.556  1.00 20.79           O  
+ATOM   5283  CB  SER C3068       8.214 -11.242 -20.386  1.00 19.37           C  
+ATOM   5284  OG  SER C3068       7.009 -11.150 -21.120  1.00 22.54           O  
+ATOM   5285  N   ASN C3069      10.365 -10.235 -22.428  1.00 22.06           N  
+ATOM   5286  CA  ASN C3069      10.698  -9.458 -23.604  1.00 23.52           C  
+ATOM   5287  C   ASN C3069      11.523 -10.292 -24.586  1.00 22.51           C  
+ATOM   5288  O   ASN C3069      11.354 -10.175 -25.798  1.00 24.23           O  
+ATOM   5289  CB  ASN C3069      11.448  -8.192 -23.182  1.00 25.68           C  
+ATOM   5290  CG  ASN C3069      11.778  -7.295 -24.352  1.00 28.29           C  
+ATOM   5291  OD1 ASN C3069      12.812  -7.459 -24.996  1.00 28.98           O  
+ATOM   5292  ND2 ASN C3069      10.893  -6.346 -24.642  1.00 28.04           N  
+ATOM   5293  N   LEU C3070      12.396 -11.148 -24.067  1.00 21.81           N  
+ATOM   5294  CA  LEU C3070      13.216 -11.994 -24.927  1.00 23.32           C  
+ATOM   5295  C   LEU C3070      12.382 -13.101 -25.583  1.00 25.30           C  
+ATOM   5296  O   LEU C3070      12.611 -13.456 -26.740  1.00 27.02           O  
+ATOM   5297  CB  LEU C3070      14.367 -12.619 -24.137  1.00 22.02           C  
+ATOM   5298  CG  LEU C3070      15.477 -11.692 -23.627  1.00 25.43           C  
+ATOM   5299  CD1 LEU C3070      16.358 -12.471 -22.663  1.00 24.56           C  
+ATOM   5300  CD2 LEU C3070      16.311 -11.158 -24.790  1.00 25.00           C  
+ATOM   5301  N   ARG C3071      11.410 -13.641 -24.856  1.00 24.23           N  
+ATOM   5302  CA  ARG C3071      10.576 -14.695 -25.406  1.00 25.88           C  
+ATOM   5303  C   ARG C3071       9.735 -14.124 -26.547  1.00 23.68           C  
+ATOM   5304  O   ARG C3071       9.653 -14.721 -27.623  1.00 22.88           O  
+ATOM   5305  CB  ARG C3071       9.672 -15.297 -24.315  1.00 29.34           C  
+ATOM   5306  CG  ARG C3071       9.002 -16.619 -24.706  1.00 37.94           C  
+ATOM   5307  CD  ARG C3071       8.031 -17.138 -23.631  1.00 42.94           C  
+ATOM   5308  NE  ARG C3071       7.578 -18.512 -23.886  1.00 47.85           N  
+ATOM   5309  CZ  ARG C3071       8.359 -19.594 -23.814  1.00 48.56           C  
+ATOM   5310  NH1 ARG C3071       9.641 -19.480 -23.495  1.00 47.93           N  
+ATOM   5311  NH2 ARG C3071       7.856 -20.800 -24.058  1.00 50.82           N  
+ATOM   5312  N   ARG C3072       9.119 -12.965 -26.315  1.00 21.61           N  
+ATOM   5313  CA  ARG C3072       8.283 -12.328 -27.333  1.00 19.77           C  
+ATOM   5314  C   ARG C3072       9.093 -12.067 -28.602  1.00 18.59           C  
+ATOM   5315  O   ARG C3072       8.608 -12.266 -29.710  1.00 17.74           O  
+ATOM   5316  CB  ARG C3072       7.700 -11.003 -26.822  1.00 18.04           C  
+ATOM   5317  CG  ARG C3072       6.681 -10.379 -27.781  1.00 18.33           C  
+ATOM   5318  CD  ARG C3072       6.223  -8.996 -27.346  1.00 20.03           C  
+ATOM   5319  NE  ARG C3072       7.273  -7.982 -27.438  1.00 21.30           N  
+ATOM   5320  CZ  ARG C3072       7.208  -6.787 -26.851  1.00 23.23           C  
+ATOM   5321  NH1 ARG C3072       6.145  -6.451 -26.124  1.00 20.99           N  
+ATOM   5322  NH2 ARG C3072       8.204  -5.920 -26.990  1.00 21.32           N  
+ATOM   5323  N   GLN C3073      10.329 -11.625 -28.417  1.00 18.93           N  
+ATOM   5324  CA  GLN C3073      11.224 -11.325 -29.525  1.00 22.10           C  
+ATOM   5325  C   GLN C3073      11.406 -12.561 -30.410  1.00 21.73           C  
+ATOM   5326  O   GLN C3073      11.420 -12.452 -31.635  1.00 21.10           O  
+ATOM   5327  CB  GLN C3073      12.567 -10.838 -28.971  1.00 23.80           C  
+ATOM   5328  CG  GLN C3073      13.495 -10.191 -29.981  1.00 27.82           C  
+ATOM   5329  CD  GLN C3073      14.302 -11.201 -30.780  1.00 33.83           C  
+ATOM   5330  OE1 GLN C3073      14.850 -12.157 -30.219  1.00 35.12           O  
+ATOM   5331  NE2 GLN C3073      14.397 -10.986 -32.096  1.00 36.05           N  
+ATOM   5332  N   ALA C3074      11.519 -13.732 -29.787  1.00 20.82           N  
+ATOM   5333  CA  ALA C3074      11.680 -14.974 -30.532  1.00 21.88           C  
+ATOM   5334  C   ALA C3074      10.404 -15.291 -31.312  1.00 21.75           C  
+ATOM   5335  O   ALA C3074      10.473 -15.735 -32.454  1.00 20.10           O  
+ATOM   5336  CB  ALA C3074      12.021 -16.124 -29.583  1.00 21.85           C  
+ATOM   5337  N   VAL C3075       9.245 -15.065 -30.692  1.00 21.27           N  
+ATOM   5338  CA  VAL C3075       7.968 -15.321 -31.350  1.00 20.23           C  
+ATOM   5339  C   VAL C3075       7.781 -14.362 -32.516  1.00 21.70           C  
+ATOM   5340  O   VAL C3075       7.280 -14.744 -33.574  1.00 22.58           O  
+ATOM   5341  CB  VAL C3075       6.775 -15.133 -30.382  1.00 20.95           C  
+ATOM   5342  CG1 VAL C3075       5.456 -15.144 -31.156  1.00 20.13           C  
+ATOM   5343  CG2 VAL C3075       6.769 -16.241 -29.350  1.00 22.46           C  
+ATOM   5344  N   LEU C3076       8.169 -13.108 -32.316  1.00 20.19           N  
+ATOM   5345  CA  LEU C3076       8.034 -12.108 -33.364  1.00 21.59           C  
+ATOM   5346  C   LEU C3076       9.051 -12.332 -34.477  1.00 22.52           C  
+ATOM   5347  O   LEU C3076       8.771 -12.065 -35.637  1.00 22.00           O  
+ATOM   5348  CB  LEU C3076       8.199 -10.699 -32.788  1.00 19.20           C  
+ATOM   5349  CG  LEU C3076       7.037 -10.233 -31.899  1.00 20.94           C  
+ATOM   5350  CD1 LEU C3076       7.373  -8.880 -31.285  1.00 16.79           C  
+ATOM   5351  CD2 LEU C3076       5.738 -10.168 -32.727  1.00 15.89           C  
+ATOM   5352  N   GLU C3077      10.226 -12.835 -34.124  1.00 24.08           N  
+ATOM   5353  CA  GLU C3077      11.251 -13.065 -35.123  1.00 27.85           C  
+ATOM   5354  C   GLU C3077      10.772 -14.124 -36.100  1.00 28.33           C  
+ATOM   5355  O   GLU C3077      10.976 -14.004 -37.310  1.00 27.25           O  
+ATOM   5356  CB  GLU C3077      12.558 -13.512 -34.465  1.00 29.57           C  
+ATOM   5357  CG  GLU C3077      13.637 -13.892 -35.469  1.00 33.45           C  
+ATOM   5358  CD  GLU C3077      14.988 -14.071 -34.816  1.00 37.56           C  
+ATOM   5359  OE1 GLU C3077      15.393 -13.158 -34.063  1.00 40.08           O  
+ATOM   5360  OE2 GLU C3077      15.646 -15.110 -35.051  1.00 38.77           O  
+ATOM   5361  N   GLN C3078      10.126 -15.154 -35.564  1.00 26.44           N  
+ATOM   5362  CA  GLN C3078       9.602 -16.234 -36.382  1.00 25.46           C  
+ATOM   5363  C   GLN C3078       8.513 -15.712 -37.318  1.00 25.41           C  
+ATOM   5364  O   GLN C3078       8.511 -16.021 -38.512  1.00 24.62           O  
+ATOM   5365  CB  GLN C3078       9.034 -17.345 -35.492  1.00 24.42           C  
+ATOM   5366  CG  GLN C3078       8.372 -18.450 -36.287  1.00 27.61           C  
+ATOM   5367  CD  GLN C3078       7.894 -19.593 -35.423  1.00 28.75           C  
+ATOM   5368  OE1 GLN C3078       6.973 -19.439 -34.612  1.00 28.78           O  
+ATOM   5369  NE2 GLN C3078       8.521 -20.755 -35.588  1.00 29.22           N  
+ATOM   5370  N   PHE C3079       7.589 -14.923 -36.770  1.00 23.57           N  
+ATOM   5371  CA  PHE C3079       6.494 -14.358 -37.557  1.00 22.60           C  
+ATOM   5372  C   PHE C3079       6.953 -13.334 -38.603  1.00 22.35           C  
+ATOM   5373  O   PHE C3079       6.623 -13.446 -39.778  1.00 21.67           O  
+ATOM   5374  CB  PHE C3079       5.479 -13.696 -36.625  1.00 21.20           C  
+ATOM   5375  CG  PHE C3079       4.373 -12.972 -37.341  1.00 20.98           C  
+ATOM   5376  CD1 PHE C3079       3.428 -13.674 -38.081  1.00 22.73           C  
+ATOM   5377  CD2 PHE C3079       4.264 -11.586 -37.259  1.00 21.59           C  
+ATOM   5378  CE1 PHE C3079       2.385 -13.006 -38.732  1.00 23.03           C  
+ATOM   5379  CE2 PHE C3079       3.232 -10.908 -37.901  1.00 21.78           C  
+ATOM   5380  CZ  PHE C3079       2.289 -11.620 -38.640  1.00 24.66           C  
+ATOM   5381  N   LEU C3080       7.694 -12.325 -38.157  1.00 23.05           N  
+ATOM   5382  CA  LEU C3080       8.178 -11.277 -39.043  1.00 25.29           C  
+ATOM   5383  C   LEU C3080       9.273 -11.824 -39.944  1.00 27.78           C  
+ATOM   5384  O   LEU C3080       9.639 -11.201 -40.931  1.00 27.90           O  
+ATOM   5385  CB  LEU C3080       8.723 -10.100 -38.226  1.00 21.53           C  
+ATOM   5386  CG  LEU C3080       7.745  -9.398 -37.282  1.00 19.72           C  
+ATOM   5387  CD1 LEU C3080       8.500  -8.421 -36.412  1.00 17.07           C  
+ATOM   5388  CD2 LEU C3080       6.651  -8.694 -38.085  1.00 20.75           C  
+ATOM   5389  N   GLY C3081       9.793 -12.992 -39.583  1.00 31.86           N  
+ATOM   5390  CA  GLY C3081      10.846 -13.625 -40.357  1.00 35.86           C  
+ATOM   5391  C   GLY C3081      12.070 -12.752 -40.562  1.00 39.66           C  
+ATOM   5392  O   GLY C3081      12.705 -12.803 -41.622  1.00 38.90           O  
+ATOM   5393  N   THR C3082      12.415 -11.956 -39.555  1.00 41.79           N  
+ATOM   5394  CA  THR C3082      13.560 -11.071 -39.667  1.00 45.95           C  
+ATOM   5395  C   THR C3082      14.841 -11.775 -39.206  1.00 48.45           C  
+ATOM   5396  O   THR C3082      14.797 -12.837 -38.579  1.00 48.56           O  
+ATOM   5397  CB  THR C3082      13.334  -9.770 -38.837  1.00 47.34           C  
+ATOM   5398  OG1 THR C3082      12.058  -9.198 -39.163  1.00 46.44           O  
+ATOM   5399  CG2 THR C3082      14.410  -8.741 -39.148  1.00 47.44           C  
+ATOM   5400  N   ASN C3083      15.987 -11.191 -39.544  1.00 50.66           N  
+ATOM   5401  CA  ASN C3083      17.275 -11.759 -39.158  1.00 51.81           C  
+ATOM   5402  C   ASN C3083      17.962 -10.874 -38.124  1.00 52.28           C  
+ATOM   5403  O   ASN C3083      19.009 -10.292 -38.395  1.00 52.78           O  
+ATOM   5404  CB  ASN C3083      18.169 -11.929 -40.385  1.00 52.39           C  
+ATOM   5405  N   ARG C3086      19.798  -7.723 -32.218  1.00 44.28           N  
+ATOM   5406  CA  ARG C3086      19.781  -7.844 -30.760  1.00 45.81           C  
+ATOM   5407  C   ARG C3086      19.041  -6.688 -30.099  1.00 44.20           C  
+ATOM   5408  O   ARG C3086      17.880  -6.814 -29.732  1.00 46.77           O  
+ATOM   5409  CB  ARG C3086      21.212  -7.920 -30.228  1.00 45.41           C  
+ATOM   5410  N   PRO C3088      19.292  -4.171 -27.002  1.00 20.53           N  
+ATOM   5411  CA  PRO C3088      19.485  -4.126 -25.553  1.00 19.57           C  
+ATOM   5412  C   PRO C3088      18.220  -3.764 -24.798  1.00 18.65           C  
+ATOM   5413  O   PRO C3088      17.462  -2.892 -25.226  1.00 17.60           O  
+ATOM   5414  CB  PRO C3088      20.547  -3.042 -25.371  1.00 21.30           C  
+ATOM   5415  CG  PRO C3088      21.303  -3.084 -26.624  1.00 23.77           C  
+ATOM   5416  CD  PRO C3088      20.233  -3.255 -27.667  1.00 20.43           C  
+ATOM   5417  N   TYR C3089      17.984  -4.449 -23.686  1.00 16.90           N  
+ATOM   5418  CA  TYR C3089      16.839  -4.133 -22.849  1.00 15.97           C  
+ATOM   5419  C   TYR C3089      17.358  -2.927 -22.067  1.00 16.20           C  
+ATOM   5420  O   TYR C3089      18.484  -2.959 -21.567  1.00 16.09           O  
+ATOM   5421  CB  TYR C3089      16.552  -5.266 -21.875  1.00 14.29           C  
+ATOM   5422  CG  TYR C3089      15.261  -5.080 -21.115  1.00 13.54           C  
+ATOM   5423  CD1 TYR C3089      14.035  -5.405 -21.695  1.00 12.72           C  
+ATOM   5424  CD2 TYR C3089      15.264  -4.566 -19.820  1.00 15.23           C  
+ATOM   5425  CE1 TYR C3089      12.846  -5.227 -20.997  1.00 16.34           C  
+ATOM   5426  CE2 TYR C3089      14.079  -4.380 -19.112  1.00 12.14           C  
+ATOM   5427  CZ  TYR C3089      12.880  -4.712 -19.699  1.00 13.71           C  
+ATOM   5428  OH  TYR C3089      11.723  -4.537 -18.991  1.00 13.73           O  
+ATOM   5429  N   ILE C3090      16.566  -1.868 -21.966  1.00 16.32           N  
+ATOM   5430  CA  ILE C3090      17.029  -0.689 -21.247  1.00 16.27           C  
+ATOM   5431  C   ILE C3090      16.238  -0.355 -19.983  1.00 15.07           C  
+ATOM   5432  O   ILE C3090      15.021  -0.228 -20.008  1.00 16.26           O  
+ATOM   5433  CB  ILE C3090      17.034   0.534 -22.166  1.00 16.21           C  
+ATOM   5434  CG1 ILE C3090      17.980   0.280 -23.355  1.00 18.11           C  
+ATOM   5435  CG2 ILE C3090      17.466   1.771 -21.380  1.00 15.82           C  
+ATOM   5436  CD1 ILE C3090      18.148   1.478 -24.277  1.00 13.00           C  
+ATOM   5437  N   ILE C3091      16.958  -0.211 -18.878  1.00 16.55           N  
+ATOM   5438  CA  ILE C3091      16.364   0.114 -17.582  1.00 16.43           C  
+ATOM   5439  C   ILE C3091      16.878   1.481 -17.131  1.00 16.88           C  
+ATOM   5440  O   ILE C3091      18.087   1.694 -17.063  1.00 17.55           O  
+ATOM   5441  CB  ILE C3091      16.773  -0.931 -16.503  1.00 16.11           C  
+ATOM   5442  CG1 ILE C3091      16.212  -2.307 -16.858  1.00 12.15           C  
+ATOM   5443  CG2 ILE C3091      16.282  -0.477 -15.126  1.00 15.59           C  
+ATOM   5444  CD1 ILE C3091      16.881  -3.456 -16.117  1.00 13.19           C  
+ATOM   5445  N   SER C3092      15.973   2.409 -16.836  1.00 16.33           N  
+ATOM   5446  CA  SER C3092      16.393   3.728 -16.366  1.00 16.27           C  
+ATOM   5447  C   SER C3092      16.051   3.871 -14.883  1.00 15.82           C  
+ATOM   5448  O   SER C3092      15.141   3.209 -14.377  1.00 16.62           O  
+ATOM   5449  CB  SER C3092      15.728   4.851 -17.177  1.00 11.31           C  
+ATOM   5450  OG  SER C3092      14.342   4.931 -16.931  1.00 16.29           O  
+ATOM   5451  N   ILE C3093      16.799   4.723 -14.194  1.00 15.03           N  
+ATOM   5452  CA  ILE C3093      16.596   4.947 -12.772  1.00 15.04           C  
+ATOM   5453  C   ILE C3093      16.604   6.447 -12.513  1.00 14.06           C  
+ATOM   5454  O   ILE C3093      17.609   7.121 -12.724  1.00 13.52           O  
+ATOM   5455  CB  ILE C3093      17.699   4.243 -11.949  1.00 14.77           C  
+ATOM   5456  CG1 ILE C3093      17.639   2.734 -12.209  1.00 14.87           C  
+ATOM   5457  CG2 ILE C3093      17.516   4.527 -10.466  1.00 14.57           C  
+ATOM   5458  CD1 ILE C3093      18.794   1.950 -11.624  1.00 14.72           C  
+ATOM   5459  N   ALA C3094      15.461   6.957 -12.070  1.00 12.88           N  
+ATOM   5460  CA  ALA C3094      15.301   8.373 -11.799  1.00 13.82           C  
+ATOM   5461  C   ALA C3094      15.143   8.664 -10.310  1.00 15.82           C  
+ATOM   5462  O   ALA C3094      15.073   7.749  -9.487  1.00 14.39           O  
+ATOM   5463  CB  ALA C3094      14.104   8.901 -12.559  1.00 13.09           C  
+ATOM   5464  N   GLY C3095      15.092   9.953  -9.982  1.00 15.77           N  
+ATOM   5465  CA  GLY C3095      14.951  10.363  -8.599  1.00 17.40           C  
+ATOM   5466  C   GLY C3095      15.826  11.551  -8.246  1.00 16.97           C  
+ATOM   5467  O   GLY C3095      16.706  11.959  -9.013  1.00 15.60           O  
+ATOM   5468  N   SER C3096      15.580  12.103  -7.066  1.00 16.13           N  
+ATOM   5469  CA  SER C3096      16.327  13.250  -6.571  1.00 16.86           C  
+ATOM   5470  C   SER C3096      17.827  13.040  -6.484  1.00 16.85           C  
+ATOM   5471  O   SER C3096      18.313  11.911  -6.358  1.00 15.41           O  
+ATOM   5472  CB  SER C3096      15.832  13.639  -5.171  1.00 18.87           C  
+ATOM   5473  OG  SER C3096      16.702  14.576  -4.551  1.00 16.09           O  
+ATOM   5474  N   VAL C3097      18.557  14.147  -6.553  1.00 16.11           N  
+ATOM   5475  CA  VAL C3097      19.995  14.098  -6.394  1.00 17.30           C  
+ATOM   5476  C   VAL C3097      20.163  13.564  -4.963  1.00 17.95           C  
+ATOM   5477  O   VAL C3097      19.432  13.967  -4.053  1.00 17.40           O  
+ATOM   5478  CB  VAL C3097      20.618  15.520  -6.493  1.00 18.76           C  
+ATOM   5479  CG1 VAL C3097      22.069  15.505  -5.991  1.00 17.07           C  
+ATOM   5480  CG2 VAL C3097      20.546  16.025  -7.939  1.00 16.87           C  
+ATOM   5481  N   ALA C3098      21.088  12.630  -4.788  1.00 17.59           N  
+ATOM   5482  CA  ALA C3098      21.388  12.037  -3.489  1.00 18.97           C  
+ATOM   5483  C   ALA C3098      20.372  11.050  -2.922  1.00 20.74           C  
+ATOM   5484  O   ALA C3098      20.471  10.685  -1.747  1.00 21.47           O  
+ATOM   5485  CB  ALA C3098      21.645  13.134  -2.469  1.00 19.60           C  
+ATOM   5486  N   VAL C3099      19.408  10.599  -3.722  1.00 19.47           N  
+ATOM   5487  CA  VAL C3099      18.439   9.644  -3.194  1.00 18.32           C  
+ATOM   5488  C   VAL C3099      19.029   8.234  -3.182  1.00 19.09           C  
+ATOM   5489  O   VAL C3099      18.579   7.374  -2.431  1.00 19.79           O  
+ATOM   5490  CB  VAL C3099      17.118   9.634  -4.005  1.00 17.23           C  
+ATOM   5491  CG1 VAL C3099      17.342   9.044  -5.395  1.00 16.33           C  
+ATOM   5492  CG2 VAL C3099      16.062   8.842  -3.248  1.00 18.58           C  
+ATOM   5493  N   GLY C3100      20.044   8.006  -4.006  1.00 17.38           N  
+ATOM   5494  CA  GLY C3100      20.674   6.698  -4.075  1.00 16.94           C  
+ATOM   5495  C   GLY C3100      20.571   5.994  -5.424  1.00 17.46           C  
+ATOM   5496  O   GLY C3100      20.605   4.760  -5.488  1.00 16.01           O  
+ATOM   5497  N   LYS C3101      20.444   6.769  -6.502  1.00 16.07           N  
+ATOM   5498  CA  LYS C3101      20.328   6.207  -7.851  1.00 17.66           C  
+ATOM   5499  C   LYS C3101      21.579   5.442  -8.248  1.00 17.77           C  
+ATOM   5500  O   LYS C3101      21.508   4.340  -8.762  1.00 17.87           O  
+ATOM   5501  CB  LYS C3101      20.083   7.308  -8.891  1.00 15.96           C  
+ATOM   5502  CG  LYS C3101      18.762   8.057  -8.746  1.00 16.04           C  
+ATOM   5503  CD  LYS C3101      18.565   9.085  -9.853  1.00 17.61           C  
+ATOM   5504  CE  LYS C3101      19.702  10.115  -9.895  1.00 18.14           C  
+ATOM   5505  NZ  LYS C3101      19.811  10.876  -8.608  1.00 18.31           N  
+ATOM   5506  N   SER C3102      22.734   6.042  -8.002  1.00 21.37           N  
+ATOM   5507  CA  SER C3102      23.993   5.415  -8.362  1.00 22.55           C  
+ATOM   5508  C   SER C3102      24.217   4.099  -7.631  1.00 22.47           C  
+ATOM   5509  O   SER C3102      24.679   3.119  -8.228  1.00 21.01           O  
+ATOM   5510  CB  SER C3102      25.148   6.369  -8.080  1.00 24.32           C  
+ATOM   5511  OG  SER C3102      26.359   5.788  -8.510  1.00 28.17           O  
+ATOM   5512  N   THR C3103      23.902   4.075  -6.338  1.00 20.52           N  
+ATOM   5513  CA  THR C3103      24.055   2.854  -5.558  1.00 20.39           C  
+ATOM   5514  C   THR C3103      23.053   1.802  -6.044  1.00 19.05           C  
+ATOM   5515  O   THR C3103      23.403   0.643  -6.240  1.00 20.00           O  
+ATOM   5516  CB  THR C3103      23.826   3.119  -4.038  1.00 21.20           C  
+ATOM   5517  OG1 THR C3103      24.887   3.937  -3.535  1.00 22.85           O  
+ATOM   5518  CG2 THR C3103      23.814   1.814  -3.256  1.00 20.10           C  
+ATOM   5519  N   THR C3104      21.806   2.211  -6.232  1.00 19.02           N  
+ATOM   5520  CA  THR C3104      20.770   1.295  -6.694  1.00 20.01           C  
+ATOM   5521  C   THR C3104      21.140   0.690  -8.055  1.00 19.85           C  
+ATOM   5522  O   THR C3104      21.021  -0.520  -8.271  1.00 21.11           O  
+ATOM   5523  CB  THR C3104      19.421   2.029  -6.815  1.00 20.63           C  
+ATOM   5524  OG1 THR C3104      19.075   2.586  -5.540  1.00 21.90           O  
+ATOM   5525  CG2 THR C3104      18.318   1.071  -7.271  1.00 18.50           C  
+ATOM   5526  N   ALA C3105      21.585   1.542  -8.970  1.00 18.56           N  
+ATOM   5527  CA  ALA C3105      21.969   1.102 -10.307  1.00 18.52           C  
+ATOM   5528  C   ALA C3105      23.077   0.058 -10.247  1.00 18.10           C  
+ATOM   5529  O   ALA C3105      22.966  -1.015 -10.839  1.00 19.02           O  
+ATOM   5530  CB  ALA C3105      22.428   2.295 -11.131  1.00 14.80           C  
+ATOM   5531  N   ARG C3106      24.136   0.373  -9.513  1.00 18.23           N  
+ATOM   5532  CA  ARG C3106      25.272  -0.526  -9.392  1.00 19.82           C  
+ATOM   5533  C   ARG C3106      24.917  -1.832  -8.710  1.00 18.95           C  
+ATOM   5534  O   ARG C3106      25.455  -2.878  -9.062  1.00 18.77           O  
+ATOM   5535  CB  ARG C3106      26.426   0.190  -8.677  1.00 21.92           C  
+ATOM   5536  CG  ARG C3106      27.030   1.298  -9.543  1.00 26.67           C  
+ATOM   5537  CD  ARG C3106      27.828   2.278  -8.721  1.00 29.41           C  
+ATOM   5538  NE  ARG C3106      29.040   1.661  -8.208  1.00 36.65           N  
+ATOM   5539  CZ  ARG C3106      29.733   2.124  -7.174  1.00 38.76           C  
+ATOM   5540  NH1 ARG C3106      29.323   3.216  -6.536  1.00 40.27           N  
+ATOM   5541  NH2 ARG C3106      30.838   1.501  -6.786  1.00 38.95           N  
+ATOM   5542  N   VAL C3107      24.004  -1.782  -7.744  1.00 19.26           N  
+ATOM   5543  CA  VAL C3107      23.577  -2.997  -7.066  1.00 17.81           C  
+ATOM   5544  C   VAL C3107      22.816  -3.852  -8.078  1.00 18.29           C  
+ATOM   5545  O   VAL C3107      23.082  -5.053  -8.208  1.00 17.85           O  
+ATOM   5546  CB  VAL C3107      22.659  -2.688  -5.842  1.00 19.83           C  
+ATOM   5547  CG1 VAL C3107      21.993  -3.969  -5.345  1.00 17.72           C  
+ATOM   5548  CG2 VAL C3107      23.482  -2.071  -4.712  1.00 16.49           C  
+ATOM   5549  N   LEU C3108      21.883  -3.231  -8.802  1.00 16.72           N  
+ATOM   5550  CA  LEU C3108      21.098  -3.953  -9.802  1.00 17.69           C  
+ATOM   5551  C   LEU C3108      21.970  -4.506 -10.928  1.00 18.67           C  
+ATOM   5552  O   LEU C3108      21.684  -5.571 -11.479  1.00 18.42           O  
+ATOM   5553  CB  LEU C3108      20.011  -3.051 -10.390  1.00 16.55           C  
+ATOM   5554  CG  LEU C3108      18.888  -2.711  -9.412  1.00 15.53           C  
+ATOM   5555  CD1 LEU C3108      17.847  -1.829 -10.097  1.00 16.68           C  
+ATOM   5556  CD2 LEU C3108      18.256  -4.004  -8.910  1.00 12.28           C  
+ATOM   5557  N   GLN C3109      23.033  -3.786 -11.270  1.00 18.87           N  
+ATOM   5558  CA  GLN C3109      23.942  -4.244 -12.318  1.00 20.89           C  
+ATOM   5559  C   GLN C3109      24.609  -5.544 -11.872  1.00 21.55           C  
+ATOM   5560  O   GLN C3109      24.725  -6.501 -12.638  1.00 19.33           O  
+ATOM   5561  CB  GLN C3109      25.008  -3.181 -12.594  1.00 20.87           C  
+ATOM   5562  CG  GLN C3109      26.159  -3.663 -13.447  1.00 21.40           C  
+ATOM   5563  CD  GLN C3109      27.133  -2.547 -13.784  1.00 23.58           C  
+ATOM   5564  OE1 GLN C3109      27.607  -1.830 -12.900  1.00 22.08           O  
+ATOM   5565  NE2 GLN C3109      27.446  -2.402 -15.070  1.00 22.15           N  
+ATOM   5566  N   ALA C3110      25.034  -5.566 -10.615  1.00 22.63           N  
+ATOM   5567  CA  ALA C3110      25.689  -6.729 -10.035  1.00 24.68           C  
+ATOM   5568  C   ALA C3110      24.738  -7.926  -9.950  1.00 25.88           C  
+ATOM   5569  O   ALA C3110      25.079  -9.033 -10.367  1.00 27.13           O  
+ATOM   5570  CB  ALA C3110      26.215  -6.380  -8.644  1.00 25.01           C  
+ATOM   5571  N   LEU C3111      23.540  -7.703  -9.421  1.00 25.04           N  
+ATOM   5572  CA  LEU C3111      22.577  -8.782  -9.291  1.00 23.87           C  
+ATOM   5573  C   LEU C3111      22.083  -9.337 -10.632  1.00 25.88           C  
+ATOM   5574  O   LEU C3111      21.981 -10.556 -10.801  1.00 25.50           O  
+ATOM   5575  CB  LEU C3111      21.396  -8.317  -8.438  1.00 22.10           C  
+ATOM   5576  CG  LEU C3111      21.789  -7.872  -7.021  1.00 22.71           C  
+ATOM   5577  CD1 LEU C3111      20.552  -7.438  -6.247  1.00 20.11           C  
+ATOM   5578  CD2 LEU C3111      22.502  -9.009  -6.298  1.00 21.00           C  
+ATOM   5579  N   LEU C3112      21.782  -8.461 -11.587  1.00 25.65           N  
+ATOM   5580  CA  LEU C3112      21.300  -8.927 -12.888  1.00 26.57           C  
+ATOM   5581  C   LEU C3112      22.358  -9.763 -13.593  1.00 26.89           C  
+ATOM   5582  O   LEU C3112      22.043 -10.560 -14.469  1.00 25.77           O  
+ATOM   5583  CB  LEU C3112      20.876  -7.748 -13.767  1.00 23.89           C  
+ATOM   5584  CG  LEU C3112      19.545  -7.106 -13.349  1.00 24.83           C  
+ATOM   5585  CD1 LEU C3112      19.356  -5.758 -14.042  1.00 25.66           C  
+ATOM   5586  CD2 LEU C3112      18.395  -8.055 -13.676  1.00 21.62           C  
+ATOM   5587  N   SER C3113      23.612  -9.592 -13.189  1.00 27.51           N  
+ATOM   5588  CA  SER C3113      24.709 -10.356 -13.779  1.00 30.28           C  
+ATOM   5589  C   SER C3113      24.675 -11.825 -13.367  1.00 29.99           C  
+ATOM   5590  O   SER C3113      25.358 -12.651 -13.961  1.00 31.75           O  
+ATOM   5591  CB  SER C3113      26.062  -9.750 -13.384  1.00 30.98           C  
+ATOM   5592  OG  SER C3113      26.326  -8.562 -14.123  1.00 34.05           O  
+ATOM   5593  N   ARG C3114      23.874 -12.148 -12.358  1.00 29.61           N  
+ATOM   5594  CA  ARG C3114      23.767 -13.523 -11.868  1.00 29.59           C  
+ATOM   5595  C   ARG C3114      23.187 -14.502 -12.888  1.00 28.18           C  
+ATOM   5596  O   ARG C3114      23.514 -15.692 -12.876  1.00 27.92           O  
+ATOM   5597  CB  ARG C3114      22.928 -13.550 -10.583  1.00 29.10           C  
+ATOM   5598  CG  ARG C3114      23.655 -12.980  -9.379  1.00 32.58           C  
+ATOM   5599  CD  ARG C3114      22.689 -12.491  -8.309  1.00 36.57           C  
+ATOM   5600  NE  ARG C3114      21.707 -13.496  -7.919  1.00 38.46           N  
+ATOM   5601  CZ  ARG C3114      22.008 -14.657  -7.349  1.00 41.71           C  
+ATOM   5602  NH1 ARG C3114      23.272 -14.967  -7.096  1.00 42.59           N  
+ATOM   5603  NH2 ARG C3114      21.042 -15.509  -7.029  1.00 43.59           N  
+ATOM   5604  N   TRP C3115      22.321 -14.005 -13.763  1.00 25.89           N  
+ATOM   5605  CA  TRP C3115      21.713 -14.850 -14.781  1.00 26.81           C  
+ATOM   5606  C   TRP C3115      22.670 -15.047 -15.946  1.00 29.24           C  
+ATOM   5607  O   TRP C3115      23.282 -14.094 -16.423  1.00 31.22           O  
+ATOM   5608  CB  TRP C3115      20.422 -14.218 -15.299  1.00 24.77           C  
+ATOM   5609  CG  TRP C3115      19.239 -14.404 -14.404  1.00 23.57           C  
+ATOM   5610  CD1 TRP C3115      18.286 -15.376 -14.497  1.00 22.07           C  
+ATOM   5611  CD2 TRP C3115      18.885 -13.601 -13.272  1.00 22.21           C  
+ATOM   5612  NE1 TRP C3115      17.359 -15.227 -13.494  1.00 21.76           N  
+ATOM   5613  CE2 TRP C3115      17.704 -14.147 -12.727  1.00 21.63           C  
+ATOM   5614  CE3 TRP C3115      19.453 -12.473 -12.664  1.00 22.11           C  
+ATOM   5615  CZ2 TRP C3115      17.080 -13.605 -11.599  1.00 20.79           C  
+ATOM   5616  CZ3 TRP C3115      18.829 -11.934 -11.540  1.00 21.49           C  
+ATOM   5617  CH2 TRP C3115      17.657 -12.502 -11.021  1.00 20.53           C  
+ATOM   5618  N   PRO C3116      22.813 -16.293 -16.419  1.00 31.43           N  
+ATOM   5619  CA  PRO C3116      23.703 -16.605 -17.544  1.00 33.07           C  
+ATOM   5620  C   PRO C3116      23.345 -15.818 -18.805  1.00 34.55           C  
+ATOM   5621  O   PRO C3116      24.218 -15.533 -19.627  1.00 36.02           O  
+ATOM   5622  CB  PRO C3116      23.505 -18.109 -17.732  1.00 32.53           C  
+ATOM   5623  CG  PRO C3116      23.215 -18.579 -16.337  1.00 31.90           C  
+ATOM   5624  CD  PRO C3116      22.257 -17.526 -15.832  1.00 30.70           C  
+ATOM   5625  N   GLU C3117      22.065 -15.481 -18.961  1.00 35.81           N  
+ATOM   5626  CA  GLU C3117      21.600 -14.729 -20.126  1.00 38.48           C  
+ATOM   5627  C   GLU C3117      22.132 -13.298 -20.147  1.00 39.55           C  
+ATOM   5628  O   GLU C3117      22.311 -12.712 -21.218  1.00 40.24           O  
+ATOM   5629  CB  GLU C3117      20.067 -14.674 -20.168  1.00 40.80           C  
+ATOM   5630  CG  GLU C3117      19.373 -15.990 -20.451  1.00 43.24           C  
+ATOM   5631  CD  GLU C3117      19.529 -16.986 -19.322  1.00 44.35           C  
+ATOM   5632  OE1 GLU C3117      19.328 -16.593 -18.149  1.00 41.50           O  
+ATOM   5633  OE2 GLU C3117      19.843 -18.160 -19.618  1.00 44.41           O  
+ATOM   5634  N   ARG C3119      24.783 -11.140 -18.447  1.00 45.09           N  
+ATOM   5635  CA  ARG C3119      26.200 -10.839 -18.307  1.00 48.52           C  
+ATOM   5636  C   ARG C3119      26.583  -9.670 -19.249  1.00 49.28           C  
+ATOM   5637  O   ARG C3119      27.435  -9.811 -20.133  1.00 49.49           O  
+ATOM   5638  CB  ARG C3119      27.048 -12.091 -18.617  1.00 49.05           C  
+ATOM   5639  N   VAL C3121      25.886  -6.386 -18.949  1.00 21.85           N  
+ATOM   5640  CA  VAL C3121      25.055  -5.379 -18.283  1.00 21.38           C  
+ATOM   5641  C   VAL C3121      25.855  -4.102 -18.152  1.00 22.08           C  
+ATOM   5642  O   VAL C3121      26.807  -4.027 -17.378  1.00 22.56           O  
+ATOM   5643  CB  VAL C3121      24.634  -5.808 -16.862  1.00 22.07           C  
+ATOM   5644  CG1 VAL C3121      23.667  -4.808 -16.284  1.00 20.16           C  
+ATOM   5645  CG2 VAL C3121      24.005  -7.205 -16.906  1.00 19.85           C  
+ATOM   5646  N   GLU C3122      25.445  -3.086 -18.899  1.00 24.09           N  
+ATOM   5647  CA  GLU C3122      26.120  -1.794 -18.901  1.00 24.40           C  
+ATOM   5648  C   GLU C3122      25.406  -0.715 -18.088  1.00 23.41           C  
+ATOM   5649  O   GLU C3122      24.176  -0.654 -18.041  1.00 22.80           O  
+ATOM   5650  CB  GLU C3122      26.266  -1.316 -20.343  1.00 27.31           C  
+ATOM   5651  CG  GLU C3122      27.528  -1.826 -21.041  1.00 34.35           C  
+ATOM   5652  CD  GLU C3122      28.768  -1.004 -20.680  1.00 38.39           C  
+ATOM   5653  OE1 GLU C3122      29.897  -1.488 -20.907  1.00 39.05           O  
+ATOM   5654  OE2 GLU C3122      28.612   0.134 -20.178  1.00 42.38           O  
+ATOM   5655  N   LEU C3123      26.196   0.148 -17.463  1.00 22.47           N  
+ATOM   5656  CA  LEU C3123      25.661   1.247 -16.673  1.00 22.35           C  
+ATOM   5657  C   LEU C3123      26.187   2.570 -17.203  1.00 19.83           C  
+ATOM   5658  O   LEU C3123      27.388   2.767 -17.292  1.00 21.62           O  
+ATOM   5659  CB  LEU C3123      26.060   1.092 -15.204  1.00 22.84           C  
+ATOM   5660  CG  LEU C3123      25.757   2.310 -14.336  1.00 23.67           C  
+ATOM   5661  CD1 LEU C3123      24.258   2.520 -14.255  1.00 23.71           C  
+ATOM   5662  CD2 LEU C3123      26.342   2.098 -12.949  1.00 26.09           C  
+ATOM   5663  N   ILE C3124      25.272   3.470 -17.549  1.00 19.51           N  
+ATOM   5664  CA  ILE C3124      25.611   4.791 -18.076  1.00 17.72           C  
+ATOM   5665  C   ILE C3124      24.813   5.823 -17.290  1.00 18.80           C  
+ATOM   5666  O   ILE C3124      23.615   5.637 -17.058  1.00 18.19           O  
+ATOM   5667  CB  ILE C3124      25.225   4.917 -19.583  1.00 17.59           C  
+ATOM   5668  CG1 ILE C3124      26.077   3.967 -20.425  1.00 18.53           C  
+ATOM   5669  CG2 ILE C3124      25.393   6.351 -20.054  1.00 13.94           C  
+ATOM   5670  CD1 ILE C3124      27.542   4.354 -20.496  1.00 19.84           C  
+ATOM   5671  N   THR C3125      25.461   6.906 -16.883  1.00 17.86           N  
+ATOM   5672  CA  THR C3125      24.764   7.940 -16.129  1.00 20.30           C  
+ATOM   5673  C   THR C3125      24.592   9.169 -17.026  1.00 19.36           C  
+ATOM   5674  O   THR C3125      25.444   9.431 -17.875  1.00 19.30           O  
+ATOM   5675  CB  THR C3125      25.556   8.311 -14.872  1.00 20.40           C  
+ATOM   5676  OG1 THR C3125      26.751   9.001 -15.249  1.00 25.77           O  
+ATOM   5677  CG2 THR C3125      25.964   7.049 -14.126  1.00 22.43           C  
+ATOM   5678  N   THR C3126      23.497   9.912 -16.839  1.00 18.05           N  
+ATOM   5679  CA  THR C3126      23.214  11.097 -17.648  1.00 19.21           C  
+ATOM   5680  C   THR C3126      24.060  12.318 -17.276  1.00 21.29           C  
+ATOM   5681  O   THR C3126      24.027  13.341 -17.982  1.00 19.97           O  
+ATOM   5682  CB  THR C3126      21.719  11.501 -17.562  1.00 20.00           C  
+ATOM   5683  OG1 THR C3126      21.412  11.962 -16.238  1.00 19.83           O  
+ATOM   5684  CG2 THR C3126      20.823  10.299 -17.909  1.00 17.59           C  
+ATOM   5685  N   ASP C3127      24.800  12.223 -16.170  1.00 19.99           N  
+ATOM   5686  CA  ASP C3127      25.656  13.332 -15.753  1.00 20.18           C  
+ATOM   5687  C   ASP C3127      26.614  13.652 -16.890  1.00 19.06           C  
+ATOM   5688  O   ASP C3127      26.996  14.798 -17.089  1.00 20.08           O  
+ATOM   5689  CB  ASP C3127      26.492  12.972 -14.521  1.00 20.66           C  
+ATOM   5690  CG  ASP C3127      25.651  12.745 -13.281  1.00 24.29           C  
+ATOM   5691  OD1 ASP C3127      24.487  13.212 -13.240  1.00 24.21           O  
+ATOM   5692  OD2 ASP C3127      26.171  12.099 -12.344  1.00 23.47           O  
+ATOM   5693  N   GLY C3128      27.013  12.622 -17.622  1.00 18.37           N  
+ATOM   5694  CA  GLY C3128      27.947  12.812 -18.716  1.00 18.95           C  
+ATOM   5695  C   GLY C3128      27.389  13.685 -19.819  1.00 19.31           C  
+ATOM   5696  O   GLY C3128      28.157  14.310 -20.552  1.00 20.39           O  
+ATOM   5697  N   PHE C3129      26.061  13.741 -19.931  1.00 16.03           N  
+ATOM   5698  CA  PHE C3129      25.427  14.540 -20.968  1.00 17.65           C  
+ATOM   5699  C   PHE C3129      25.170  15.994 -20.584  1.00 17.34           C  
+ATOM   5700  O   PHE C3129      24.450  16.714 -21.272  1.00 17.67           O  
+ATOM   5701  CB  PHE C3129      24.129  13.869 -21.450  1.00 15.87           C  
+ATOM   5702  CG  PHE C3129      24.338  12.487 -22.009  1.00 13.34           C  
+ATOM   5703  CD1 PHE C3129      24.570  11.403 -21.160  1.00 15.68           C  
+ATOM   5704  CD2 PHE C3129      24.335  12.271 -23.380  1.00 16.33           C  
+ATOM   5705  CE1 PHE C3129      24.797  10.125 -21.665  1.00 14.36           C  
+ATOM   5706  CE2 PHE C3129      24.563  10.990 -23.904  1.00 15.70           C  
+ATOM   5707  CZ  PHE C3129      24.794   9.914 -23.041  1.00 14.74           C  
+ATOM   5708  N   LEU C3130      25.762  16.428 -19.480  1.00 19.32           N  
+ATOM   5709  CA  LEU C3130      25.627  17.820 -19.063  1.00 19.90           C  
+ATOM   5710  C   LEU C3130      26.563  18.600 -19.984  1.00 19.96           C  
+ATOM   5711  O   LEU C3130      27.568  18.053 -20.438  1.00 18.13           O  
+ATOM   5712  CB  LEU C3130      26.108  18.007 -17.620  1.00 18.24           C  
+ATOM   5713  CG  LEU C3130      25.231  17.528 -16.455  1.00 22.72           C  
+ATOM   5714  CD1 LEU C3130      26.056  17.557 -15.166  1.00 21.69           C  
+ATOM   5715  CD2 LEU C3130      23.992  18.415 -16.332  1.00 17.79           C  
+ATOM   5716  N   HIS C3131      26.235  19.860 -20.263  1.00 20.28           N  
+ATOM   5717  CA  HIS C3131      27.104  20.696 -21.086  1.00 22.18           C  
+ATOM   5718  C   HIS C3131      28.354  20.969 -20.244  1.00 23.87           C  
+ATOM   5719  O   HIS C3131      28.249  21.153 -19.031  1.00 24.99           O  
+ATOM   5720  CB  HIS C3131      26.428  22.039 -21.397  1.00 21.19           C  
+ATOM   5721  CG  HIS C3131      25.312  21.950 -22.389  1.00 22.88           C  
+ATOM   5722  ND1 HIS C3131      25.496  21.518 -23.685  1.00 23.15           N  
+ATOM   5723  CD2 HIS C3131      23.996  22.273 -22.285  1.00 21.84           C  
+ATOM   5724  CE1 HIS C3131      24.349  21.583 -24.338  1.00 21.19           C  
+ATOM   5725  NE2 HIS C3131      23.425  22.039 -23.508  1.00 19.14           N  
+ATOM   5726  N   PRO C3132      29.547  21.008 -20.867  1.00 23.77           N  
+ATOM   5727  CA  PRO C3132      30.765  21.274 -20.093  1.00 25.10           C  
+ATOM   5728  C   PRO C3132      30.631  22.584 -19.320  1.00 25.28           C  
+ATOM   5729  O   PRO C3132      29.769  23.412 -19.630  1.00 23.87           O  
+ATOM   5730  CB  PRO C3132      31.846  21.362 -21.170  1.00 24.69           C  
+ATOM   5731  CG  PRO C3132      31.366  20.409 -22.204  1.00 25.95           C  
+ATOM   5732  CD  PRO C3132      29.876  20.760 -22.280  1.00 25.68           C  
+ATOM   5733  N   ASN C3133      31.476  22.775 -18.315  1.00 24.95           N  
+ATOM   5734  CA  ASN C3133      31.418  24.009 -17.542  1.00 28.61           C  
+ATOM   5735  C   ASN C3133      31.572  25.229 -18.447  1.00 29.62           C  
+ATOM   5736  O   ASN C3133      30.864  26.222 -18.284  1.00 29.82           O  
+ATOM   5737  CB  ASN C3133      32.502  24.028 -16.469  1.00 28.07           C  
+ATOM   5738  CG  ASN C3133      32.283  22.976 -15.409  1.00 29.47           C  
+ATOM   5739  OD1 ASN C3133      31.154  22.550 -15.160  1.00 28.82           O  
+ATOM   5740  ND2 ASN C3133      33.362  22.562 -14.764  1.00 30.86           N  
+ATOM   5741  N   GLN C3134      32.497  25.151 -19.399  1.00 30.57           N  
+ATOM   5742  CA  GLN C3134      32.724  26.256 -20.321  1.00 32.58           C  
+ATOM   5743  C   GLN C3134      31.412  26.704 -20.952  1.00 31.85           C  
+ATOM   5744  O   GLN C3134      31.148  27.902 -21.084  1.00 30.98           O  
+ATOM   5745  CB  GLN C3134      33.694  25.840 -21.418  1.00 36.97           C  
+ATOM   5746  CG  GLN C3134      33.772  26.835 -22.561  1.00 43.82           C  
+ATOM   5747  CD  GLN C3134      34.753  26.405 -23.624  1.00 47.09           C  
+ATOM   5748  OE1 GLN C3134      34.687  25.281 -24.126  1.00 51.01           O  
+ATOM   5749  NE2 GLN C3134      35.670  27.298 -23.980  1.00 49.24           N  
+ATOM   5750  N   VAL C3135      30.590  25.736 -21.344  1.00 30.18           N  
+ATOM   5751  CA  VAL C3135      29.305  26.046 -21.949  1.00 27.25           C  
+ATOM   5752  C   VAL C3135      28.310  26.555 -20.906  1.00 27.00           C  
+ATOM   5753  O   VAL C3135      27.627  27.554 -21.125  1.00 27.60           O  
+ATOM   5754  CB  VAL C3135      28.720  24.818 -22.665  1.00 25.65           C  
+ATOM   5755  CG1 VAL C3135      27.346  25.141 -23.185  1.00 22.93           C  
+ATOM   5756  CG2 VAL C3135      29.637  24.408 -23.824  1.00 25.05           C  
+ATOM   5757  N   LEU C3136      28.221  25.878 -19.770  1.00 26.35           N  
+ATOM   5758  CA  LEU C3136      27.298  26.325 -18.735  1.00 26.91           C  
+ATOM   5759  C   LEU C3136      27.597  27.771 -18.333  1.00 27.40           C  
+ATOM   5760  O   LEU C3136      26.683  28.584 -18.208  1.00 28.64           O  
+ATOM   5761  CB  LEU C3136      27.383  25.410 -17.510  1.00 26.23           C  
+ATOM   5762  CG  LEU C3136      26.896  23.973 -17.725  1.00 25.77           C  
+ATOM   5763  CD1 LEU C3136      27.237  23.138 -16.512  1.00 25.54           C  
+ATOM   5764  CD2 LEU C3136      25.396  23.972 -17.984  1.00 21.65           C  
+ATOM   5765  N   LYS C3137      28.876  28.088 -18.136  1.00 29.04           N  
+ATOM   5766  CA  LYS C3137      29.291  29.434 -17.753  1.00 29.23           C  
+ATOM   5767  C   LYS C3137      28.851  30.456 -18.798  1.00 31.11           C  
+ATOM   5768  O   LYS C3137      28.334  31.526 -18.456  1.00 31.57           O  
+ATOM   5769  CB  LYS C3137      30.811  29.490 -17.571  1.00 29.31           C  
+ATOM   5770  N   GLU C3138      29.059  30.127 -20.069  1.00 32.36           N  
+ATOM   5771  CA  GLU C3138      28.674  31.016 -21.161  1.00 34.15           C  
+ATOM   5772  C   GLU C3138      27.185  31.305 -21.106  1.00 34.10           C  
+ATOM   5773  O   GLU C3138      26.746  32.427 -21.346  1.00 33.96           O  
+ATOM   5774  CB  GLU C3138      29.009  30.385 -22.516  1.00 35.49           C  
+ATOM   5775  CG  GLU C3138      30.502  30.281 -22.789  1.00 41.19           C  
+ATOM   5776  CD  GLU C3138      30.817  29.780 -24.191  1.00 44.83           C  
+ATOM   5777  OE1 GLU C3138      30.207  30.295 -25.158  1.00 48.10           O  
+ATOM   5778  OE2 GLU C3138      31.681  28.880 -24.328  1.00 45.71           O  
+ATOM   5779  N   ARG C3139      26.409  30.282 -20.776  1.00 32.70           N  
+ATOM   5780  CA  ARG C3139      24.965  30.425 -20.715  1.00 30.63           C  
+ATOM   5781  C   ARG C3139      24.473  30.840 -19.338  1.00 30.26           C  
+ATOM   5782  O   ARG C3139      23.268  30.918 -19.104  1.00 31.30           O  
+ATOM   5783  CB  ARG C3139      24.312  29.114 -21.147  1.00 29.48           C  
+ATOM   5784  CG  ARG C3139      24.800  28.643 -22.501  1.00 27.56           C  
+ATOM   5785  CD  ARG C3139      24.051  27.418 -23.009  1.00 26.58           C  
+ATOM   5786  NE  ARG C3139      24.548  26.996 -24.317  1.00 24.75           N  
+ATOM   5787  CZ  ARG C3139      24.069  25.965 -25.007  1.00 26.89           C  
+ATOM   5788  NH1 ARG C3139      23.071  25.238 -24.517  1.00 22.62           N  
+ATOM   5789  NH2 ARG C3139      24.590  25.659 -26.190  1.00 24.90           N  
+ATOM   5790  N   GLY C3140      25.412  31.112 -18.438  1.00 29.81           N  
+ATOM   5791  CA  GLY C3140      25.060  31.523 -17.089  1.00 30.90           C  
+ATOM   5792  C   GLY C3140      24.303  30.455 -16.322  1.00 31.56           C  
+ATOM   5793  O   GLY C3140      23.395  30.762 -15.553  1.00 31.13           O  
+ATOM   5794  N   LEU C3141      24.692  29.199 -16.512  1.00 32.35           N  
+ATOM   5795  CA  LEU C3141      24.013  28.086 -15.857  1.00 32.24           C  
+ATOM   5796  C   LEU C3141      24.896  27.284 -14.910  1.00 32.50           C  
+ATOM   5797  O   LEU C3141      24.570  26.144 -14.571  1.00 31.90           O  
+ATOM   5798  CB  LEU C3141      23.449  27.144 -16.921  1.00 30.58           C  
+ATOM   5799  CG  LEU C3141      22.407  27.729 -17.864  1.00 28.91           C  
+ATOM   5800  CD1 LEU C3141      22.072  26.715 -18.944  1.00 28.75           C  
+ATOM   5801  CD2 LEU C3141      21.167  28.106 -17.068  1.00 28.72           C  
+ATOM   5802  N   MET C3142      26.002  27.872 -14.470  1.00 34.33           N  
+ATOM   5803  CA  MET C3142      26.915  27.162 -13.581  1.00 36.07           C  
+ATOM   5804  C   MET C3142      26.306  26.860 -12.211  1.00 35.55           C  
+ATOM   5805  O   MET C3142      26.840  26.047 -11.456  1.00 37.11           O  
+ATOM   5806  CB  MET C3142      28.213  27.952 -13.418  1.00 38.69           C  
+ATOM   5807  CG  MET C3142      29.420  27.076 -13.110  1.00 44.46           C  
+ATOM   5808  SD  MET C3142      29.890  25.988 -14.486  1.00 47.01           S  
+ATOM   5809  CE  MET C3142      31.211  26.956 -15.230  1.00 49.53           C  
+ATOM   5810  N   LYS C3143      25.190  27.508 -11.893  1.00 33.87           N  
+ATOM   5811  CA  LYS C3143      24.503  27.283 -10.621  1.00 33.91           C  
+ATOM   5812  C   LYS C3143      23.207  26.527 -10.893  1.00 32.93           C  
+ATOM   5813  O   LYS C3143      22.306  26.494 -10.054  1.00 32.23           O  
+ATOM   5814  CB  LYS C3143      24.169  28.617  -9.951  1.00 36.62           C  
+ATOM   5815  CG  LYS C3143      25.380  29.441  -9.542  1.00 40.78           C  
+ATOM   5816  CD  LYS C3143      25.892  29.025  -8.183  1.00 44.74           C  
+ATOM   5817  CE  LYS C3143      24.863  29.334  -7.108  1.00 48.55           C  
+ATOM   5818  NZ  LYS C3143      25.339  28.949  -5.748  1.00 51.66           N  
+ATOM   5819  N   LYS C3144      23.123  25.927 -12.078  1.00 30.36           N  
+ATOM   5820  CA  LYS C3144      21.936  25.186 -12.484  1.00 29.12           C  
+ATOM   5821  C   LYS C3144      22.218  23.767 -12.975  1.00 27.29           C  
+ATOM   5822  O   LYS C3144      21.442  23.218 -13.763  1.00 28.63           O  
+ATOM   5823  CB  LYS C3144      21.188  25.958 -13.577  1.00 29.10           C  
+ATOM   5824  CG  LYS C3144      20.485  27.211 -13.084  1.00 31.70           C  
+ATOM   5825  CD  LYS C3144      19.342  26.865 -12.140  1.00 31.59           C  
+ATOM   5826  CE  LYS C3144      18.590  28.109 -11.697  1.00 33.69           C  
+ATOM   5827  NZ  LYS C3144      17.443  27.776 -10.805  1.00 36.62           N  
+ATOM   5828  N   LYS C3145      23.320  23.169 -12.531  1.00 24.26           N  
+ATOM   5829  CA  LYS C3145      23.610  21.803 -12.949  1.00 22.93           C  
+ATOM   5830  C   LYS C3145      22.489  20.897 -12.455  1.00 22.04           C  
+ATOM   5831  O   LYS C3145      22.122  20.939 -11.272  1.00 19.17           O  
+ATOM   5832  CB  LYS C3145      24.944  21.326 -12.391  1.00 21.42           C  
+ATOM   5833  CG  LYS C3145      26.136  21.733 -13.248  1.00 26.64           C  
+ATOM   5834  CD  LYS C3145      27.445  21.171 -12.695  1.00 25.62           C  
+ATOM   5835  CE  LYS C3145      28.617  21.508 -13.611  1.00 25.69           C  
+ATOM   5836  NZ  LYS C3145      29.934  21.030 -13.085  1.00 25.15           N  
+ATOM   5837  N   GLY C3146      21.942  20.101 -13.372  1.00 19.46           N  
+ATOM   5838  CA  GLY C3146      20.860  19.196 -13.032  1.00 19.41           C  
+ATOM   5839  C   GLY C3146      19.532  19.656 -13.596  1.00 19.56           C  
+ATOM   5840  O   GLY C3146      18.585  18.868 -13.745  1.00 19.64           O  
+ATOM   5841  N   PHE C3147      19.451  20.947 -13.898  1.00 18.28           N  
+ATOM   5842  CA  PHE C3147      18.238  21.502 -14.462  1.00 18.08           C  
+ATOM   5843  C   PHE C3147      18.235  21.178 -15.950  1.00 18.55           C  
+ATOM   5844  O   PHE C3147      19.292  20.985 -16.553  1.00 17.43           O  
+ATOM   5845  CB  PHE C3147      18.183  23.017 -14.228  1.00 18.51           C  
+ATOM   5846  CG  PHE C3147      17.826  23.400 -12.812  1.00 20.80           C  
+ATOM   5847  CD1 PHE C3147      18.696  23.124 -11.754  1.00 20.90           C  
+ATOM   5848  CD2 PHE C3147      16.613  24.025 -12.531  1.00 21.38           C  
+ATOM   5849  CE1 PHE C3147      18.360  23.465 -10.443  1.00 19.62           C  
+ATOM   5850  CE2 PHE C3147      16.271  24.370 -11.219  1.00 20.49           C  
+ATOM   5851  CZ  PHE C3147      17.148  24.088 -10.176  1.00 19.31           C  
+ATOM   5852  N   PRO C3148      17.043  21.113 -16.562  1.00 19.57           N  
+ATOM   5853  CA  PRO C3148      16.901  20.802 -17.987  1.00 21.06           C  
+ATOM   5854  C   PRO C3148      17.880  21.526 -18.914  1.00 22.35           C  
+ATOM   5855  O   PRO C3148      18.553  20.907 -19.740  1.00 23.99           O  
+ATOM   5856  CB  PRO C3148      15.452  21.181 -18.273  1.00 20.72           C  
+ATOM   5857  CG  PRO C3148      14.773  20.865 -16.969  1.00 20.04           C  
+ATOM   5858  CD  PRO C3148      15.735  21.423 -15.958  1.00 18.24           C  
+ATOM   5859  N   GLU C3149      17.970  22.838 -18.767  1.00 23.53           N  
+ATOM   5860  CA  GLU C3149      18.839  23.630 -19.620  1.00 24.96           C  
+ATOM   5861  C   GLU C3149      20.335  23.328 -19.528  1.00 24.04           C  
+ATOM   5862  O   GLU C3149      21.100  23.733 -20.402  1.00 24.41           O  
+ATOM   5863  CB  GLU C3149      18.573  25.124 -19.379  1.00 27.11           C  
+ATOM   5864  CG  GLU C3149      18.692  25.604 -17.926  1.00 31.68           C  
+ATOM   5865  CD  GLU C3149      17.450  25.348 -17.050  1.00 33.55           C  
+ATOM   5866  OE1 GLU C3149      17.329  26.046 -16.019  1.00 34.85           O  
+ATOM   5867  OE2 GLU C3149      16.614  24.469 -17.363  1.00 30.89           O  
+ATOM   5868  N   SER C3150      20.755  22.603 -18.493  1.00 21.40           N  
+ATOM   5869  CA  SER C3150      22.171  22.283 -18.332  1.00 19.72           C  
+ATOM   5870  C   SER C3150      22.547  20.994 -19.045  1.00 18.23           C  
+ATOM   5871  O   SER C3150      23.719  20.609 -19.065  1.00 18.47           O  
+ATOM   5872  CB  SER C3150      22.536  22.158 -16.848  1.00 18.92           C  
+ATOM   5873  OG  SER C3150      22.088  20.925 -16.305  1.00 20.72           O  
+ATOM   5874  N   TYR C3151      21.557  20.325 -19.625  1.00 17.83           N  
+ATOM   5875  CA  TYR C3151      21.810  19.068 -20.323  1.00 19.50           C  
+ATOM   5876  C   TYR C3151      21.775  19.190 -21.830  1.00 20.77           C  
+ATOM   5877  O   TYR C3151      21.013  19.984 -22.395  1.00 20.47           O  
+ATOM   5878  CB  TYR C3151      20.771  18.007 -19.955  1.00 19.15           C  
+ATOM   5879  CG  TYR C3151      20.869  17.447 -18.564  1.00 19.12           C  
+ATOM   5880  CD1 TYR C3151      20.078  17.952 -17.536  1.00 18.64           C  
+ATOM   5881  CD2 TYR C3151      21.729  16.380 -18.281  1.00 17.86           C  
+ATOM   5882  CE1 TYR C3151      20.135  17.403 -16.253  1.00 19.49           C  
+ATOM   5883  CE2 TYR C3151      21.792  15.829 -17.007  1.00 17.80           C  
+ATOM   5884  CZ  TYR C3151      20.993  16.344 -16.002  1.00 18.36           C  
+ATOM   5885  OH  TYR C3151      21.038  15.797 -14.751  1.00 20.66           O  
+ATOM   5886  N   ASP C3152      22.592  18.375 -22.476  1.00 21.65           N  
+ATOM   5887  CA  ASP C3152      22.616  18.321 -23.927  1.00 22.71           C  
+ATOM   5888  C   ASP C3152      21.642  17.169 -24.168  1.00 23.55           C  
+ATOM   5889  O   ASP C3152      22.053  16.049 -24.486  1.00 23.66           O  
+ATOM   5890  CB  ASP C3152      24.022  17.961 -24.404  1.00 23.66           C  
+ATOM   5891  CG  ASP C3152      24.108  17.784 -25.913  1.00 26.68           C  
+ATOM   5892  OD1 ASP C3152      23.075  17.950 -26.601  1.00 24.70           O  
+ATOM   5893  OD2 ASP C3152      25.215  17.473 -26.404  1.00 25.83           O  
+ATOM   5894  N   MET C3153      20.354  17.446 -23.969  1.00 24.31           N  
+ATOM   5895  CA  MET C3153      19.312  16.436 -24.109  1.00 25.95           C  
+ATOM   5896  C   MET C3153      19.211  15.739 -25.449  1.00 25.92           C  
+ATOM   5897  O   MET C3153      18.999  14.529 -25.491  1.00 27.13           O  
+ATOM   5898  CB  MET C3153      17.949  17.017 -23.753  1.00 26.95           C  
+ATOM   5899  CG  MET C3153      17.495  16.632 -22.373  1.00 31.64           C  
+ATOM   5900  SD  MET C3153      17.376  14.856 -22.129  1.00 32.80           S  
+ATOM   5901  CE  MET C3153      16.039  14.737 -20.934  1.00 31.96           C  
+ATOM   5902  N   HIS C3154      19.338  16.486 -26.541  1.00 23.93           N  
+ATOM   5903  CA  HIS C3154      19.250  15.872 -27.855  1.00 23.88           C  
+ATOM   5904  C   HIS C3154      20.268  14.752 -27.975  1.00 23.13           C  
+ATOM   5905  O   HIS C3154      19.996  13.721 -28.589  1.00 25.14           O  
+ATOM   5906  CB  HIS C3154      19.480  16.910 -28.953  1.00 23.18           C  
+ATOM   5907  CG  HIS C3154      18.358  17.896 -29.087  1.00 25.55           C  
+ATOM   5908  ND1 HIS C3154      17.066  17.511 -29.390  1.00 23.20           N  
+ATOM   5909  CD2 HIS C3154      18.329  19.236 -28.940  1.00 25.96           C  
+ATOM   5910  CE1 HIS C3154      16.293  18.579 -29.421  1.00 24.58           C  
+ATOM   5911  NE2 HIS C3154      17.027  19.640 -29.152  1.00 25.94           N  
+ATOM   5912  N   ARG C3155      21.433  14.945 -27.371  1.00 20.31           N  
+ATOM   5913  CA  ARG C3155      22.466  13.930 -27.429  1.00 21.10           C  
+ATOM   5914  C   ARG C3155      22.084  12.699 -26.605  1.00 20.95           C  
+ATOM   5915  O   ARG C3155      22.326  11.566 -27.028  1.00 22.18           O  
+ATOM   5916  CB  ARG C3155      23.801  14.497 -26.946  1.00 21.19           C  
+ATOM   5917  CG  ARG C3155      24.939  13.515 -27.090  1.00 19.53           C  
+ATOM   5918  CD  ARG C3155      26.260  14.117 -26.708  1.00 22.75           C  
+ATOM   5919  NE  ARG C3155      27.335  13.142 -26.876  1.00 24.27           N  
+ATOM   5920  CZ  ARG C3155      28.623  13.410 -26.697  1.00 27.16           C  
+ATOM   5921  NH1 ARG C3155      29.010  14.634 -26.346  1.00 24.75           N  
+ATOM   5922  NH2 ARG C3155      29.525  12.449 -26.861  1.00 28.43           N  
+ATOM   5923  N   LEU C3156      21.494  12.917 -25.429  1.00 20.31           N  
+ATOM   5924  CA  LEU C3156      21.076  11.807 -24.574  1.00 17.64           C  
+ATOM   5925  C   LEU C3156      20.002  10.997 -25.286  1.00 17.36           C  
+ATOM   5926  O   LEU C3156      20.035   9.775 -25.270  1.00 17.82           O  
+ATOM   5927  CB  LEU C3156      20.524  12.322 -23.236  1.00 16.81           C  
+ATOM   5928  CG  LEU C3156      19.951  11.255 -22.290  1.00 17.20           C  
+ATOM   5929  CD1 LEU C3156      21.022  10.229 -21.966  1.00 14.60           C  
+ATOM   5930  CD2 LEU C3156      19.443  11.918 -21.015  1.00 17.86           C  
+ATOM   5931  N   VAL C3157      19.043  11.688 -25.900  1.00 17.59           N  
+ATOM   5932  CA  VAL C3157      17.970  11.017 -26.621  1.00 19.84           C  
+ATOM   5933  C   VAL C3157      18.548  10.168 -27.760  1.00 20.72           C  
+ATOM   5934  O   VAL C3157      18.159   9.012 -27.948  1.00 20.54           O  
+ATOM   5935  CB  VAL C3157      16.962  12.039 -27.206  1.00 20.72           C  
+ATOM   5936  CG1 VAL C3157      16.003  11.344 -28.162  1.00 20.32           C  
+ATOM   5937  CG2 VAL C3157      16.180  12.701 -26.083  1.00 20.99           C  
+ATOM   5938  N   LYS C3158      19.484  10.738 -28.510  1.00 20.61           N  
+ATOM   5939  CA  LYS C3158      20.094  10.008 -29.616  1.00 21.48           C  
+ATOM   5940  C   LYS C3158      20.882   8.788 -29.120  1.00 21.18           C  
+ATOM   5941  O   LYS C3158      20.985   7.779 -29.821  1.00 18.62           O  
+ATOM   5942  CB  LYS C3158      21.023  10.928 -30.414  1.00 22.69           C  
+ATOM   5943  CG  LYS C3158      21.659  10.237 -31.612  1.00 24.84           C  
+ATOM   5944  CD  LYS C3158      22.484  11.199 -32.444  1.00 27.26           C  
+ATOM   5945  CE  LYS C3158      22.951  10.550 -33.752  1.00 28.51           C  
+ATOM   5946  NZ  LYS C3158      23.911   9.436 -33.526  1.00 27.64           N  
+ATOM   5947  N   PHE C3159      21.437   8.880 -27.913  1.00 20.31           N  
+ATOM   5948  CA  PHE C3159      22.193   7.761 -27.357  1.00 20.32           C  
+ATOM   5949  C   PHE C3159      21.295   6.525 -27.207  1.00 20.92           C  
+ATOM   5950  O   PHE C3159      21.610   5.453 -27.717  1.00 20.54           O  
+ATOM   5951  CB  PHE C3159      22.786   8.136 -25.995  1.00 20.93           C  
+ATOM   5952  CG  PHE C3159      23.533   7.016 -25.333  1.00 21.40           C  
+ATOM   5953  CD1 PHE C3159      24.796   6.633 -25.789  1.00 21.84           C  
+ATOM   5954  CD2 PHE C3159      22.969   6.323 -24.270  1.00 21.58           C  
+ATOM   5955  CE1 PHE C3159      25.485   5.577 -25.194  1.00 22.41           C  
+ATOM   5956  CE2 PHE C3159      23.651   5.260 -23.664  1.00 23.80           C  
+ATOM   5957  CZ  PHE C3159      24.910   4.888 -24.128  1.00 21.92           C  
+ATOM   5958  N   VAL C3160      20.174   6.672 -26.510  1.00 19.30           N  
+ATOM   5959  CA  VAL C3160      19.282   5.541 -26.327  1.00 19.05           C  
+ATOM   5960  C   VAL C3160      18.585   5.197 -27.639  1.00 19.65           C  
+ATOM   5961  O   VAL C3160      18.257   4.040 -27.893  1.00 18.94           O  
+ATOM   5962  CB  VAL C3160      18.240   5.814 -25.215  1.00 17.84           C  
+ATOM   5963  CG1 VAL C3160      18.938   5.855 -23.870  1.00 17.36           C  
+ATOM   5964  CG2 VAL C3160      17.519   7.119 -25.474  1.00 18.27           C  
+ATOM   5965  N   SER C3161      18.362   6.203 -28.476  1.00 19.47           N  
+ATOM   5966  CA  SER C3161      17.735   5.963 -29.767  1.00 20.98           C  
+ATOM   5967  C   SER C3161      18.649   5.058 -30.610  1.00 18.84           C  
+ATOM   5968  O   SER C3161      18.191   4.098 -31.219  1.00 20.05           O  
+ATOM   5969  CB  SER C3161      17.484   7.289 -30.498  1.00 20.29           C  
+ATOM   5970  OG  SER C3161      16.829   7.053 -31.735  1.00 23.87           O  
+ATOM   5971  N   ASP C3162      19.942   5.362 -30.636  1.00 18.51           N  
+ATOM   5972  CA  ASP C3162      20.886   4.546 -31.398  1.00 19.75           C  
+ATOM   5973  C   ASP C3162      20.936   3.117 -30.871  1.00 19.76           C  
+ATOM   5974  O   ASP C3162      20.990   2.171 -31.655  1.00 18.43           O  
+ATOM   5975  CB  ASP C3162      22.298   5.140 -31.359  1.00 19.18           C  
+ATOM   5976  CG  ASP C3162      22.425   6.398 -32.192  1.00 20.41           C  
+ATOM   5977  OD1 ASP C3162      21.587   6.612 -33.087  1.00 21.11           O  
+ATOM   5978  OD2 ASP C3162      23.371   7.173 -31.955  1.00 25.95           O  
+ATOM   5979  N   LEU C3163      20.932   2.965 -29.545  1.00 18.61           N  
+ATOM   5980  CA  LEU C3163      20.963   1.637 -28.934  1.00 18.83           C  
+ATOM   5981  C   LEU C3163      19.723   0.868 -29.362  1.00 17.88           C  
+ATOM   5982  O   LEU C3163      19.794  -0.302 -29.720  1.00 18.78           O  
+ATOM   5983  CB  LEU C3163      20.979   1.743 -27.406  1.00 18.88           C  
+ATOM   5984  CG  LEU C3163      22.272   2.181 -26.726  1.00 18.77           C  
+ATOM   5985  CD1 LEU C3163      21.973   2.645 -25.304  1.00 22.13           C  
+ATOM   5986  CD2 LEU C3163      23.261   1.023 -26.728  1.00 19.68           C  
+ATOM   5987  N   LYS C3164      18.583   1.545 -29.334  1.00 19.40           N  
+ATOM   5988  CA  LYS C3164      17.338   0.916 -29.713  1.00 19.67           C  
+ATOM   5989  C   LYS C3164      17.180   0.792 -31.225  1.00 21.65           C  
+ATOM   5990  O   LYS C3164      16.155   0.309 -31.701  1.00 20.08           O  
+ATOM   5991  CB  LYS C3164      16.166   1.686 -29.117  1.00 21.01           C  
+ATOM   5992  CG  LYS C3164      15.298   0.846 -28.187  1.00 24.95           C  
+ATOM   5993  CD  LYS C3164      16.039   0.457 -26.932  1.00 22.12           C  
+ATOM   5994  CE  LYS C3164      15.127  -0.224 -25.912  1.00 21.26           C  
+ATOM   5995  NZ  LYS C3164      14.963  -1.683 -26.107  1.00 19.14           N  
+ATOM   5996  N   SER C3165      18.190   1.234 -31.972  1.00 22.36           N  
+ATOM   5997  CA  SER C3165      18.164   1.139 -33.430  1.00 23.81           C  
+ATOM   5998  C   SER C3165      19.033  -0.043 -33.841  1.00 25.77           C  
+ATOM   5999  O   SER C3165      19.052  -0.445 -35.004  1.00 26.19           O  
+ATOM   6000  CB  SER C3165      18.706   2.420 -34.072  1.00 23.01           C  
+ATOM   6001  OG  SER C3165      17.800   3.502 -33.921  1.00 22.97           O  
+ATOM   6002  N   GLY C3166      19.759  -0.594 -32.873  1.00 26.99           N  
+ATOM   6003  CA  GLY C3166      20.619  -1.724 -33.162  1.00 28.10           C  
+ATOM   6004  C   GLY C3166      22.058  -1.350 -33.465  1.00 29.05           C  
+ATOM   6005  O   GLY C3166      22.848  -2.212 -33.851  1.00 30.10           O  
+ATOM   6006  N   VAL C3167      22.412  -0.079 -33.302  1.00 28.83           N  
+ATOM   6007  CA  VAL C3167      23.785   0.346 -33.553  1.00 29.89           C  
+ATOM   6008  C   VAL C3167      24.713  -0.448 -32.629  1.00 32.32           C  
+ATOM   6009  O   VAL C3167      24.603  -0.373 -31.402  1.00 31.39           O  
+ATOM   6010  CB  VAL C3167      23.979   1.842 -33.277  1.00 29.44           C  
+ATOM   6011  CG1 VAL C3167      25.423   2.224 -33.551  1.00 27.71           C  
+ATOM   6012  CG2 VAL C3167      23.023   2.667 -34.139  1.00 25.92           C  
+ATOM   6013  N   PRO C3168      25.649  -1.210 -33.215  1.00 33.98           N  
+ATOM   6014  CA  PRO C3168      26.607  -2.037 -32.474  1.00 35.39           C  
+ATOM   6015  C   PRO C3168      27.396  -1.335 -31.361  1.00 36.51           C  
+ATOM   6016  O   PRO C3168      27.387  -1.782 -30.215  1.00 37.08           O  
+ATOM   6017  CB  PRO C3168      27.504  -2.605 -33.583  1.00 35.69           C  
+ATOM   6018  CG  PRO C3168      27.438  -1.544 -34.651  1.00 36.81           C  
+ATOM   6019  CD  PRO C3168      25.977  -1.182 -34.653  1.00 33.96           C  
+ATOM   6020  N   ASN C3169      28.071  -0.242 -31.686  1.00 37.33           N  
+ATOM   6021  CA  ASN C3169      28.848   0.469 -30.680  1.00 39.18           C  
+ATOM   6022  C   ASN C3169      28.357   1.896 -30.550  1.00 38.04           C  
+ATOM   6023  O   ASN C3169      28.301   2.636 -31.531  1.00 39.62           O  
+ATOM   6024  CB  ASN C3169      30.333   0.471 -31.052  1.00 42.66           C  
+ATOM   6025  CG  ASN C3169      30.869  -0.921 -31.322  1.00 45.88           C  
+ATOM   6026  OD1 ASN C3169      30.804  -1.803 -30.463  1.00 48.57           O  
+ATOM   6027  ND2 ASN C3169      31.400  -1.128 -32.524  1.00 47.83           N  
+ATOM   6028  N   VAL C3170      28.004   2.282 -29.332  1.00 35.91           N  
+ATOM   6029  CA  VAL C3170      27.515   3.627 -29.085  1.00 34.94           C  
+ATOM   6030  C   VAL C3170      28.413   4.282 -28.045  1.00 34.40           C  
+ATOM   6031  O   VAL C3170      28.833   3.640 -27.081  1.00 33.95           O  
+ATOM   6032  CB  VAL C3170      26.059   3.600 -28.578  1.00 34.53           C  
+ATOM   6033  CG1 VAL C3170      25.479   4.995 -28.587  1.00 35.82           C  
+ATOM   6034  CG2 VAL C3170      25.225   2.685 -29.458  1.00 35.61           C  
+ATOM   6035  N   THR C3171      28.709   5.560 -28.247  1.00 33.18           N  
+ATOM   6036  CA  THR C3171      29.577   6.286 -27.332  1.00 32.45           C  
+ATOM   6037  C   THR C3171      28.826   7.302 -26.480  1.00 30.74           C  
+ATOM   6038  O   THR C3171      27.908   7.976 -26.955  1.00 30.40           O  
+ATOM   6039  CB  THR C3171      30.692   7.012 -28.113  1.00 34.02           C  
+ATOM   6040  OG1 THR C3171      31.483   6.044 -28.813  1.00 36.41           O  
+ATOM   6041  CG2 THR C3171      31.597   7.793 -27.165  1.00 35.46           C  
+ATOM   6042  N   ALA C3172      29.225   7.408 -25.219  1.00 29.05           N  
+ATOM   6043  CA  ALA C3172      28.606   8.349 -24.294  1.00 28.65           C  
+ATOM   6044  C   ALA C3172      29.656   9.210 -23.596  1.00 27.64           C  
+ATOM   6045  O   ALA C3172      30.739   8.737 -23.252  1.00 26.52           O  
+ATOM   6046  CB  ALA C3172      27.788   7.597 -23.251  1.00 30.01           C  
+ATOM   6047  N   PRO C3173      29.352  10.497 -23.397  1.00 26.59           N  
+ATOM   6048  CA  PRO C3173      30.319  11.362 -22.721  1.00 28.08           C  
+ATOM   6049  C   PRO C3173      30.357  10.945 -21.250  1.00 28.20           C  
+ATOM   6050  O   PRO C3173      29.420  10.324 -20.761  1.00 28.23           O  
+ATOM   6051  CB  PRO C3173      29.736  12.760 -22.931  1.00 26.81           C  
+ATOM   6052  CG  PRO C3173      28.255  12.501 -22.973  1.00 26.41           C  
+ATOM   6053  CD  PRO C3173      28.159  11.254 -23.816  1.00 26.02           C  
+ATOM   6054  N   VAL C3174      31.440  11.269 -20.557  1.00 27.72           N  
+ATOM   6055  CA  VAL C3174      31.576  10.909 -19.152  1.00 27.23           C  
+ATOM   6056  C   VAL C3174      31.845  12.133 -18.279  1.00 28.67           C  
+ATOM   6057  O   VAL C3174      32.625  13.021 -18.643  1.00 27.99           O  
+ATOM   6058  CB  VAL C3174      32.714   9.885 -18.944  1.00 27.23           C  
+ATOM   6059  CG1 VAL C3174      32.933   9.644 -17.451  1.00 28.44           C  
+ATOM   6060  CG2 VAL C3174      32.365   8.575 -19.634  1.00 27.06           C  
+ATOM   6061  N   TYR C3175      31.196  12.157 -17.118  1.00 28.92           N  
+ATOM   6062  CA  TYR C3175      31.313  13.248 -16.158  1.00 29.44           C  
+ATOM   6063  C   TYR C3175      32.135  12.793 -14.957  1.00 31.69           C  
+ATOM   6064  O   TYR C3175      32.096  11.626 -14.581  1.00 31.56           O  
+ATOM   6065  CB  TYR C3175      29.916  13.657 -15.688  1.00 27.80           C  
+ATOM   6066  CG  TYR C3175      29.876  14.871 -14.789  1.00 26.95           C  
+ATOM   6067  CD1 TYR C3175      30.008  16.159 -15.315  1.00 24.36           C  
+ATOM   6068  CD2 TYR C3175      29.683  14.736 -13.411  1.00 24.91           C  
+ATOM   6069  CE1 TYR C3175      29.944  17.282 -14.498  1.00 24.59           C  
+ATOM   6070  CE2 TYR C3175      29.622  15.854 -12.582  1.00 23.49           C  
+ATOM   6071  CZ  TYR C3175      29.751  17.122 -13.129  1.00 24.07           C  
+ATOM   6072  OH  TYR C3175      29.690  18.231 -12.317  1.00 22.90           O  
+ATOM   6073  N   SER C3176      32.867  13.722 -14.353  1.00 33.35           N  
+ATOM   6074  CA  SER C3176      33.696  13.419 -13.188  1.00 35.78           C  
+ATOM   6075  C   SER C3176      33.334  14.330 -12.013  1.00 36.91           C  
+ATOM   6076  O   SER C3176      33.580  15.536 -12.071  1.00 36.01           O  
+ATOM   6077  CB  SER C3176      35.173  13.610 -13.543  1.00 37.06           C  
+ATOM   6078  OG  SER C3176      35.991  13.562 -12.388  1.00 39.18           O  
+ATOM   6079  N   HIS C3177      32.748  13.768 -10.951  1.00 38.43           N  
+ATOM   6080  CA  HIS C3177      32.385  14.581  -9.785  1.00 39.86           C  
+ATOM   6081  C   HIS C3177      33.650  15.068  -9.080  1.00 40.57           C  
+ATOM   6082  O   HIS C3177      33.617  16.052  -8.338  1.00 41.02           O  
+ATOM   6083  CB  HIS C3177      31.507  13.798  -8.792  1.00 41.32           C  
+ATOM   6084  CG  HIS C3177      30.051  13.758  -9.163  1.00 42.16           C  
+ATOM   6085  ND1 HIS C3177      29.439  12.630  -9.674  1.00 43.52           N  
+ATOM   6086  CD2 HIS C3177      29.093  14.713  -9.115  1.00 41.44           C  
+ATOM   6087  CE1 HIS C3177      28.169  12.895  -9.925  1.00 41.72           C  
+ATOM   6088  NE2 HIS C3177      27.933  14.151  -9.596  1.00 41.58           N  
+ATOM   6089  N   LEU C3178      34.762  14.378  -9.329  1.00 39.67           N  
+ATOM   6090  CA  LEU C3178      36.046  14.730  -8.739  1.00 38.34           C  
+ATOM   6091  C   LEU C3178      36.556  16.045  -9.322  1.00 37.74           C  
+ATOM   6092  O   LEU C3178      37.197  16.831  -8.624  1.00 37.04           O  
+ATOM   6093  CB  LEU C3178      37.060  13.620  -8.990  1.00 39.04           C  
+ATOM   6094  N   ILE C3179      36.288  16.283 -10.604  1.00 36.83           N  
+ATOM   6095  CA  ILE C3179      36.722  17.533 -11.221  1.00 35.79           C  
+ATOM   6096  C   ILE C3179      35.520  18.445 -11.430  1.00 33.59           C  
+ATOM   6097  O   ILE C3179      35.673  19.603 -11.810  1.00 34.22           O  
+ATOM   6098  CB  ILE C3179      37.442  17.306 -12.574  1.00 37.42           C  
+ATOM   6099  CG1 ILE C3179      36.429  17.021 -13.681  1.00 38.68           C  
+ATOM   6100  CG2 ILE C3179      38.421  16.145 -12.443  1.00 37.88           C  
+ATOM   6101  CD1 ILE C3179      37.069  16.841 -15.053  1.00 40.21           C  
+ATOM   6102  N   TYR C3180      34.326  17.912 -11.185  1.00 32.54           N  
+ATOM   6103  CA  TYR C3180      33.092  18.687 -11.299  1.00 32.06           C  
+ATOM   6104  C   TYR C3180      32.894  19.183 -12.726  1.00 30.73           C  
+ATOM   6105  O   TYR C3180      32.531  20.338 -12.957  1.00 30.41           O  
+ATOM   6106  CB  TYR C3180      33.165  19.869 -10.325  1.00 34.93           C  
+ATOM   6107  CG  TYR C3180      31.914  20.702 -10.172  1.00 36.34           C  
+ATOM   6108  CD1 TYR C3180      30.809  20.222  -9.476  1.00 37.49           C  
+ATOM   6109  CD2 TYR C3180      31.859  22.000 -10.683  1.00 38.94           C  
+ATOM   6110  CE1 TYR C3180      29.680  21.015  -9.285  1.00 39.48           C  
+ATOM   6111  CE2 TYR C3180      30.733  22.803 -10.502  1.00 39.24           C  
+ATOM   6112  CZ  TYR C3180      29.649  22.306  -9.801  1.00 39.73           C  
+ATOM   6113  OH  TYR C3180      28.537  23.097  -9.617  1.00 41.67           O  
+ATOM   6114  N   ASP C3181      33.128  18.307 -13.691  1.00 28.48           N  
+ATOM   6115  CA  ASP C3181      32.975  18.703 -15.076  1.00 29.09           C  
+ATOM   6116  C   ASP C3181      33.029  17.512 -16.016  1.00 28.23           C  
+ATOM   6117  O   ASP C3181      33.468  16.432 -15.637  1.00 27.24           O  
+ATOM   6118  CB  ASP C3181      34.072  19.713 -15.447  1.00 28.37           C  
+ATOM   6119  CG  ASP C3181      33.832  20.367 -16.799  1.00 29.54           C  
+ATOM   6120  OD1 ASP C3181      32.678  20.350 -17.263  1.00 29.54           O  
+ATOM   6121  OD2 ASP C3181      34.787  20.909 -17.391  1.00 31.11           O  
+ATOM   6122  N   VAL C3182      32.566  17.716 -17.243  1.00 27.93           N  
+ATOM   6123  CA  VAL C3182      32.600  16.668 -18.248  1.00 28.02           C  
+ATOM   6124  C   VAL C3182      34.068  16.435 -18.600  1.00 29.75           C  
+ATOM   6125  O   VAL C3182      34.824  17.388 -18.771  1.00 30.52           O  
+ATOM   6126  CB  VAL C3182      31.842  17.104 -19.523  1.00 26.38           C  
+ATOM   6127  CG1 VAL C3182      31.943  16.019 -20.600  1.00 24.95           C  
+ATOM   6128  CG2 VAL C3182      30.392  17.391 -19.180  1.00 24.47           C  
+ATOM   6129  N   ILE C3183      34.478  15.175 -18.685  1.00 31.93           N  
+ATOM   6130  CA  ILE C3183      35.859  14.854 -19.041  1.00 34.74           C  
+ATOM   6131  C   ILE C3183      36.005  15.029 -20.560  1.00 37.00           C  
+ATOM   6132  O   ILE C3183      35.446  14.258 -21.332  1.00 35.96           O  
+ATOM   6133  CB  ILE C3183      36.203  13.402 -18.655  1.00 34.04           C  
+ATOM   6134  CG1 ILE C3183      35.927  13.188 -17.166  1.00 33.78           C  
+ATOM   6135  CG2 ILE C3183      37.670  13.107 -18.979  1.00 34.67           C  
+ATOM   6136  CD1 ILE C3183      36.115  11.759 -16.705  1.00 34.65           C  
+ATOM   6137  N   PRO C3184      36.772  16.045 -21.000  1.00 40.75           N  
+ATOM   6138  CA  PRO C3184      37.003  16.355 -22.422  1.00 43.29           C  
+ATOM   6139  C   PRO C3184      37.164  15.180 -23.393  1.00 45.73           C  
+ATOM   6140  O   PRO C3184      36.425  15.087 -24.377  1.00 47.17           O  
+ATOM   6141  CB  PRO C3184      38.226  17.280 -22.389  1.00 42.34           C  
+ATOM   6142  CG  PRO C3184      38.886  16.955 -21.082  1.00 43.32           C  
+ATOM   6143  CD  PRO C3184      37.717  16.792 -20.153  1.00 40.83           C  
+ATOM   6144  N   ASP C3185      38.112  14.286 -23.136  1.00 46.72           N  
+ATOM   6145  CA  ASP C3185      38.295  13.145 -24.027  1.00 48.99           C  
+ATOM   6146  C   ASP C3185      38.209  11.816 -23.295  1.00 49.25           C  
+ATOM   6147  O   ASP C3185      39.092  10.964 -23.428  1.00 50.50           O  
+ATOM   6148  CB  ASP C3185      39.639  13.243 -24.761  1.00 51.87           C  
+ATOM   6149  CG  ASP C3185      39.621  14.276 -25.875  1.00 54.44           C  
+ATOM   6150  OD1 ASP C3185      38.724  14.193 -26.747  1.00 55.34           O  
+ATOM   6151  OD2 ASP C3185      40.501  15.164 -25.884  1.00 55.62           O  
+ATOM   6152  N   GLY C3186      37.136  11.639 -22.530  1.00 47.92           N  
+ATOM   6153  CA  GLY C3186      36.959  10.408 -21.783  1.00 45.87           C  
+ATOM   6154  C   GLY C3186      35.672   9.677 -22.113  1.00 43.72           C  
+ATOM   6155  O   GLY C3186      35.143   8.946 -21.285  1.00 42.99           O  
+ATOM   6156  N   ASP C3187      35.167   9.870 -23.325  1.00 42.08           N  
+ATOM   6157  CA  ASP C3187      33.934   9.215 -23.746  1.00 41.99           C  
+ATOM   6158  C   ASP C3187      34.003   7.694 -23.585  1.00 40.60           C  
+ATOM   6159  O   ASP C3187      35.019   7.075 -23.883  1.00 41.34           O  
+ATOM   6160  CB  ASP C3187      33.628   9.590 -25.196  1.00 42.26           C  
+ATOM   6161  CG  ASP C3187      33.295  11.056 -25.348  1.00 43.96           C  
+ATOM   6162  OD1 ASP C3187      33.801  11.859 -24.538  1.00 46.41           O  
+ATOM   6163  OD2 ASP C3187      32.539  11.413 -26.274  1.00 46.39           O  
+ATOM   6164  N   LYS C3188      32.913   7.105 -23.101  1.00 39.41           N  
+ATOM   6165  CA  LYS C3188      32.829   5.663 -22.878  1.00 38.64           C  
+ATOM   6166  C   LYS C3188      32.071   4.961 -24.006  1.00 37.95           C  
+ATOM   6167  O   LYS C3188      30.945   5.335 -24.335  1.00 36.81           O  
+ATOM   6168  CB  LYS C3188      32.128   5.401 -21.544  1.00 39.76           C  
+ATOM   6169  CG  LYS C3188      31.876   3.942 -21.222  1.00 41.57           C  
+ATOM   6170  CD  LYS C3188      31.114   3.835 -19.912  1.00 43.68           C  
+ATOM   6171  CE  LYS C3188      30.736   2.401 -19.580  1.00 44.25           C  
+ATOM   6172  NZ  LYS C3188      29.846   2.330 -18.382  1.00 43.72           N  
+ATOM   6173  N   THR C3189      32.688   3.936 -24.586  1.00 36.30           N  
+ATOM   6174  CA  THR C3189      32.065   3.191 -25.673  1.00 36.64           C  
+ATOM   6175  C   THR C3189      31.333   1.951 -25.187  1.00 36.10           C  
+ATOM   6176  O   THR C3189      31.923   1.066 -24.581  1.00 36.44           O  
+ATOM   6177  CB  THR C3189      33.101   2.747 -26.725  1.00 37.62           C  
+ATOM   6178  OG1 THR C3189      33.714   3.903 -27.308  1.00 38.16           O  
+ATOM   6179  CG2 THR C3189      32.424   1.925 -27.824  1.00 37.24           C  
+ATOM   6180  N   VAL C3190      30.043   1.898 -25.481  1.00 36.51           N  
+ATOM   6181  CA  VAL C3190      29.189   0.790 -25.097  1.00 36.86           C  
+ATOM   6182  C   VAL C3190      29.124  -0.197 -26.259  1.00 36.95           C  
+ATOM   6183  O   VAL C3190      28.796   0.187 -27.380  1.00 37.26           O  
+ATOM   6184  CB  VAL C3190      27.766   1.308 -24.772  1.00 36.44           C  
+ATOM   6185  CG1 VAL C3190      26.817   0.170 -24.545  1.00 35.92           C  
+ATOM   6186  CG2 VAL C3190      27.823   2.194 -23.544  1.00 37.90           C  
+ATOM   6187  N   VAL C3191      29.441  -1.465 -26.000  1.00 38.13           N  
+ATOM   6188  CA  VAL C3191      29.414  -2.478 -27.056  1.00 40.81           C  
+ATOM   6189  C   VAL C3191      28.359  -3.564 -26.867  1.00 40.87           C  
+ATOM   6190  O   VAL C3191      28.460  -4.396 -25.958  1.00 42.48           O  
+ATOM   6191  CB  VAL C3191      30.806  -3.129 -27.212  1.00 42.02           C  
+ATOM   6192  CG1 VAL C3191      31.823  -2.073 -27.565  1.00 43.40           C  
+ATOM   6193  CG2 VAL C3191      31.211  -3.825 -25.930  1.00 43.41           C  
+ATOM   6194  N   PRO C3193      25.428  -4.347 -25.352  1.00 29.57           N  
+ATOM   6195  CA  PRO C3193      24.991  -4.860 -24.050  1.00 27.52           C  
+ATOM   6196  C   PRO C3193      23.702  -5.644 -24.194  1.00 26.67           C  
+ATOM   6197  O   PRO C3193      22.939  -5.396 -25.134  1.00 27.87           O  
+ATOM   6198  CB  PRO C3193      24.777  -3.573 -23.194  1.00 28.07           C  
+ATOM   6199  CG  PRO C3193      25.479  -2.498 -23.915  1.00 31.11           C  
+ATOM   6200  CD  PRO C3193      25.401  -2.872 -25.384  1.00 29.17           C  
+ATOM   6201  N   ASP C3194      23.459  -6.565 -23.259  1.00 26.18           N  
+ATOM   6202  CA  ASP C3194      22.222  -7.340 -23.243  1.00 24.83           C  
+ATOM   6203  C   ASP C3194      21.244  -6.462 -22.470  1.00 23.42           C  
+ATOM   6204  O   ASP C3194      20.033  -6.439 -22.727  1.00 22.61           O  
+ATOM   6205  CB  ASP C3194      22.426  -8.655 -22.500  1.00 26.98           C  
+ATOM   6206  CG  ASP C3194      23.430  -9.560 -23.190  1.00 29.27           C  
+ATOM   6207  OD1 ASP C3194      23.118 -10.085 -24.288  1.00 28.86           O  
+ATOM   6208  OD2 ASP C3194      24.548  -9.734 -22.659  1.00 28.94           O  
+ATOM   6209  N   ILE C3195      21.817  -5.723 -21.522  1.00 21.78           N  
+ATOM   6210  CA  ILE C3195      21.068  -4.811 -20.675  1.00 20.54           C  
+ATOM   6211  C   ILE C3195      21.848  -3.526 -20.446  1.00 19.70           C  
+ATOM   6212  O   ILE C3195      23.065  -3.534 -20.213  1.00 19.92           O  
+ATOM   6213  CB  ILE C3195      20.769  -5.432 -19.301  1.00 21.60           C  
+ATOM   6214  CG1 ILE C3195      19.893  -6.680 -19.467  1.00 22.77           C  
+ATOM   6215  CG2 ILE C3195      20.074  -4.408 -18.413  1.00 19.47           C  
+ATOM   6216  CD1 ILE C3195      19.726  -7.486 -18.182  1.00 20.42           C  
+ATOM   6217  N   LEU C3196      21.146  -2.411 -20.540  1.00 18.52           N  
+ATOM   6218  CA  LEU C3196      21.768  -1.129 -20.277  1.00 18.90           C  
+ATOM   6219  C   LEU C3196      20.975  -0.432 -19.173  1.00 18.33           C  
+ATOM   6220  O   LEU C3196      19.754  -0.277 -19.268  1.00 16.38           O  
+ATOM   6221  CB  LEU C3196      21.786  -0.239 -21.523  1.00 19.25           C  
+ATOM   6222  CG  LEU C3196      22.479   1.108 -21.272  1.00 21.47           C  
+ATOM   6223  CD1 LEU C3196      23.710   1.250 -22.174  1.00 22.62           C  
+ATOM   6224  CD2 LEU C3196      21.494   2.233 -21.519  1.00 18.56           C  
+ATOM   6225  N   ILE C3197      21.669  -0.042 -18.114  1.00 18.17           N  
+ATOM   6226  CA  ILE C3197      21.028   0.672 -17.022  1.00 18.51           C  
+ATOM   6227  C   ILE C3197      21.399   2.138 -17.216  1.00 16.78           C  
+ATOM   6228  O   ILE C3197      22.575   2.481 -17.250  1.00 14.60           O  
+ATOM   6229  CB  ILE C3197      21.527   0.174 -15.638  1.00 19.00           C  
+ATOM   6230  CG1 ILE C3197      21.161  -1.305 -15.459  1.00 19.36           C  
+ATOM   6231  CG2 ILE C3197      20.898   1.013 -14.523  1.00 17.93           C  
+ATOM   6232  CD1 ILE C3197      21.731  -1.942 -14.196  1.00 18.52           C  
+ATOM   6233  N   LEU C3198      20.383   2.981 -17.385  1.00 17.03           N  
+ATOM   6234  CA  LEU C3198      20.567   4.415 -17.579  1.00 16.16           C  
+ATOM   6235  C   LEU C3198      20.114   5.125 -16.310  1.00 15.40           C  
+ATOM   6236  O   LEU C3198      18.920   5.186 -16.005  1.00 14.01           O  
+ATOM   6237  CB  LEU C3198      19.746   4.907 -18.774  1.00 15.23           C  
+ATOM   6238  CG  LEU C3198      19.913   6.395 -19.101  1.00 17.71           C  
+ATOM   6239  CD1 LEU C3198      21.338   6.652 -19.570  1.00 15.59           C  
+ATOM   6240  CD2 LEU C3198      18.910   6.812 -20.179  1.00 17.82           C  
+ATOM   6241  N   GLU C3199      21.080   5.673 -15.585  1.00 15.84           N  
+ATOM   6242  CA  GLU C3199      20.810   6.349 -14.327  1.00 18.38           C  
+ATOM   6243  C   GLU C3199      20.935   7.870 -14.409  1.00 17.90           C  
+ATOM   6244  O   GLU C3199      21.960   8.399 -14.844  1.00 17.79           O  
+ATOM   6245  CB  GLU C3199      21.747   5.778 -13.260  1.00 22.12           C  
+ATOM   6246  CG  GLU C3199      21.673   6.470 -11.921  1.00 29.46           C  
+ATOM   6247  CD  GLU C3199      22.762   7.503 -11.760  1.00 32.72           C  
+ATOM   6248  OE1 GLU C3199      23.945   7.104 -11.687  1.00 33.89           O  
+ATOM   6249  OE2 GLU C3199      22.437   8.711 -11.716  1.00 36.58           O  
+ATOM   6250  N   GLY C3200      19.880   8.566 -13.994  1.00 17.10           N  
+ATOM   6251  CA  GLY C3200      19.890  10.017 -14.032  1.00 17.93           C  
+ATOM   6252  C   GLY C3200      18.599  10.613 -13.514  1.00 18.21           C  
+ATOM   6253  O   GLY C3200      17.531  10.020 -13.661  1.00 18.65           O  
+ATOM   6254  N   LEU C3201      18.690  11.798 -12.923  1.00 18.46           N  
+ATOM   6255  CA  LEU C3201      17.516  12.464 -12.365  1.00 18.88           C  
+ATOM   6256  C   LEU C3201      16.492  12.858 -13.419  1.00 18.42           C  
+ATOM   6257  O   LEU C3201      15.322  13.058 -13.108  1.00 17.70           O  
+ATOM   6258  CB  LEU C3201      17.950  13.714 -11.604  1.00 18.42           C  
+ATOM   6259  CG  LEU C3201      18.626  14.796 -12.448  1.00 18.23           C  
+ATOM   6260  CD1 LEU C3201      17.565  15.679 -13.082  1.00 17.78           C  
+ATOM   6261  CD2 LEU C3201      19.556  15.643 -11.577  1.00 19.36           C  
+ATOM   6262  N   ASN C3202      16.932  12.943 -14.669  1.00 18.77           N  
+ATOM   6263  CA  ASN C3202      16.056  13.379 -15.756  1.00 19.11           C  
+ATOM   6264  C   ASN C3202      15.565  12.330 -16.754  1.00 17.96           C  
+ATOM   6265  O   ASN C3202      14.991  12.700 -17.781  1.00 19.52           O  
+ATOM   6266  CB  ASN C3202      16.770  14.490 -16.524  1.00 17.40           C  
+ATOM   6267  CG  ASN C3202      18.069  14.014 -17.145  1.00 19.82           C  
+ATOM   6268  OD1 ASN C3202      18.738  13.123 -16.613  1.00 19.80           O  
+ATOM   6269  ND2 ASN C3202      18.441  14.611 -18.266  1.00 20.21           N  
+ATOM   6270  N   VAL C3203      15.761  11.045 -16.471  1.00 16.35           N  
+ATOM   6271  CA  VAL C3203      15.342  10.009 -17.418  1.00 16.81           C  
+ATOM   6272  C   VAL C3203      13.841   9.899 -17.695  1.00 17.53           C  
+ATOM   6273  O   VAL C3203      13.437   9.237 -18.658  1.00 19.25           O  
+ATOM   6274  CB  VAL C3203      15.881   8.610 -17.010  1.00 14.98           C  
+ATOM   6275  CG1 VAL C3203      17.400   8.637 -17.012  1.00 13.16           C  
+ATOM   6276  CG2 VAL C3203      15.352   8.207 -15.634  1.00 14.52           C  
+ATOM   6277  N   LEU C3204      13.017  10.534 -16.865  1.00 16.62           N  
+ATOM   6278  CA  LEU C3204      11.568  10.487 -17.062  1.00 17.01           C  
+ATOM   6279  C   LEU C3204      11.036  11.793 -17.631  1.00 16.95           C  
+ATOM   6280  O   LEU C3204       9.848  11.908 -17.946  1.00 19.44           O  
+ATOM   6281  CB  LEU C3204      10.848  10.160 -15.746  1.00 14.15           C  
+ATOM   6282  CG  LEU C3204      11.009   8.704 -15.277  1.00 16.95           C  
+ATOM   6283  CD1 LEU C3204      10.398   8.535 -13.885  1.00 16.46           C  
+ATOM   6284  CD2 LEU C3204      10.350   7.757 -16.283  1.00 12.93           C  
+ATOM   6285  N   GLN C3205      11.916  12.778 -17.767  1.00 17.33           N  
+ATOM   6286  CA  GLN C3205      11.514  14.068 -18.301  1.00 19.05           C  
+ATOM   6287  C   GLN C3205      11.223  13.950 -19.795  1.00 21.46           C  
+ATOM   6288  O   GLN C3205      11.529  12.931 -20.419  1.00 19.77           O  
+ATOM   6289  CB  GLN C3205      12.604  15.113 -18.027  1.00 19.52           C  
+ATOM   6290  CG  GLN C3205      12.662  15.519 -16.560  1.00 18.12           C  
+ATOM   6291  CD  GLN C3205      13.829  16.421 -16.226  1.00 20.97           C  
+ATOM   6292  OE1 GLN C3205      14.598  16.822 -17.100  1.00 18.77           O  
+ATOM   6293  NE2 GLN C3205      13.968  16.749 -14.944  1.00 23.65           N  
+ATOM   6294  N   SER C3206      10.622  14.993 -20.360  1.00 23.10           N  
+ATOM   6295  CA  SER C3206      10.262  14.991 -21.767  1.00 23.01           C  
+ATOM   6296  C   SER C3206      10.338  16.378 -22.408  1.00 22.93           C  
+ATOM   6297  O   SER C3206      10.930  17.300 -21.853  1.00 23.78           O  
+ATOM   6298  CB  SER C3206       8.853  14.428 -21.918  1.00 22.40           C  
+ATOM   6299  OG  SER C3206       7.929  15.216 -21.192  1.00 24.03           O  
+ATOM   6300  N   GLY C3207       9.732  16.512 -23.584  1.00 22.67           N  
+ATOM   6301  CA  GLY C3207       9.753  17.773 -24.303  1.00 22.86           C  
+ATOM   6302  C   GLY C3207       9.268  18.976 -23.518  1.00 22.96           C  
+ATOM   6303  O   GLY C3207       9.836  20.071 -23.631  1.00 20.85           O  
+ATOM   6304  N   MET C3208       8.221  18.780 -22.719  1.00 22.50           N  
+ATOM   6305  CA  MET C3208       7.664  19.868 -21.920  1.00 24.82           C  
+ATOM   6306  C   MET C3208       8.682  20.465 -20.947  1.00 24.61           C  
+ATOM   6307  O   MET C3208       8.532  21.599 -20.506  1.00 25.06           O  
+ATOM   6308  CB  MET C3208       6.437  19.384 -21.144  1.00 25.39           C  
+ATOM   6309  CG  MET C3208       6.742  18.372 -20.041  1.00 27.95           C  
+ATOM   6310  SD  MET C3208       5.220  17.758 -19.257  1.00 30.99           S  
+ATOM   6311  CE  MET C3208       4.495  19.341 -18.715  1.00 26.95           C  
+ATOM   6312  N   ASP C3209       9.713  19.700 -20.613  1.00 25.00           N  
+ATOM   6313  CA  ASP C3209      10.738  20.174 -19.692  1.00 27.72           C  
+ATOM   6314  C   ASP C3209      11.813  20.975 -20.406  1.00 28.22           C  
+ATOM   6315  O   ASP C3209      12.678  21.552 -19.765  1.00 27.96           O  
+ATOM   6316  CB  ASP C3209      11.394  18.998 -18.974  1.00 30.02           C  
+ATOM   6317  CG  ASP C3209      10.414  18.218 -18.128  1.00 32.55           C  
+ATOM   6318  OD1 ASP C3209       9.910  18.785 -17.133  1.00 33.74           O  
+ATOM   6319  OD2 ASP C3209      10.147  17.043 -18.464  1.00 30.96           O  
+ATOM   6320  N   TYR C3210      11.765  21.005 -21.735  1.00 30.12           N  
+ATOM   6321  CA  TYR C3210      12.761  21.741 -22.507  1.00 30.31           C  
+ATOM   6322  C   TYR C3210      12.095  22.669 -23.514  1.00 31.83           C  
+ATOM   6323  O   TYR C3210      12.341  22.577 -24.717  1.00 31.17           O  
+ATOM   6324  CB  TYR C3210      13.701  20.761 -23.221  1.00 29.30           C  
+ATOM   6325  CG  TYR C3210      14.438  19.848 -22.261  1.00 31.55           C  
+ATOM   6326  CD1 TYR C3210      13.757  18.853 -21.557  1.00 31.29           C  
+ATOM   6327  CD2 TYR C3210      15.798  20.030 -21.992  1.00 31.46           C  
+ATOM   6328  CE1 TYR C3210      14.405  18.069 -20.601  1.00 33.03           C  
+ATOM   6329  CE2 TYR C3210      16.458  19.252 -21.040  1.00 32.23           C  
+ATOM   6330  CZ  TYR C3210      15.756  18.274 -20.343  1.00 34.47           C  
+ATOM   6331  OH  TYR C3210      16.396  17.509 -19.380  1.00 35.25           O  
+ATOM   6332  N   PRO C3211      11.250  23.593 -23.027  1.00 33.21           N  
+ATOM   6333  CA  PRO C3211      10.553  24.535 -23.909  1.00 34.49           C  
+ATOM   6334  C   PRO C3211      11.521  25.405 -24.710  1.00 35.94           C  
+ATOM   6335  O   PRO C3211      11.187  25.887 -25.793  1.00 36.85           O  
+ATOM   6336  CB  PRO C3211       9.704  25.348 -22.930  1.00 33.87           C  
+ATOM   6337  CG  PRO C3211      10.577  25.395 -21.715  1.00 32.87           C  
+ATOM   6338  CD  PRO C3211      11.054  23.961 -21.612  1.00 33.00           C  
+ATOM   6339  N   HIS C3212      12.720  25.597 -24.170  1.00 35.89           N  
+ATOM   6340  CA  HIS C3212      13.736  26.407 -24.830  1.00 36.85           C  
+ATOM   6341  C   HIS C3212      14.354  25.703 -26.037  1.00 37.18           C  
+ATOM   6342  O   HIS C3212      14.904  26.354 -26.926  1.00 37.30           O  
+ATOM   6343  CB  HIS C3212      14.845  26.775 -23.836  1.00 38.01           C  
+ATOM   6344  CG  HIS C3212      15.443  25.596 -23.129  1.00 39.08           C  
+ATOM   6345  ND1 HIS C3212      14.775  24.900 -22.142  1.00 37.92           N  
+ATOM   6346  CD2 HIS C3212      16.636  24.973 -23.285  1.00 38.01           C  
+ATOM   6347  CE1 HIS C3212      15.530  23.900 -21.723  1.00 38.12           C  
+ATOM   6348  NE2 HIS C3212      16.664  23.921 -22.401  1.00 37.57           N  
+ATOM   6349  N   ASP C3213      14.252  24.376 -26.065  1.00 35.75           N  
+ATOM   6350  CA  ASP C3213      14.819  23.567 -27.142  1.00 33.16           C  
+ATOM   6351  C   ASP C3213      14.123  22.204 -27.099  1.00 31.94           C  
+ATOM   6352  O   ASP C3213      14.719  21.201 -26.710  1.00 30.41           O  
+ATOM   6353  CB  ASP C3213      16.318  23.402 -26.893  1.00 34.82           C  
+ATOM   6354  CG  ASP C3213      17.028  22.714 -28.030  1.00 34.74           C  
+ATOM   6355  OD1 ASP C3213      18.230  22.418 -27.872  1.00 37.62           O  
+ATOM   6356  OD2 ASP C3213      16.390  22.476 -29.077  1.00 36.87           O  
+ATOM   6357  N   PRO C3214      12.855  22.151 -27.524  1.00 30.92           N  
+ATOM   6358  CA  PRO C3214      12.020  20.946 -27.540  1.00 31.26           C  
+ATOM   6359  C   PRO C3214      12.386  19.731 -28.398  1.00 30.32           C  
+ATOM   6360  O   PRO C3214      12.840  19.860 -29.535  1.00 31.76           O  
+ATOM   6361  CB  PRO C3214      10.646  21.499 -27.915  1.00 32.45           C  
+ATOM   6362  CG  PRO C3214      11.001  22.599 -28.860  1.00 32.61           C  
+ATOM   6363  CD  PRO C3214      12.141  23.283 -28.146  1.00 30.76           C  
+ATOM   6364  N   HIS C3215      12.188  18.546 -27.823  1.00 28.01           N  
+ATOM   6365  CA  HIS C3215      12.405  17.294 -28.537  1.00 25.65           C  
+ATOM   6366  C   HIS C3215      11.041  16.610 -28.513  1.00 23.84           C  
+ATOM   6367  O   HIS C3215      10.265  16.793 -27.574  1.00 23.55           O  
+ATOM   6368  CB  HIS C3215      13.507  16.419 -27.893  1.00 26.43           C  
+ATOM   6369  CG  HIS C3215      13.321  16.141 -26.434  1.00 26.01           C  
+ATOM   6370  ND1 HIS C3215      13.633  17.060 -25.454  1.00 26.77           N  
+ATOM   6371  CD2 HIS C3215      12.917  15.023 -25.787  1.00 26.66           C  
+ATOM   6372  CE1 HIS C3215      13.435  16.517 -24.267  1.00 25.83           C  
+ATOM   6373  NE2 HIS C3215      13.001  15.281 -24.438  1.00 26.84           N  
+ATOM   6374  N   HIS C3216      10.744  15.830 -29.544  1.00 21.61           N  
+ATOM   6375  CA  HIS C3216       9.437  15.197 -29.662  1.00 21.30           C  
+ATOM   6376  C   HIS C3216       9.356  13.703 -29.413  1.00 20.61           C  
+ATOM   6377  O   HIS C3216       8.270  13.127 -29.440  1.00 19.65           O  
+ATOM   6378  CB  HIS C3216       8.863  15.550 -31.032  1.00 22.43           C  
+ATOM   6379  CG  HIS C3216       8.775  17.024 -31.257  1.00 27.67           C  
+ATOM   6380  ND1 HIS C3216       7.718  17.783 -30.803  1.00 28.56           N  
+ATOM   6381  CD2 HIS C3216       9.673  17.900 -31.775  1.00 28.34           C  
+ATOM   6382  CE1 HIS C3216       7.967  19.061 -31.025  1.00 29.53           C  
+ATOM   6383  NE2 HIS C3216       9.148  19.158 -31.612  1.00 30.73           N  
+ATOM   6384  N   VAL C3217      10.505  13.079 -29.195  1.00 19.80           N  
+ATOM   6385  CA  VAL C3217      10.564  11.659 -28.886  1.00 22.07           C  
+ATOM   6386  C   VAL C3217      11.399  11.685 -27.620  1.00 20.88           C  
+ATOM   6387  O   VAL C3217      12.503  12.235 -27.614  1.00 20.26           O  
+ATOM   6388  CB  VAL C3217      11.284  10.830 -29.976  1.00 24.82           C  
+ATOM   6389  CG1 VAL C3217      11.137   9.346 -29.659  1.00 25.93           C  
+ATOM   6390  CG2 VAL C3217      10.677  11.118 -31.345  1.00 25.60           C  
+ATOM   6391  N   PHE C3218      10.875  11.102 -26.549  1.00 18.51           N  
+ATOM   6392  CA  PHE C3218      11.562  11.148 -25.262  1.00 18.41           C  
+ATOM   6393  C   PHE C3218      12.440   9.950 -24.916  1.00 17.59           C  
+ATOM   6394  O   PHE C3218      12.362   8.891 -25.546  1.00 17.26           O  
+ATOM   6395  CB  PHE C3218      10.514  11.352 -24.161  1.00 18.40           C  
+ATOM   6396  CG  PHE C3218       9.354  12.205 -24.589  1.00 17.77           C  
+ATOM   6397  CD1 PHE C3218       8.046  11.822 -24.304  1.00 17.21           C  
+ATOM   6398  CD2 PHE C3218       9.567  13.384 -25.306  1.00 19.32           C  
+ATOM   6399  CE1 PHE C3218       6.961  12.603 -24.729  1.00 17.70           C  
+ATOM   6400  CE2 PHE C3218       8.495  14.172 -25.738  1.00 17.94           C  
+ATOM   6401  CZ  PHE C3218       7.186  13.780 -25.449  1.00 18.95           C  
+ATOM   6402  N   VAL C3219      13.276  10.140 -23.901  1.00 17.71           N  
+ATOM   6403  CA  VAL C3219      14.153   9.090 -23.420  1.00 17.16           C  
+ATOM   6404  C   VAL C3219      13.307   7.859 -23.085  1.00 17.94           C  
+ATOM   6405  O   VAL C3219      13.662   6.732 -23.448  1.00 18.62           O  
+ATOM   6406  CB  VAL C3219      14.924   9.552 -22.146  1.00 18.12           C  
+ATOM   6407  CG1 VAL C3219      15.546   8.351 -21.428  1.00 16.10           C  
+ATOM   6408  CG2 VAL C3219      16.016  10.544 -22.530  1.00 15.15           C  
+ATOM   6409  N   SER C3220      12.187   8.086 -22.398  1.00 16.52           N  
+ATOM   6410  CA  SER C3220      11.297   7.010 -21.996  1.00 16.35           C  
+ATOM   6411  C   SER C3220      10.785   6.192 -23.185  1.00 16.08           C  
+ATOM   6412  O   SER C3220      10.434   5.025 -23.039  1.00 14.27           O  
+ATOM   6413  CB  SER C3220      10.117   7.571 -21.191  1.00 14.81           C  
+ATOM   6414  OG  SER C3220       9.290   8.412 -21.977  1.00 17.76           O  
+ATOM   6415  N   ASP C3221      10.738   6.812 -24.359  1.00 17.94           N  
+ATOM   6416  CA  ASP C3221      10.280   6.122 -25.561  1.00 18.07           C  
+ATOM   6417  C   ASP C3221      11.282   5.063 -26.012  1.00 17.50           C  
+ATOM   6418  O   ASP C3221      10.979   4.247 -26.874  1.00 19.81           O  
+ATOM   6419  CB  ASP C3221      10.011   7.128 -26.689  1.00 17.15           C  
+ATOM   6420  CG  ASP C3221       8.799   8.004 -26.404  1.00 18.90           C  
+ATOM   6421  OD1 ASP C3221       7.801   7.468 -25.865  1.00 17.65           O  
+ATOM   6422  OD2 ASP C3221       8.833   9.217 -26.724  1.00 16.41           O  
+ATOM   6423  N   PHE C3222      12.466   5.067 -25.415  1.00 17.06           N  
+ATOM   6424  CA  PHE C3222      13.491   4.082 -25.747  1.00 19.57           C  
+ATOM   6425  C   PHE C3222      13.917   3.298 -24.499  1.00 18.86           C  
+ATOM   6426  O   PHE C3222      14.968   2.651 -24.481  1.00 17.69           O  
+ATOM   6427  CB  PHE C3222      14.708   4.772 -26.382  1.00 20.11           C  
+ATOM   6428  CG  PHE C3222      14.374   5.547 -27.626  1.00 21.82           C  
+ATOM   6429  CD1 PHE C3222      14.287   6.936 -27.597  1.00 22.00           C  
+ATOM   6430  CD2 PHE C3222      14.104   4.885 -28.819  1.00 21.42           C  
+ATOM   6431  CE1 PHE C3222      13.931   7.651 -28.739  1.00 23.25           C  
+ATOM   6432  CE2 PHE C3222      13.746   5.591 -29.966  1.00 22.81           C  
+ATOM   6433  CZ  PHE C3222      13.661   6.976 -29.925  1.00 23.04           C  
+ATOM   6434  N   VAL C3223      13.086   3.353 -23.461  1.00 17.79           N  
+ATOM   6435  CA  VAL C3223      13.366   2.651 -22.210  1.00 17.31           C  
+ATOM   6436  C   VAL C3223      12.294   1.588 -21.967  1.00 16.38           C  
+ATOM   6437  O   VAL C3223      11.102   1.858 -22.073  1.00 15.97           O  
+ATOM   6438  CB  VAL C3223      13.407   3.644 -21.007  1.00 17.50           C  
+ATOM   6439  CG1 VAL C3223      13.484   2.879 -19.674  1.00 16.35           C  
+ATOM   6440  CG2 VAL C3223      14.611   4.557 -21.138  1.00 15.27           C  
+ATOM   6441  N   ASP C3224      12.727   0.376 -21.648  1.00 15.50           N  
+ATOM   6442  CA  ASP C3224      11.788  -0.713 -21.407  1.00 17.36           C  
+ATOM   6443  C   ASP C3224      11.178  -0.688 -20.010  1.00 18.05           C  
+ATOM   6444  O   ASP C3224       9.982  -0.914 -19.855  1.00 18.17           O  
+ATOM   6445  CB  ASP C3224      12.465  -2.066 -21.627  1.00 18.22           C  
+ATOM   6446  CG  ASP C3224      12.945  -2.253 -23.057  1.00 22.42           C  
+ATOM   6447  OD1 ASP C3224      14.138  -1.969 -23.336  1.00 19.39           O  
+ATOM   6448  OD2 ASP C3224      12.119  -2.674 -23.899  1.00 23.00           O  
+ATOM   6449  N   PHE C3225      12.000  -0.421 -18.996  1.00 18.26           N  
+ATOM   6450  CA  PHE C3225      11.520  -0.401 -17.616  1.00 18.54           C  
+ATOM   6451  C   PHE C3225      12.138   0.788 -16.874  1.00 17.83           C  
+ATOM   6452  O   PHE C3225      13.341   1.011 -16.951  1.00 19.76           O  
+ATOM   6453  CB  PHE C3225      11.918  -1.705 -16.908  1.00 18.23           C  
+ATOM   6454  CG  PHE C3225      11.147  -1.981 -15.634  1.00 17.31           C  
+ATOM   6455  CD1 PHE C3225       9.992  -2.765 -15.661  1.00 16.54           C  
+ATOM   6456  CD2 PHE C3225      11.584  -1.475 -14.415  1.00 16.01           C  
+ATOM   6457  CE1 PHE C3225       9.282  -3.045 -14.482  1.00 19.32           C  
+ATOM   6458  CE2 PHE C3225      10.886  -1.746 -13.230  1.00 17.82           C  
+ATOM   6459  CZ  PHE C3225       9.733  -2.533 -13.261  1.00 16.11           C  
+ATOM   6460  N   SER C3226      11.320   1.552 -16.165  1.00 15.34           N  
+ATOM   6461  CA  SER C3226      11.847   2.686 -15.429  1.00 16.97           C  
+ATOM   6462  C   SER C3226      11.534   2.593 -13.932  1.00 17.15           C  
+ATOM   6463  O   SER C3226      10.433   2.195 -13.526  1.00 16.11           O  
+ATOM   6464  CB  SER C3226      11.302   4.004 -16.002  1.00 14.85           C  
+ATOM   6465  OG  SER C3226       9.910   4.138 -15.797  1.00 13.77           O  
+ATOM   6466  N   ILE C3227      12.525   2.961 -13.127  1.00 18.01           N  
+ATOM   6467  CA  ILE C3227      12.414   2.956 -11.673  1.00 17.88           C  
+ATOM   6468  C   ILE C3227      12.649   4.365 -11.126  1.00 19.11           C  
+ATOM   6469  O   ILE C3227      13.600   5.041 -11.521  1.00 17.27           O  
+ATOM   6470  CB  ILE C3227      13.489   2.043 -11.026  1.00 18.98           C  
+ATOM   6471  CG1 ILE C3227      13.232   0.579 -11.373  1.00 19.08           C  
+ATOM   6472  CG2 ILE C3227      13.513   2.242  -9.505  1.00 16.26           C  
+ATOM   6473  CD1 ILE C3227      14.467  -0.292 -11.173  1.00 22.48           C  
+ATOM   6474  N   TYR C3228      11.782   4.805 -10.219  1.00 17.64           N  
+ATOM   6475  CA  TYR C3228      11.962   6.101  -9.596  1.00 18.31           C  
+ATOM   6476  C   TYR C3228      12.264   5.863  -8.103  1.00 18.49           C  
+ATOM   6477  O   TYR C3228      11.420   5.345  -7.367  1.00 18.23           O  
+ATOM   6478  CB  TYR C3228      10.706   6.956  -9.747  1.00 16.03           C  
+ATOM   6479  CG  TYR C3228      10.865   8.356  -9.187  1.00 17.22           C  
+ATOM   6480  CD1 TYR C3228      11.179   9.432 -10.019  1.00 18.50           C  
+ATOM   6481  CD2 TYR C3228      10.692   8.608  -7.817  1.00 18.22           C  
+ATOM   6482  CE1 TYR C3228      11.311  10.728  -9.506  1.00 18.41           C  
+ATOM   6483  CE2 TYR C3228      10.822   9.890  -7.294  1.00 16.22           C  
+ATOM   6484  CZ  TYR C3228      11.131  10.950  -8.140  1.00 18.11           C  
+ATOM   6485  OH  TYR C3228      11.254  12.224  -7.628  1.00 14.39           O  
+ATOM   6486  N   VAL C3229      13.467   6.220  -7.669  1.00 17.14           N  
+ATOM   6487  CA  VAL C3229      13.843   6.053  -6.269  1.00 19.24           C  
+ATOM   6488  C   VAL C3229      13.310   7.289  -5.554  1.00 20.98           C  
+ATOM   6489  O   VAL C3229      13.643   8.419  -5.916  1.00 22.10           O  
+ATOM   6490  CB  VAL C3229      15.366   5.947  -6.118  1.00 18.40           C  
+ATOM   6491  CG1 VAL C3229      15.727   5.438  -4.725  1.00 15.93           C  
+ATOM   6492  CG2 VAL C3229      15.904   5.007  -7.183  1.00 15.75           C  
+ATOM   6493  N   ASP C3230      12.471   7.064  -4.547  1.00 20.99           N  
+ATOM   6494  CA  ASP C3230      11.813   8.141  -3.820  1.00 19.14           C  
+ATOM   6495  C   ASP C3230      12.149   8.197  -2.334  1.00 20.13           C  
+ATOM   6496  O   ASP C3230      12.363   7.166  -1.704  1.00 18.67           O  
+ATOM   6497  CB  ASP C3230      10.307   7.967  -4.015  1.00 19.64           C  
+ATOM   6498  CG  ASP C3230       9.511   9.209  -3.677  1.00 22.38           C  
+ATOM   6499  OD1 ASP C3230      10.003  10.341  -3.890  1.00 21.18           O  
+ATOM   6500  OD2 ASP C3230       8.367   9.047  -3.218  1.00 24.31           O  
+ATOM   6501  N   ALA C3231      12.185   9.413  -1.783  1.00 21.40           N  
+ATOM   6502  CA  ALA C3231      12.471   9.632  -0.362  1.00 23.12           C  
+ATOM   6503  C   ALA C3231      12.070  11.044   0.062  1.00 24.54           C  
+ATOM   6504  O   ALA C3231      12.015  11.955  -0.760  1.00 25.84           O  
+ATOM   6505  CB  ALA C3231      13.945   9.402  -0.074  1.00 20.82           C  
+ATOM   6506  N   PRO C3232      11.778  11.239   1.358  1.00 26.69           N  
+ATOM   6507  CA  PRO C3232      11.378  12.550   1.895  1.00 27.46           C  
+ATOM   6508  C   PRO C3232      12.505  13.573   1.796  1.00 26.68           C  
+ATOM   6509  O   PRO C3232      13.681  13.214   1.827  1.00 24.71           O  
+ATOM   6510  CB  PRO C3232      11.038  12.244   3.355  1.00 28.60           C  
+ATOM   6511  CG  PRO C3232      10.678  10.785   3.337  1.00 28.07           C  
+ATOM   6512  CD  PRO C3232      11.701  10.203   2.402  1.00 26.90           C  
+ATOM   6513  N   GLU C3233      12.132  14.845   1.697  1.00 26.53           N  
+ATOM   6514  CA  GLU C3233      13.095  15.935   1.601  1.00 27.43           C  
+ATOM   6515  C   GLU C3233      14.076  15.973   2.776  1.00 27.32           C  
+ATOM   6516  O   GLU C3233      15.262  16.241   2.584  1.00 26.35           O  
+ATOM   6517  CB  GLU C3233      12.347  17.268   1.502  1.00 29.21           C  
+ATOM   6518  CG  GLU C3233      13.204  18.490   1.201  1.00 34.35           C  
+ATOM   6519  CD  GLU C3233      14.008  18.975   2.396  1.00 38.09           C  
+ATOM   6520  OE1 GLU C3233      13.468  18.942   3.527  1.00 39.04           O  
+ATOM   6521  OE2 GLU C3233      15.168  19.407   2.198  1.00 37.37           O  
+ATOM   6522  N   ASP C3234      13.589  15.701   3.988  1.00 26.49           N  
+ATOM   6523  CA  ASP C3234      14.452  15.728   5.166  1.00 27.16           C  
+ATOM   6524  C   ASP C3234      15.552  14.668   5.117  1.00 25.27           C  
+ATOM   6525  O   ASP C3234      16.668  14.904   5.575  1.00 26.54           O  
+ATOM   6526  CB  ASP C3234      13.624  15.564   6.449  1.00 30.46           C  
+ATOM   6527  CG  ASP C3234      12.953  14.211   6.543  1.00 33.03           C  
+ATOM   6528  OD1 ASP C3234      12.067  13.927   5.710  1.00 36.28           O  
+ATOM   6529  OD2 ASP C3234      13.318  13.431   7.450  1.00 36.24           O  
+ATOM   6530  N   LEU C3235      15.245  13.500   4.565  1.00 23.98           N  
+ATOM   6531  CA  LEU C3235      16.246  12.442   4.458  1.00 22.31           C  
+ATOM   6532  C   LEU C3235      17.210  12.736   3.311  1.00 21.78           C  
+ATOM   6533  O   LEU C3235      18.412  12.488   3.417  1.00 21.72           O  
+ATOM   6534  CB  LEU C3235      15.572  11.090   4.234  1.00 22.27           C  
+ATOM   6535  CG  LEU C3235      14.831  10.518   5.444  1.00 22.76           C  
+ATOM   6536  CD1 LEU C3235      14.071   9.251   5.060  1.00 21.28           C  
+ATOM   6537  CD2 LEU C3235      15.837  10.226   6.539  1.00 21.62           C  
+ATOM   6538  N   LEU C3236      16.676  13.271   2.215  1.00 21.56           N  
+ATOM   6539  CA  LEU C3236      17.492  13.608   1.053  1.00 21.15           C  
+ATOM   6540  C   LEU C3236      18.553  14.642   1.435  1.00 21.52           C  
+ATOM   6541  O   LEU C3236      19.716  14.534   1.028  1.00 19.32           O  
+ATOM   6542  CB  LEU C3236      16.607  14.155  -0.075  1.00 20.96           C  
+ATOM   6543  CG  LEU C3236      15.666  13.159  -0.779  1.00 20.25           C  
+ATOM   6544  CD1 LEU C3236      14.811  13.890  -1.795  1.00 21.22           C  
+ATOM   6545  CD2 LEU C3236      16.475  12.084  -1.474  1.00 17.69           C  
+ATOM   6546  N   GLN C3237      18.153  15.628   2.234  1.00 20.73           N  
+ATOM   6547  CA  GLN C3237      19.068  16.677   2.672  1.00 23.86           C  
+ATOM   6548  C   GLN C3237      20.220  16.073   3.483  1.00 23.76           C  
+ATOM   6549  O   GLN C3237      21.400  16.362   3.240  1.00 24.10           O  
+ATOM   6550  CB  GLN C3237      18.312  17.721   3.509  1.00 24.00           C  
+ATOM   6551  CG  GLN C3237      19.141  18.934   3.883  1.00 28.14           C  
+ATOM   6552  CD  GLN C3237      18.401  19.911   4.786  1.00 32.81           C  
+ATOM   6553  OE1 GLN C3237      17.330  20.416   4.437  1.00 34.06           O  
+ATOM   6554  NE2 GLN C3237      18.975  20.187   5.952  1.00 34.08           N  
+ATOM   6555  N   THR C3238      19.872  15.228   4.443  1.00 22.64           N  
+ATOM   6556  CA  THR C3238      20.869  14.571   5.280  1.00 22.71           C  
+ATOM   6557  C   THR C3238      21.850  13.744   4.440  1.00 22.50           C  
+ATOM   6558  O   THR C3238      23.071  13.836   4.623  1.00 21.77           O  
+ATOM   6559  CB  THR C3238      20.192  13.638   6.302  1.00 22.10           C  
+ATOM   6560  OG1 THR C3238      19.304  14.404   7.129  1.00 22.94           O  
+ATOM   6561  CG2 THR C3238      21.235  12.953   7.171  1.00 22.66           C  
+ATOM   6562  N   TRP C3239      21.314  12.934   3.528  1.00 20.09           N  
+ATOM   6563  CA  TRP C3239      22.148  12.097   2.674  1.00 19.06           C  
+ATOM   6564  C   TRP C3239      23.058  12.942   1.792  1.00 18.41           C  
+ATOM   6565  O   TRP C3239      24.223  12.611   1.605  1.00 19.09           O  
+ATOM   6566  CB  TRP C3239      21.276  11.179   1.810  1.00 18.35           C  
+ATOM   6567  CG  TRP C3239      20.381  10.298   2.631  1.00 20.18           C  
+ATOM   6568  CD1 TRP C3239      20.507  10.019   3.961  1.00 20.16           C  
+ATOM   6569  CD2 TRP C3239      19.219   9.591   2.182  1.00 20.83           C  
+ATOM   6570  NE1 TRP C3239      19.497   9.189   4.371  1.00 20.78           N  
+ATOM   6571  CE2 TRP C3239      18.689   8.907   3.302  1.00 21.90           C  
+ATOM   6572  CE3 TRP C3239      18.573   9.468   0.947  1.00 19.92           C  
+ATOM   6573  CZ2 TRP C3239      17.541   8.107   3.222  1.00 19.29           C  
+ATOM   6574  CZ3 TRP C3239      17.430   8.674   0.865  1.00 19.49           C  
+ATOM   6575  CH2 TRP C3239      16.927   8.004   2.000  1.00 20.27           C  
+ATOM   6576  N   TYR C3240      22.520  14.038   1.264  1.00 19.41           N  
+ATOM   6577  CA  TYR C3240      23.285  14.943   0.421  1.00 18.17           C  
+ATOM   6578  C   TYR C3240      24.456  15.531   1.209  1.00 18.83           C  
+ATOM   6579  O   TYR C3240      25.606  15.488   0.767  1.00 17.42           O  
+ATOM   6580  CB  TYR C3240      22.409  16.097  -0.082  1.00 18.17           C  
+ATOM   6581  CG  TYR C3240      23.197  17.089  -0.913  1.00 19.30           C  
+ATOM   6582  CD1 TYR C3240      23.520  16.810  -2.242  1.00 18.62           C  
+ATOM   6583  CD2 TYR C3240      23.711  18.255  -0.339  1.00 18.59           C  
+ATOM   6584  CE1 TYR C3240      24.342  17.657  -2.978  1.00 19.80           C  
+ATOM   6585  CE2 TYR C3240      24.537  19.109  -1.065  1.00 20.13           C  
+ATOM   6586  CZ  TYR C3240      24.851  18.801  -2.382  1.00 21.04           C  
+ATOM   6587  OH  TYR C3240      25.690  19.625  -3.090  1.00 20.11           O  
+ATOM   6588  N   ILE C3241      24.151  16.088   2.378  1.00 20.38           N  
+ATOM   6589  CA  ILE C3241      25.170  16.698   3.224  1.00 21.98           C  
+ATOM   6590  C   ILE C3241      26.247  15.695   3.631  1.00 22.21           C  
+ATOM   6591  O   ILE C3241      27.441  15.969   3.488  1.00 20.32           O  
+ATOM   6592  CB  ILE C3241      24.538  17.320   4.489  1.00 23.08           C  
+ATOM   6593  CG1 ILE C3241      23.649  18.497   4.086  1.00 24.23           C  
+ATOM   6594  CG2 ILE C3241      25.629  17.792   5.449  1.00 23.53           C  
+ATOM   6595  CD1 ILE C3241      22.852  19.094   5.228  1.00 25.20           C  
+ATOM   6596  N   ASN C3242      25.833  14.527   4.115  1.00 22.62           N  
+ATOM   6597  CA  ASN C3242      26.815  13.531   4.531  1.00 24.47           C  
+ATOM   6598  C   ASN C3242      27.692  13.084   3.364  1.00 23.67           C  
+ATOM   6599  O   ASN C3242      28.873  12.788   3.550  1.00 23.15           O  
+ATOM   6600  CB  ASN C3242      26.131  12.325   5.187  1.00 26.29           C  
+ATOM   6601  CG  ASN C3242      25.448  12.685   6.502  1.00 28.93           C  
+ATOM   6602  OD1 ASN C3242      25.876  13.597   7.206  1.00 30.95           O  
+ATOM   6603  ND2 ASN C3242      24.394  11.956   6.844  1.00 29.80           N  
+ATOM   6604  N   ARG C3243      27.129  13.037   2.158  1.00 23.59           N  
+ATOM   6605  CA  ARG C3243      27.924  12.645   0.992  1.00 22.27           C  
+ATOM   6606  C   ARG C3243      28.908  13.771   0.696  1.00 21.12           C  
+ATOM   6607  O   ARG C3243      30.056  13.532   0.341  1.00 20.19           O  
+ATOM   6608  CB  ARG C3243      27.033  12.388  -0.231  1.00 23.27           C  
+ATOM   6609  CG  ARG C3243      27.822  11.868  -1.441  1.00 22.60           C  
+ATOM   6610  CD  ARG C3243      26.928  11.618  -2.641  1.00 21.08           C  
+ATOM   6611  NE  ARG C3243      26.322  12.857  -3.122  1.00 20.91           N  
+ATOM   6612  CZ  ARG C3243      25.474  12.936  -4.144  1.00 22.22           C  
+ATOM   6613  NH1 ARG C3243      25.117  11.840  -4.813  1.00 21.40           N  
+ATOM   6614  NH2 ARG C3243      24.978  14.115  -4.491  1.00 20.21           N  
+ATOM   6615  N   PHE C3244      28.443  15.006   0.860  1.00 21.89           N  
+ATOM   6616  CA  PHE C3244      29.273  16.187   0.645  1.00 22.48           C  
+ATOM   6617  C   PHE C3244      30.477  16.141   1.583  1.00 22.96           C  
+ATOM   6618  O   PHE C3244      31.628  16.311   1.156  1.00 24.47           O  
+ATOM   6619  CB  PHE C3244      28.465  17.454   0.930  1.00 23.18           C  
+ATOM   6620  CG  PHE C3244      29.277  18.729   0.871  1.00 25.33           C  
+ATOM   6621  CD1 PHE C3244      29.448  19.405  -0.333  1.00 26.89           C  
+ATOM   6622  CD2 PHE C3244      29.864  19.255   2.023  1.00 24.72           C  
+ATOM   6623  CE1 PHE C3244      30.191  20.590  -0.390  1.00 28.49           C  
+ATOM   6624  CE2 PHE C3244      30.606  20.437   1.975  1.00 25.88           C  
+ATOM   6625  CZ  PHE C3244      30.769  21.106   0.767  1.00 26.21           C  
+ATOM   6626  N   LEU C3245      30.208  15.907   2.862  1.00 22.70           N  
+ATOM   6627  CA  LEU C3245      31.268  15.849   3.862  1.00 24.60           C  
+ATOM   6628  C   LEU C3245      32.311  14.797   3.527  1.00 24.87           C  
+ATOM   6629  O   LEU C3245      33.506  15.048   3.646  1.00 24.89           O  
+ATOM   6630  CB  LEU C3245      30.672  15.590   5.247  1.00 23.43           C  
+ATOM   6631  CG  LEU C3245      29.779  16.735   5.740  1.00 25.04           C  
+ATOM   6632  CD1 LEU C3245      29.257  16.438   7.133  1.00 25.45           C  
+ATOM   6633  CD2 LEU C3245      30.583  18.030   5.744  1.00 26.20           C  
+ATOM   6634  N   LYS C3246      31.857  13.616   3.114  1.00 27.41           N  
+ATOM   6635  CA  LYS C3246      32.766  12.534   2.738  1.00 29.14           C  
+ATOM   6636  C   LYS C3246      33.642  13.023   1.586  1.00 28.08           C  
+ATOM   6637  O   LYS C3246      34.843  12.775   1.557  1.00 28.15           O  
+ATOM   6638  CB  LYS C3246      31.980  11.299   2.288  1.00 31.91           C  
+ATOM   6639  CG  LYS C3246      32.860  10.199   1.689  1.00 39.35           C  
+ATOM   6640  CD  LYS C3246      32.074   9.289   0.729  1.00 43.88           C  
+ATOM   6641  CE  LYS C3246      32.955   8.194   0.111  1.00 45.42           C  
+ATOM   6642  NZ  LYS C3246      33.456   7.204   1.119  1.00 47.17           N  
+ATOM   6643  N   PHE C3247      33.030  13.714   0.629  1.00 28.14           N  
+ATOM   6644  CA  PHE C3247      33.775  14.246  -0.505  1.00 27.96           C  
+ATOM   6645  C   PHE C3247      34.783  15.270   0.004  1.00 26.91           C  
+ATOM   6646  O   PHE C3247      35.916  15.315  -0.468  1.00 27.84           O  
+ATOM   6647  CB  PHE C3247      32.828  14.904  -1.513  1.00 30.58           C  
+ATOM   6648  CG  PHE C3247      32.248  13.949  -2.518  1.00 33.65           C  
+ATOM   6649  CD1 PHE C3247      30.915  14.051  -2.899  1.00 33.81           C  
+ATOM   6650  CD2 PHE C3247      33.045  12.973  -3.116  1.00 36.55           C  
+ATOM   6651  CE1 PHE C3247      30.377  13.200  -3.865  1.00 36.09           C  
+ATOM   6652  CE2 PHE C3247      32.520  12.114  -4.086  1.00 37.95           C  
+ATOM   6653  CZ  PHE C3247      31.180  12.230  -4.461  1.00 37.91           C  
+ATOM   6654  N   ARG C3248      34.368  16.094   0.963  1.00 25.06           N  
+ATOM   6655  CA  ARG C3248      35.269  17.096   1.523  1.00 24.75           C  
+ATOM   6656  C   ARG C3248      36.473  16.413   2.164  1.00 25.38           C  
+ATOM   6657  O   ARG C3248      37.612  16.745   1.839  1.00 24.26           O  
+ATOM   6658  CB  ARG C3248      34.540  17.958   2.558  1.00 24.56           C  
+ATOM   6659  CG  ARG C3248      35.396  19.061   3.175  1.00 21.86           C  
+ATOM   6660  CD  ARG C3248      34.539  20.016   3.988  1.00 19.80           C  
+ATOM   6661  NE  ARG C3248      35.341  20.822   4.903  1.00 25.04           N  
+ATOM   6662  CZ  ARG C3248      35.759  20.404   6.093  1.00 21.40           C  
+ATOM   6663  NH1 ARG C3248      35.449  19.185   6.516  1.00 22.62           N  
+ATOM   6664  NH2 ARG C3248      36.492  21.201   6.858  1.00 22.21           N  
+ATOM   6665  N   GLU C3249      36.225  15.458   3.062  1.00 25.70           N  
+ATOM   6666  CA  GLU C3249      37.321  14.738   3.720  1.00 29.29           C  
+ATOM   6667  C   GLU C3249      38.278  14.124   2.714  1.00 28.50           C  
+ATOM   6668  O   GLU C3249      39.492  14.241   2.851  1.00 31.23           O  
+ATOM   6669  CB  GLU C3249      36.803  13.600   4.600  1.00 30.86           C  
+ATOM   6670  CG  GLU C3249      36.123  14.017   5.876  1.00 37.01           C  
+ATOM   6671  CD  GLU C3249      35.670  12.819   6.690  1.00 40.11           C  
+ATOM   6672  OE1 GLU C3249      36.540  12.005   7.076  1.00 44.89           O  
+ATOM   6673  OE2 GLU C3249      34.451  12.690   6.939  1.00 41.72           O  
+ATOM   6674  N   GLY C3250      37.728  13.450   1.713  1.00 28.81           N  
+ATOM   6675  CA  GLY C3250      38.564  12.815   0.713  1.00 28.87           C  
+ATOM   6676  C   GLY C3250      39.370  13.796  -0.111  1.00 29.89           C  
+ATOM   6677  O   GLY C3250      40.161  13.390  -0.961  1.00 32.42           O  
+ATOM   6678  N   ALA C3251      39.195  15.088   0.145  1.00 28.26           N  
+ATOM   6679  CA  ALA C3251      39.909  16.103  -0.615  1.00 27.82           C  
+ATOM   6680  C   ALA C3251      40.988  16.841   0.174  1.00 27.51           C  
+ATOM   6681  O   ALA C3251      41.758  17.611  -0.404  1.00 26.37           O  
+ATOM   6682  CB  ALA C3251      38.905  17.109  -1.191  1.00 29.14           C  
+ATOM   6683  N   PHE C3252      41.046  16.609   1.484  1.00 26.14           N  
+ATOM   6684  CA  PHE C3252      42.023  17.284   2.339  1.00 26.88           C  
+ATOM   6685  C   PHE C3252      43.442  17.341   1.771  1.00 28.12           C  
+ATOM   6686  O   PHE C3252      44.100  18.368   1.840  1.00 28.48           O  
+ATOM   6687  CB  PHE C3252      42.071  16.621   3.721  1.00 25.38           C  
+ATOM   6688  CG  PHE C3252      40.858  16.898   4.582  1.00 23.75           C  
+ATOM   6689  CD1 PHE C3252      40.612  16.135   5.718  1.00 23.21           C  
+ATOM   6690  CD2 PHE C3252      39.973  17.930   4.269  1.00 22.30           C  
+ATOM   6691  CE1 PHE C3252      39.505  16.392   6.526  1.00 23.07           C  
+ATOM   6692  CE2 PHE C3252      38.865  18.192   5.071  1.00 22.16           C  
+ATOM   6693  CZ  PHE C3252      38.631  17.419   6.204  1.00 19.50           C  
+ATOM   6694  N   THR C3253      43.910  16.244   1.196  1.00 30.72           N  
+ATOM   6695  CA  THR C3253      45.266  16.206   0.668  1.00 32.82           C  
+ATOM   6696  C   THR C3253      45.360  16.131  -0.860  1.00 35.76           C  
+ATOM   6697  O   THR C3253      46.412  15.796  -1.406  1.00 36.79           O  
+ATOM   6698  CB  THR C3253      46.032  15.015   1.284  1.00 30.64           C  
+ATOM   6699  OG1 THR C3253      45.325  13.803   1.007  1.00 32.25           O  
+ATOM   6700  CG2 THR C3253      46.147  15.174   2.791  1.00 27.46           C  
+ATOM   6701  N   ASP C3254      44.271  16.447  -1.555  1.00 38.51           N  
+ATOM   6702  CA  ASP C3254      44.278  16.401  -3.016  1.00 40.82           C  
+ATOM   6703  C   ASP C3254      43.885  17.746  -3.619  1.00 42.34           C  
+ATOM   6704  O   ASP C3254      42.714  17.994  -3.901  1.00 43.03           O  
+ATOM   6705  CB  ASP C3254      43.328  15.302  -3.514  1.00 41.95           C  
+ATOM   6706  CG  ASP C3254      43.360  15.139  -5.030  1.00 42.91           C  
+ATOM   6707  OD1 ASP C3254      44.151  15.846  -5.692  1.00 42.94           O  
+ATOM   6708  OD2 ASP C3254      42.594  14.302  -5.556  1.00 42.23           O  
+ATOM   6709  N   PRO C3255      44.868  18.637  -3.820  1.00 44.21           N  
+ATOM   6710  CA  PRO C3255      44.604  19.960  -4.394  1.00 45.27           C  
+ATOM   6711  C   PRO C3255      44.061  19.903  -5.822  1.00 45.59           C  
+ATOM   6712  O   PRO C3255      43.626  20.917  -6.364  1.00 45.55           O  
+ATOM   6713  CB  PRO C3255      45.966  20.646  -4.314  1.00 46.36           C  
+ATOM   6714  CG  PRO C3255      46.595  20.006  -3.094  1.00 45.64           C  
+ATOM   6715  CD  PRO C3255      46.254  18.551  -3.327  1.00 45.90           C  
+ATOM   6716  N   ASP C3256      44.086  18.720  -6.428  1.00 45.76           N  
+ATOM   6717  CA  ASP C3256      43.571  18.559  -7.786  1.00 45.64           C  
+ATOM   6718  C   ASP C3256      42.055  18.310  -7.785  1.00 44.80           C  
+ATOM   6719  O   ASP C3256      41.420  18.325  -8.841  1.00 45.09           O  
+ATOM   6720  CB  ASP C3256      44.271  17.394  -8.508  1.00 48.06           C  
+ATOM   6721  CG  ASP C3256      45.732  17.688  -8.836  1.00 50.33           C  
+ATOM   6722  OD1 ASP C3256      46.019  18.793  -9.350  1.00 51.64           O  
+ATOM   6723  OD2 ASP C3256      46.586  16.804  -8.594  1.00 50.32           O  
+ATOM   6724  N   SER C3257      41.486  18.079  -6.601  1.00 41.88           N  
+ATOM   6725  CA  SER C3257      40.054  17.819  -6.470  1.00 39.28           C  
+ATOM   6726  C   SER C3257      39.274  19.121  -6.290  1.00 37.48           C  
+ATOM   6727  O   SER C3257      39.754  20.086  -5.684  1.00 38.14           O  
+ATOM   6728  CB  SER C3257      39.789  16.865  -5.286  1.00 39.80           C  
+ATOM   6729  OG  SER C3257      38.439  16.401  -5.229  1.00 37.01           O  
+ATOM   6730  N   TYR C3258      38.074  19.140  -6.854  1.00 35.18           N  
+ATOM   6731  CA  TYR C3258      37.178  20.283  -6.770  1.00 33.00           C  
+ATOM   6732  C   TYR C3258      36.845  20.564  -5.298  1.00 31.63           C  
+ATOM   6733  O   TYR C3258      36.833  21.713  -4.865  1.00 29.36           O  
+ATOM   6734  CB  TYR C3258      35.897  19.960  -7.551  1.00 32.97           C  
+ATOM   6735  CG  TYR C3258      34.786  20.978  -7.435  1.00 31.33           C  
+ATOM   6736  CD1 TYR C3258      34.894  22.225  -8.040  1.00 31.77           C  
+ATOM   6737  CD2 TYR C3258      33.623  20.687  -6.721  1.00 30.26           C  
+ATOM   6738  CE1 TYR C3258      33.865  23.168  -7.937  1.00 33.99           C  
+ATOM   6739  CE2 TYR C3258      32.593  21.614  -6.608  1.00 31.97           C  
+ATOM   6740  CZ  TYR C3258      32.721  22.854  -7.217  1.00 32.82           C  
+ATOM   6741  OH  TYR C3258      31.722  23.794  -7.087  1.00 34.75           O  
+ATOM   6742  N   PHE C3259      36.591  19.504  -4.533  1.00 30.44           N  
+ATOM   6743  CA  PHE C3259      36.235  19.641  -3.122  1.00 29.80           C  
+ATOM   6744  C   PHE C3259      37.330  20.163  -2.214  1.00 29.79           C  
+ATOM   6745  O   PHE C3259      37.079  20.474  -1.047  1.00 28.04           O  
+ATOM   6746  CB  PHE C3259      35.722  18.316  -2.562  1.00 28.92           C  
+ATOM   6747  CG  PHE C3259      34.323  17.998  -2.979  1.00 30.20           C  
+ATOM   6748  CD1 PHE C3259      34.071  17.330  -4.173  1.00 30.46           C  
+ATOM   6749  CD2 PHE C3259      33.244  18.413  -2.197  1.00 29.47           C  
+ATOM   6750  CE1 PHE C3259      32.757  17.083  -4.584  1.00 29.71           C  
+ATOM   6751  CE2 PHE C3259      31.931  18.173  -2.600  1.00 28.27           C  
+ATOM   6752  CZ  PHE C3259      31.689  17.506  -3.794  1.00 26.86           C  
+ATOM   6753  N   HIS C3260      38.545  20.262  -2.732  1.00 30.27           N  
+ATOM   6754  CA  HIS C3260      39.628  20.769  -1.914  1.00 31.83           C  
+ATOM   6755  C   HIS C3260      39.295  22.200  -1.489  1.00 31.75           C  
+ATOM   6756  O   HIS C3260      39.719  22.654  -0.427  1.00 32.12           O  
+ATOM   6757  CB  HIS C3260      40.943  20.754  -2.686  1.00 34.97           C  
+ATOM   6758  CG  HIS C3260      42.124  21.134  -1.853  1.00 38.82           C  
+ATOM   6759  ND1 HIS C3260      42.824  20.221  -1.094  1.00 39.83           N  
+ATOM   6760  CD2 HIS C3260      42.701  22.339  -1.621  1.00 39.59           C  
+ATOM   6761  CE1 HIS C3260      43.782  20.846  -0.431  1.00 41.87           C  
+ATOM   6762  NE2 HIS C3260      43.726  22.132  -0.734  1.00 42.01           N  
+ATOM   6763  N   ASN C3261      38.523  22.905  -2.314  1.00 31.48           N  
+ATOM   6764  CA  ASN C3261      38.133  24.279  -2.008  1.00 31.11           C  
+ATOM   6765  C   ASN C3261      37.334  24.348  -0.705  1.00 31.55           C  
+ATOM   6766  O   ASN C3261      37.352  25.363  -0.004  1.00 30.51           O  
+ATOM   6767  CB  ASN C3261      37.270  24.869  -3.135  1.00 32.93           C  
+ATOM   6768  CG  ASN C3261      38.024  25.019  -4.448  1.00 34.98           C  
+ATOM   6769  OD1 ASN C3261      39.063  25.681  -4.518  1.00 35.25           O  
+ATOM   6770  ND2 ASN C3261      37.491  24.409  -5.502  1.00 35.88           N  
+ATOM   6771  N   TYR C3262      36.617  23.272  -0.394  1.00 30.21           N  
+ATOM   6772  CA  TYR C3262      35.791  23.227   0.809  1.00 29.66           C  
+ATOM   6773  C   TYR C3262      36.543  22.832   2.075  1.00 28.45           C  
+ATOM   6774  O   TYR C3262      35.988  22.879   3.177  1.00 28.06           O  
+ATOM   6775  CB  TYR C3262      34.613  22.271   0.593  1.00 28.76           C  
+ATOM   6776  CG  TYR C3262      33.639  22.747  -0.459  1.00 28.34           C  
+ATOM   6777  CD1 TYR C3262      33.406  22.001  -1.615  1.00 29.90           C  
+ATOM   6778  CD2 TYR C3262      32.939  23.937  -0.294  1.00 28.76           C  
+ATOM   6779  CE1 TYR C3262      32.489  22.433  -2.583  1.00 29.48           C  
+ATOM   6780  CE2 TYR C3262      32.023  24.380  -1.250  1.00 29.18           C  
+ATOM   6781  CZ  TYR C3262      31.803  23.623  -2.390  1.00 30.58           C  
+ATOM   6782  OH  TYR C3262      30.892  24.059  -3.327  1.00 30.64           O  
+ATOM   6783  N   ALA C3263      37.802  22.442   1.923  1.00 27.41           N  
+ATOM   6784  CA  ALA C3263      38.596  22.038   3.073  1.00 27.86           C  
+ATOM   6785  C   ALA C3263      39.087  23.280   3.796  1.00 28.27           C  
+ATOM   6786  O   ALA C3263      39.512  23.211   4.951  1.00 26.50           O  
+ATOM   6787  CB  ALA C3263      39.772  21.192   2.632  1.00 28.55           C  
+ATOM   6788  N   LYS C3264      39.023  24.414   3.102  1.00 27.94           N  
+ATOM   6789  CA  LYS C3264      39.445  25.689   3.666  1.00 27.90           C  
+ATOM   6790  C   LYS C3264      38.406  26.185   4.672  1.00 26.19           C  
+ATOM   6791  O   LYS C3264      38.713  26.991   5.543  1.00 26.43           O  
+ATOM   6792  CB  LYS C3264      39.608  26.724   2.552  1.00 30.63           C  
+ATOM   6793  CG  LYS C3264      40.606  26.319   1.470  1.00 36.03           C  
+ATOM   6794  CD  LYS C3264      40.535  27.250   0.266  1.00 37.79           C  
+ATOM   6795  CE  LYS C3264      41.548  26.864  -0.805  1.00 39.54           C  
+ATOM   6796  NZ  LYS C3264      42.957  27.120  -0.368  1.00 41.14           N  
+ATOM   6797  N   LEU C3265      37.177  25.695   4.544  1.00 24.17           N  
+ATOM   6798  CA  LEU C3265      36.092  26.095   5.433  1.00 23.15           C  
+ATOM   6799  C   LEU C3265      36.066  25.237   6.686  1.00 23.74           C  
+ATOM   6800  O   LEU C3265      36.526  24.093   6.665  1.00 24.09           O  
+ATOM   6801  CB  LEU C3265      34.746  25.946   4.726  1.00 20.43           C  
+ATOM   6802  CG  LEU C3265      34.465  26.679   3.413  1.00 21.42           C  
+ATOM   6803  CD1 LEU C3265      33.064  26.286   2.952  1.00 16.89           C  
+ATOM   6804  CD2 LEU C3265      34.570  28.200   3.590  1.00 17.03           C  
+ATOM   6805  N   THR C3266      35.534  25.782   7.778  1.00 23.24           N  
+ATOM   6806  CA  THR C3266      35.422  24.994   8.995  1.00 24.11           C  
+ATOM   6807  C   THR C3266      34.338  23.971   8.667  1.00 26.01           C  
+ATOM   6808  O   THR C3266      33.558  24.160   7.722  1.00 24.99           O  
+ATOM   6809  CB  THR C3266      34.960  25.829  10.215  1.00 25.28           C  
+ATOM   6810  OG1 THR C3266      33.662  26.381   9.956  1.00 24.95           O  
+ATOM   6811  CG2 THR C3266      35.956  26.947  10.512  1.00 22.14           C  
+ATOM   6812  N   LYS C3267      34.286  22.888   9.432  1.00 25.83           N  
+ATOM   6813  CA  LYS C3267      33.287  21.864   9.183  1.00 26.20           C  
+ATOM   6814  C   LYS C3267      31.904  22.482   9.255  1.00 25.59           C  
+ATOM   6815  O   LYS C3267      31.046  22.191   8.424  1.00 25.65           O  
+ATOM   6816  CB  LYS C3267      33.405  20.738  10.210  1.00 27.07           C  
+ATOM   6817  CG  LYS C3267      32.615  19.496   9.845  1.00 29.04           C  
+ATOM   6818  CD  LYS C3267      32.897  18.372  10.825  1.00 33.94           C  
+ATOM   6819  CE  LYS C3267      32.171  17.105  10.435  1.00 37.07           C  
+ATOM   6820  NZ  LYS C3267      32.447  16.020  11.417  1.00 42.41           N  
+ATOM   6821  N   GLU C3268      31.711  23.349  10.245  1.00 25.55           N  
+ATOM   6822  CA  GLU C3268      30.434  24.014  10.467  1.00 27.92           C  
+ATOM   6823  C   GLU C3268      29.985  24.801   9.241  1.00 26.42           C  
+ATOM   6824  O   GLU C3268      28.850  24.665   8.787  1.00 25.42           O  
+ATOM   6825  CB  GLU C3268      30.523  24.956  11.670  1.00 30.05           C  
+ATOM   6826  CG  GLU C3268      29.182  25.522  12.105  1.00 38.60           C  
+ATOM   6827  CD  GLU C3268      29.304  26.707  13.066  1.00 43.51           C  
+ATOM   6828  OE1 GLU C3268      29.989  26.579  14.105  1.00 45.29           O  
+ATOM   6829  OE2 GLU C3268      28.703  27.770  12.783  1.00 45.86           O  
+ATOM   6830  N   GLU C3269      30.871  25.624   8.700  1.00 25.22           N  
+ATOM   6831  CA  GLU C3269      30.500  26.406   7.535  1.00 24.46           C  
+ATOM   6832  C   GLU C3269      30.307  25.513   6.311  1.00 22.26           C  
+ATOM   6833  O   GLU C3269      29.443  25.779   5.481  1.00 22.51           O  
+ATOM   6834  CB  GLU C3269      31.551  27.478   7.258  1.00 24.66           C  
+ATOM   6835  CG  GLU C3269      31.243  28.317   6.035  1.00 26.66           C  
+ATOM   6836  CD  GLU C3269      31.849  29.707   6.097  1.00 27.93           C  
+ATOM   6837  OE1 GLU C3269      33.076  29.839   6.325  1.00 28.22           O  
+ATOM   6838  OE2 GLU C3269      31.086  30.673   5.911  1.00 26.63           O  
+ATOM   6839  N   ALA C3270      31.097  24.448   6.215  1.00 20.93           N  
+ATOM   6840  CA  ALA C3270      31.009  23.511   5.093  1.00 19.40           C  
+ATOM   6841  C   ALA C3270      29.635  22.849   5.036  1.00 20.27           C  
+ATOM   6842  O   ALA C3270      29.079  22.629   3.959  1.00 18.93           O  
+ATOM   6843  CB  ALA C3270      32.078  22.442   5.232  1.00 17.42           C  
+ATOM   6844  N   ILE C3271      29.097  22.522   6.206  1.00 20.41           N  
+ATOM   6845  CA  ILE C3271      27.799  21.885   6.282  1.00 22.12           C  
+ATOM   6846  C   ILE C3271      26.727  22.874   5.850  1.00 24.04           C  
+ATOM   6847  O   ILE C3271      25.780  22.509   5.154  1.00 23.40           O  
+ATOM   6848  CB  ILE C3271      27.500  21.396   7.718  1.00 21.94           C  
+ATOM   6849  CG1 ILE C3271      28.415  20.217   8.070  1.00 21.09           C  
+ATOM   6850  CG2 ILE C3271      26.032  21.004   7.847  1.00 21.46           C  
+ATOM   6851  CD1 ILE C3271      28.247  19.714   9.510  1.00 18.14           C  
+ATOM   6852  N   LYS C3272      26.879  24.128   6.262  1.00 25.45           N  
+ATOM   6853  CA  LYS C3272      25.909  25.157   5.914  1.00 25.76           C  
+ATOM   6854  C   LYS C3272      25.987  25.424   4.414  1.00 24.03           C  
+ATOM   6855  O   LYS C3272      24.974  25.696   3.766  1.00 22.81           O  
+ATOM   6856  CB  LYS C3272      26.193  26.436   6.712  1.00 30.30           C  
+ATOM   6857  CG  LYS C3272      24.959  27.091   7.333  1.00 34.96           C  
+ATOM   6858  CD  LYS C3272      25.350  28.075   8.436  1.00 38.93           C  
+ATOM   6859  CE  LYS C3272      26.112  27.380   9.574  1.00 42.28           C  
+ATOM   6860  NZ  LYS C3272      26.606  28.337  10.619  1.00 42.87           N  
+ATOM   6861  N   THR C3273      27.195  25.339   3.864  1.00 22.56           N  
+ATOM   6862  CA  THR C3273      27.403  25.559   2.435  1.00 22.47           C  
+ATOM   6863  C   THR C3273      26.685  24.456   1.659  1.00 22.21           C  
+ATOM   6864  O   THR C3273      25.985  24.719   0.675  1.00 24.24           O  
+ATOM   6865  CB  THR C3273      28.908  25.522   2.068  1.00 22.86           C  
+ATOM   6866  OG1 THR C3273      29.629  26.466   2.874  1.00 23.23           O  
+ATOM   6867  CG2 THR C3273      29.099  25.870   0.594  1.00 23.20           C  
+ATOM   6868  N   ALA C3274      26.865  23.220   2.112  1.00 21.44           N  
+ATOM   6869  CA  ALA C3274      26.238  22.070   1.480  1.00 22.24           C  
+ATOM   6870  C   ALA C3274      24.727  22.157   1.587  1.00 22.16           C  
+ATOM   6871  O   ALA C3274      24.004  21.773   0.667  1.00 21.37           O  
+ATOM   6872  CB  ALA C3274      26.730  20.778   2.140  1.00 22.92           C  
+ATOM   6873  N   MET C3275      24.248  22.654   2.721  1.00 22.19           N  
+ATOM   6874  CA  MET C3275      22.815  22.771   2.934  1.00 23.48           C  
+ATOM   6875  C   MET C3275      22.205  23.769   1.951  1.00 22.92           C  
+ATOM   6876  O   MET C3275      21.089  23.580   1.467  1.00 21.47           O  
+ATOM   6877  CB  MET C3275      22.535  23.211   4.368  1.00 25.45           C  
+ATOM   6878  CG  MET C3275      21.075  23.111   4.744  1.00 31.61           C  
+ATOM   6879  SD  MET C3275      20.769  23.641   6.440  1.00 38.02           S  
+ATOM   6880  CE  MET C3275      21.915  22.569   7.344  1.00 30.40           C  
+ATOM   6881  N   THR C3276      22.954  24.830   1.665  1.00 22.18           N  
+ATOM   6882  CA  THR C3276      22.524  25.863   0.734  1.00 22.97           C  
+ATOM   6883  C   THR C3276      22.524  25.301  -0.693  1.00 22.36           C  
+ATOM   6884  O   THR C3276      21.613  25.565  -1.473  1.00 22.60           O  
+ATOM   6885  CB  THR C3276      23.448  27.094   0.829  1.00 23.26           C  
+ATOM   6886  OG1 THR C3276      23.396  27.613   2.163  1.00 25.38           O  
+ATOM   6887  CG2 THR C3276      23.002  28.182  -0.138  1.00 22.06           C  
+ATOM   6888  N   LEU C3277      23.535  24.512  -1.031  1.00 21.83           N  
+ATOM   6889  CA  LEU C3277      23.580  23.911  -2.359  1.00 22.19           C  
+ATOM   6890  C   LEU C3277      22.326  23.054  -2.497  1.00 22.22           C  
+ATOM   6891  O   LEU C3277      21.671  23.045  -3.543  1.00 20.07           O  
+ATOM   6892  CB  LEU C3277      24.830  23.036  -2.519  1.00 21.13           C  
+ATOM   6893  CG  LEU C3277      26.172  23.776  -2.601  1.00 24.00           C  
+ATOM   6894  CD1 LEU C3277      27.338  22.791  -2.588  1.00 22.65           C  
+ATOM   6895  CD2 LEU C3277      26.203  24.604  -3.867  1.00 22.10           C  
+ATOM   6896  N   TRP C3278      21.984  22.356  -1.415  1.00 22.27           N  
+ATOM   6897  CA  TRP C3278      20.817  21.489  -1.410  1.00 23.73           C  
+ATOM   6898  C   TRP C3278      19.498  22.221  -1.596  1.00 25.46           C  
+ATOM   6899  O   TRP C3278      18.717  21.885  -2.490  1.00 26.03           O  
+ATOM   6900  CB  TRP C3278      20.739  20.656  -0.121  1.00 22.03           C  
+ATOM   6901  CG  TRP C3278      19.438  19.926  -0.040  1.00 22.67           C  
+ATOM   6902  CD1 TRP C3278      18.343  20.276   0.704  1.00 22.82           C  
+ATOM   6903  CD2 TRP C3278      19.018  18.841  -0.880  1.00 21.78           C  
+ATOM   6904  NE1 TRP C3278      17.265  19.490   0.367  1.00 21.14           N  
+ATOM   6905  CE2 TRP C3278      17.649  18.603  -0.604  1.00 21.97           C  
+ATOM   6906  CE3 TRP C3278      19.661  18.056  -1.847  1.00 21.22           C  
+ATOM   6907  CZ2 TRP C3278      16.909  17.609  -1.264  1.00 21.28           C  
+ATOM   6908  CZ3 TRP C3278      18.922  17.062  -2.508  1.00 20.54           C  
+ATOM   6909  CH2 TRP C3278      17.559  16.854  -2.211  1.00 22.01           C  
+ATOM   6910  N   LYS C3279      19.246  23.214  -0.751  1.00 26.65           N  
+ATOM   6911  CA  LYS C3279      17.996  23.964  -0.817  1.00 27.76           C  
+ATOM   6912  C   LYS C3279      17.811  24.845  -2.049  1.00 26.51           C  
+ATOM   6913  O   LYS C3279      16.740  24.857  -2.647  1.00 27.68           O  
+ATOM   6914  CB  LYS C3279      17.827  24.821   0.445  1.00 29.69           C  
+ATOM   6915  CG  LYS C3279      17.543  24.020   1.705  1.00 35.78           C  
+ATOM   6916  CD  LYS C3279      17.459  24.918   2.938  1.00 39.85           C  
+ATOM   6917  CE  LYS C3279      17.178  24.105   4.198  1.00 42.89           C  
+ATOM   6918  NZ  LYS C3279      17.087  24.967   5.416  1.00 44.70           N  
+ATOM   6919  N   GLU C3280      18.842  25.579  -2.441  1.00 25.36           N  
+ATOM   6920  CA  GLU C3280      18.704  26.475  -3.586  1.00 26.39           C  
+ATOM   6921  C   GLU C3280      18.849  25.830  -4.965  1.00 24.98           C  
+ATOM   6922  O   GLU C3280      18.321  26.342  -5.952  1.00 24.94           O  
+ATOM   6923  CB  GLU C3280      19.700  27.632  -3.445  1.00 27.10           C  
+ATOM   6924  CG  GLU C3280      19.483  28.446  -2.172  1.00 31.08           C  
+ATOM   6925  CD  GLU C3280      20.493  29.569  -1.998  1.00 33.49           C  
+ATOM   6926  OE1 GLU C3280      20.329  30.358  -1.042  1.00 33.70           O  
+ATOM   6927  OE2 GLU C3280      21.446  29.660  -2.811  1.00 33.78           O  
+ATOM   6928  N   ILE C3281      19.552  24.709  -5.043  1.00 23.21           N  
+ATOM   6929  CA  ILE C3281      19.741  24.082  -6.337  1.00 22.26           C  
+ATOM   6930  C   ILE C3281      19.081  22.721  -6.502  1.00 21.66           C  
+ATOM   6931  O   ILE C3281      18.150  22.582  -7.287  1.00 21.91           O  
+ATOM   6932  CB  ILE C3281      21.245  23.948  -6.674  1.00 21.57           C  
+ATOM   6933  CG1 ILE C3281      21.921  25.323  -6.607  1.00 21.33           C  
+ATOM   6934  CG2 ILE C3281      21.410  23.350  -8.071  1.00 17.60           C  
+ATOM   6935  CD1 ILE C3281      23.423  25.284  -6.849  1.00 22.92           C  
+ATOM   6936  N   ASN C3282      19.552  21.724  -5.761  1.00 21.95           N  
+ATOM   6937  CA  ASN C3282      19.007  20.377  -5.892  1.00 22.85           C  
+ATOM   6938  C   ASN C3282      17.564  20.174  -5.473  1.00 24.08           C  
+ATOM   6939  O   ASN C3282      16.816  19.470  -6.156  1.00 24.30           O  
+ATOM   6940  CB  ASN C3282      19.889  19.377  -5.155  1.00 22.09           C  
+ATOM   6941  CG  ASN C3282      21.278  19.310  -5.736  1.00 23.71           C  
+ATOM   6942  OD1 ASN C3282      21.446  19.250  -6.954  1.00 22.06           O  
+ATOM   6943  ND2 ASN C3282      22.282  19.319  -4.873  1.00 22.50           N  
+ATOM   6944  N   TRP C3283      17.171  20.775  -4.355  1.00 24.27           N  
+ATOM   6945  CA  TRP C3283      15.807  20.628  -3.878  1.00 23.06           C  
+ATOM   6946  C   TRP C3283      14.838  21.373  -4.793  1.00 24.08           C  
+ATOM   6947  O   TRP C3283      13.729  20.905  -5.062  1.00 22.77           O  
+ATOM   6948  CB  TRP C3283      15.689  21.154  -2.454  1.00 24.76           C  
+ATOM   6949  CG  TRP C3283      14.321  21.014  -1.891  1.00 30.14           C  
+ATOM   6950  CD1 TRP C3283      13.475  19.945  -2.032  1.00 30.21           C  
+ATOM   6951  CD2 TRP C3283      13.632  21.964  -1.077  1.00 32.53           C  
+ATOM   6952  NE1 TRP C3283      12.303  20.177  -1.356  1.00 33.44           N  
+ATOM   6953  CE2 TRP C3283      12.373  21.409  -0.760  1.00 34.43           C  
+ATOM   6954  CE3 TRP C3283      13.959  23.233  -0.581  1.00 34.90           C  
+ATOM   6955  CZ2 TRP C3283      11.436  22.078   0.030  1.00 37.69           C  
+ATOM   6956  CZ3 TRP C3283      13.027  23.903   0.208  1.00 38.73           C  
+ATOM   6957  CH2 TRP C3283      11.777  23.321   0.505  1.00 39.27           C  
+ATOM   6958  N   LEU C3284      15.258  22.538  -5.267  1.00 23.55           N  
+ATOM   6959  CA  LEU C3284      14.423  23.323  -6.164  1.00 24.89           C  
+ATOM   6960  C   LEU C3284      14.226  22.508  -7.440  1.00 22.79           C  
+ATOM   6961  O   LEU C3284      13.132  22.449  -7.994  1.00 21.75           O  
+ATOM   6962  CB  LEU C3284      15.104  24.648  -6.501  1.00 27.49           C  
+ATOM   6963  CG  LEU C3284      14.251  25.648  -7.277  1.00 31.62           C  
+ATOM   6964  CD1 LEU C3284      13.104  26.122  -6.381  1.00 33.24           C  
+ATOM   6965  CD2 LEU C3284      15.108  26.828  -7.720  1.00 32.82           C  
+ATOM   6966  N   ASN C3285      15.300  21.867  -7.888  1.00 21.41           N  
+ATOM   6967  CA  ASN C3285      15.259  21.046  -9.093  1.00 21.41           C  
+ATOM   6968  C   ASN C3285      14.308  19.872  -8.874  1.00 20.39           C  
+ATOM   6969  O   ASN C3285      13.561  19.495  -9.769  1.00 17.75           O  
+ATOM   6970  CB  ASN C3285      16.665  20.530  -9.434  1.00 19.96           C  
+ATOM   6971  CG  ASN C3285      16.725  19.838 -10.788  1.00 20.97           C  
+ATOM   6972  OD1 ASN C3285      15.815  19.971 -11.608  1.00 20.89           O  
+ATOM   6973  ND2 ASN C3285      17.807  19.108 -11.034  1.00 20.14           N  
+ATOM   6974  N   LEU C3286      14.330  19.311  -7.669  1.00 20.60           N  
+ATOM   6975  CA  LEU C3286      13.463  18.190  -7.345  1.00 21.12           C  
+ATOM   6976  C   LEU C3286      11.995  18.581  -7.469  1.00 20.93           C  
+ATOM   6977  O   LEU C3286      11.213  17.900  -8.131  1.00 21.75           O  
+ATOM   6978  CB  LEU C3286      13.747  17.685  -5.924  1.00 21.01           C  
+ATOM   6979  CG  LEU C3286      12.772  16.639  -5.365  1.00 21.01           C  
+ATOM   6980  CD1 LEU C3286      12.766  15.405  -6.259  1.00 21.68           C  
+ATOM   6981  CD2 LEU C3286      13.176  16.265  -3.951  1.00 21.19           C  
+ATOM   6982  N   LYS C3287      11.628  19.685  -6.835  1.00 22.80           N  
+ATOM   6983  CA  LYS C3287      10.249  20.171  -6.860  1.00 24.30           C  
+ATOM   6984  C   LYS C3287       9.748  20.621  -8.234  1.00 24.16           C  
+ATOM   6985  O   LYS C3287       8.629  20.297  -8.626  1.00 24.41           O  
+ATOM   6986  CB  LYS C3287      10.093  21.326  -5.868  1.00 24.37           C  
+ATOM   6987  CG  LYS C3287      10.094  20.890  -4.416  1.00 26.71           C  
+ATOM   6988  CD  LYS C3287      10.762  21.918  -3.523  1.00 31.33           C  
+ATOM   6989  CE  LYS C3287      10.023  23.237  -3.501  1.00 34.36           C  
+ATOM   6990  NZ  LYS C3287      10.799  24.263  -2.739  1.00 35.53           N  
+ATOM   6991  N   GLN C3288      10.568  21.364  -8.966  1.00 23.93           N  
+ATOM   6992  CA  GLN C3288      10.135  21.859 -10.265  1.00 25.07           C  
+ATOM   6993  C   GLN C3288      10.273  20.907 -11.441  1.00 24.13           C  
+ATOM   6994  O   GLN C3288       9.462  20.965 -12.365  1.00 24.57           O  
+ATOM   6995  CB  GLN C3288      10.880  23.143 -10.631  1.00 26.16           C  
+ATOM   6996  CG  GLN C3288      10.856  24.225  -9.585  1.00 29.68           C  
+ATOM   6997  CD  GLN C3288      11.559  25.481 -10.062  1.00 31.96           C  
+ATOM   6998  OE1 GLN C3288      12.550  25.411 -10.792  1.00 30.05           O  
+ATOM   6999  NE2 GLN C3288      11.056  26.638  -9.644  1.00 32.67           N  
+ATOM   7000  N   ASN C3289      11.277  20.031 -11.412  1.00 22.50           N  
+ATOM   7001  CA  ASN C3289      11.518  19.150 -12.557  1.00 22.06           C  
+ATOM   7002  C   ASN C3289      11.577  17.643 -12.371  1.00 21.47           C  
+ATOM   7003  O   ASN C3289      11.253  16.895 -13.292  1.00 22.45           O  
+ATOM   7004  CB  ASN C3289      12.818  19.569 -13.238  1.00 19.95           C  
+ATOM   7005  CG  ASN C3289      12.895  21.059 -13.471  1.00 21.48           C  
+ATOM   7006  OD1 ASN C3289      12.041  21.628 -14.146  1.00 18.84           O  
+ATOM   7007  ND2 ASN C3289      13.921  21.703 -12.909  1.00 19.00           N  
+ATOM   7008  N   ILE C3290      12.015  17.192 -11.204  1.00 18.82           N  
+ATOM   7009  CA  ILE C3290      12.163  15.767 -10.982  1.00 17.58           C  
+ATOM   7010  C   ILE C3290      10.940  15.068 -10.407  1.00 16.87           C  
+ATOM   7011  O   ILE C3290      10.416  14.136 -11.017  1.00 15.42           O  
+ATOM   7012  CB  ILE C3290      13.400  15.489 -10.085  1.00 17.04           C  
+ATOM   7013  CG1 ILE C3290      14.636  16.183 -10.676  1.00 16.51           C  
+ATOM   7014  CG2 ILE C3290      13.645  13.997  -9.993  1.00 14.34           C  
+ATOM   7015  CD1 ILE C3290      15.885  16.119  -9.802  1.00 14.85           C  
+ATOM   7016  N   LEU C3291      10.477  15.521  -9.245  1.00 16.89           N  
+ATOM   7017  CA  LEU C3291       9.327  14.900  -8.597  1.00 15.50           C  
+ATOM   7018  C   LEU C3291       8.083  14.756  -9.481  1.00 15.81           C  
+ATOM   7019  O   LEU C3291       7.372  13.755  -9.403  1.00 15.98           O  
+ATOM   7020  CB  LEU C3291       8.984  15.667  -7.320  1.00 14.33           C  
+ATOM   7021  CG  LEU C3291       7.930  15.044  -6.408  1.00 16.53           C  
+ATOM   7022  CD1 LEU C3291       8.278  13.593  -6.101  1.00 15.71           C  
+ATOM   7023  CD2 LEU C3291       7.840  15.863  -5.126  1.00 17.22           C  
+ATOM   7024  N   PRO C3292       7.803  15.747 -10.339  1.00 16.22           N  
+ATOM   7025  CA  PRO C3292       6.620  15.650 -11.205  1.00 16.39           C  
+ATOM   7026  C   PRO C3292       6.635  14.489 -12.206  1.00 16.93           C  
+ATOM   7027  O   PRO C3292       5.588  14.107 -12.729  1.00 16.76           O  
+ATOM   7028  CB  PRO C3292       6.591  17.006 -11.910  1.00 15.61           C  
+ATOM   7029  CG  PRO C3292       7.206  17.920 -10.898  1.00 17.03           C  
+ATOM   7030  CD  PRO C3292       8.372  17.104 -10.384  1.00 16.59           C  
+ATOM   7031  N   THR C3293       7.816  13.933 -12.471  1.00 17.19           N  
+ATOM   7032  CA  THR C3293       7.940  12.830 -13.421  1.00 16.76           C  
+ATOM   7033  C   THR C3293       7.783  11.467 -12.767  1.00 18.68           C  
+ATOM   7034  O   THR C3293       7.767  10.443 -13.457  1.00 18.26           O  
+ATOM   7035  CB  THR C3293       9.321  12.825 -14.129  1.00 16.88           C  
+ATOM   7036  OG1 THR C3293      10.337  12.453 -13.190  1.00 16.48           O  
+ATOM   7037  CG2 THR C3293       9.647  14.196 -14.712  1.00 14.54           C  
+ATOM   7038  N   ARG C3294       7.663  11.450 -11.443  1.00 18.65           N  
+ATOM   7039  CA  ARG C3294       7.551  10.198 -10.703  1.00 18.20           C  
+ATOM   7040  C   ARG C3294       6.479   9.216 -11.164  1.00 17.18           C  
+ATOM   7041  O   ARG C3294       6.739   8.012 -11.242  1.00 15.70           O  
+ATOM   7042  CB  ARG C3294       7.352  10.475  -9.203  1.00 18.96           C  
+ATOM   7043  CG  ARG C3294       7.355   9.211  -8.350  1.00 22.35           C  
+ATOM   7044  CD  ARG C3294       7.215   9.526  -6.871  1.00 24.32           C  
+ATOM   7045  NE  ARG C3294       5.950  10.189  -6.586  1.00 26.86           N  
+ATOM   7046  CZ  ARG C3294       5.581  10.614  -5.382  1.00 29.67           C  
+ATOM   7047  NH1 ARG C3294       6.382  10.449  -4.341  1.00 26.70           N  
+ATOM   7048  NH2 ARG C3294       4.403  11.202  -5.220  1.00 31.38           N  
+ATOM   7049  N   GLU C3295       5.275   9.708 -11.456  1.00 16.10           N  
+ATOM   7050  CA  GLU C3295       4.198   8.817 -11.876  1.00 17.24           C  
+ATOM   7051  C   GLU C3295       4.351   8.244 -13.281  1.00 17.10           C  
+ATOM   7052  O   GLU C3295       3.485   7.513 -13.756  1.00 14.14           O  
+ATOM   7053  CB  GLU C3295       2.843   9.513 -11.734  1.00 21.19           C  
+ATOM   7054  CG  GLU C3295       2.363   9.581 -10.286  1.00 24.80           C  
+ATOM   7055  CD  GLU C3295       3.287  10.404  -9.408  1.00 26.15           C  
+ATOM   7056  OE1 GLU C3295       3.459  10.050  -8.227  1.00 30.38           O  
+ATOM   7057  OE2 GLU C3295       3.833  11.411  -9.894  1.00 29.68           O  
+ATOM   7058  N   ARG C3296       5.456   8.570 -13.946  1.00 17.27           N  
+ATOM   7059  CA  ARG C3296       5.703   8.026 -15.276  1.00 18.95           C  
+ATOM   7060  C   ARG C3296       6.567   6.766 -15.165  1.00 19.17           C  
+ATOM   7061  O   ARG C3296       6.806   6.083 -16.155  1.00 19.16           O  
+ATOM   7062  CB  ARG C3296       6.416   9.042 -16.169  1.00 17.97           C  
+ATOM   7063  CG  ARG C3296       5.609  10.298 -16.487  1.00 17.08           C  
+ATOM   7064  CD  ARG C3296       6.160  10.959 -17.746  1.00 17.66           C  
+ATOM   7065  NE  ARG C3296       5.954  10.106 -18.916  1.00 15.18           N  
+ATOM   7066  CZ  ARG C3296       6.871   9.874 -19.848  1.00 17.08           C  
+ATOM   7067  NH1 ARG C3296       8.069  10.438 -19.755  1.00 17.85           N  
+ATOM   7068  NH2 ARG C3296       6.598   9.062 -20.863  1.00 17.01           N  
+ATOM   7069  N   ALA C3297       7.026   6.454 -13.955  1.00 18.06           N  
+ATOM   7070  CA  ALA C3297       7.881   5.282 -13.754  1.00 17.90           C  
+ATOM   7071  C   ALA C3297       7.130   3.962 -13.711  1.00 18.42           C  
+ATOM   7072  O   ALA C3297       5.964   3.909 -13.322  1.00 20.36           O  
+ATOM   7073  CB  ALA C3297       8.702   5.443 -12.479  1.00 15.59           C  
+ATOM   7074  N   SER C3298       7.806   2.897 -14.134  1.00 18.23           N  
+ATOM   7075  CA  SER C3298       7.216   1.566 -14.115  1.00 16.90           C  
+ATOM   7076  C   SER C3298       7.140   1.132 -12.662  1.00 16.59           C  
+ATOM   7077  O   SER C3298       6.185   0.486 -12.251  1.00 17.29           O  
+ATOM   7078  CB  SER C3298       8.090   0.567 -14.871  1.00 14.74           C  
+ATOM   7079  OG  SER C3298       8.339   0.987 -16.192  1.00 19.72           O  
+ATOM   7080  N   LEU C3299       8.158   1.505 -11.890  1.00 16.89           N  
+ATOM   7081  CA  LEU C3299       8.238   1.129 -10.487  1.00 17.04           C  
+ATOM   7082  C   LEU C3299       8.800   2.238  -9.615  1.00 18.45           C  
+ATOM   7083  O   LEU C3299       9.787   2.884  -9.969  1.00 19.29           O  
+ATOM   7084  CB  LEU C3299       9.103  -0.124 -10.340  1.00 14.80           C  
+ATOM   7085  CG  LEU C3299       9.391  -0.678  -8.941  1.00 16.07           C  
+ATOM   7086  CD1 LEU C3299       9.622  -2.179  -9.028  1.00 13.08           C  
+ATOM   7087  CD2 LEU C3299      10.592   0.029  -8.328  1.00 11.91           C  
+ATOM   7088  N   ILE C3300       8.159   2.452  -8.471  1.00 18.59           N  
+ATOM   7089  CA  ILE C3300       8.595   3.462  -7.519  1.00 18.17           C  
+ATOM   7090  C   ILE C3300       9.148   2.760  -6.286  1.00 18.67           C  
+ATOM   7091  O   ILE C3300       8.439   1.996  -5.619  1.00 19.33           O  
+ATOM   7092  CB  ILE C3300       7.435   4.375  -7.092  1.00 18.41           C  
+ATOM   7093  CG1 ILE C3300       6.820   5.040  -8.317  1.00 17.19           C  
+ATOM   7094  CG2 ILE C3300       7.939   5.432  -6.129  1.00 18.11           C  
+ATOM   7095  CD1 ILE C3300       5.555   5.818  -8.021  1.00 20.13           C  
+ATOM   7096  N   LEU C3301      10.424   3.007  -6.013  1.00 17.69           N  
+ATOM   7097  CA  LEU C3301      11.122   2.429  -4.870  1.00 18.68           C  
+ATOM   7098  C   LEU C3301      11.252   3.515  -3.786  1.00 20.28           C  
+ATOM   7099  O   LEU C3301      12.093   4.417  -3.903  1.00 20.79           O  
+ATOM   7100  CB  LEU C3301      12.514   1.958  -5.305  1.00 17.18           C  
+ATOM   7101  CG  LEU C3301      13.297   1.092  -4.309  1.00 17.71           C  
+ATOM   7102  CD1 LEU C3301      12.594  -0.242  -4.154  1.00 15.95           C  
+ATOM   7103  CD2 LEU C3301      14.715   0.889  -4.788  1.00 17.24           C  
+ATOM   7104  N   THR C3302      10.413   3.435  -2.750  1.00 21.19           N  
+ATOM   7105  CA  THR C3302      10.420   4.415  -1.659  1.00 20.90           C  
+ATOM   7106  C   THR C3302      11.325   4.027  -0.488  1.00 22.10           C  
+ATOM   7107  O   THR C3302      11.217   2.928   0.064  1.00 22.44           O  
+ATOM   7108  CB  THR C3302       8.994   4.658  -1.129  1.00 21.74           C  
+ATOM   7109  OG1 THR C3302       8.157   5.084  -2.209  1.00 21.01           O  
+ATOM   7110  CG2 THR C3302       8.994   5.747  -0.051  1.00 21.19           C  
+ATOM   7111  N   LYS C3303      12.211   4.947  -0.114  1.00 21.16           N  
+ATOM   7112  CA  LYS C3303      13.164   4.733   0.972  1.00 21.66           C  
+ATOM   7113  C   LYS C3303      12.844   5.569   2.222  1.00 21.17           C  
+ATOM   7114  O   LYS C3303      12.112   6.551   2.157  1.00 20.20           O  
+ATOM   7115  CB  LYS C3303      14.574   5.081   0.486  1.00 20.74           C  
+ATOM   7116  CG  LYS C3303      15.012   4.277  -0.725  1.00 21.46           C  
+ATOM   7117  CD  LYS C3303      16.303   4.799  -1.321  1.00 18.53           C  
+ATOM   7118  CE  LYS C3303      17.486   4.497  -0.448  1.00 19.70           C  
+ATOM   7119  NZ  LYS C3303      18.746   4.931  -1.109  1.00 23.17           N  
+ATOM   7120  N   SER C3304      13.389   5.166   3.363  1.00 23.01           N  
+ATOM   7121  CA  SER C3304      13.178   5.914   4.606  1.00 24.89           C  
+ATOM   7122  C   SER C3304      14.520   5.977   5.317  1.00 25.02           C  
+ATOM   7123  O   SER C3304      15.564   5.761   4.687  1.00 24.18           O  
+ATOM   7124  CB  SER C3304      12.128   5.228   5.494  1.00 26.00           C  
+ATOM   7125  OG  SER C3304      12.493   3.885   5.774  1.00 29.18           O  
+ATOM   7126  N   ALA C3305      14.498   6.256   6.619  1.00 23.91           N  
+ATOM   7127  CA  ALA C3305      15.728   6.354   7.402  1.00 23.34           C  
+ATOM   7128  C   ALA C3305      16.718   5.215   7.150  1.00 23.80           C  
+ATOM   7129  O   ALA C3305      16.348   4.045   7.042  1.00 24.32           O  
+ATOM   7130  CB  ALA C3305      15.392   6.439   8.889  1.00 22.55           C  
+ATOM   7131  N   ASN C3306      17.993   5.580   7.077  1.00 24.90           N  
+ATOM   7132  CA  ASN C3306      19.075   4.633   6.833  1.00 25.64           C  
+ATOM   7133  C   ASN C3306      18.967   3.959   5.477  1.00 25.18           C  
+ATOM   7134  O   ASN C3306      19.546   2.894   5.269  1.00 22.44           O  
+ATOM   7135  CB  ASN C3306      19.116   3.570   7.922  1.00 30.03           C  
+ATOM   7136  CG  ASN C3306      19.214   4.173   9.305  1.00 33.73           C  
+ATOM   7137  OD1 ASN C3306      20.148   4.925   9.602  1.00 33.32           O  
+ATOM   7138  ND2 ASN C3306      18.243   3.856  10.158  1.00 31.11           N  
+ATOM   7139  N   HIS C3307      18.211   4.578   4.572  1.00 23.60           N  
+ATOM   7140  CA  HIS C3307      18.049   4.072   3.214  1.00 25.34           C  
+ATOM   7141  C   HIS C3307      17.236   2.793   3.091  1.00 24.73           C  
+ATOM   7142  O   HIS C3307      17.212   2.170   2.030  1.00 25.24           O  
+ATOM   7143  CB  HIS C3307      19.424   3.857   2.577  1.00 23.92           C  
+ATOM   7144  CG  HIS C3307      20.166   5.125   2.318  1.00 25.63           C  
+ATOM   7145  ND1 HIS C3307      19.940   5.905   1.208  1.00 27.03           N  
+ATOM   7146  CD2 HIS C3307      21.114   5.772   3.043  1.00 26.59           C  
+ATOM   7147  CE1 HIS C3307      20.711   6.976   1.256  1.00 27.04           C  
+ATOM   7148  NE2 HIS C3307      21.434   6.917   2.361  1.00 25.92           N  
+ATOM   7149  N   ALA C3308      16.561   2.408   4.164  1.00 23.63           N  
+ATOM   7150  CA  ALA C3308      15.750   1.199   4.141  1.00 22.22           C  
+ATOM   7151  C   ALA C3308      14.540   1.416   3.256  1.00 20.71           C  
+ATOM   7152  O   ALA C3308      13.869   2.439   3.357  1.00 21.76           O  
+ATOM   7153  CB  ALA C3308      15.301   0.837   5.556  1.00 21.10           C  
+ATOM   7154  N   VAL C3309      14.268   0.460   2.375  1.00 21.84           N  
+ATOM   7155  CA  VAL C3309      13.112   0.562   1.497  1.00 21.69           C  
+ATOM   7156  C   VAL C3309      11.886   0.203   2.325  1.00 22.53           C  
+ATOM   7157  O   VAL C3309      11.893  -0.796   3.036  1.00 23.22           O  
+ATOM   7158  CB  VAL C3309      13.227  -0.408   0.308  1.00 21.47           C  
+ATOM   7159  CG1 VAL C3309      11.901  -0.474  -0.440  1.00 19.65           C  
+ATOM   7160  CG2 VAL C3309      14.351   0.048  -0.626  1.00 18.91           C  
+ATOM   7161  N   GLU C3310      10.840   1.018   2.239  1.00 24.87           N  
+ATOM   7162  CA  GLU C3310       9.627   0.760   3.004  1.00 27.50           C  
+ATOM   7163  C   GLU C3310       8.426   0.465   2.128  1.00 26.78           C  
+ATOM   7164  O   GLU C3310       7.416  -0.051   2.602  1.00 26.52           O  
+ATOM   7165  CB  GLU C3310       9.294   1.943   3.920  1.00 30.70           C  
+ATOM   7166  CG  GLU C3310       8.992   3.251   3.206  1.00 36.19           C  
+ATOM   7167  CD  GLU C3310       8.319   4.276   4.119  1.00 38.84           C  
+ATOM   7168  OE1 GLU C3310       8.774   4.456   5.270  1.00 41.44           O  
+ATOM   7169  OE2 GLU C3310       7.338   4.911   3.682  1.00 41.42           O  
+ATOM   7170  N   GLU C3311       8.532   0.795   0.848  1.00 25.74           N  
+ATOM   7171  CA  GLU C3311       7.430   0.556  -0.068  1.00 25.77           C  
+ATOM   7172  C   GLU C3311       7.897   0.359  -1.511  1.00 25.67           C  
+ATOM   7173  O   GLU C3311       8.894   0.944  -1.946  1.00 23.08           O  
+ATOM   7174  CB  GLU C3311       6.443   1.723  -0.011  1.00 26.37           C  
+ATOM   7175  CG  GLU C3311       5.256   1.567  -0.942  1.00 30.50           C  
+ATOM   7176  CD  GLU C3311       4.284   2.721  -0.860  1.00 33.33           C  
+ATOM   7177  OE1 GLU C3311       4.667   3.861  -1.196  1.00 36.67           O  
+ATOM   7178  OE2 GLU C3311       3.128   2.491  -0.457  1.00 36.99           O  
+ATOM   7179  N   VAL C3312       7.174  -0.484  -2.238  1.00 22.57           N  
+ATOM   7180  CA  VAL C3312       7.477  -0.732  -3.631  1.00 22.57           C  
+ATOM   7181  C   VAL C3312       6.173  -0.706  -4.403  1.00 23.40           C  
+ATOM   7182  O   VAL C3312       5.234  -1.437  -4.071  1.00 25.39           O  
+ATOM   7183  CB  VAL C3312       8.147  -2.101  -3.861  1.00 22.17           C  
+ATOM   7184  CG1 VAL C3312       8.500  -2.249  -5.334  1.00 21.90           C  
+ATOM   7185  CG2 VAL C3312       9.404  -2.227  -3.025  1.00 20.10           C  
+ATOM   7186  N   ARG C3313       6.106   0.158  -5.413  1.00 21.76           N  
+ATOM   7187  CA  ARG C3313       4.919   0.263  -6.249  1.00 19.42           C  
+ATOM   7188  C   ARG C3313       5.263  -0.064  -7.693  1.00 19.56           C  
+ATOM   7189  O   ARG C3313       6.201   0.506  -8.268  1.00 18.80           O  
+ATOM   7190  CB  ARG C3313       4.314   1.657  -6.138  1.00 20.14           C  
+ATOM   7191  CG  ARG C3313       3.479   1.826  -4.872  1.00 22.70           C  
+ATOM   7192  CD  ARG C3313       2.701   3.112  -4.903  1.00 25.33           C  
+ATOM   7193  NE  ARG C3313       3.556   4.264  -4.651  1.00 28.37           N  
+ATOM   7194  CZ  ARG C3313       3.302   5.485  -5.114  1.00 31.61           C  
+ATOM   7195  NH1 ARG C3313       2.220   5.694  -5.859  1.00 28.08           N  
+ATOM   7196  NH2 ARG C3313       4.115   6.497  -4.819  1.00 30.72           N  
+ATOM   7197  N   LEU C3314       4.506  -0.997  -8.264  1.00 16.84           N  
+ATOM   7198  CA  LEU C3314       4.721  -1.458  -9.631  1.00 16.91           C  
+ATOM   7199  C   LEU C3314       3.471  -1.271 -10.488  1.00 16.06           C  
+ATOM   7200  O   LEU C3314       2.374  -1.636 -10.068  1.00 14.66           O  
+ATOM   7201  CB  LEU C3314       5.110  -2.945  -9.607  1.00 16.41           C  
+ATOM   7202  CG  LEU C3314       5.186  -3.699 -10.934  1.00 14.62           C  
+ATOM   7203  CD1 LEU C3314       6.295  -3.105 -11.794  1.00 17.62           C  
+ATOM   7204  CD2 LEU C3314       5.448  -5.176 -10.676  1.00 14.82           C  
+ATOM   7205  N   ARG C3315       3.641  -0.707 -11.683  1.00 14.60           N  
+ATOM   7206  CA  ARG C3315       2.518  -0.487 -12.590  1.00 15.21           C  
+ATOM   7207  C   ARG C3315       1.799  -1.793 -12.869  1.00 16.29           C  
+ATOM   7208  O   ARG C3315       2.427  -2.819 -13.164  1.00 15.96           O  
+ATOM   7209  CB  ARG C3315       2.987   0.130 -13.920  1.00 14.68           C  
+ATOM   7210  CG  ARG C3315       3.176   1.656 -13.904  1.00 15.15           C  
+ATOM   7211  CD  ARG C3315       1.860   2.398 -13.647  1.00 15.77           C  
+ATOM   7212  NE  ARG C3315       0.834   2.058 -14.631  1.00 17.34           N  
+ATOM   7213  CZ  ARG C3315       0.828   2.492 -15.892  1.00 16.82           C  
+ATOM   7214  NH1 ARG C3315       1.787   3.297 -16.319  1.00 13.39           N  
+ATOM   7215  NH2 ARG C3315      -0.117   2.088 -16.730  1.00 12.16           N  
+ATOM   7216  N   LYS C3316       0.478  -1.752 -12.753  1.00 16.21           N  
+ATOM   7217  CA  LYS C3316      -0.346  -2.922 -13.000  1.00 17.87           C  
+ATOM   7218  C   LYS C3316      -0.296  -3.218 -14.505  1.00 20.59           C  
+ATOM   7219  O   LYS C3316      -0.230  -4.409 -14.880  1.00 21.78           O  
+ATOM   7220  CB  LYS C3316      -1.794  -2.653 -12.581  1.00 18.01           C  
+ATOM   7221  CG  LYS C3316      -2.006  -2.337 -11.100  1.00 20.08           C  
+ATOM   7222  CD  LYS C3316      -3.487  -2.054 -10.845  1.00 20.94           C  
+ATOM   7223  CE  LYS C3316      -3.761  -1.731  -9.386  1.00 24.33           C  
+ATOM   7224  NZ  LYS C3316      -5.184  -1.339  -9.174  1.00 26.04           N  
+ATOM   7225  OXT LYS C3316      -0.340  -2.243 -15.294  1.00 18.41           O  
+TER    7226      LYS C3316                                                      
+ATOM   7227  N   MET D4009      77.709 -13.026  -6.234  1.00 39.99           N  
+ATOM   7228  CA  MET D4009      77.800 -13.570  -4.843  1.00 38.93           C  
+ATOM   7229  C   MET D4009      76.449 -14.062  -4.335  1.00 36.80           C  
+ATOM   7230  O   MET D4009      75.395 -13.543  -4.709  1.00 36.78           O  
+ATOM   7231  CB  MET D4009      78.356 -12.503  -3.898  1.00 41.91           C  
+ATOM   7232  CG  MET D4009      79.794 -12.124  -4.201  1.00 43.44           C  
+ATOM   7233  SD  MET D4009      80.410 -10.809  -3.156  1.00 49.64           S  
+ATOM   7234  CE  MET D4009      80.517  -9.463  -4.320  1.00 48.96           C  
+ATOM   7235  N   THR D4010      76.495 -15.073  -3.479  1.00 34.18           N  
+ATOM   7236  CA  THR D4010      75.294 -15.685  -2.910  1.00 31.23           C  
+ATOM   7237  C   THR D4010      75.377 -15.645  -1.381  1.00 29.37           C  
+ATOM   7238  O   THR D4010      76.416 -15.304  -0.827  1.00 28.57           O  
+ATOM   7239  CB  THR D4010      75.184 -17.152  -3.383  1.00 31.20           C  
+ATOM   7240  OG1 THR D4010      74.612 -17.960  -2.352  1.00 35.16           O  
+ATOM   7241  CG2 THR D4010      76.556 -17.708  -3.712  1.00 33.24           C  
+ATOM   7242  N   PRO D4011      74.273 -15.968  -0.683  1.00 27.91           N  
+ATOM   7243  CA  PRO D4011      74.284 -15.961   0.788  1.00 26.97           C  
+ATOM   7244  C   PRO D4011      74.986 -17.222   1.323  1.00 26.43           C  
+ATOM   7245  O   PRO D4011      75.010 -17.469   2.533  1.00 25.45           O  
+ATOM   7246  CB  PRO D4011      72.794 -15.963   1.148  1.00 27.03           C  
+ATOM   7247  CG  PRO D4011      72.135 -15.343  -0.051  1.00 28.20           C  
+ATOM   7248  CD  PRO D4011      72.889 -15.975  -1.192  1.00 27.69           C  
+ATOM   7249  N   TYR D4012      75.555 -18.009   0.411  1.00 25.15           N  
+ATOM   7250  CA  TYR D4012      76.205 -19.265   0.775  1.00 24.56           C  
+ATOM   7251  C   TYR D4012      77.674 -19.445   0.415  1.00 24.19           C  
+ATOM   7252  O   TYR D4012      78.126 -19.028  -0.653  1.00 23.81           O  
+ATOM   7253  CB  TYR D4012      75.462 -20.450   0.141  1.00 24.47           C  
+ATOM   7254  CG  TYR D4012      74.047 -20.688   0.622  1.00 27.49           C  
+ATOM   7255  CD1 TYR D4012      72.953 -20.106  -0.023  1.00 26.79           C  
+ATOM   7256  CD2 TYR D4012      73.802 -21.520   1.713  1.00 28.02           C  
+ATOM   7257  CE1 TYR D4012      71.642 -20.355   0.414  1.00 27.25           C  
+ATOM   7258  CE2 TYR D4012      72.504 -21.775   2.155  1.00 29.64           C  
+ATOM   7259  CZ  TYR D4012      71.429 -21.193   1.506  1.00 29.07           C  
+ATOM   7260  OH  TYR D4012      70.153 -21.465   1.964  1.00 31.07           O  
+ATOM   7261  N   LEU D4013      78.406 -20.080   1.322  1.00 22.87           N  
+ATOM   7262  CA  LEU D4013      79.795 -20.433   1.070  1.00 25.44           C  
+ATOM   7263  C   LEU D4013      79.584 -21.752   0.333  1.00 26.08           C  
+ATOM   7264  O   LEU D4013      78.665 -22.503   0.670  1.00 25.59           O  
+ATOM   7265  CB  LEU D4013      80.550 -20.719   2.369  1.00 24.74           C  
+ATOM   7266  CG  LEU D4013      80.861 -19.579   3.340  1.00 25.71           C  
+ATOM   7267  CD1 LEU D4013      81.527 -20.165   4.572  1.00 24.56           C  
+ATOM   7268  CD2 LEU D4013      81.752 -18.542   2.672  1.00 24.15           C  
+ATOM   7269  N   GLN D4014      80.408 -22.049  -0.663  1.00 27.86           N  
+ATOM   7270  CA  GLN D4014      80.222 -23.291  -1.400  1.00 29.57           C  
+ATOM   7271  C   GLN D4014      81.444 -24.199  -1.398  1.00 28.33           C  
+ATOM   7272  O   GLN D4014      82.566 -23.728  -1.530  1.00 28.46           O  
+ATOM   7273  CB  GLN D4014      79.831 -22.983  -2.838  1.00 32.68           C  
+ATOM   7274  CG  GLN D4014      79.439 -24.211  -3.619  1.00 39.43           C  
+ATOM   7275  CD  GLN D4014      79.166 -23.901  -5.072  1.00 44.32           C  
+ATOM   7276  OE1 GLN D4014      78.334 -23.049  -5.397  1.00 46.51           O  
+ATOM   7277  NE2 GLN D4014      79.867 -24.597  -5.963  1.00 46.04           N  
+ATOM   7278  N   PHE D4015      81.213 -25.502  -1.259  1.00 27.03           N  
+ATOM   7279  CA  PHE D4015      82.296 -26.484  -1.246  1.00 26.49           C  
+ATOM   7280  C   PHE D4015      81.931 -27.716  -2.077  1.00 28.33           C  
+ATOM   7281  O   PHE D4015      80.865 -28.301  -1.877  1.00 27.32           O  
+ATOM   7282  CB  PHE D4015      82.585 -26.975   0.179  1.00 25.96           C  
+ATOM   7283  CG  PHE D4015      82.802 -25.883   1.181  1.00 26.28           C  
+ATOM   7284  CD1 PHE D4015      81.721 -25.246   1.781  1.00 25.51           C  
+ATOM   7285  CD2 PHE D4015      84.093 -25.498   1.541  1.00 26.12           C  
+ATOM   7286  CE1 PHE D4015      81.921 -24.237   2.729  1.00 24.27           C  
+ATOM   7287  CE2 PHE D4015      84.302 -24.489   2.486  1.00 25.32           C  
+ATOM   7288  CZ  PHE D4015      83.210 -23.861   3.079  1.00 25.11           C  
+ATOM   7289  N   ASP D4016      82.794 -28.112  -3.011  1.00 29.14           N  
+ATOM   7290  CA  ASP D4016      82.520 -29.323  -3.775  1.00 28.09           C  
+ATOM   7291  C   ASP D4016      83.013 -30.438  -2.867  1.00 26.91           C  
+ATOM   7292  O   ASP D4016      83.589 -30.160  -1.819  1.00 26.49           O  
+ATOM   7293  CB  ASP D4016      83.264 -29.346  -5.121  1.00 30.50           C  
+ATOM   7294  CG  ASP D4016      84.772 -29.225  -4.977  1.00 30.75           C  
+ATOM   7295  OD1 ASP D4016      85.352 -29.830  -4.048  1.00 29.70           O  
+ATOM   7296  OD2 ASP D4016      85.380 -28.534  -5.820  1.00 32.61           O  
+ATOM   7297  N   ARG D4017      82.800 -31.689  -3.252  1.00 26.86           N  
+ATOM   7298  CA  ARG D4017      83.219 -32.791  -2.404  1.00 26.94           C  
+ATOM   7299  C   ARG D4017      84.659 -32.724  -1.899  1.00 26.03           C  
+ATOM   7300  O   ARG D4017      84.903 -32.888  -0.698  1.00 24.46           O  
+ATOM   7301  CB  ARG D4017      83.016 -34.135  -3.101  1.00 27.12           C  
+ATOM   7302  CG  ARG D4017      83.121 -35.281  -2.111  1.00 29.71           C  
+ATOM   7303  CD  ARG D4017      83.382 -36.605  -2.774  1.00 31.11           C  
+ATOM   7304  NE  ARG D4017      83.454 -37.678  -1.787  1.00 34.49           N  
+ATOM   7305  CZ  ARG D4017      82.404 -38.198  -1.154  1.00 34.41           C  
+ATOM   7306  NH1 ARG D4017      81.180 -37.743  -1.399  1.00 33.38           N  
+ATOM   7307  NH2 ARG D4017      82.581 -39.184  -0.282  1.00 34.47           N  
+ATOM   7308  N   ASN D4018      85.607 -32.499  -2.804  1.00 24.82           N  
+ATOM   7309  CA  ASN D4018      87.010 -32.451  -2.406  1.00 27.64           C  
+ATOM   7310  C   ASN D4018      87.341 -31.356  -1.396  1.00 26.10           C  
+ATOM   7311  O   ASN D4018      88.049 -31.597  -0.433  1.00 24.65           O  
+ATOM   7312  CB  ASN D4018      87.912 -32.303  -3.636  1.00 30.53           C  
+ATOM   7313  CG  ASN D4018      87.837 -33.505  -4.558  1.00 34.68           C  
+ATOM   7314  OD1 ASN D4018      87.855 -34.655  -4.109  1.00 35.71           O  
+ATOM   7315  ND2 ASN D4018      87.760 -33.244  -5.856  1.00 38.00           N  
+ATOM   7316  N   GLN D4019      86.829 -30.154  -1.615  1.00 26.41           N  
+ATOM   7317  CA  GLN D4019      87.104 -29.050  -0.710  1.00 26.87           C  
+ATOM   7318  C   GLN D4019      86.494 -29.314   0.662  1.00 26.38           C  
+ATOM   7319  O   GLN D4019      87.064 -28.924   1.684  1.00 25.05           O  
+ATOM   7320  CB  GLN D4019      86.555 -27.756  -1.299  1.00 27.78           C  
+ATOM   7321  CG  GLN D4019      87.013 -27.543  -2.724  1.00 30.35           C  
+ATOM   7322  CD  GLN D4019      86.276 -26.425  -3.417  1.00 31.80           C  
+ATOM   7323  OE1 GLN D4019      85.059 -26.284  -3.272  1.00 33.96           O  
+ATOM   7324  NE2 GLN D4019      87.002 -25.635  -4.197  1.00 35.22           N  
+ATOM   7325  N   TRP D4020      85.346 -29.982   0.682  1.00 24.68           N  
+ATOM   7326  CA  TRP D4020      84.681 -30.295   1.939  1.00 24.50           C  
+ATOM   7327  C   TRP D4020      85.445 -31.370   2.693  1.00 24.76           C  
+ATOM   7328  O   TRP D4020      85.727 -31.230   3.881  1.00 25.05           O  
+ATOM   7329  CB  TRP D4020      83.255 -30.782   1.692  1.00 23.35           C  
+ATOM   7330  CG  TRP D4020      82.495 -31.009   2.968  1.00 21.88           C  
+ATOM   7331  CD1 TRP D4020      82.234 -32.206   3.570  1.00 21.68           C  
+ATOM   7332  CD2 TRP D4020      81.944 -30.001   3.823  1.00 20.83           C  
+ATOM   7333  NE1 TRP D4020      81.553 -32.007   4.748  1.00 20.88           N  
+ATOM   7334  CE2 TRP D4020      81.364 -30.661   4.930  1.00 20.34           C  
+ATOM   7335  CE3 TRP D4020      81.883 -28.600   3.759  1.00 19.63           C  
+ATOM   7336  CZ2 TRP D4020      80.730 -29.970   5.972  1.00 19.18           C  
+ATOM   7337  CZ3 TRP D4020      81.252 -27.910   4.794  1.00 21.17           C  
+ATOM   7338  CH2 TRP D4020      80.684 -28.602   5.887  1.00 20.59           C  
+ATOM   7339  N   ALA D4021      85.781 -32.446   1.991  1.00 25.90           N  
+ATOM   7340  CA  ALA D4021      86.508 -33.554   2.587  1.00 26.84           C  
+ATOM   7341  C   ALA D4021      87.850 -33.083   3.134  1.00 27.71           C  
+ATOM   7342  O   ALA D4021      88.407 -33.691   4.044  1.00 28.18           O  
+ATOM   7343  CB  ALA D4021      86.716 -34.660   1.551  1.00 28.03           C  
+ATOM   7344  N   ALA D4022      88.362 -31.995   2.573  1.00 28.19           N  
+ATOM   7345  CA  ALA D4022      89.633 -31.430   3.004  1.00 29.19           C  
+ATOM   7346  C   ALA D4022      89.531 -30.780   4.383  1.00 31.29           C  
+ATOM   7347  O   ALA D4022      90.538 -30.355   4.956  1.00 31.34           O  
+ATOM   7348  CB  ALA D4022      90.105 -30.406   1.992  1.00 27.90           C  
+ATOM   7349  N   LEU D4023      88.322 -30.700   4.924  1.00 33.02           N  
+ATOM   7350  CA  LEU D4023      88.152 -30.088   6.232  1.00 35.04           C  
+ATOM   7351  C   LEU D4023      88.548 -31.018   7.371  1.00 37.75           C  
+ATOM   7352  O   LEU D4023      88.781 -30.565   8.491  1.00 38.41           O  
+ATOM   7353  CB  LEU D4023      86.713 -29.618   6.419  1.00 34.46           C  
+ATOM   7354  CG  LEU D4023      86.217 -28.641   5.350  1.00 35.82           C  
+ATOM   7355  CD1 LEU D4023      84.865 -28.100   5.776  1.00 35.77           C  
+ATOM   7356  CD2 LEU D4023      87.217 -27.507   5.158  1.00 34.54           C  
+ATOM   7357  N   ARG D4024      88.630 -32.315   7.096  1.00 40.39           N  
+ATOM   7358  CA  ARG D4024      89.025 -33.260   8.136  1.00 44.07           C  
+ATOM   7359  C   ARG D4024      90.520 -33.106   8.438  1.00 45.20           C  
+ATOM   7360  O   ARG D4024      91.302 -32.722   7.568  1.00 45.22           O  
+ATOM   7361  CB  ARG D4024      88.706 -34.687   7.692  1.00 44.87           C  
+ATOM   7362  CG  ARG D4024      89.260 -35.034   6.333  1.00 47.97           C  
+ATOM   7363  CD  ARG D4024      88.547 -36.227   5.718  1.00 49.40           C  
+ATOM   7364  NE  ARG D4024      89.053 -36.507   4.378  1.00 53.53           N  
+ATOM   7365  CZ  ARG D4024      90.275 -36.959   4.123  1.00 55.40           C  
+ATOM   7366  NH1 ARG D4024      91.115 -37.191   5.122  1.00 57.77           N  
+ATOM   7367  NH2 ARG D4024      90.665 -37.164   2.872  1.00 55.72           N  
+ATOM   7368  N   ASP D4025      90.906 -33.389   9.677  1.00 47.56           N  
+ATOM   7369  CA  ASP D4025      92.302 -33.273  10.090  1.00 50.38           C  
+ATOM   7370  C   ASP D4025      93.252 -34.141   9.271  1.00 50.47           C  
+ATOM   7371  O   ASP D4025      92.896 -35.240   8.856  1.00 51.48           O  
+ATOM   7372  CB  ASP D4025      92.442 -33.625  11.571  1.00 53.39           C  
+ATOM   7373  CG  ASP D4025      92.147 -32.447  12.478  1.00 56.24           C  
+ATOM   7374  OD1 ASP D4025      92.860 -31.425  12.359  1.00 58.03           O  
+ATOM   7375  OD2 ASP D4025      91.210 -32.540  13.305  1.00 57.06           O  
+ATOM   7376  N   MET D4029      90.320 -37.956  12.682  1.00 65.03           N  
+ATOM   7377  CA  MET D4029      89.547 -38.657  13.707  1.00 65.77           C  
+ATOM   7378  C   MET D4029      89.350 -40.128  13.336  1.00 64.89           C  
+ATOM   7379  O   MET D4029      89.168 -40.462  12.165  1.00 64.74           O  
+ATOM   7380  CB  MET D4029      88.175 -38.000  13.893  1.00 67.02           C  
+ATOM   7381  CG  MET D4029      88.210 -36.489  14.086  1.00 68.43           C  
+ATOM   7382  SD  MET D4029      86.594 -35.803  14.540  1.00 70.38           S  
+ATOM   7383  CE  MET D4029      87.066 -34.632  15.811  1.00 69.96           C  
+ATOM   7384  N   THR D4030      89.380 -40.998  14.341  1.00 63.92           N  
+ATOM   7385  CA  THR D4030      89.203 -42.432  14.125  1.00 62.73           C  
+ATOM   7386  C   THR D4030      87.945 -42.934  14.818  1.00 61.80           C  
+ATOM   7387  O   THR D4030      87.660 -42.564  15.960  1.00 61.48           O  
+ATOM   7388  CB  THR D4030      90.405 -43.235  14.671  1.00 62.99           C  
+ATOM   7389  OG1 THR D4030      91.600 -42.822  13.999  1.00 63.72           O  
+ATOM   7390  CG2 THR D4030      90.196 -44.733  14.458  1.00 62.74           C  
+ATOM   7391  N   LEU D4031      87.194 -43.783  14.124  1.00 60.69           N  
+ATOM   7392  CA  LEU D4031      85.971 -44.340  14.686  1.00 59.20           C  
+ATOM   7393  C   LEU D4031      86.259 -45.684  15.337  1.00 58.26           C  
+ATOM   7394  O   LEU D4031      86.976 -46.514  14.779  1.00 58.45           O  
+ATOM   7395  CB  LEU D4031      84.906 -44.497  13.594  1.00 58.59           C  
+ATOM   7396  CG  LEU D4031      84.337 -43.192  13.028  1.00 58.35           C  
+ATOM   7397  CD1 LEU D4031      83.412 -43.487  11.856  1.00 57.40           C  
+ATOM   7398  CD2 LEU D4031      83.596 -42.444  14.132  1.00 57.02           C  
+ATOM   7399  N   SER D4032      85.707 -45.884  16.528  1.00 57.04           N  
+ATOM   7400  CA  SER D4032      85.899 -47.128  17.258  1.00 56.50           C  
+ATOM   7401  C   SER D4032      85.273 -48.288  16.500  1.00 55.78           C  
+ATOM   7402  O   SER D4032      84.595 -48.089  15.494  1.00 56.97           O  
+ATOM   7403  CB  SER D4032      85.254 -47.029  18.641  1.00 56.16           C  
+ATOM   7404  OG  SER D4032      85.382 -48.252  19.348  1.00 57.47           O  
+ATOM   7405  N   GLU D4033      85.511 -49.503  16.983  1.00 54.43           N  
+ATOM   7406  CA  GLU D4033      84.941 -50.691  16.366  1.00 52.75           C  
+ATOM   7407  C   GLU D4033      83.440 -50.644  16.633  1.00 51.86           C  
+ATOM   7408  O   GLU D4033      82.633 -50.983  15.772  1.00 50.67           O  
+ATOM   7409  CB  GLU D4033      85.554 -51.946  16.979  1.00 51.20           C  
+ATOM   7410  N   ASP D4034      83.077 -50.215  17.839  1.00 51.99           N  
+ATOM   7411  CA  ASP D4034      81.680 -50.108  18.233  1.00 53.56           C  
+ATOM   7412  C   ASP D4034      80.999 -49.001  17.440  1.00 53.30           C  
+ATOM   7413  O   ASP D4034      79.828 -49.118  17.085  1.00 53.00           O  
+ATOM   7414  CB  ASP D4034      81.562 -49.800  19.730  1.00 55.98           C  
+ATOM   7415  CG  ASP D4034      82.157 -50.891  20.603  1.00 59.05           C  
+ATOM   7416  OD1 ASP D4034      81.671 -52.041  20.533  1.00 60.18           O  
+ATOM   7417  OD2 ASP D4034      83.106 -50.594  21.363  1.00 60.58           O  
+ATOM   7418  N   GLU D4035      81.733 -47.922  17.173  1.00 52.81           N  
+ATOM   7419  CA  GLU D4035      81.190 -46.798  16.418  1.00 52.10           C  
+ATOM   7420  C   GLU D4035      80.942 -47.225  14.981  1.00 50.56           C  
+ATOM   7421  O   GLU D4035      79.960 -46.818  14.356  1.00 51.45           O  
+ATOM   7422  CB  GLU D4035      82.156 -45.613  16.428  1.00 53.76           C  
+ATOM   7423  CG  GLU D4035      82.462 -45.048  17.803  1.00 55.97           C  
+ATOM   7424  CD  GLU D4035      83.350 -43.817  17.737  1.00 58.68           C  
+ATOM   7425  OE1 GLU D4035      82.891 -42.769  17.227  1.00 60.44           O  
+ATOM   7426  OE2 GLU D4035      84.511 -43.895  18.191  1.00 59.81           O  
+ATOM   7427  N   ILE D4036      81.841 -48.046  14.457  1.00 48.19           N  
+ATOM   7428  CA  ILE D4036      81.714 -48.532  13.091  1.00 47.18           C  
+ATOM   7429  C   ILE D4036      80.550 -49.507  12.993  1.00 45.29           C  
+ATOM   7430  O   ILE D4036      79.841 -49.546  11.986  1.00 45.02           O  
+ATOM   7431  CB  ILE D4036      83.016 -49.226  12.637  1.00 46.90           C  
+ATOM   7432  CG1 ILE D4036      84.124 -48.179  12.500  1.00 47.04           C  
+ATOM   7433  CG2 ILE D4036      82.789 -49.959  11.329  1.00 46.85           C  
+ATOM   7434  CD1 ILE D4036      85.487 -48.754  12.176  1.00 48.29           C  
+ATOM   7435  N   ALA D4037      80.351 -50.285  14.052  1.00 43.33           N  
+ATOM   7436  CA  ALA D4037      79.270 -51.258  14.092  1.00 43.03           C  
+ATOM   7437  C   ALA D4037      77.930 -50.544  14.145  1.00 42.51           C  
+ATOM   7438  O   ALA D4037      76.957 -50.990  13.542  1.00 42.31           O  
+ATOM   7439  CB  ALA D4037      79.421 -52.162  15.307  1.00 42.36           C  
+ATOM   7440  N   ARG D4038      77.888 -49.430  14.870  1.00 41.78           N  
+ATOM   7441  CA  ARG D4038      76.662 -48.654  15.006  1.00 41.09           C  
+ATOM   7442  C   ARG D4038      76.260 -48.028  13.674  1.00 40.37           C  
+ATOM   7443  O   ARG D4038      75.080 -48.032  13.309  1.00 39.41           O  
+ATOM   7444  CB  ARG D4038      76.836 -47.561  16.058  1.00 41.16           C  
+ATOM   7445  CG  ARG D4038      75.538 -46.871  16.403  1.00 44.61           C  
+ATOM   7446  CD  ARG D4038      75.733 -45.718  17.362  1.00 47.01           C  
+ATOM   7447  NE  ARG D4038      74.463 -45.045  17.625  1.00 51.37           N  
+ATOM   7448  CZ  ARG D4038      74.332 -43.946  18.359  1.00 52.66           C  
+ATOM   7449  NH1 ARG D4038      75.402 -43.383  18.909  1.00 54.05           N  
+ATOM   7450  NH2 ARG D4038      73.131 -43.413  18.549  1.00 52.78           N  
+ATOM   7451  N   LEU D4039      77.239 -47.492  12.950  1.00 38.58           N  
+ATOM   7452  CA  LEU D4039      76.969 -46.874  11.659  1.00 37.70           C  
+ATOM   7453  C   LEU D4039      76.420 -47.899  10.669  1.00 37.77           C  
+ATOM   7454  O   LEU D4039      75.463 -47.621   9.944  1.00 36.93           O  
+ATOM   7455  CB  LEU D4039      78.237 -46.211  11.108  1.00 36.76           C  
+ATOM   7456  CG  LEU D4039      78.626 -44.896  11.803  1.00 37.03           C  
+ATOM   7457  CD1 LEU D4039      79.920 -44.351  11.214  1.00 36.54           C  
+ATOM   7458  CD2 LEU D4039      77.493 -43.882  11.639  1.00 34.47           C  
+ATOM   7459  N   LYS D4040      77.017 -49.087  10.639  1.00 37.62           N  
+ATOM   7460  CA  LYS D4040      76.538 -50.131   9.741  1.00 37.33           C  
+ATOM   7461  C   LYS D4040      75.112 -50.467  10.160  1.00 37.24           C  
+ATOM   7462  O   LYS D4040      74.230 -50.653   9.326  1.00 37.62           O  
+ATOM   7463  CB  LYS D4040      77.425 -51.375   9.847  1.00 37.88           C  
+ATOM   7464  N   GLY D4041      74.894 -50.526  11.471  1.00 37.47           N  
+ATOM   7465  CA  GLY D4041      73.573 -50.831  11.993  1.00 36.81           C  
+ATOM   7466  C   GLY D4041      72.547 -49.784  11.591  1.00 38.03           C  
+ATOM   7467  O   GLY D4041      71.379 -50.105  11.361  1.00 37.38           O  
+ATOM   7468  N   ILE D4042      72.981 -48.528  11.515  1.00 37.25           N  
+ATOM   7469  CA  ILE D4042      72.090 -47.445  11.127  1.00 37.56           C  
+ATOM   7470  C   ILE D4042      71.623 -47.684   9.700  1.00 36.97           C  
+ATOM   7471  O   ILE D4042      70.436 -47.595   9.409  1.00 37.08           O  
+ATOM   7472  CB  ILE D4042      72.793 -46.058  11.227  1.00 37.78           C  
+ATOM   7473  CG1 ILE D4042      72.952 -45.656  12.697  1.00 37.97           C  
+ATOM   7474  CG2 ILE D4042      71.986 -45.002  10.489  1.00 38.20           C  
+ATOM   7475  CD1 ILE D4042      73.754 -44.388  12.909  1.00 36.54           C  
+ATOM   7476  N   ASN D4043      72.566 -47.998   8.819  1.00 37.91           N  
+ATOM   7477  CA  ASN D4043      72.261 -48.264   7.417  1.00 39.67           C  
+ATOM   7478  C   ASN D4043      73.398 -49.095   6.837  1.00 40.70           C  
+ATOM   7479  O   ASN D4043      74.534 -48.631   6.749  1.00 39.14           O  
+ATOM   7480  CB  ASN D4043      72.144 -46.956   6.629  1.00 39.83           C  
+ATOM   7481  CG  ASN D4043      71.564 -47.162   5.241  1.00 40.69           C  
+ATOM   7482  OD1 ASN D4043      71.867 -48.148   4.561  1.00 41.98           O  
+ATOM   7483  ND2 ASN D4043      70.733 -46.224   4.807  1.00 39.52           N  
+ATOM   7484  N   GLU D4044      73.079 -50.318   6.432  1.00 42.40           N  
+ATOM   7485  CA  GLU D4044      74.067 -51.233   5.871  1.00 45.41           C  
+ATOM   7486  C   GLU D4044      74.733 -50.734   4.595  1.00 44.48           C  
+ATOM   7487  O   GLU D4044      75.841 -51.161   4.265  1.00 45.03           O  
+ATOM   7488  CB  GLU D4044      73.416 -52.587   5.594  1.00 49.36           C  
+ATOM   7489  CG  GLU D4044      72.972 -53.332   6.840  1.00 55.05           C  
+ATOM   7490  CD  GLU D4044      71.925 -54.391   6.536  1.00 59.08           C  
+ATOM   7491  OE1 GLU D4044      72.110 -55.151   5.556  1.00 60.62           O  
+ATOM   7492  OE2 GLU D4044      70.919 -54.463   7.283  1.00 60.94           O  
+ATOM   7493  N   ASP D4045      74.065 -49.837   3.881  1.00 43.07           N  
+ATOM   7494  CA  ASP D4045      74.611 -49.319   2.633  1.00 42.82           C  
+ATOM   7495  C   ASP D4045      75.406 -48.038   2.804  1.00 41.14           C  
+ATOM   7496  O   ASP D4045      76.013 -47.544   1.854  1.00 40.67           O  
+ATOM   7497  CB  ASP D4045      73.486 -49.095   1.623  1.00 43.81           C  
+ATOM   7498  CG  ASP D4045      72.792 -50.383   1.238  1.00 45.47           C  
+ATOM   7499  OD1 ASP D4045      73.499 -51.358   0.899  1.00 45.51           O  
+ATOM   7500  OD2 ASP D4045      71.542 -50.421   1.271  1.00 47.07           O  
+ATOM   7501  N   LEU D4046      75.407 -47.502   4.017  1.00 40.27           N  
+ATOM   7502  CA  LEU D4046      76.142 -46.276   4.292  1.00 38.73           C  
+ATOM   7503  C   LEU D4046      77.642 -46.507   4.163  1.00 37.60           C  
+ATOM   7504  O   LEU D4046      78.229 -47.290   4.910  1.00 35.63           O  
+ATOM   7505  CB  LEU D4046      75.819 -45.767   5.696  1.00 38.90           C  
+ATOM   7506  CG  LEU D4046      76.654 -44.593   6.206  1.00 38.23           C  
+ATOM   7507  CD1 LEU D4046      76.582 -43.411   5.245  1.00 39.50           C  
+ATOM   7508  CD2 LEU D4046      76.141 -44.205   7.572  1.00 38.28           C  
+ATOM   7509  N   SER D4047      78.253 -45.818   3.207  1.00 37.13           N  
+ATOM   7510  CA  SER D4047      79.681 -45.938   2.964  1.00 36.35           C  
+ATOM   7511  C   SER D4047      80.495 -45.386   4.127  1.00 37.25           C  
+ATOM   7512  O   SER D4047      80.252 -44.273   4.596  1.00 37.42           O  
+ATOM   7513  CB  SER D4047      80.053 -45.191   1.688  1.00 35.43           C  
+ATOM   7514  OG  SER D4047      81.444 -44.942   1.650  1.00 34.62           O  
+ATOM   7515  N   LEU D4048      81.465 -46.168   4.589  1.00 37.20           N  
+ATOM   7516  CA  LEU D4048      82.314 -45.751   5.694  1.00 36.88           C  
+ATOM   7517  C   LEU D4048      83.258 -44.649   5.247  1.00 36.55           C  
+ATOM   7518  O   LEU D4048      83.684 -43.817   6.039  1.00 35.56           O  
+ATOM   7519  CB  LEU D4048      83.103 -46.940   6.226  1.00 37.88           C  
+ATOM   7520  CG  LEU D4048      82.206 -48.011   6.848  1.00 39.23           C  
+ATOM   7521  CD1 LEU D4048      83.052 -49.173   7.358  1.00 40.54           C  
+ATOM   7522  CD2 LEU D4048      81.406 -47.389   7.984  1.00 39.84           C  
+ATOM   7523  N   GLU D4049      83.586 -44.646   3.965  1.00 36.71           N  
+ATOM   7524  CA  GLU D4049      84.456 -43.614   3.445  1.00 37.25           C  
+ATOM   7525  C   GLU D4049      83.653 -42.317   3.453  1.00 35.89           C  
+ATOM   7526  O   GLU D4049      84.146 -41.273   3.870  1.00 36.55           O  
+ATOM   7527  CB  GLU D4049      84.896 -43.956   2.024  1.00 39.74           C  
+ATOM   7528  CG  GLU D4049      85.768 -42.897   1.391  1.00 46.80           C  
+ATOM   7529  CD  GLU D4049      86.174 -43.251  -0.023  1.00 51.05           C  
+ATOM   7530  OE1 GLU D4049      86.803 -44.316  -0.202  1.00 52.75           O  
+ATOM   7531  OE2 GLU D4049      85.867 -42.463  -0.949  1.00 54.21           O  
+ATOM   7532  N   GLU D4050      82.402 -42.406   3.006  1.00 33.96           N  
+ATOM   7533  CA  GLU D4050      81.500 -41.260   2.945  1.00 33.05           C  
+ATOM   7534  C   GLU D4050      81.403 -40.622   4.332  1.00 32.06           C  
+ATOM   7535  O   GLU D4050      81.458 -39.400   4.478  1.00 31.08           O  
+ATOM   7536  CB  GLU D4050      80.109 -41.718   2.477  1.00 33.95           C  
+ATOM   7537  CG  GLU D4050      79.091 -40.596   2.260  1.00 35.41           C  
+ATOM   7538  CD  GLU D4050      79.316 -39.825   0.969  1.00 35.10           C  
+ATOM   7539  OE1 GLU D4050      78.552 -38.873   0.716  1.00 37.85           O  
+ATOM   7540  OE2 GLU D4050      80.245 -40.169   0.208  1.00 36.15           O  
+ATOM   7541  N   VAL D4051      81.269 -41.462   5.351  1.00 29.85           N  
+ATOM   7542  CA  VAL D4051      81.171 -40.963   6.710  1.00 29.52           C  
+ATOM   7543  C   VAL D4051      82.428 -40.193   7.090  1.00 30.50           C  
+ATOM   7544  O   VAL D4051      82.358 -39.078   7.616  1.00 29.61           O  
+ATOM   7545  CB  VAL D4051      80.963 -42.119   7.710  1.00 28.75           C  
+ATOM   7546  CG1 VAL D4051      81.126 -41.611   9.133  1.00 29.00           C  
+ATOM   7547  CG2 VAL D4051      79.570 -42.717   7.527  1.00 26.50           C  
+ATOM   7548  N   ALA D4052      83.580 -40.788   6.809  1.00 30.49           N  
+ATOM   7549  CA  ALA D4052      84.855 -40.172   7.137  1.00 31.68           C  
+ATOM   7550  C   ALA D4052      85.129 -38.867   6.386  1.00 32.09           C  
+ATOM   7551  O   ALA D4052      85.684 -37.925   6.961  1.00 31.33           O  
+ATOM   7552  CB  ALA D4052      85.993 -41.171   6.892  1.00 29.77           C  
+ATOM   7553  N   GLU D4053      84.743 -38.800   5.114  1.00 31.90           N  
+ATOM   7554  CA  GLU D4053      85.004 -37.596   4.323  1.00 32.69           C  
+ATOM   7555  C   GLU D4053      83.912 -36.534   4.339  1.00 30.58           C  
+ATOM   7556  O   GLU D4053      84.189 -35.362   4.095  1.00 31.91           O  
+ATOM   7557  CB  GLU D4053      85.282 -37.964   2.865  1.00 34.42           C  
+ATOM   7558  CG  GLU D4053      86.355 -39.021   2.673  1.00 38.77           C  
+ATOM   7559  CD  GLU D4053      86.695 -39.251   1.205  1.00 41.31           C  
+ATOM   7560  OE1 GLU D4053      85.800 -39.108   0.340  1.00 42.86           O  
+ATOM   7561  OE2 GLU D4053      87.862 -39.592   0.916  1.00 44.11           O  
+ATOM   7562  N   ILE D4054      82.678 -36.930   4.623  1.00 28.54           N  
+ATOM   7563  CA  ILE D4054      81.578 -35.975   4.614  1.00 26.42           C  
+ATOM   7564  C   ILE D4054      80.920 -35.709   5.964  1.00 26.40           C  
+ATOM   7565  O   ILE D4054      80.879 -34.571   6.425  1.00 27.86           O  
+ATOM   7566  CB  ILE D4054      80.467 -36.428   3.643  1.00 26.63           C  
+ATOM   7567  CG1 ILE D4054      81.053 -36.689   2.249  1.00 26.51           C  
+ATOM   7568  CG2 ILE D4054      79.364 -35.381   3.594  1.00 24.40           C  
+ATOM   7569  CD1 ILE D4054      81.785 -35.505   1.644  1.00 25.09           C  
+ATOM   7570  N   TYR D4055      80.416 -36.761   6.597  1.00 24.23           N  
+ATOM   7571  CA  TYR D4055      79.718 -36.609   7.863  1.00 25.03           C  
+ATOM   7572  C   TYR D4055      80.535 -36.287   9.111  1.00 25.17           C  
+ATOM   7573  O   TYR D4055      80.029 -35.625  10.014  1.00 27.43           O  
+ATOM   7574  CB  TYR D4055      78.820 -37.830   8.088  1.00 24.82           C  
+ATOM   7575  CG  TYR D4055      77.794 -37.960   6.982  1.00 24.65           C  
+ATOM   7576  CD1 TYR D4055      78.004 -38.822   5.903  1.00 25.15           C  
+ATOM   7577  CD2 TYR D4055      76.666 -37.142   6.958  1.00 25.28           C  
+ATOM   7578  CE1 TYR D4055      77.117 -38.855   4.822  1.00 25.05           C  
+ATOM   7579  CE2 TYR D4055      75.772 -37.165   5.884  1.00 25.42           C  
+ATOM   7580  CZ  TYR D4055      76.003 -38.020   4.819  1.00 26.07           C  
+ATOM   7581  OH  TYR D4055      75.130 -38.021   3.751  1.00 24.95           O  
+ATOM   7582  N   LEU D4056      81.781 -36.732   9.187  1.00 24.89           N  
+ATOM   7583  CA  LEU D4056      82.582 -36.389  10.352  1.00 24.12           C  
+ATOM   7584  C   LEU D4056      82.835 -34.882  10.324  1.00 22.74           C  
+ATOM   7585  O   LEU D4056      82.662 -34.200  11.332  1.00 22.89           O  
+ATOM   7586  CB  LEU D4056      83.903 -37.165  10.366  1.00 26.13           C  
+ATOM   7587  CG  LEU D4056      83.825 -38.496  11.117  1.00 28.21           C  
+ATOM   7588  CD1 LEU D4056      85.118 -39.282  10.931  1.00 30.28           C  
+ATOM   7589  CD2 LEU D4056      83.567 -38.220  12.597  1.00 28.21           C  
+ATOM   7590  N   PRO D4057      83.249 -34.342   9.166  1.00 20.10           N  
+ATOM   7591  CA  PRO D4057      83.493 -32.898   9.078  1.00 19.55           C  
+ATOM   7592  C   PRO D4057      82.204 -32.105   9.354  1.00 19.37           C  
+ATOM   7593  O   PRO D4057      82.242 -31.035   9.959  1.00 16.52           O  
+ATOM   7594  CB  PRO D4057      83.987 -32.722   7.645  1.00 19.84           C  
+ATOM   7595  CG  PRO D4057      84.721 -34.011   7.400  1.00 20.84           C  
+ATOM   7596  CD  PRO D4057      83.767 -35.032   7.970  1.00 20.97           C  
+ATOM   7597  N   LEU D4058      81.070 -32.638   8.899  1.00 17.92           N  
+ATOM   7598  CA  LEU D4058      79.781 -31.990   9.118  1.00 16.86           C  
+ATOM   7599  C   LEU D4058      79.451 -31.982  10.616  1.00 17.79           C  
+ATOM   7600  O   LEU D4058      78.916 -31.003  11.133  1.00 17.23           O  
+ATOM   7601  CB  LEU D4058      78.670 -32.721   8.349  1.00 16.27           C  
+ATOM   7602  CG  LEU D4058      77.232 -32.200   8.521  1.00 17.78           C  
+ATOM   7603  CD1 LEU D4058      77.126 -30.771   8.005  1.00 16.15           C  
+ATOM   7604  CD2 LEU D4058      76.263 -33.089   7.767  1.00 17.19           C  
+ATOM   7605  N   SER D4059      79.773 -33.066  11.317  1.00 17.18           N  
+ATOM   7606  CA  SER D4059      79.494 -33.115  12.746  1.00 18.24           C  
+ATOM   7607  C   SER D4059      80.425 -32.147  13.467  1.00 18.43           C  
+ATOM   7608  O   SER D4059      80.050 -31.571  14.483  1.00 18.32           O  
+ATOM   7609  CB  SER D4059      79.657 -34.541  13.298  1.00 19.96           C  
+ATOM   7610  OG  SER D4059      81.005 -34.971  13.272  1.00 23.95           O  
+ATOM   7611  N   ARG D4060      81.630 -31.954  12.935  1.00 19.50           N  
+ATOM   7612  CA  ARG D4060      82.572 -31.021  13.540  1.00 21.62           C  
+ATOM   7613  C   ARG D4060      82.006 -29.612  13.389  1.00 20.46           C  
+ATOM   7614  O   ARG D4060      81.977 -28.846  14.347  1.00 21.35           O  
+ATOM   7615  CB  ARG D4060      83.954 -31.087  12.869  1.00 25.26           C  
+ATOM   7616  CG  ARG D4060      84.821 -32.291  13.265  1.00 31.99           C  
+ATOM   7617  CD  ARG D4060      86.268 -32.125  12.776  1.00 33.91           C  
+ATOM   7618  NE  ARG D4060      86.913 -30.955  13.377  1.00 38.93           N  
+ATOM   7619  CZ  ARG D4060      88.084 -30.456  12.989  1.00 39.67           C  
+ATOM   7620  NH1 ARG D4060      88.748 -31.026  11.993  1.00 42.02           N  
+ATOM   7621  NH2 ARG D4060      88.586 -29.382  13.590  1.00 40.28           N  
+ATOM   7622  N   LEU D4061      81.549 -29.285  12.185  1.00 19.71           N  
+ATOM   7623  CA  LEU D4061      80.974 -27.971  11.913  1.00 19.34           C  
+ATOM   7624  C   LEU D4061      79.823 -27.693  12.873  1.00 18.21           C  
+ATOM   7625  O   LEU D4061      79.739 -26.630  13.477  1.00 18.12           O  
+ATOM   7626  CB  LEU D4061      80.436 -27.888  10.485  1.00 19.51           C  
+ATOM   7627  CG  LEU D4061      79.805 -26.528  10.169  1.00 19.42           C  
+ATOM   7628  CD1 LEU D4061      80.894 -25.546   9.750  1.00 18.77           C  
+ATOM   7629  CD2 LEU D4061      78.787 -26.672   9.066  1.00 18.10           C  
+ATOM   7630  N   LEU D4062      78.933 -28.660  13.002  1.00 18.47           N  
+ATOM   7631  CA  LEU D4062      77.800 -28.502  13.891  1.00 19.26           C  
+ATOM   7632  C   LEU D4062      78.260 -28.261  15.326  1.00 19.72           C  
+ATOM   7633  O   LEU D4062      77.694 -27.425  16.031  1.00 19.74           O  
+ATOM   7634  CB  LEU D4062      76.908 -29.738  13.813  1.00 17.41           C  
+ATOM   7635  CG  LEU D4062      76.164 -29.871  12.480  1.00 18.45           C  
+ATOM   7636  CD1 LEU D4062      75.451 -31.213  12.424  1.00 14.75           C  
+ATOM   7637  CD2 LEU D4062      75.183 -28.717  12.329  1.00 13.37           C  
+ATOM   7638  N   ASN D4063      79.294 -28.984  15.751  1.00 20.46           N  
+ATOM   7639  CA  ASN D4063      79.809 -28.826  17.101  1.00 20.72           C  
+ATOM   7640  C   ASN D4063      80.335 -27.412  17.335  1.00 19.94           C  
+ATOM   7641  O   ASN D4063      80.230 -26.881  18.437  1.00 20.25           O  
+ATOM   7642  CB  ASN D4063      80.913 -29.845  17.389  1.00 21.25           C  
+ATOM   7643  CG  ASN D4063      81.503 -29.667  18.774  1.00 22.63           C  
+ATOM   7644  OD1 ASN D4063      82.552 -29.038  18.945  1.00 23.99           O  
+ATOM   7645  ND2 ASN D4063      80.812 -30.190  19.778  1.00 21.80           N  
+ATOM   7646  N   PHE D4064      80.906 -26.801  16.305  1.00 19.96           N  
+ATOM   7647  CA  PHE D4064      81.398 -25.433  16.445  1.00 20.34           C  
+ATOM   7648  C   PHE D4064      80.219 -24.478  16.694  1.00 19.58           C  
+ATOM   7649  O   PHE D4064      80.319 -23.559  17.509  1.00 18.77           O  
+ATOM   7650  CB  PHE D4064      82.168 -24.999  15.185  1.00 22.07           C  
+ATOM   7651  CG  PHE D4064      83.588 -25.510  15.128  1.00 21.79           C  
+ATOM   7652  CD1 PHE D4064      84.059 -26.173  13.996  1.00 23.49           C  
+ATOM   7653  CD2 PHE D4064      84.459 -25.306  16.196  1.00 22.90           C  
+ATOM   7654  CE1 PHE D4064      85.391 -26.629  13.924  1.00 23.12           C  
+ATOM   7655  CE2 PHE D4064      85.789 -25.754  16.141  1.00 23.86           C  
+ATOM   7656  CZ  PHE D4064      86.255 -26.418  15.000  1.00 22.32           C  
+ATOM   7657  N   TYR D4065      79.109 -24.693  15.991  1.00 18.09           N  
+ATOM   7658  CA  TYR D4065      77.945 -23.836  16.173  1.00 17.63           C  
+ATOM   7659  C   TYR D4065      77.362 -24.067  17.562  1.00 18.29           C  
+ATOM   7660  O   TYR D4065      76.983 -23.126  18.248  1.00 17.52           O  
+ATOM   7661  CB  TYR D4065      76.871 -24.128  15.117  1.00 16.18           C  
+ATOM   7662  CG  TYR D4065      77.096 -23.425  13.798  1.00 17.45           C  
+ATOM   7663  CD1 TYR D4065      78.061 -23.871  12.900  1.00 15.71           C  
+ATOM   7664  CD2 TYR D4065      76.365 -22.277  13.469  1.00 17.26           C  
+ATOM   7665  CE1 TYR D4065      78.298 -23.192  11.704  1.00 17.96           C  
+ATOM   7666  CE2 TYR D4065      76.599 -21.589  12.279  1.00 16.71           C  
+ATOM   7667  CZ  TYR D4065      77.567 -22.049  11.404  1.00 18.81           C  
+ATOM   7668  OH  TYR D4065      77.823 -21.351  10.246  1.00 22.45           O  
+ATOM   7669  N   ILE D4066      77.302 -25.327  17.971  1.00 18.81           N  
+ATOM   7670  CA  ILE D4066      76.760 -25.672  19.275  1.00 19.86           C  
+ATOM   7671  C   ILE D4066      77.628 -25.115  20.390  1.00 20.15           C  
+ATOM   7672  O   ILE D4066      77.111 -24.541  21.341  1.00 20.97           O  
+ATOM   7673  CB  ILE D4066      76.636 -27.200  19.429  1.00 19.01           C  
+ATOM   7674  CG1 ILE D4066      75.692 -27.733  18.349  1.00 18.69           C  
+ATOM   7675  CG2 ILE D4066      76.135 -27.558  20.827  1.00 17.32           C  
+ATOM   7676  CD1 ILE D4066      75.694 -29.245  18.207  1.00 18.24           C  
+ATOM   7677  N   SER D4067      78.945 -25.287  20.267  1.00 21.90           N  
+ATOM   7678  CA  SER D4067      79.887 -24.794  21.272  1.00 22.86           C  
+ATOM   7679  C   SER D4067      79.738 -23.293  21.399  1.00 22.04           C  
+ATOM   7680  O   SER D4067      79.635 -22.758  22.499  1.00 20.33           O  
+ATOM   7681  CB  SER D4067      81.335 -25.103  20.877  1.00 24.88           C  
+ATOM   7682  OG  SER D4067      81.610 -26.488  20.931  1.00 30.97           O  
+ATOM   7683  N   SER D4068      79.739 -22.619  20.257  1.00 21.75           N  
+ATOM   7684  CA  SER D4068      79.596 -21.173  20.250  1.00 22.84           C  
+ATOM   7685  C   SER D4068      78.332 -20.780  21.010  1.00 23.65           C  
+ATOM   7686  O   SER D4068      78.309 -19.790  21.733  1.00 23.67           O  
+ATOM   7687  CB  SER D4068      79.514 -20.656  18.818  1.00 20.34           C  
+ATOM   7688  OG  SER D4068      79.392 -19.245  18.816  1.00 22.68           O  
+ATOM   7689  N   ASN D4069      77.284 -21.576  20.848  1.00 24.98           N  
+ATOM   7690  CA  ASN D4069      76.026 -21.308  21.519  1.00 27.42           C  
+ATOM   7691  C   ASN D4069      76.165 -21.491  23.029  1.00 26.61           C  
+ATOM   7692  O   ASN D4069      75.688 -20.665  23.803  1.00 26.94           O  
+ATOM   7693  CB  ASN D4069      74.934 -22.223  20.962  1.00 28.97           C  
+ATOM   7694  CG  ASN D4069      73.606 -22.061  21.689  1.00 31.49           C  
+ATOM   7695  OD1 ASN D4069      73.352 -22.719  22.699  1.00 31.17           O  
+ATOM   7696  ND2 ASN D4069      72.758 -21.170  21.183  1.00 32.20           N  
+ATOM   7697  N   LEU D4070      76.834 -22.564  23.444  1.00 25.97           N  
+ATOM   7698  CA  LEU D4070      77.029 -22.838  24.864  1.00 24.51           C  
+ATOM   7699  C   LEU D4070      77.894 -21.770  25.536  1.00 24.60           C  
+ATOM   7700  O   LEU D4070      77.602 -21.354  26.658  1.00 25.89           O  
+ATOM   7701  CB  LEU D4070      77.654 -24.225  25.062  1.00 23.73           C  
+ATOM   7702  CG  LEU D4070      76.778 -25.424  24.668  1.00 23.51           C  
+ATOM   7703  CD1 LEU D4070      77.605 -26.704  24.659  1.00 20.94           C  
+ATOM   7704  CD2 LEU D4070      75.615 -25.543  25.629  1.00 21.22           C  
+ATOM   7705  N   ARG D4071      78.945 -21.322  24.856  1.00 22.36           N  
+ATOM   7706  CA  ARG D4071      79.816 -20.305  25.424  1.00 24.02           C  
+ATOM   7707  C   ARG D4071      79.031 -19.014  25.617  1.00 23.34           C  
+ATOM   7708  O   ARG D4071      79.072 -18.405  26.682  1.00 23.18           O  
+ATOM   7709  CB  ARG D4071      81.019 -20.031  24.509  1.00 27.94           C  
+ATOM   7710  CG  ARG D4071      81.849 -21.253  24.140  1.00 34.14           C  
+ATOM   7711  CD  ARG D4071      82.543 -21.847  25.344  1.00 39.22           C  
+ATOM   7712  NE  ARG D4071      83.010 -23.207  25.092  1.00 43.38           N  
+ATOM   7713  CZ  ARG D4071      83.691 -23.936  25.972  1.00 44.08           C  
+ATOM   7714  NH1 ARG D4071      83.991 -23.435  27.163  1.00 44.39           N  
+ATOM   7715  NH2 ARG D4071      84.067 -25.171  25.666  1.00 46.14           N  
+ATOM   7716  N   ARG D4072      78.323 -18.591  24.577  1.00 21.42           N  
+ATOM   7717  CA  ARG D4072      77.540 -17.365  24.656  1.00 20.23           C  
+ATOM   7718  C   ARG D4072      76.504 -17.458  25.780  1.00 19.36           C  
+ATOM   7719  O   ARG D4072      76.224 -16.479  26.459  1.00 18.91           O  
+ATOM   7720  CB  ARG D4072      76.839 -17.094  23.318  1.00 19.61           C  
+ATOM   7721  CG  ARG D4072      76.070 -15.777  23.272  1.00 19.72           C  
+ATOM   7722  CD  ARG D4072      75.246 -15.657  21.994  1.00 21.92           C  
+ATOM   7723  NE  ARG D4072      73.994 -16.412  22.049  1.00 19.87           N  
+ATOM   7724  CZ  ARG D4072      73.207 -16.621  21.002  1.00 20.68           C  
+ATOM   7725  NH1 ARG D4072      73.543 -16.142  19.807  1.00 21.17           N  
+ATOM   7726  NH2 ARG D4072      72.074 -17.287  21.151  1.00 20.14           N  
+ATOM   7727  N   GLN D4073      75.937 -18.646  25.959  1.00 21.90           N  
+ATOM   7728  CA  GLN D4073      74.933 -18.884  26.988  1.00 25.45           C  
+ATOM   7729  C   GLN D4073      75.549 -18.600  28.355  1.00 25.17           C  
+ATOM   7730  O   GLN D4073      74.876 -18.091  29.247  1.00 25.14           O  
+ATOM   7731  CB  GLN D4073      74.451 -20.338  26.918  1.00 30.41           C  
+ATOM   7732  CG  GLN D4073      73.090 -20.602  27.558  1.00 36.55           C  
+ATOM   7733  CD  GLN D4073      72.498 -21.962  27.140  1.00 44.05           C  
+ATOM   7734  OE1 GLN D4073      72.912 -22.561  26.131  1.00 44.61           O  
+ATOM   7735  NE2 GLN D4073      71.510 -22.441  27.902  1.00 45.16           N  
+ATOM   7736  N   ALA D4074      76.834 -18.920  28.502  1.00 24.69           N  
+ATOM   7737  CA  ALA D4074      77.550 -18.689  29.752  1.00 24.18           C  
+ATOM   7738  C   ALA D4074      77.764 -17.191  29.951  1.00 24.40           C  
+ATOM   7739  O   ALA D4074      77.532 -16.656  31.036  1.00 24.23           O  
+ATOM   7740  CB  ALA D4074      78.895 -19.420  29.732  1.00 22.74           C  
+ATOM   7741  N   VAL D4075      78.206 -16.514  28.896  1.00 24.20           N  
+ATOM   7742  CA  VAL D4075      78.445 -15.074  28.957  1.00 22.47           C  
+ATOM   7743  C   VAL D4075      77.161 -14.326  29.281  1.00 23.08           C  
+ATOM   7744  O   VAL D4075      77.171 -13.327  30.003  1.00 21.80           O  
+ATOM   7745  CB  VAL D4075      78.971 -14.552  27.617  1.00 23.52           C  
+ATOM   7746  CG1 VAL D4075      78.876 -13.038  27.577  1.00 21.24           C  
+ATOM   7747  CG2 VAL D4075      80.421 -15.017  27.408  1.00 22.82           C  
+ATOM   7748  N   LEU D4076      76.056 -14.811  28.729  1.00 23.28           N  
+ATOM   7749  CA  LEU D4076      74.767 -14.180  28.939  1.00 25.10           C  
+ATOM   7750  C   LEU D4076      74.181 -14.526  30.299  1.00 25.98           C  
+ATOM   7751  O   LEU D4076      73.499 -13.713  30.906  1.00 25.22           O  
+ATOM   7752  CB  LEU D4076      73.802 -14.588  27.825  1.00 24.88           C  
+ATOM   7753  CG  LEU D4076      74.141 -13.972  26.459  1.00 26.41           C  
+ATOM   7754  CD1 LEU D4076      73.258 -14.572  25.373  1.00 26.03           C  
+ATOM   7755  CD2 LEU D4076      73.968 -12.458  26.529  1.00 24.22           C  
+ATOM   7756  N   GLU D4077      74.449 -15.734  30.778  1.00 26.98           N  
+ATOM   7757  CA  GLU D4077      73.927 -16.139  32.073  1.00 28.76           C  
+ATOM   7758  C   GLU D4077      74.517 -15.215  33.129  1.00 28.86           C  
+ATOM   7759  O   GLU D4077      73.811 -14.742  34.013  1.00 29.07           O  
+ATOM   7760  CB  GLU D4077      74.303 -17.585  32.360  1.00 29.43           C  
+ATOM   7761  CG  GLU D4077      73.977 -18.050  33.767  1.00 33.34           C  
+ATOM   7762  CD  GLU D4077      74.079 -19.558  33.897  1.00 34.95           C  
+ATOM   7763  OE1 GLU D4077      73.202 -20.256  33.341  1.00 35.73           O  
+ATOM   7764  OE2 GLU D4077      75.037 -20.043  34.537  1.00 34.60           O  
+ATOM   7765  N   GLN D4078      75.811 -14.948  33.006  1.00 28.57           N  
+ATOM   7766  CA  GLN D4078      76.523 -14.080  33.930  1.00 29.22           C  
+ATOM   7767  C   GLN D4078      75.972 -12.659  33.902  1.00 30.31           C  
+ATOM   7768  O   GLN D4078      75.752 -12.045  34.954  1.00 30.63           O  
+ATOM   7769  CB  GLN D4078      78.009 -14.047  33.575  1.00 30.42           C  
+ATOM   7770  CG  GLN D4078      78.834 -13.112  34.446  1.00 30.78           C  
+ATOM   7771  CD  GLN D4078      80.287 -13.103  34.041  1.00 31.69           C  
+ATOM   7772  OE1 GLN D4078      80.638 -12.665  32.943  1.00 32.07           O  
+ATOM   7773  NE2 GLN D4078      81.147 -13.600  34.920  1.00 33.28           N  
+ATOM   7774  N   PHE D4079      75.761 -12.141  32.695  1.00 28.65           N  
+ATOM   7775  CA  PHE D4079      75.242 -10.790  32.499  1.00 27.91           C  
+ATOM   7776  C   PHE D4079      73.796 -10.639  32.963  1.00 27.77           C  
+ATOM   7777  O   PHE D4079      73.472  -9.722  33.715  1.00 26.33           O  
+ATOM   7778  CB  PHE D4079      75.340 -10.406  31.016  1.00 26.28           C  
+ATOM   7779  CG  PHE D4079      74.686  -9.088  30.677  1.00 25.76           C  
+ATOM   7780  CD1 PHE D4079      75.189  -7.896  31.184  1.00 27.72           C  
+ATOM   7781  CD2 PHE D4079      73.578  -9.043  29.836  1.00 25.97           C  
+ATOM   7782  CE1 PHE D4079      74.599  -6.674  30.859  1.00 26.80           C  
+ATOM   7783  CE2 PHE D4079      72.980  -7.834  29.502  1.00 27.13           C  
+ATOM   7784  CZ  PHE D4079      73.492  -6.644  30.015  1.00 28.01           C  
+ATOM   7785  N   LEU D4080      72.936 -11.535  32.493  1.00 27.99           N  
+ATOM   7786  CA  LEU D4080      71.513 -11.506  32.820  1.00 30.97           C  
+ATOM   7787  C   LEU D4080      71.222 -12.057  34.209  1.00 35.01           C  
+ATOM   7788  O   LEU D4080      70.102 -11.953  34.701  1.00 35.65           O  
+ATOM   7789  CB  LEU D4080      70.716 -12.321  31.791  1.00 28.23           C  
+ATOM   7790  CG  LEU D4080      70.763 -11.906  30.315  1.00 25.98           C  
+ATOM   7791  CD1 LEU D4080      70.067 -12.952  29.465  1.00 22.36           C  
+ATOM   7792  CD2 LEU D4080      70.103 -10.553  30.135  1.00 25.66           C  
+ATOM   7793  N   GLY D4081      72.230 -12.651  34.839  1.00 38.86           N  
+ATOM   7794  CA  GLY D4081      72.028 -13.208  36.163  1.00 43.76           C  
+ATOM   7795  C   GLY D4081      70.888 -14.208  36.190  1.00 47.14           C  
+ATOM   7796  O   GLY D4081      70.252 -14.415  37.221  1.00 47.52           O  
+ATOM   7797  N   THR D4082      70.623 -14.832  35.050  1.00 51.20           N  
+ATOM   7798  CA  THR D4082      69.546 -15.808  34.971  1.00 54.94           C  
+ATOM   7799  C   THR D4082      70.109 -17.207  34.828  1.00 57.03           C  
+ATOM   7800  O   THR D4082      70.399 -17.653  33.716  1.00 56.44           O  
+ATOM   7801  CB  THR D4082      68.617 -15.545  33.767  1.00 55.32           C  
+ATOM   7802  OG1 THR D4082      68.157 -14.191  33.798  1.00 56.80           O  
+ATOM   7803  CG2 THR D4082      67.408 -16.472  33.819  1.00 56.49           C  
+ATOM   7804  N   ASN D4083      70.280 -17.888  35.958  1.00 59.55           N  
+ATOM   7805  CA  ASN D4083      70.786 -19.257  35.951  1.00 61.90           C  
+ATOM   7806  C   ASN D4083      69.614 -20.137  35.524  1.00 61.52           C  
+ATOM   7807  O   ASN D4083      69.301 -21.144  36.161  1.00 61.82           O  
+ATOM   7808  CB  ASN D4083      71.270 -19.655  37.350  1.00 63.96           C  
+ATOM   7809  CG  ASN D4083      72.766 -19.936  37.394  1.00 66.34           C  
+ATOM   7810  OD1 ASN D4083      73.264 -20.816  36.685  1.00 66.61           O  
+ATOM   7811  ND2 ASN D4083      73.487 -19.192  38.231  1.00 66.65           N  
+ATOM   7812  N   GLY D4084      68.966 -19.732  34.437  1.00 60.92           N  
+ATOM   7813  CA  GLY D4084      67.819 -20.453  33.927  1.00 60.12           C  
+ATOM   7814  C   GLY D4084      68.091 -21.890  33.542  1.00 59.04           C  
+ATOM   7815  O   GLY D4084      69.216 -22.383  33.660  1.00 59.24           O  
+ATOM   7816  N   GLN D4085      67.042 -22.564  33.082  1.00 57.61           N  
+ATOM   7817  CA  GLN D4085      67.138 -23.954  32.666  1.00 55.76           C  
+ATOM   7818  C   GLN D4085      67.990 -24.066  31.411  1.00 53.73           C  
+ATOM   7819  O   GLN D4085      68.117 -23.109  30.646  1.00 53.97           O  
+ATOM   7820  CB  GLN D4085      65.744 -24.511  32.398  1.00 57.30           C  
+ATOM   7821  N   ARG D4086      68.585 -25.232  31.209  1.00 50.89           N  
+ATOM   7822  CA  ARG D4086      69.399 -25.451  30.026  1.00 47.92           C  
+ATOM   7823  C   ARG D4086      68.419 -25.674  28.884  1.00 44.75           C  
+ATOM   7824  O   ARG D4086      67.501 -26.491  28.997  1.00 46.18           O  
+ATOM   7825  CB  ARG D4086      70.286 -26.680  30.212  1.00 49.00           C  
+ATOM   7826  N   ILE D4087      68.597 -24.939  27.792  1.00 39.29           N  
+ATOM   7827  CA  ILE D4087      67.716 -25.073  26.639  1.00 32.64           C  
+ATOM   7828  C   ILE D4087      68.391 -25.918  25.563  1.00 29.78           C  
+ATOM   7829  O   ILE D4087      69.541 -25.674  25.212  1.00 28.03           O  
+ATOM   7830  CB  ILE D4087      67.380 -23.689  26.049  1.00 32.15           C  
+ATOM   7831  CG1 ILE D4087      66.746 -22.805  27.131  1.00 30.55           C  
+ATOM   7832  CG2 ILE D4087      66.465 -23.846  24.841  1.00 31.83           C  
+ATOM   7833  CD1 ILE D4087      65.463 -23.364  27.717  1.00 23.40           C  
+ATOM   7834  N   PRO D4088      67.686 -26.927  25.035  1.00 27.28           N  
+ATOM   7835  CA  PRO D4088      68.206 -27.819  23.996  1.00 26.71           C  
+ATOM   7836  C   PRO D4088      68.560 -27.112  22.689  1.00 25.72           C  
+ATOM   7837  O   PRO D4088      67.806 -26.266  22.204  1.00 24.79           O  
+ATOM   7838  CB  PRO D4088      67.066 -28.812  23.793  1.00 27.10           C  
+ATOM   7839  CG  PRO D4088      66.430 -28.866  25.132  1.00 28.85           C  
+ATOM   7840  CD  PRO D4088      66.383 -27.412  25.518  1.00 28.70           C  
+ATOM   7841  N   TYR D4089      69.715 -27.457  22.127  1.00 22.95           N  
+ATOM   7842  CA  TYR D4089      70.127 -26.881  20.854  1.00 20.94           C  
+ATOM   7843  C   TYR D4089      69.353 -27.729  19.862  1.00 21.52           C  
+ATOM   7844  O   TYR D4089      69.409 -28.960  19.927  1.00 21.01           O  
+ATOM   7845  CB  TYR D4089      71.621 -27.068  20.623  1.00 18.54           C  
+ATOM   7846  CG  TYR D4089      72.124 -26.359  19.389  1.00 19.08           C  
+ATOM   7847  CD1 TYR D4089      72.591 -25.043  19.453  1.00 19.42           C  
+ATOM   7848  CD2 TYR D4089      72.118 -26.993  18.155  1.00 18.78           C  
+ATOM   7849  CE1 TYR D4089      73.045 -24.385  18.313  1.00 19.83           C  
+ATOM   7850  CE2 TYR D4089      72.568 -26.339  17.004  1.00 19.60           C  
+ATOM   7851  CZ  TYR D4089      73.031 -25.041  17.091  1.00 17.34           C  
+ATOM   7852  OH  TYR D4089      73.475 -24.411  15.959  1.00 16.54           O  
+ATOM   7853  N   ILE D4090      68.627 -27.093  18.950  1.00 22.04           N  
+ATOM   7854  CA  ILE D4090      67.827 -27.859  17.999  1.00 20.71           C  
+ATOM   7855  C   ILE D4090      68.297 -27.782  16.552  1.00 19.89           C  
+ATOM   7856  O   ILE D4090      68.495 -26.695  15.997  1.00 20.52           O  
+ATOM   7857  CB  ILE D4090      66.344 -27.428  18.058  1.00 19.96           C  
+ATOM   7858  CG1 ILE D4090      65.801 -27.618  19.477  1.00 19.82           C  
+ATOM   7859  CG2 ILE D4090      65.528 -28.250  17.065  1.00 20.40           C  
+ATOM   7860  CD1 ILE D4090      64.316 -27.234  19.634  1.00 18.74           C  
+ATOM   7861  N   ILE D4091      68.457 -28.955  15.948  1.00 19.36           N  
+ATOM   7862  CA  ILE D4091      68.885 -29.062  14.559  1.00 20.58           C  
+ATOM   7863  C   ILE D4091      67.776 -29.754  13.763  1.00 21.42           C  
+ATOM   7864  O   ILE D4091      67.320 -30.834  14.144  1.00 22.34           O  
+ATOM   7865  CB  ILE D4091      70.161 -29.931  14.412  1.00 19.42           C  
+ATOM   7866  CG1 ILE D4091      71.325 -29.325  15.209  1.00 17.58           C  
+ATOM   7867  CG2 ILE D4091      70.513 -30.062  12.931  1.00 21.05           C  
+ATOM   7868  CD1 ILE D4091      72.513 -30.269  15.400  1.00 13.92           C  
+ATOM   7869  N   SER D4092      67.343 -29.139  12.668  1.00 20.57           N  
+ATOM   7870  CA  SER D4092      66.306 -29.747  11.839  1.00 20.22           C  
+ATOM   7871  C   SER D4092      66.918 -30.200  10.514  1.00 19.54           C  
+ATOM   7872  O   SER D4092      67.942 -29.672  10.070  1.00 20.05           O  
+ATOM   7873  CB  SER D4092      65.148 -28.767  11.586  1.00 16.32           C  
+ATOM   7874  OG  SER D4092      65.532 -27.688  10.763  1.00 20.18           O  
+ATOM   7875  N   ILE D4093      66.296 -31.201   9.901  1.00 18.80           N  
+ATOM   7876  CA  ILE D4093      66.773 -31.741   8.638  1.00 18.52           C  
+ATOM   7877  C   ILE D4093      65.579 -31.883   7.704  1.00 18.14           C  
+ATOM   7878  O   ILE D4093      64.642 -32.627   7.988  1.00 15.99           O  
+ATOM   7879  CB  ILE D4093      67.461 -33.109   8.857  1.00 18.54           C  
+ATOM   7880  CG1 ILE D4093      68.669 -32.928   9.784  1.00 18.32           C  
+ATOM   7881  CG2 ILE D4093      67.907 -33.697   7.526  1.00 18.29           C  
+ATOM   7882  CD1 ILE D4093      69.316 -34.206  10.221  1.00 17.67           C  
+ATOM   7883  N   ALA D4094      65.626 -31.145   6.598  1.00 17.58           N  
+ATOM   7884  CA  ALA D4094      64.552 -31.138   5.618  1.00 18.33           C  
+ATOM   7885  C   ALA D4094      64.977 -31.747   4.293  1.00 20.14           C  
+ATOM   7886  O   ALA D4094      66.144 -32.087   4.092  1.00 21.41           O  
+ATOM   7887  CB  ALA D4094      64.073 -29.703   5.395  1.00 17.45           C  
+ATOM   7888  N   GLY D4095      64.012 -31.873   3.386  1.00 20.83           N  
+ATOM   7889  CA  GLY D4095      64.293 -32.438   2.083  1.00 20.03           C  
+ATOM   7890  C   GLY D4095      63.200 -33.376   1.603  1.00 19.78           C  
+ATOM   7891  O   GLY D4095      62.276 -33.737   2.349  1.00 18.31           O  
+ATOM   7892  N   SER D4096      63.313 -33.775   0.344  1.00 18.26           N  
+ATOM   7893  CA  SER D4096      62.345 -34.671  -0.274  1.00 20.45           C  
+ATOM   7894  C   SER D4096      62.179 -36.005   0.430  1.00 21.33           C  
+ATOM   7895  O   SER D4096      63.076 -36.477   1.139  1.00 21.23           O  
+ATOM   7896  CB  SER D4096      62.738 -34.962  -1.728  1.00 19.91           C  
+ATOM   7897  OG  SER D4096      61.944 -36.014  -2.266  1.00 19.12           O  
+ATOM   7898  N   VAL D4097      61.015 -36.609   0.230  1.00 21.10           N  
+ATOM   7899  CA  VAL D4097      60.764 -37.930   0.777  1.00 21.48           C  
+ATOM   7900  C   VAL D4097      61.806 -38.801   0.058  1.00 20.33           C  
+ATOM   7901  O   VAL D4097      62.041 -38.634  -1.144  1.00 19.27           O  
+ATOM   7902  CB  VAL D4097      59.327 -38.416   0.419  1.00 21.39           C  
+ATOM   7903  CG1 VAL D4097      59.183 -39.912   0.707  1.00 19.91           C  
+ATOM   7904  CG2 VAL D4097      58.291 -37.618   1.215  1.00 20.14           C  
+ATOM   7905  N   ALA D4098      62.450 -39.692   0.807  1.00 20.82           N  
+ATOM   7906  CA  ALA D4098      63.461 -40.602   0.268  1.00 21.66           C  
+ATOM   7907  C   ALA D4098      64.817 -39.999  -0.106  1.00 22.75           C  
+ATOM   7908  O   ALA D4098      65.618 -40.669  -0.762  1.00 24.27           O  
+ATOM   7909  CB  ALA D4098      62.895 -41.339  -0.937  1.00 21.67           C  
+ATOM   7910  N   VAL D4099      65.100 -38.760   0.292  1.00 21.57           N  
+ATOM   7911  CA  VAL D4099      66.395 -38.186  -0.058  1.00 20.69           C  
+ATOM   7912  C   VAL D4099      67.478 -38.694   0.891  1.00 21.60           C  
+ATOM   7913  O   VAL D4099      68.662 -38.678   0.555  1.00 22.10           O  
+ATOM   7914  CB  VAL D4099      66.381 -36.635  -0.021  1.00 18.50           C  
+ATOM   7915  CG1 VAL D4099      66.210 -36.136   1.403  1.00 17.28           C  
+ATOM   7916  CG2 VAL D4099      67.669 -36.101  -0.636  1.00 17.98           C  
+ATOM   7917  N   GLY D4100      67.059 -39.148   2.072  1.00 21.72           N  
+ATOM   7918  CA  GLY D4100      67.996 -39.661   3.055  1.00 20.83           C  
+ATOM   7919  C   GLY D4100      68.051 -38.888   4.362  1.00 22.46           C  
+ATOM   7920  O   GLY D4100      69.088 -38.886   5.044  1.00 21.69           O  
+ATOM   7921  N   LYS D4101      66.944 -38.235   4.720  1.00 21.23           N  
+ATOM   7922  CA  LYS D4101      66.879 -37.455   5.954  1.00 21.66           C  
+ATOM   7923  C   LYS D4101      67.057 -38.330   7.183  1.00 22.42           C  
+ATOM   7924  O   LYS D4101      67.805 -37.994   8.094  1.00 25.12           O  
+ATOM   7925  CB  LYS D4101      65.531 -36.732   6.071  1.00 20.19           C  
+ATOM   7926  CG  LYS D4101      65.284 -35.642   5.035  1.00 18.78           C  
+ATOM   7927  CD  LYS D4101      63.962 -34.926   5.289  1.00 16.69           C  
+ATOM   7928  CE  LYS D4101      62.779 -35.900   5.275  1.00 17.90           C  
+ATOM   7929  NZ  LYS D4101      62.649 -36.615   3.960  1.00 18.43           N  
+ATOM   7930  N   SER D4102      66.350 -39.451   7.210  1.00 23.79           N  
+ATOM   7931  CA  SER D4102      66.413 -40.349   8.351  1.00 25.43           C  
+ATOM   7932  C   SER D4102      67.814 -40.900   8.573  1.00 25.55           C  
+ATOM   7933  O   SER D4102      68.282 -40.982   9.708  1.00 25.80           O  
+ATOM   7934  CB  SER D4102      65.429 -41.494   8.167  1.00 25.76           C  
+ATOM   7935  OG  SER D4102      65.442 -42.326   9.307  1.00 30.49           O  
+ATOM   7936  N   THR D4103      68.477 -41.282   7.488  1.00 25.01           N  
+ATOM   7937  CA  THR D4103      69.832 -41.803   7.585  1.00 25.13           C  
+ATOM   7938  C   THR D4103      70.781 -40.686   8.036  1.00 24.65           C  
+ATOM   7939  O   THR D4103      71.605 -40.877   8.935  1.00 24.83           O  
+ATOM   7940  CB  THR D4103      70.308 -42.377   6.226  1.00 24.58           C  
+ATOM   7941  OG1 THR D4103      69.543 -43.550   5.919  1.00 28.86           O  
+ATOM   7942  CG2 THR D4103      71.781 -42.761   6.284  1.00 25.36           C  
+ATOM   7943  N   THR D4104      70.650 -39.516   7.422  1.00 23.51           N  
+ATOM   7944  CA  THR D4104      71.498 -38.379   7.765  1.00 22.98           C  
+ATOM   7945  C   THR D4104      71.347 -38.003   9.236  1.00 22.38           C  
+ATOM   7946  O   THR D4104      72.332 -37.775   9.937  1.00 23.23           O  
+ATOM   7947  CB  THR D4104      71.159 -37.154   6.891  1.00 22.14           C  
+ATOM   7948  OG1 THR D4104      71.342 -37.495   5.514  1.00 22.57           O  
+ATOM   7949  CG2 THR D4104      72.066 -35.983   7.225  1.00 22.99           C  
+ATOM   7950  N   ALA D4105      70.104 -37.951   9.698  1.00 21.51           N  
+ATOM   7951  CA  ALA D4105      69.816 -37.607  11.085  1.00 20.80           C  
+ATOM   7952  C   ALA D4105      70.465 -38.594  12.050  1.00 22.02           C  
+ATOM   7953  O   ALA D4105      71.162 -38.200  12.995  1.00 21.71           O  
+ATOM   7954  CB  ALA D4105      68.321 -37.585  11.315  1.00 18.39           C  
+ATOM   7955  N   ARG D4106      70.240 -39.879  11.806  1.00 21.88           N  
+ATOM   7956  CA  ARG D4106      70.785 -40.914  12.667  1.00 22.47           C  
+ATOM   7957  C   ARG D4106      72.303 -40.938  12.654  1.00 21.27           C  
+ATOM   7958  O   ARG D4106      72.925 -41.213  13.681  1.00 21.49           O  
+ATOM   7959  CB  ARG D4106      70.192 -42.273  12.275  1.00 24.00           C  
+ATOM   7960  CG  ARG D4106      68.701 -42.364  12.628  1.00 28.37           C  
+ATOM   7961  CD  ARG D4106      68.010 -43.474  11.874  1.00 31.42           C  
+ATOM   7962  NE  ARG D4106      68.454 -44.779  12.339  1.00 37.57           N  
+ATOM   7963  CZ  ARG D4106      68.326 -45.901  11.642  1.00 39.99           C  
+ATOM   7964  NH1 ARG D4106      67.767 -45.879  10.437  1.00 42.03           N  
+ATOM   7965  NH2 ARG D4106      68.761 -47.047  12.154  1.00 40.91           N  
+ATOM   7966  N   VAL D4107      72.905 -40.647  11.502  1.00 20.83           N  
+ATOM   7967  CA  VAL D4107      74.363 -40.613  11.421  1.00 20.55           C  
+ATOM   7968  C   VAL D4107      74.857 -39.443  12.272  1.00 21.62           C  
+ATOM   7969  O   VAL D4107      75.770 -39.603  13.084  1.00 22.05           O  
+ATOM   7970  CB  VAL D4107      74.861 -40.434   9.960  1.00 21.12           C  
+ATOM   7971  CG1 VAL D4107      76.343 -40.105   9.949  1.00 20.95           C  
+ATOM   7972  CG2 VAL D4107      74.621 -41.717   9.164  1.00 20.17           C  
+ATOM   7973  N   LEU D4108      74.240 -38.273  12.092  1.00 21.41           N  
+ATOM   7974  CA  LEU D4108      74.623 -37.086  12.858  1.00 19.35           C  
+ATOM   7975  C   LEU D4108      74.388 -37.274  14.351  1.00 19.45           C  
+ATOM   7976  O   LEU D4108      75.145 -36.752  15.171  1.00 19.93           O  
+ATOM   7977  CB  LEU D4108      73.854 -35.860  12.367  1.00 17.73           C  
+ATOM   7978  CG  LEU D4108      74.268 -35.381  10.974  1.00 17.88           C  
+ATOM   7979  CD1 LEU D4108      73.478 -34.136  10.594  1.00 17.60           C  
+ATOM   7980  CD2 LEU D4108      75.767 -35.093  10.961  1.00 15.26           C  
+ATOM   7981  N   GLN D4109      73.344 -38.014  14.710  1.00 20.01           N  
+ATOM   7982  CA  GLN D4109      73.059 -38.270  16.120  1.00 22.12           C  
+ATOM   7983  C   GLN D4109      74.212 -39.070  16.736  1.00 23.73           C  
+ATOM   7984  O   GLN D4109      74.681 -38.776  17.838  1.00 22.89           O  
+ATOM   7985  CB  GLN D4109      71.758 -39.059  16.259  1.00 22.61           C  
+ATOM   7986  CG  GLN D4109      71.511 -39.612  17.652  1.00 23.30           C  
+ATOM   7987  CD  GLN D4109      70.169 -40.300  17.762  1.00 24.93           C  
+ATOM   7988  OE1 GLN D4109      69.837 -41.155  16.944  1.00 25.36           O  
+ATOM   7989  NE2 GLN D4109      69.391 -39.938  18.783  1.00 22.86           N  
+ATOM   7990  N   ALA D4110      74.665 -40.075  15.999  1.00 25.46           N  
+ATOM   7991  CA  ALA D4110      75.757 -40.931  16.436  1.00 26.92           C  
+ATOM   7992  C   ALA D4110      77.062 -40.148  16.561  1.00 27.73           C  
+ATOM   7993  O   ALA D4110      77.745 -40.223  17.582  1.00 29.63           O  
+ATOM   7994  CB  ALA D4110      75.928 -42.085  15.451  1.00 24.80           C  
+ATOM   7995  N   LEU D4111      77.408 -39.386  15.528  1.00 27.90           N  
+ATOM   7996  CA  LEU D4111      78.645 -38.617  15.553  1.00 27.89           C  
+ATOM   7997  C   LEU D4111      78.669 -37.507  16.614  1.00 28.96           C  
+ATOM   7998  O   LEU D4111      79.672 -37.320  17.306  1.00 28.78           O  
+ATOM   7999  CB  LEU D4111      78.919 -38.031  14.165  1.00 25.67           C  
+ATOM   8000  CG  LEU D4111      79.045 -39.086  13.058  1.00 26.22           C  
+ATOM   8001  CD1 LEU D4111      79.309 -38.412  11.720  1.00 24.95           C  
+ATOM   8002  CD2 LEU D4111      80.177 -40.056  13.395  1.00 26.44           C  
+ATOM   8003  N   LEU D4112      77.572 -36.771  16.754  1.00 29.29           N  
+ATOM   8004  CA  LEU D4112      77.532 -35.697  17.740  1.00 29.61           C  
+ATOM   8005  C   LEU D4112      77.694 -36.237  19.151  1.00 30.13           C  
+ATOM   8006  O   LEU D4112      78.081 -35.504  20.062  1.00 29.67           O  
+ATOM   8007  CB  LEU D4112      76.231 -34.899  17.615  1.00 27.72           C  
+ATOM   8008  CG  LEU D4112      76.188 -33.962  16.400  1.00 27.62           C  
+ATOM   8009  CD1 LEU D4112      74.778 -33.442  16.183  1.00 28.25           C  
+ATOM   8010  CD2 LEU D4112      77.162 -32.802  16.619  1.00 27.58           C  
+ATOM   8011  N   SER D4113      77.412 -37.526  19.320  1.00 30.95           N  
+ATOM   8012  CA  SER D4113      77.533 -38.179  20.623  1.00 32.65           C  
+ATOM   8013  C   SER D4113      78.993 -38.358  21.044  1.00 32.49           C  
+ATOM   8014  O   SER D4113      79.278 -38.647  22.203  1.00 33.07           O  
+ATOM   8015  CB  SER D4113      76.841 -39.549  20.605  1.00 32.44           C  
+ATOM   8016  OG  SER D4113      75.430 -39.420  20.686  1.00 35.97           O  
+ATOM   8017  N   ARG D4114      79.911 -38.181  20.100  1.00 32.01           N  
+ATOM   8018  CA  ARG D4114      81.337 -38.327  20.373  1.00 31.84           C  
+ATOM   8019  C   ARG D4114      81.884 -37.301  21.374  1.00 31.68           C  
+ATOM   8020  O   ARG D4114      82.835 -37.587  22.113  1.00 30.80           O  
+ATOM   8021  CB  ARG D4114      82.121 -38.252  19.059  1.00 31.69           C  
+ATOM   8022  CG  ARG D4114      81.968 -39.490  18.193  1.00 34.63           C  
+ATOM   8023  CD  ARG D4114      82.261 -39.208  16.726  1.00 37.83           C  
+ATOM   8024  NE  ARG D4114      83.546 -38.545  16.517  1.00 40.25           N  
+ATOM   8025  CZ  ARG D4114      84.724 -39.084  16.814  1.00 42.89           C  
+ATOM   8026  NH1 ARG D4114      84.785 -40.303  17.335  1.00 43.10           N  
+ATOM   8027  NH2 ARG D4114      85.842 -38.406  16.586  1.00 44.36           N  
+ATOM   8028  N   TRP D4115      81.289 -36.114  21.398  1.00 29.49           N  
+ATOM   8029  CA  TRP D4115      81.731 -35.069  22.308  1.00 28.62           C  
+ATOM   8030  C   TRP D4115      81.151 -35.304  23.694  1.00 31.26           C  
+ATOM   8031  O   TRP D4115      79.965 -35.587  23.839  1.00 32.03           O  
+ATOM   8032  CB  TRP D4115      81.281 -33.699  21.805  1.00 26.24           C  
+ATOM   8033  CG  TRP D4115      82.133 -33.133  20.717  1.00 24.55           C  
+ATOM   8034  CD1 TRP D4115      83.178 -32.266  20.861  1.00 22.01           C  
+ATOM   8035  CD2 TRP D4115      82.020 -33.401  19.313  1.00 23.43           C  
+ATOM   8036  NE1 TRP D4115      83.723 -31.974  19.632  1.00 21.81           N  
+ATOM   8037  CE2 TRP D4115      83.031 -32.659  18.665  1.00 23.00           C  
+ATOM   8038  CE3 TRP D4115      81.166 -34.198  18.539  1.00 23.12           C  
+ATOM   8039  CZ2 TRP D4115      83.210 -32.688  17.280  1.00 22.93           C  
+ATOM   8040  CZ3 TRP D4115      81.344 -34.225  17.162  1.00 23.20           C  
+ATOM   8041  CH2 TRP D4115      82.358 -33.476  16.549  1.00 24.02           C  
+ATOM   8042  N   PRO D4116      81.989 -35.197  24.735  1.00 33.04           N  
+ATOM   8043  CA  PRO D4116      81.550 -35.398  26.118  1.00 34.18           C  
+ATOM   8044  C   PRO D4116      80.418 -34.452  26.503  1.00 35.72           C  
+ATOM   8045  O   PRO D4116      79.605 -34.776  27.365  1.00 38.17           O  
+ATOM   8046  CB  PRO D4116      82.821 -35.126  26.925  1.00 33.33           C  
+ATOM   8047  CG  PRO D4116      83.903 -35.581  25.998  1.00 33.52           C  
+ATOM   8048  CD  PRO D4116      83.451 -35.013  24.671  1.00 31.50           C  
+ATOM   8049  N   GLU D4117      80.374 -33.282  25.869  1.00 37.06           N  
+ATOM   8050  CA  GLU D4117      79.339 -32.291  26.157  1.00 39.22           C  
+ATOM   8051  C   GLU D4117      77.945 -32.710  25.688  1.00 39.05           C  
+ATOM   8052  O   GLU D4117      76.951 -32.352  26.313  1.00 41.17           O  
+ATOM   8053  CB  GLU D4117      79.663 -30.948  25.501  1.00 40.77           C  
+ATOM   8054  CG  GLU D4117      80.849 -30.205  26.076  1.00 43.12           C  
+ATOM   8055  CD  GLU D4117      82.159 -30.903  25.814  1.00 44.16           C  
+ATOM   8056  OE1 GLU D4117      82.389 -31.322  24.654  1.00 41.03           O  
+ATOM   8057  OE2 GLU D4117      82.957 -31.021  26.771  1.00 45.39           O  
+ATOM   8058  N   HIS D4118      77.868 -33.447  24.583  1.00 38.07           N  
+ATOM   8059  CA  HIS D4118      76.568 -33.869  24.062  1.00 37.31           C  
+ATOM   8060  C   HIS D4118      76.183 -35.273  24.521  1.00 37.89           C  
+ATOM   8061  O   HIS D4118      76.138 -36.221  23.732  1.00 37.40           O  
+ATOM   8062  CB  HIS D4118      76.550 -33.797  22.523  1.00 33.78           C  
+ATOM   8063  CG  HIS D4118      77.226 -32.581  21.965  1.00 29.01           C  
+ATOM   8064  ND1 HIS D4118      77.178 -31.351  22.587  1.00 28.20           N  
+ATOM   8065  CD2 HIS D4118      77.977 -32.410  20.851  1.00 27.04           C  
+ATOM   8066  CE1 HIS D4118      77.877 -30.476  21.882  1.00 27.30           C  
+ATOM   8067  NE2 HIS D4118      78.371 -31.095  20.824  1.00 27.74           N  
+ATOM   8068  N   ARG D4119      75.889 -35.407  25.807  1.00 39.52           N  
+ATOM   8069  CA  ARG D4119      75.505 -36.703  26.344  1.00 40.10           C  
+ATOM   8070  C   ARG D4119      74.163 -37.141  25.749  1.00 40.41           C  
+ATOM   8071  O   ARG D4119      74.039 -38.261  25.248  1.00 41.49           O  
+ATOM   8072  CB  ARG D4119      75.413 -36.629  27.862  1.00 41.95           C  
+ATOM   8073  N   ARG D4120      73.174 -36.248  25.781  1.00 38.31           N  
+ATOM   8074  CA  ARG D4120      71.844 -36.566  25.266  1.00 36.20           C  
+ATOM   8075  C   ARG D4120      71.511 -35.922  23.917  1.00 35.21           C  
+ATOM   8076  O   ARG D4120      71.322 -34.706  23.825  1.00 33.91           O  
+ATOM   8077  CB  ARG D4120      70.784 -36.187  26.312  1.00 36.36           C  
+ATOM   8078  N   VAL D4121      71.434 -36.755  22.880  1.00 33.53           N  
+ATOM   8079  CA  VAL D4121      71.117 -36.313  21.525  1.00 31.50           C  
+ATOM   8080  C   VAL D4121      69.870 -37.047  21.033  1.00 32.84           C  
+ATOM   8081  O   VAL D4121      69.960 -38.141  20.474  1.00 33.04           O  
+ATOM   8082  CB  VAL D4121      72.290 -36.603  20.552  1.00 29.97           C  
+ATOM   8083  CG1 VAL D4121      71.945 -36.127  19.151  1.00 27.27           C  
+ATOM   8084  CG2 VAL D4121      73.548 -35.914  21.042  1.00 28.69           C  
+ATOM   8085  N   GLU D4122      68.709 -36.437  21.250  1.00 32.82           N  
+ATOM   8086  CA  GLU D4122      67.431 -37.017  20.851  1.00 32.77           C  
+ATOM   8087  C   GLU D4122      67.129 -36.847  19.371  1.00 32.14           C  
+ATOM   8088  O   GLU D4122      67.647 -35.943  18.716  1.00 31.65           O  
+ATOM   8089  CB  GLU D4122      66.305 -36.396  21.674  1.00 35.80           C  
+ATOM   8090  CG  GLU D4122      66.147 -36.996  23.060  1.00 40.08           C  
+ATOM   8091  CD  GLU D4122      65.462 -38.347  23.014  1.00 42.56           C  
+ATOM   8092  OE1 GLU D4122      65.273 -38.954  24.089  1.00 44.18           O  
+ATOM   8093  OE2 GLU D4122      65.103 -38.796  21.901  1.00 44.41           O  
+ATOM   8094  N   LEU D4123      66.276 -37.724  18.855  1.00 31.49           N  
+ATOM   8095  CA  LEU D4123      65.888 -37.688  17.454  1.00 31.55           C  
+ATOM   8096  C   LEU D4123      64.376 -37.833  17.335  1.00 30.25           C  
+ATOM   8097  O   LEU D4123      63.809 -38.835  17.752  1.00 30.20           O  
+ATOM   8098  CB  LEU D4123      66.576 -38.822  16.695  1.00 33.50           C  
+ATOM   8099  CG  LEU D4123      66.674 -38.736  15.173  1.00 34.45           C  
+ATOM   8100  CD1 LEU D4123      67.264 -40.035  14.658  1.00 36.37           C  
+ATOM   8101  CD2 LEU D4123      65.318 -38.511  14.555  1.00 36.39           C  
+ATOM   8102  N   ILE D4124      63.726 -36.821  16.765  1.00 29.62           N  
+ATOM   8103  CA  ILE D4124      62.279 -36.832  16.587  1.00 27.30           C  
+ATOM   8104  C   ILE D4124      61.959 -36.560  15.126  1.00 26.77           C  
+ATOM   8105  O   ILE D4124      62.524 -35.654  14.519  1.00 26.35           O  
+ATOM   8106  CB  ILE D4124      61.596 -35.743  17.443  1.00 26.81           C  
+ATOM   8107  CG1 ILE D4124      61.857 -35.996  18.928  1.00 28.14           C  
+ATOM   8108  CG2 ILE D4124      60.102 -35.728  17.174  1.00 24.71           C  
+ATOM   8109  CD1 ILE D4124      61.168 -37.231  19.479  1.00 29.88           C  
+ATOM   8110  N   THR D4125      61.060 -37.357  14.564  1.00 25.72           N  
+ATOM   8111  CA  THR D4125      60.654 -37.197  13.174  1.00 27.18           C  
+ATOM   8112  C   THR D4125      59.260 -36.572  13.144  1.00 26.58           C  
+ATOM   8113  O   THR D4125      58.421 -36.897  13.980  1.00 26.49           O  
+ATOM   8114  CB  THR D4125      60.600 -38.557  12.455  1.00 29.10           C  
+ATOM   8115  OG1 THR D4125      59.977 -38.401  11.173  1.00 32.35           O  
+ATOM   8116  CG2 THR D4125      59.805 -39.560  13.281  1.00 30.44           C  
+ATOM   8117  N   THR D4126      59.008 -35.687  12.184  1.00 25.23           N  
+ATOM   8118  CA  THR D4126      57.700 -35.044  12.088  1.00 25.31           C  
+ATOM   8119  C   THR D4126      56.589 -35.975  11.573  1.00 24.69           C  
+ATOM   8120  O   THR D4126      55.409 -35.607  11.590  1.00 23.16           O  
+ATOM   8121  CB  THR D4126      57.755 -33.789  11.191  1.00 24.99           C  
+ATOM   8122  OG1 THR D4126      57.936 -34.176   9.822  1.00 25.68           O  
+ATOM   8123  CG2 THR D4126      58.911 -32.888  11.624  1.00 24.30           C  
+ATOM   8124  N   ASP D4127      56.964 -37.174  11.120  1.00 23.86           N  
+ATOM   8125  CA  ASP D4127      55.985 -38.148  10.632  1.00 22.68           C  
+ATOM   8126  C   ASP D4127      54.938 -38.396  11.713  1.00 22.99           C  
+ATOM   8127  O   ASP D4127      53.754 -38.559  11.424  1.00 22.71           O  
+ATOM   8128  CB  ASP D4127      56.648 -39.484  10.296  1.00 24.13           C  
+ATOM   8129  CG  ASP D4127      57.554 -39.411   9.084  1.00 26.11           C  
+ATOM   8130  OD1 ASP D4127      57.315 -38.566   8.199  1.00 25.17           O  
+ATOM   8131  OD2 ASP D4127      58.503 -40.223   9.013  1.00 29.34           O  
+ATOM   8132  N   GLY D4128      55.392 -38.433  12.961  1.00 22.88           N  
+ATOM   8133  CA  GLY D4128      54.495 -38.671  14.074  1.00 23.12           C  
+ATOM   8134  C   GLY D4128      53.416 -37.618  14.200  1.00 23.94           C  
+ATOM   8135  O   GLY D4128      52.325 -37.910  14.691  1.00 25.95           O  
+ATOM   8136  N   PHE D4129      53.700 -36.401  13.746  1.00 22.59           N  
+ATOM   8137  CA  PHE D4129      52.723 -35.326  13.845  1.00 22.71           C  
+ATOM   8138  C   PHE D4129      51.699 -35.306  12.714  1.00 22.55           C  
+ATOM   8139  O   PHE D4129      50.956 -34.343  12.550  1.00 24.19           O  
+ATOM   8140  CB  PHE D4129      53.434 -33.967  13.967  1.00 21.96           C  
+ATOM   8141  CG  PHE D4129      54.284 -33.839  15.210  1.00 20.20           C  
+ATOM   8142  CD1 PHE D4129      55.497 -34.511  15.315  1.00 21.52           C  
+ATOM   8143  CD2 PHE D4129      53.854 -33.077  16.290  1.00 21.09           C  
+ATOM   8144  CE1 PHE D4129      56.272 -34.425  16.479  1.00 19.92           C  
+ATOM   8145  CE2 PHE D4129      54.623 -32.986  17.458  1.00 20.68           C  
+ATOM   8146  CZ  PHE D4129      55.833 -33.663  17.548  1.00 21.19           C  
+ATOM   8147  N   LEU D4130      51.657 -36.370  11.922  1.00 24.18           N  
+ATOM   8148  CA  LEU D4130      50.665 -36.448  10.853  1.00 24.18           C  
+ATOM   8149  C   LEU D4130      49.338 -36.749  11.527  1.00 24.92           C  
+ATOM   8150  O   LEU D4130      49.308 -37.314  12.630  1.00 23.52           O  
+ATOM   8151  CB  LEU D4130      50.971 -37.592   9.884  1.00 23.11           C  
+ATOM   8152  CG  LEU D4130      52.029 -37.400   8.800  1.00 24.98           C  
+ATOM   8153  CD1 LEU D4130      52.391 -38.751   8.212  1.00 25.50           C  
+ATOM   8154  CD2 LEU D4130      51.506 -36.459   7.721  1.00 23.15           C  
+ATOM   8155  N   HIS D4131      48.242 -36.371  10.881  1.00 25.04           N  
+ATOM   8156  CA  HIS D4131      46.929 -36.683  11.432  1.00 25.85           C  
+ATOM   8157  C   HIS D4131      46.760 -38.195  11.249  1.00 25.46           C  
+ATOM   8158  O   HIS D4131      47.221 -38.757  10.253  1.00 26.20           O  
+ATOM   8159  CB  HIS D4131      45.828 -35.963  10.652  1.00 25.71           C  
+ATOM   8160  CG  HIS D4131      45.707 -34.506  10.967  1.00 27.37           C  
+ATOM   8161  ND1 HIS D4131      45.394 -34.038  12.224  1.00 26.55           N  
+ATOM   8162  CD2 HIS D4131      45.813 -33.409  10.173  1.00 26.38           C  
+ATOM   8163  CE1 HIS D4131      45.310 -32.719  12.195  1.00 26.56           C  
+ATOM   8164  NE2 HIS D4131      45.558 -32.316  10.960  1.00 26.62           N  
+ATOM   8165  N   PRO D4132      46.122 -38.881  12.211  1.00 26.40           N  
+ATOM   8166  CA  PRO D4132      45.953 -40.326  12.027  1.00 27.50           C  
+ATOM   8167  C   PRO D4132      45.200 -40.613  10.725  1.00 29.34           C  
+ATOM   8168  O   PRO D4132      44.605 -39.706  10.124  1.00 28.77           O  
+ATOM   8169  CB  PRO D4132      45.157 -40.736  13.261  1.00 28.29           C  
+ATOM   8170  CG  PRO D4132      45.669 -39.773  14.309  1.00 27.41           C  
+ATOM   8171  CD  PRO D4132      45.664 -38.461  13.547  1.00 25.40           C  
+ATOM   8172  N   ASN D4133      45.223 -41.867  10.285  1.00 30.63           N  
+ATOM   8173  CA  ASN D4133      44.537 -42.228   9.049  1.00 33.14           C  
+ATOM   8174  C   ASN D4133      43.038 -41.944   9.104  1.00 34.19           C  
+ATOM   8175  O   ASN D4133      42.444 -41.538   8.104  1.00 35.20           O  
+ATOM   8176  CB  ASN D4133      44.771 -43.699   8.711  1.00 32.87           C  
+ATOM   8177  CG  ASN D4133      46.200 -43.975   8.315  1.00 32.91           C  
+ATOM   8178  OD1 ASN D4133      46.915 -43.080   7.861  1.00 33.19           O  
+ATOM   8179  ND2 ASN D4133      46.623 -45.221   8.467  1.00 35.25           N  
+ATOM   8180  N   GLN D4134      42.436 -42.145  10.272  1.00 34.65           N  
+ATOM   8181  CA  GLN D4134      41.014 -41.901  10.433  1.00 36.84           C  
+ATOM   8182  C   GLN D4134      40.696 -40.456  10.080  1.00 36.55           C  
+ATOM   8183  O   GLN D4134      39.794 -40.180   9.287  1.00 36.39           O  
+ATOM   8184  CB  GLN D4134      40.571 -42.162  11.871  1.00 40.92           C  
+ATOM   8185  CG  GLN D4134      39.081 -41.921  12.066  1.00 47.74           C  
+ATOM   8186  CD  GLN D4134      38.671 -41.890  13.523  1.00 51.94           C  
+ATOM   8187  OE1 GLN D4134      38.848 -42.868  14.254  1.00 54.42           O  
+ATOM   8188  NE2 GLN D4134      38.115 -40.762  13.957  1.00 54.38           N  
+ATOM   8189  N   VAL D4135      41.442 -39.538  10.687  1.00 34.73           N  
+ATOM   8190  CA  VAL D4135      41.251 -38.118  10.443  1.00 32.85           C  
+ATOM   8191  C   VAL D4135      41.549 -37.778   8.983  1.00 32.67           C  
+ATOM   8192  O   VAL D4135      40.851 -36.970   8.371  1.00 33.60           O  
+ATOM   8193  CB  VAL D4135      42.169 -37.268  11.348  1.00 31.80           C  
+ATOM   8194  CG1 VAL D4135      41.927 -35.800  11.078  1.00 29.42           C  
+ATOM   8195  CG2 VAL D4135      41.904 -37.590  12.814  1.00 30.42           C  
+ATOM   8196  N   LEU D4136      42.590 -38.384   8.430  1.00 30.85           N  
+ATOM   8197  CA  LEU D4136      42.954 -38.135   7.046  1.00 30.44           C  
+ATOM   8198  C   LEU D4136      41.882 -38.622   6.073  1.00 32.20           C  
+ATOM   8199  O   LEU D4136      41.617 -37.971   5.065  1.00 32.43           O  
+ATOM   8200  CB  LEU D4136      44.277 -38.823   6.718  1.00 28.12           C  
+ATOM   8201  CG  LEU D4136      45.529 -38.304   7.425  1.00 26.86           C  
+ATOM   8202  CD1 LEU D4136      46.657 -39.298   7.219  1.00 24.74           C  
+ATOM   8203  CD2 LEU D4136      45.904 -36.924   6.892  1.00 22.96           C  
+ATOM   8204  N   LYS D4137      41.278 -39.772   6.367  1.00 34.36           N  
+ATOM   8205  CA  LYS D4137      40.251 -40.328   5.490  1.00 35.67           C  
+ATOM   8206  C   LYS D4137      38.992 -39.476   5.500  1.00 37.07           C  
+ATOM   8207  O   LYS D4137      38.401 -39.222   4.447  1.00 37.57           O  
+ATOM   8208  CB  LYS D4137      39.919 -41.754   5.900  1.00 36.23           C  
+ATOM   8209  N   GLU D4138      38.583 -39.027   6.683  1.00 38.37           N  
+ATOM   8210  CA  GLU D4138      37.386 -38.201   6.794  1.00 39.35           C  
+ATOM   8211  C   GLU D4138      37.581 -36.876   6.063  1.00 39.12           C  
+ATOM   8212  O   GLU D4138      36.623 -36.299   5.545  1.00 40.33           O  
+ATOM   8213  CB  GLU D4138      37.030 -37.948   8.267  1.00 41.19           C  
+ATOM   8214  CG  GLU D4138      37.928 -36.962   8.997  1.00 44.98           C  
+ATOM   8215  CD  GLU D4138      37.657 -36.930  10.496  1.00 47.61           C  
+ATOM   8216  OE1 GLU D4138      38.215 -36.049  11.188  1.00 47.72           O  
+ATOM   8217  OE2 GLU D4138      36.889 -37.794  10.978  1.00 48.48           O  
+ATOM   8218  N   ARG D4139      38.823 -36.398   6.012  1.00 36.46           N  
+ATOM   8219  CA  ARG D4139      39.119 -35.143   5.325  1.00 33.93           C  
+ATOM   8220  C   ARG D4139      39.535 -35.424   3.884  1.00 33.21           C  
+ATOM   8221  O   ARG D4139      39.983 -34.525   3.174  1.00 33.72           O  
+ATOM   8222  CB  ARG D4139      40.233 -34.377   6.051  1.00 32.96           C  
+ATOM   8223  CG  ARG D4139      39.907 -34.078   7.509  1.00 31.46           C  
+ATOM   8224  CD  ARG D4139      40.909 -33.138   8.151  1.00 29.57           C  
+ATOM   8225  NE  ARG D4139      40.603 -32.954   9.566  1.00 29.63           N  
+ATOM   8226  CZ  ARG D4139      41.301 -32.182  10.391  1.00 31.00           C  
+ATOM   8227  NH1 ARG D4139      42.360 -31.514   9.947  1.00 30.93           N  
+ATOM   8228  NH2 ARG D4139      40.937 -32.076  11.664  1.00 32.30           N  
+ATOM   8229  N   GLY D4140      39.366 -36.676   3.464  1.00 32.42           N  
+ATOM   8230  CA  GLY D4140      39.721 -37.075   2.111  1.00 32.53           C  
+ATOM   8231  C   GLY D4140      41.154 -36.733   1.761  1.00 32.92           C  
+ATOM   8232  O   GLY D4140      41.439 -36.285   0.654  1.00 31.88           O  
+ATOM   8233  N   LEU D4141      42.061 -36.959   2.705  1.00 33.04           N  
+ATOM   8234  CA  LEU D4141      43.473 -36.646   2.507  1.00 33.68           C  
+ATOM   8235  C   LEU D4141      44.386 -37.865   2.578  1.00 34.05           C  
+ATOM   8236  O   LEU D4141      45.596 -37.721   2.754  1.00 32.96           O  
+ATOM   8237  CB  LEU D4141      43.921 -35.645   3.572  1.00 33.43           C  
+ATOM   8238  CG  LEU D4141      43.309 -34.251   3.518  1.00 33.77           C  
+ATOM   8239  CD1 LEU D4141      43.678 -33.476   4.777  1.00 33.94           C  
+ATOM   8240  CD2 LEU D4141      43.814 -33.544   2.267  1.00 35.26           C  
+ATOM   8241  N   MET D4142      43.814 -39.056   2.433  1.00 34.08           N  
+ATOM   8242  CA  MET D4142      44.590 -40.288   2.525  1.00 36.53           C  
+ATOM   8243  C   MET D4142      45.605 -40.447   1.394  1.00 35.78           C  
+ATOM   8244  O   MET D4142      46.510 -41.279   1.480  1.00 36.87           O  
+ATOM   8245  CB  MET D4142      43.654 -41.497   2.567  1.00 38.39           C  
+ATOM   8246  CG  MET D4142      44.233 -42.694   3.315  1.00 44.34           C  
+ATOM   8247  SD  MET D4142      44.434 -42.400   5.097  1.00 46.86           S  
+ATOM   8248  CE  MET D4142      42.953 -43.186   5.716  1.00 48.80           C  
+ATOM   8249  N   LYS D4143      45.458 -39.649   0.342  1.00 34.06           N  
+ATOM   8250  CA  LYS D4143      46.376 -39.690  -0.794  1.00 34.19           C  
+ATOM   8251  C   LYS D4143      47.233 -38.431  -0.769  1.00 31.86           C  
+ATOM   8252  O   LYS D4143      47.844 -38.062  -1.773  1.00 30.32           O  
+ATOM   8253  CB  LYS D4143      45.598 -39.736  -2.111  1.00 36.61           C  
+ATOM   8254  CG  LYS D4143      44.767 -40.996  -2.307  1.00 41.75           C  
+ATOM   8255  CD  LYS D4143      45.597 -42.125  -2.891  1.00 45.11           C  
+ATOM   8256  CE  LYS D4143      46.084 -41.767  -4.291  1.00 47.69           C  
+ATOM   8257  NZ  LYS D4143      46.883 -42.867  -4.900  1.00 49.46           N  
+ATOM   8258  N   LYS D4144      47.263 -37.776   0.388  1.00 29.18           N  
+ATOM   8259  CA  LYS D4144      48.020 -36.541   0.548  1.00 28.58           C  
+ATOM   8260  C   LYS D4144      48.963 -36.530   1.744  1.00 25.17           C  
+ATOM   8261  O   LYS D4144      49.293 -35.465   2.260  1.00 26.02           O  
+ATOM   8262  CB  LYS D4144      47.059 -35.351   0.645  1.00 27.28           C  
+ATOM   8263  CG  LYS D4144      46.375 -35.001  -0.666  1.00 30.62           C  
+ATOM   8264  CD  LYS D4144      47.379 -34.492  -1.694  1.00 31.03           C  
+ATOM   8265  CE  LYS D4144      46.694 -34.053  -2.981  1.00 32.64           C  
+ATOM   8266  NZ  LYS D4144      47.668 -33.502  -3.969  1.00 34.19           N  
+ATOM   8267  N   LYS D4145      49.389 -37.702   2.198  1.00 24.15           N  
+ATOM   8268  CA  LYS D4145      50.318 -37.746   3.317  1.00 23.30           C  
+ATOM   8269  C   LYS D4145      51.596 -37.030   2.914  1.00 22.19           C  
+ATOM   8270  O   LYS D4145      52.174 -37.312   1.857  1.00 20.24           O  
+ATOM   8271  CB  LYS D4145      50.636 -39.188   3.720  1.00 23.49           C  
+ATOM   8272  CG  LYS D4145      49.628 -39.787   4.682  1.00 26.20           C  
+ATOM   8273  CD  LYS D4145      50.011 -41.203   5.095  1.00 26.03           C  
+ATOM   8274  CE  LYS D4145      49.026 -41.757   6.122  1.00 27.83           C  
+ATOM   8275  NZ  LYS D4145      49.340 -43.152   6.554  1.00 26.78           N  
+ATOM   8276  N   GLY D4146      52.022 -36.094   3.760  1.00 21.42           N  
+ATOM   8277  CA  GLY D4146      53.226 -35.329   3.496  1.00 21.14           C  
+ATOM   8278  C   GLY D4146      52.927 -33.898   3.118  1.00 21.16           C  
+ATOM   8279  O   GLY D4146      53.785 -33.019   3.226  1.00 21.16           O  
+ATOM   8280  N   PHE D4147      51.708 -33.671   2.644  1.00 21.41           N  
+ATOM   8281  CA  PHE D4147      51.287 -32.334   2.259  1.00 20.66           C  
+ATOM   8282  C   PHE D4147      50.920 -31.586   3.539  1.00 21.62           C  
+ATOM   8283  O   PHE D4147      50.578 -32.199   4.554  1.00 22.59           O  
+ATOM   8284  CB  PHE D4147      50.093 -32.405   1.305  1.00 20.97           C  
+ATOM   8285  CG  PHE D4147      50.459 -32.818  -0.094  1.00 20.55           C  
+ATOM   8286  CD1 PHE D4147      50.956 -34.098  -0.357  1.00 21.42           C  
+ATOM   8287  CD2 PHE D4147      50.331 -31.919  -1.151  1.00 19.03           C  
+ATOM   8288  CE1 PHE D4147      51.321 -34.471  -1.658  1.00 17.48           C  
+ATOM   8289  CE2 PHE D4147      50.693 -32.283  -2.449  1.00 18.19           C  
+ATOM   8290  CZ  PHE D4147      51.189 -33.560  -2.701  1.00 18.02           C  
+ATOM   8291  N   PRO D4148      50.995 -30.255   3.510  1.00 21.58           N  
+ATOM   8292  CA  PRO D4148      50.678 -29.423   4.673  1.00 22.56           C  
+ATOM   8293  C   PRO D4148      49.402 -29.799   5.421  1.00 24.06           C  
+ATOM   8294  O   PRO D4148      49.409 -29.964   6.643  1.00 25.09           O  
+ATOM   8295  CB  PRO D4148      50.605 -28.024   4.077  1.00 24.65           C  
+ATOM   8296  CG  PRO D4148      51.632 -28.089   2.968  1.00 22.48           C  
+ATOM   8297  CD  PRO D4148      51.337 -29.426   2.340  1.00 20.88           C  
+ATOM   8298  N   GLU D4149      48.306 -29.948   4.690  1.00 25.27           N  
+ATOM   8299  CA  GLU D4149      47.031 -30.275   5.311  1.00 27.26           C  
+ATOM   8300  C   GLU D4149      46.959 -31.622   6.042  1.00 26.99           C  
+ATOM   8301  O   GLU D4149      46.032 -31.861   6.825  1.00 25.93           O  
+ATOM   8302  CB  GLU D4149      45.905 -30.165   4.270  1.00 29.10           C  
+ATOM   8303  CG  GLU D4149      46.087 -30.989   2.991  1.00 33.85           C  
+ATOM   8304  CD  GLU D4149      47.010 -30.358   1.943  1.00 35.82           C  
+ATOM   8305  OE1 GLU D4149      46.901 -30.768   0.763  1.00 36.98           O  
+ATOM   8306  OE2 GLU D4149      47.838 -29.479   2.275  1.00 35.91           O  
+ATOM   8307  N   SER D4150      47.935 -32.495   5.812  1.00 25.29           N  
+ATOM   8308  CA  SER D4150      47.928 -33.803   6.467  1.00 24.39           C  
+ATOM   8309  C   SER D4150      48.629 -33.770   7.815  1.00 22.87           C  
+ATOM   8310  O   SER D4150      48.660 -34.773   8.527  1.00 22.45           O  
+ATOM   8311  CB  SER D4150      48.595 -34.861   5.577  1.00 23.94           C  
+ATOM   8312  OG  SER D4150      50.008 -34.745   5.599  1.00 23.11           O  
+ATOM   8313  N   TYR D4151      49.199 -32.618   8.160  1.00 22.41           N  
+ATOM   8314  CA  TYR D4151      49.911 -32.483   9.425  1.00 22.04           C  
+ATOM   8315  C   TYR D4151      49.156 -31.705  10.481  1.00 22.82           C  
+ATOM   8316  O   TYR D4151      48.398 -30.783  10.180  1.00 22.90           O  
+ATOM   8317  CB  TYR D4151      51.256 -31.769   9.234  1.00 21.61           C  
+ATOM   8318  CG  TYR D4151      52.325 -32.551   8.515  1.00 21.59           C  
+ATOM   8319  CD1 TYR D4151      52.522 -32.403   7.146  1.00 20.39           C  
+ATOM   8320  CD2 TYR D4151      53.167 -33.425   9.216  1.00 21.83           C  
+ATOM   8321  CE1 TYR D4151      53.531 -33.093   6.488  1.00 21.42           C  
+ATOM   8322  CE2 TYR D4151      54.180 -34.126   8.566  1.00 19.95           C  
+ATOM   8323  CZ  TYR D4151      54.359 -33.955   7.207  1.00 22.00           C  
+ATOM   8324  OH  TYR D4151      55.376 -34.621   6.561  1.00 22.72           O  
+ATOM   8325  N   ASP D4152      49.383 -32.079  11.728  1.00 23.13           N  
+ATOM   8326  CA  ASP D4152      48.790 -31.377  12.849  1.00 24.30           C  
+ATOM   8327  C   ASP D4152      49.927 -30.415  13.188  1.00 25.51           C  
+ATOM   8328  O   ASP D4152      50.647 -30.602  14.172  1.00 25.53           O  
+ATOM   8329  CB  ASP D4152      48.540 -32.352  13.999  1.00 26.22           C  
+ATOM   8330  CG  ASP D4152      48.009 -31.671  15.244  1.00 29.37           C  
+ATOM   8331  OD1 ASP D4152      47.846 -30.428  15.227  1.00 30.61           O  
+ATOM   8332  OD2 ASP D4152      47.756 -32.380  16.245  1.00 30.57           O  
+ATOM   8333  N   MET D4153      50.102 -29.404  12.336  1.00 26.51           N  
+ATOM   8334  CA  MET D4153      51.172 -28.425  12.495  1.00 26.85           C  
+ATOM   8335  C   MET D4153      51.214 -27.654  13.801  1.00 27.28           C  
+ATOM   8336  O   MET D4153      52.293 -27.423  14.337  1.00 28.52           O  
+ATOM   8337  CB  MET D4153      51.158 -27.428  11.341  1.00 28.75           C  
+ATOM   8338  CG  MET D4153      52.206 -27.723  10.304  1.00 32.37           C  
+ATOM   8339  SD  MET D4153      53.860 -27.726  10.982  1.00 35.85           S  
+ATOM   8340  CE  MET D4153      54.852 -27.188   9.564  1.00 33.66           C  
+ATOM   8341  N   HIS D4154      50.058 -27.240  14.309  1.00 25.25           N  
+ATOM   8342  CA  HIS D4154      50.029 -26.496  15.557  1.00 24.82           C  
+ATOM   8343  C   HIS D4154      50.681 -27.309  16.656  1.00 23.87           C  
+ATOM   8344  O   HIS D4154      51.349 -26.763  17.533  1.00 24.13           O  
+ATOM   8345  CB  HIS D4154      48.589 -26.148  15.946  1.00 25.17           C  
+ATOM   8346  CG  HIS D4154      47.965 -25.111  15.066  1.00 27.79           C  
+ATOM   8347  ND1 HIS D4154      48.486 -23.841  14.935  1.00 27.86           N  
+ATOM   8348  CD2 HIS D4154      46.885 -25.163  14.252  1.00 28.47           C  
+ATOM   8349  CE1 HIS D4154      47.753 -23.155  14.075  1.00 29.95           C  
+ATOM   8350  NE2 HIS D4154      46.776 -23.933  13.644  1.00 29.59           N  
+ATOM   8351  N   ARG D4155      50.504 -28.623  16.595  1.00 23.35           N  
+ATOM   8352  CA  ARG D4155      51.085 -29.489  17.601  1.00 23.87           C  
+ATOM   8353  C   ARG D4155      52.605 -29.572  17.437  1.00 23.07           C  
+ATOM   8354  O   ARG D4155      53.342 -29.569  18.424  1.00 23.97           O  
+ATOM   8355  CB  ARG D4155      50.461 -30.883  17.527  1.00 24.02           C  
+ATOM   8356  CG  ARG D4155      50.978 -31.807  18.609  1.00 27.46           C  
+ATOM   8357  CD  ARG D4155      50.276 -33.143  18.613  1.00 28.39           C  
+ATOM   8358  NE  ARG D4155      50.779 -33.984  19.694  1.00 29.48           N  
+ATOM   8359  CZ  ARG D4155      50.289 -35.181  19.997  1.00 30.19           C  
+ATOM   8360  NH1 ARG D4155      49.280 -35.679  19.296  1.00 28.98           N  
+ATOM   8361  NH2 ARG D4155      50.809 -35.883  21.000  1.00 29.26           N  
+ATOM   8362  N   LEU D4156      53.074 -29.644  16.194  1.00 22.06           N  
+ATOM   8363  CA  LEU D4156      54.508 -29.713  15.937  1.00 21.29           C  
+ATOM   8364  C   LEU D4156      55.171 -28.422  16.417  1.00 21.71           C  
+ATOM   8365  O   LEU D4156      56.224 -28.456  17.052  1.00 21.45           O  
+ATOM   8366  CB  LEU D4156      54.790 -29.903  14.441  1.00 19.59           C  
+ATOM   8367  CG  LEU D4156      56.267 -29.870  14.024  1.00 19.45           C  
+ATOM   8368  CD1 LEU D4156      57.046 -30.955  14.768  1.00 17.44           C  
+ATOM   8369  CD2 LEU D4156      56.379 -30.068  12.520  1.00 17.96           C  
+ATOM   8370  N   VAL D4157      54.546 -27.289  16.116  1.00 21.43           N  
+ATOM   8371  CA  VAL D4157      55.084 -26.001  16.529  1.00 22.11           C  
+ATOM   8372  C   VAL D4157      55.183 -25.929  18.047  1.00 22.64           C  
+ATOM   8373  O   VAL D4157      56.203 -25.496  18.592  1.00 22.85           O  
+ATOM   8374  CB  VAL D4157      54.208 -24.836  16.010  1.00 22.10           C  
+ATOM   8375  CG1 VAL D4157      54.635 -23.529  16.650  1.00 22.23           C  
+ATOM   8376  CG2 VAL D4157      54.334 -24.734  14.489  1.00 21.88           C  
+ATOM   8377  N   LYS D4158      54.130 -26.361  18.733  1.00 23.25           N  
+ATOM   8378  CA  LYS D4158      54.127 -26.332  20.190  1.00 23.65           C  
+ATOM   8379  C   LYS D4158      55.203 -27.252  20.774  1.00 24.51           C  
+ATOM   8380  O   LYS D4158      55.746 -26.977  21.851  1.00 23.90           O  
+ATOM   8381  CB  LYS D4158      52.755 -26.746  20.728  1.00 24.94           C  
+ATOM   8382  CG  LYS D4158      52.666 -26.678  22.243  1.00 25.32           C  
+ATOM   8383  CD  LYS D4158      51.253 -26.972  22.736  1.00 28.29           C  
+ATOM   8384  CE  LYS D4158      51.123 -26.735  24.245  1.00 30.52           C  
+ATOM   8385  NZ  LYS D4158      51.948 -27.682  25.054  1.00 31.09           N  
+ATOM   8386  N   PHE D4159      55.505 -28.344  20.071  1.00 23.25           N  
+ATOM   8387  CA  PHE D4159      56.523 -29.276  20.542  1.00 23.60           C  
+ATOM   8388  C   PHE D4159      57.886 -28.577  20.654  1.00 24.22           C  
+ATOM   8389  O   PHE D4159      58.514 -28.594  21.713  1.00 24.37           O  
+ATOM   8390  CB  PHE D4159      56.631 -30.480  19.597  1.00 24.84           C  
+ATOM   8391  CG  PHE D4159      57.698 -31.465  19.993  1.00 24.19           C  
+ATOM   8392  CD1 PHE D4159      57.508 -32.326  21.071  1.00 25.38           C  
+ATOM   8393  CD2 PHE D4159      58.910 -31.507  19.309  1.00 25.57           C  
+ATOM   8394  CE1 PHE D4159      58.514 -33.215  21.462  1.00 25.29           C  
+ATOM   8395  CE2 PHE D4159      59.927 -32.392  19.694  1.00 24.66           C  
+ATOM   8396  CZ  PHE D4159      59.729 -33.244  20.766  1.00 24.47           C  
+ATOM   8397  N   VAL D4160      58.343 -27.963  19.567  1.00 22.96           N  
+ATOM   8398  CA  VAL D4160      59.627 -27.277  19.612  1.00 23.40           C  
+ATOM   8399  C   VAL D4160      59.524 -26.009  20.462  1.00 23.82           C  
+ATOM   8400  O   VAL D4160      60.503 -25.579  21.072  1.00 23.13           O  
+ATOM   8401  CB  VAL D4160      60.139 -26.930  18.199  1.00 21.90           C  
+ATOM   8402  CG1 VAL D4160      60.509 -28.200  17.469  1.00 21.54           C  
+ATOM   8403  CG2 VAL D4160      59.075 -26.176  17.422  1.00 21.94           C  
+ATOM   8404  N   SER D4161      58.334 -25.424  20.516  1.00 22.93           N  
+ATOM   8405  CA  SER D4161      58.142 -24.225  21.323  1.00 23.72           C  
+ATOM   8406  C   SER D4161      58.329 -24.578  22.804  1.00 21.67           C  
+ATOM   8407  O   SER D4161      59.010 -23.865  23.540  1.00 21.37           O  
+ATOM   8408  CB  SER D4161      56.745 -23.631  21.087  1.00 22.66           C  
+ATOM   8409  OG  SER D4161      56.576 -22.448  21.851  1.00 24.73           O  
+ATOM   8410  N   ASP D4162      57.731 -25.685  23.232  1.00 22.01           N  
+ATOM   8411  CA  ASP D4162      57.860 -26.121  24.622  1.00 23.62           C  
+ATOM   8412  C   ASP D4162      59.315 -26.425  24.960  1.00 23.77           C  
+ATOM   8413  O   ASP D4162      59.792 -26.062  26.034  1.00 23.99           O  
+ATOM   8414  CB  ASP D4162      57.002 -27.366  24.893  1.00 21.91           C  
+ATOM   8415  CG  ASP D4162      55.516 -27.054  24.936  1.00 22.54           C  
+ATOM   8416  OD1 ASP D4162      55.154 -25.886  25.174  1.00 22.40           O  
+ATOM   8417  OD2 ASP D4162      54.702 -27.982  24.747  1.00 24.84           O  
+ATOM   8418  N   LEU D4163      60.016 -27.096  24.047  1.00 23.25           N  
+ATOM   8419  CA  LEU D4163      61.422 -27.421  24.267  1.00 23.54           C  
+ATOM   8420  C   LEU D4163      62.208 -26.127  24.436  1.00 24.19           C  
+ATOM   8421  O   LEU D4163      63.054 -26.005  25.327  1.00 25.59           O  
+ATOM   8422  CB  LEU D4163      61.989 -28.200  23.078  1.00 23.28           C  
+ATOM   8423  CG  LEU D4163      61.597 -29.670  22.911  1.00 24.40           C  
+ATOM   8424  CD1 LEU D4163      61.894 -30.131  21.491  1.00 23.95           C  
+ATOM   8425  CD2 LEU D4163      62.355 -30.519  23.922  1.00 25.33           C  
+ATOM   8426  N   LYS D4164      61.918 -25.150  23.582  1.00 23.66           N  
+ATOM   8427  CA  LYS D4164      62.616 -23.878  23.650  1.00 23.65           C  
+ATOM   8428  C   LYS D4164      62.101 -22.986  24.775  1.00 25.13           C  
+ATOM   8429  O   LYS D4164      62.553 -21.851  24.933  1.00 25.84           O  
+ATOM   8430  CB  LYS D4164      62.517 -23.155  22.310  1.00 22.02           C  
+ATOM   8431  CG  LYS D4164      63.863 -22.882  21.653  1.00 25.48           C  
+ATOM   8432  CD  LYS D4164      64.561 -24.158  21.231  1.00 23.65           C  
+ATOM   8433  CE  LYS D4164      65.819 -23.881  20.421  1.00 21.86           C  
+ATOM   8434  NZ  LYS D4164      67.032 -23.611  21.237  1.00 20.04           N  
+ATOM   8435  N   SER D4165      61.151 -23.496  25.553  1.00 26.35           N  
+ATOM   8436  CA  SER D4165      60.596 -22.746  26.675  1.00 26.37           C  
+ATOM   8437  C   SER D4165      61.216 -23.286  27.953  1.00 28.42           C  
+ATOM   8438  O   SER D4165      61.061 -22.708  29.028  1.00 29.05           O  
+ATOM   8439  CB  SER D4165      59.071 -22.901  26.740  1.00 25.69           C  
+ATOM   8440  OG  SER D4165      58.428 -22.183  25.701  1.00 23.44           O  
+ATOM   8441  N   GLY D4166      61.919 -24.406  27.826  1.00 29.71           N  
+ATOM   8442  CA  GLY D4166      62.566 -25.002  28.978  1.00 30.18           C  
+ATOM   8443  C   GLY D4166      61.755 -26.100  29.638  1.00 31.03           C  
+ATOM   8444  O   GLY D4166      62.135 -26.586  30.703  1.00 30.99           O  
+ATOM   8445  N   VAL D4167      60.637 -26.488  29.025  1.00 30.73           N  
+ATOM   8446  CA  VAL D4167      59.811 -27.547  29.590  1.00 31.32           C  
+ATOM   8447  C   VAL D4167      60.665 -28.812  29.710  1.00 33.26           C  
+ATOM   8448  O   VAL D4167      61.165 -29.337  28.713  1.00 32.36           O  
+ATOM   8449  CB  VAL D4167      58.596 -27.851  28.710  1.00 31.24           C  
+ATOM   8450  CG1 VAL D4167      57.782 -28.973  29.338  1.00 29.36           C  
+ATOM   8451  CG2 VAL D4167      57.742 -26.596  28.539  1.00 27.88           C  
+ATOM   8452  N   PRO D4168      60.828 -29.323  30.940  1.00 34.96           N  
+ATOM   8453  CA  PRO D4168      61.627 -30.521  31.219  1.00 36.78           C  
+ATOM   8454  C   PRO D4168      61.312 -31.766  30.380  1.00 38.12           C  
+ATOM   8455  O   PRO D4168      62.209 -32.340  29.754  1.00 39.07           O  
+ATOM   8456  CB  PRO D4168      61.411 -30.736  32.721  1.00 36.69           C  
+ATOM   8457  CG  PRO D4168      60.041 -30.149  32.954  1.00 37.59           C  
+ATOM   8458  CD  PRO D4168      60.095 -28.887  32.142  1.00 34.75           C  
+ATOM   8459  N   ASN D4169      60.053 -32.188  30.364  1.00 39.04           N  
+ATOM   8460  CA  ASN D4169      59.682 -33.365  29.591  1.00 40.43           C  
+ATOM   8461  C   ASN D4169      58.631 -33.013  28.560  1.00 40.04           C  
+ATOM   8462  O   ASN D4169      57.577 -32.475  28.894  1.00 40.60           O  
+ATOM   8463  CB  ASN D4169      59.148 -34.460  30.512  1.00 44.03           C  
+ATOM   8464  CG  ASN D4169      60.102 -34.781  31.649  1.00 47.40           C  
+ATOM   8465  OD1 ASN D4169      61.256 -35.146  31.421  1.00 49.15           O  
+ATOM   8466  ND2 ASN D4169      59.621 -34.641  32.883  1.00 47.96           N  
+ATOM   8467  N   VAL D4170      58.924 -33.313  27.302  1.00 39.03           N  
+ATOM   8468  CA  VAL D4170      57.996 -33.020  26.222  1.00 37.77           C  
+ATOM   8469  C   VAL D4170      57.659 -34.311  25.492  1.00 36.50           C  
+ATOM   8470  O   VAL D4170      58.531 -35.143  25.244  1.00 37.20           O  
+ATOM   8471  CB  VAL D4170      58.603 -32.005  25.234  1.00 37.94           C  
+ATOM   8472  CG1 VAL D4170      57.534 -31.497  24.287  1.00 38.98           C  
+ATOM   8473  CG2 VAL D4170      59.211 -30.838  26.000  1.00 38.98           C  
+ATOM   8474  N   THR D4171      56.388 -34.477  25.149  1.00 35.25           N  
+ATOM   8475  CA  THR D4171      55.941 -35.685  24.472  1.00 33.86           C  
+ATOM   8476  C   THR D4171      55.626 -35.458  22.998  1.00 32.96           C  
+ATOM   8477  O   THR D4171      55.083 -34.419  22.614  1.00 32.20           O  
+ATOM   8478  CB  THR D4171      54.694 -36.250  25.167  1.00 35.36           C  
+ATOM   8479  OG1 THR D4171      55.020 -36.574  26.523  1.00 37.19           O  
+ATOM   8480  CG2 THR D4171      54.205 -37.501  24.465  1.00 36.86           C  
+ATOM   8481  N   ALA D4172      55.976 -36.440  22.175  1.00 31.14           N  
+ATOM   8482  CA  ALA D4172      55.727 -36.362  20.741  1.00 30.60           C  
+ATOM   8483  C   ALA D4172      55.033 -37.620  20.243  1.00 29.15           C  
+ATOM   8484  O   ALA D4172      55.327 -38.726  20.690  1.00 28.43           O  
+ATOM   8485  CB  ALA D4172      57.043 -36.172  19.983  1.00 31.74           C  
+ATOM   8486  N   PRO D4173      54.086 -37.461  19.317  1.00 29.35           N  
+ATOM   8487  CA  PRO D4173      53.392 -38.640  18.792  1.00 29.36           C  
+ATOM   8488  C   PRO D4173      54.383 -39.408  17.915  1.00 29.35           C  
+ATOM   8489  O   PRO D4173      55.373 -38.840  17.451  1.00 29.11           O  
+ATOM   8490  CB  PRO D4173      52.239 -38.032  17.996  1.00 28.67           C  
+ATOM   8491  CG  PRO D4173      52.824 -36.736  17.505  1.00 28.00           C  
+ATOM   8492  CD  PRO D4173      53.562 -36.221  18.719  1.00 28.02           C  
+ATOM   8493  N   VAL D4174      54.132 -40.696  17.708  1.00 29.22           N  
+ATOM   8494  CA  VAL D4174      55.023 -41.514  16.897  1.00 29.22           C  
+ATOM   8495  C   VAL D4174      54.273 -42.187  15.756  1.00 29.38           C  
+ATOM   8496  O   VAL D4174      53.151 -42.667  15.932  1.00 29.49           O  
+ATOM   8497  CB  VAL D4174      55.717 -42.595  17.750  1.00 28.45           C  
+ATOM   8498  CG1 VAL D4174      56.520 -43.523  16.859  1.00 28.35           C  
+ATOM   8499  CG2 VAL D4174      56.626 -41.938  18.774  1.00 29.82           C  
+ATOM   8500  N   TYR D4175      54.918 -42.214  14.592  1.00 29.37           N  
+ATOM   8501  CA  TYR D4175      54.362 -42.799  13.376  1.00 30.40           C  
+ATOM   8502  C   TYR D4175      55.077 -44.107  13.068  1.00 32.44           C  
+ATOM   8503  O   TYR D4175      56.258 -44.259  13.366  1.00 33.93           O  
+ATOM   8504  CB  TYR D4175      54.562 -41.827  12.208  1.00 28.28           C  
+ATOM   8505  CG  TYR D4175      53.920 -42.246  10.907  1.00 26.83           C  
+ATOM   8506  CD1 TYR D4175      52.546 -42.111  10.712  1.00 25.63           C  
+ATOM   8507  CD2 TYR D4175      54.688 -42.756   9.858  1.00 25.62           C  
+ATOM   8508  CE1 TYR D4175      51.953 -42.461   9.510  1.00 24.50           C  
+ATOM   8509  CE2 TYR D4175      54.105 -43.117   8.652  1.00 22.55           C  
+ATOM   8510  CZ  TYR D4175      52.741 -42.968   8.484  1.00 24.80           C  
+ATOM   8511  OH  TYR D4175      52.153 -43.330   7.296  1.00 24.98           O  
+ATOM   8512  N   SER D4176      54.358 -45.045  12.465  1.00 35.25           N  
+ATOM   8513  CA  SER D4176      54.918 -46.347  12.106  1.00 37.78           C  
+ATOM   8514  C   SER D4176      54.736 -46.608  10.607  1.00 38.89           C  
+ATOM   8515  O   SER D4176      53.613 -46.840  10.148  1.00 37.39           O  
+ATOM   8516  CB  SER D4176      54.219 -47.449  12.911  1.00 38.97           C  
+ATOM   8517  OG  SER D4176      54.553 -48.740  12.419  1.00 41.12           O  
+ATOM   8518  N   HIS D4177      55.831 -46.551   9.846  1.00 40.56           N  
+ATOM   8519  CA  HIS D4177      55.773 -46.784   8.399  1.00 42.25           C  
+ATOM   8520  C   HIS D4177      55.326 -48.215   8.073  1.00 43.69           C  
+ATOM   8521  O   HIS D4177      54.903 -48.502   6.947  1.00 43.80           O  
+ATOM   8522  CB  HIS D4177      57.138 -46.512   7.736  1.00 42.97           C  
+ATOM   8523  CG  HIS D4177      57.360 -45.077   7.353  1.00 44.26           C  
+ATOM   8524  ND1 HIS D4177      58.269 -44.264   7.994  1.00 44.14           N  
+ATOM   8525  CD2 HIS D4177      56.796 -44.314   6.383  1.00 44.51           C  
+ATOM   8526  CE1 HIS D4177      58.257 -43.063   7.440  1.00 43.95           C  
+ATOM   8527  NE2 HIS D4177      57.370 -43.069   6.460  1.00 44.38           N  
+ATOM   8528  N   LEU D4178      55.418 -49.107   9.057  1.00 44.28           N  
+ATOM   8529  CA  LEU D4178      55.022 -50.495   8.858  1.00 44.45           C  
+ATOM   8530  C   LEU D4178      53.519 -50.696   8.974  1.00 44.03           C  
+ATOM   8531  O   LEU D4178      52.958 -51.574   8.315  1.00 44.39           O  
+ATOM   8532  CB  LEU D4178      55.764 -51.409   9.834  1.00 46.77           C  
+ATOM   8533  CG  LEU D4178      57.103 -51.918   9.274  1.00 49.28           C  
+ATOM   8534  CD1 LEU D4178      57.971 -50.739   8.842  1.00 50.71           C  
+ATOM   8535  CD2 LEU D4178      57.821 -52.763  10.320  1.00 50.43           C  
+ATOM   8536  N   ILE D4179      52.861 -49.899   9.809  1.00 42.53           N  
+ATOM   8537  CA  ILE D4179      51.416 -50.016   9.926  1.00 41.09           C  
+ATOM   8538  C   ILE D4179      50.819 -48.879   9.109  1.00 39.19           C  
+ATOM   8539  O   ILE D4179      49.605 -48.787   8.934  1.00 38.07           O  
+ATOM   8540  CB  ILE D4179      50.931 -49.925  11.392  1.00 42.19           C  
+ATOM   8541  CG1 ILE D4179      50.921 -48.474  11.863  1.00 42.76           C  
+ATOM   8542  CG2 ILE D4179      51.839 -50.757  12.284  1.00 43.34           C  
+ATOM   8543  CD1 ILE D4179      50.395 -48.310  13.273  1.00 43.94           C  
+ATOM   8544  N   TYR D4180      51.700 -48.011   8.615  1.00 37.57           N  
+ATOM   8545  CA  TYR D4180      51.306 -46.878   7.787  1.00 36.37           C  
+ATOM   8546  C   TYR D4180      50.316 -45.983   8.537  1.00 35.18           C  
+ATOM   8547  O   TYR D4180      49.282 -45.599   7.999  1.00 34.71           O  
+ATOM   8548  CB  TYR D4180      50.675 -47.413   6.499  1.00 37.46           C  
+ATOM   8549  CG  TYR D4180      50.430 -46.396   5.404  1.00 39.90           C  
+ATOM   8550  CD1 TYR D4180      51.489 -45.854   4.673  1.00 39.35           C  
+ATOM   8551  CD2 TYR D4180      49.132 -46.006   5.071  1.00 40.39           C  
+ATOM   8552  CE1 TYR D4180      51.257 -44.955   3.635  1.00 40.89           C  
+ATOM   8553  CE2 TYR D4180      48.889 -45.108   4.037  1.00 41.00           C  
+ATOM   8554  CZ  TYR D4180      49.953 -44.586   3.322  1.00 42.66           C  
+ATOM   8555  OH  TYR D4180      49.714 -43.699   2.291  1.00 43.97           O  
+ATOM   8556  N   ASP D4181      50.632 -45.642   9.779  1.00 34.11           N  
+ATOM   8557  CA  ASP D4181      49.734 -44.796  10.556  1.00 35.02           C  
+ATOM   8558  C   ASP D4181      50.333 -44.374  11.892  1.00 35.22           C  
+ATOM   8559  O   ASP D4181      51.337 -44.921  12.335  1.00 34.77           O  
+ATOM   8560  CB  ASP D4181      48.409 -45.534  10.797  1.00 34.77           C  
+ATOM   8561  CG  ASP D4181      47.305 -44.612  11.296  1.00 34.40           C  
+ATOM   8562  OD1 ASP D4181      47.351 -43.406  10.987  1.00 35.44           O  
+ATOM   8563  OD2 ASP D4181      46.378 -45.096  11.976  1.00 35.40           O  
+ATOM   8564  N   VAL D4182      49.717 -43.381  12.522  1.00 36.12           N  
+ATOM   8565  CA  VAL D4182      50.177 -42.913  13.818  1.00 36.56           C  
+ATOM   8566  C   VAL D4182      49.908 -44.024  14.828  1.00 37.93           C  
+ATOM   8567  O   VAL D4182      48.861 -44.672  14.781  1.00 36.89           O  
+ATOM   8568  CB  VAL D4182      49.416 -41.640  14.252  1.00 36.77           C  
+ATOM   8569  CG1 VAL D4182      49.827 -41.239  15.666  1.00 35.56           C  
+ATOM   8570  CG2 VAL D4182      49.693 -40.513  13.269  1.00 34.41           C  
+ATOM   8571  N   ILE D4183      50.859 -44.262  15.725  1.00 39.59           N  
+ATOM   8572  CA  ILE D4183      50.690 -45.297  16.735  1.00 41.41           C  
+ATOM   8573  C   ILE D4183      49.839 -44.711  17.852  1.00 43.75           C  
+ATOM   8574  O   ILE D4183      50.293 -43.845  18.603  1.00 43.23           O  
+ATOM   8575  CB  ILE D4183      52.037 -45.754  17.312  1.00 41.76           C  
+ATOM   8576  CG1 ILE D4183      52.964 -46.190  16.176  1.00 42.25           C  
+ATOM   8577  CG2 ILE D4183      51.813 -46.915  18.273  1.00 42.60           C  
+ATOM   8578  CD1 ILE D4183      54.334 -46.636  16.636  1.00 42.58           C  
+ATOM   8579  N   PRO D4184      48.592 -45.189  17.978  1.00 46.00           N  
+ATOM   8580  CA  PRO D4184      47.602 -44.758  18.973  1.00 47.54           C  
+ATOM   8581  C   PRO D4184      48.098 -44.481  20.389  1.00 48.65           C  
+ATOM   8582  O   PRO D4184      47.730 -43.468  20.985  1.00 49.68           O  
+ATOM   8583  CB  PRO D4184      46.554 -45.874  18.928  1.00 47.03           C  
+ATOM   8584  CG  PRO D4184      47.322 -47.059  18.423  1.00 47.86           C  
+ATOM   8585  CD  PRO D4184      48.151 -46.438  17.335  1.00 47.18           C  
+ATOM   8586  N   ASP D4185      48.919 -45.369  20.936  1.00 48.76           N  
+ATOM   8587  CA  ASP D4185      49.413 -45.163  22.289  1.00 49.53           C  
+ATOM   8588  C   ASP D4185      50.926 -45.303  22.376  1.00 50.14           C  
+ATOM   8589  O   ASP D4185      51.445 -45.834  23.360  1.00 51.66           O  
+ATOM   8590  CB  ASP D4185      48.738 -46.151  23.243  1.00 49.09           C  
+ATOM   8591  N   GLY D4186      51.636 -44.819  21.360  1.00 49.05           N  
+ATOM   8592  CA  GLY D4186      53.087 -44.931  21.369  1.00 48.00           C  
+ATOM   8593  C   GLY D4186      53.852 -43.622  21.425  1.00 47.16           C  
+ATOM   8594  O   GLY D4186      54.933 -43.510  20.849  1.00 47.53           O  
+ATOM   8595  N   ASP D4187      53.299 -42.632  22.116  1.00 46.24           N  
+ATOM   8596  CA  ASP D4187      53.939 -41.328  22.241  1.00 46.71           C  
+ATOM   8597  C   ASP D4187      55.302 -41.439  22.909  1.00 46.72           C  
+ATOM   8598  O   ASP D4187      55.445 -42.101  23.933  1.00 47.36           O  
+ATOM   8599  CB  ASP D4187      53.050 -40.384  23.048  1.00 47.45           C  
+ATOM   8600  CG  ASP D4187      51.803 -39.982  22.300  1.00 48.50           C  
+ATOM   8601  OD1 ASP D4187      51.256 -40.837  21.575  1.00 50.88           O  
+ATOM   8602  OD2 ASP D4187      51.360 -38.820  22.442  1.00 49.88           O  
+ATOM   8603  N   LYS D4188      56.291 -40.774  22.323  1.00 46.53           N  
+ATOM   8604  CA  LYS D4188      57.662 -40.779  22.825  1.00 46.13           C  
+ATOM   8605  C   LYS D4188      57.972 -39.538  23.671  1.00 46.02           C  
+ATOM   8606  O   LYS D4188      57.761 -38.406  23.230  1.00 45.27           O  
+ATOM   8607  CB  LYS D4188      58.623 -40.858  21.639  1.00 46.83           C  
+ATOM   8608  CG  LYS D4188      60.096 -40.781  21.989  1.00 49.25           C  
+ATOM   8609  CD  LYS D4188      60.939 -40.745  20.722  1.00 48.82           C  
+ATOM   8610  CE  LYS D4188      62.403 -40.486  21.034  1.00 49.32           C  
+ATOM   8611  NZ  LYS D4188      63.208 -40.358  19.787  1.00 48.86           N  
+ATOM   8612  N   THR D4189      58.484 -39.758  24.880  1.00 46.74           N  
+ATOM   8613  CA  THR D4189      58.818 -38.670  25.797  1.00 46.10           C  
+ATOM   8614  C   THR D4189      60.291 -38.273  25.767  1.00 47.10           C  
+ATOM   8615  O   THR D4189      61.173 -39.077  26.073  1.00 47.54           O  
+ATOM   8616  CB  THR D4189      58.459 -39.035  27.249  1.00 45.55           C  
+ATOM   8617  OG1 THR D4189      57.040 -39.179  27.368  1.00 45.60           O  
+ATOM   8618  CG2 THR D4189      58.940 -37.957  28.204  1.00 44.71           C  
+ATOM   8619  N   VAL D4190      60.542 -37.017  25.407  1.00 47.61           N  
+ATOM   8620  CA  VAL D4190      61.893 -36.476  25.343  1.00 47.86           C  
+ATOM   8621  C   VAL D4190      62.229 -35.791  26.673  1.00 48.07           C  
+ATOM   8622  O   VAL D4190      61.507 -34.899  27.110  1.00 48.66           O  
+ATOM   8623  CB  VAL D4190      62.008 -35.447  24.195  1.00 48.14           C  
+ATOM   8624  CG1 VAL D4190      63.379 -34.801  24.207  1.00 48.80           C  
+ATOM   8625  CG2 VAL D4190      61.768 -36.130  22.856  1.00 48.17           C  
+ATOM   8626  N   VAL D4191      63.320 -36.212  27.312  1.00 48.21           N  
+ATOM   8627  CA  VAL D4191      63.727 -35.635  28.590  1.00 48.54           C  
+ATOM   8628  C   VAL D4191      65.035 -34.850  28.506  1.00 47.45           C  
+ATOM   8629  O   VAL D4191      66.074 -35.392  28.128  1.00 47.05           O  
+ATOM   8630  CB  VAL D4191      63.864 -36.724  29.677  1.00 48.84           C  
+ATOM   8631  CG1 VAL D4191      62.547 -37.469  29.833  1.00 49.69           C  
+ATOM   8632  CG2 VAL D4191      64.978 -37.696  29.328  1.00 49.55           C  
+ATOM   8633  N   PRO D4193      67.093 -33.143  26.620  1.00 32.09           N  
+ATOM   8634  CA  PRO D4193      68.258 -33.373  25.765  1.00 31.53           C  
+ATOM   8635  C   PRO D4193      69.171 -32.157  25.529  1.00 30.77           C  
+ATOM   8636  O   PRO D4193      68.712 -31.015  25.506  1.00 33.52           O  
+ATOM   8637  CB  PRO D4193      67.630 -33.901  24.466  1.00 30.19           C  
+ATOM   8638  CG  PRO D4193      66.380 -33.117  24.354  1.00 30.25           C  
+ATOM   8639  CD  PRO D4193      65.859 -33.039  25.822  1.00 31.87           C  
+ATOM   8640  N   ASP D4194      70.465 -32.409  25.355  1.00 28.35           N  
+ATOM   8641  CA  ASP D4194      71.409 -31.331  25.091  1.00 26.64           C  
+ATOM   8642  C   ASP D4194      71.153 -30.877  23.665  1.00 23.58           C  
+ATOM   8643  O   ASP D4194      71.184 -29.687  23.353  1.00 22.46           O  
+ATOM   8644  CB  ASP D4194      72.846 -31.835  25.212  1.00 29.31           C  
+ATOM   8645  CG  ASP D4194      73.203 -32.220  26.629  1.00 30.58           C  
+ATOM   8646  OD1 ASP D4194      73.165 -31.333  27.504  1.00 33.41           O  
+ATOM   8647  OD2 ASP D4194      73.496 -33.409  26.882  1.00 33.72           O  
+ATOM   8648  N   ILE D4195      70.859 -31.855  22.814  1.00 23.34           N  
+ATOM   8649  CA  ILE D4195      70.606 -31.623  21.403  1.00 22.15           C  
+ATOM   8650  C   ILE D4195      69.403 -32.415  20.921  1.00 22.68           C  
+ATOM   8651  O   ILE D4195      69.222 -33.581  21.282  1.00 22.15           O  
+ATOM   8652  CB  ILE D4195      71.814 -32.051  20.557  1.00 21.89           C  
+ATOM   8653  CG1 ILE D4195      73.043 -31.224  20.946  1.00 23.68           C  
+ATOM   8654  CG2 ILE D4195      71.498 -31.893  19.067  1.00 22.99           C  
+ATOM   8655  CD1 ILE D4195      74.330 -31.681  20.266  1.00 20.91           C  
+ATOM   8656  N   LEU D4196      68.573 -31.769  20.113  1.00 20.97           N  
+ATOM   8657  CA  LEU D4196      67.422 -32.443  19.542  1.00 20.89           C  
+ATOM   8658  C   LEU D4196      67.500 -32.312  18.030  1.00 19.86           C  
+ATOM   8659  O   LEU D4196      67.635 -31.210  17.505  1.00 19.11           O  
+ATOM   8660  CB  LEU D4196      66.105 -31.838  20.032  1.00 20.83           C  
+ATOM   8661  CG  LEU D4196      64.876 -32.578  19.473  1.00 23.18           C  
+ATOM   8662  CD1 LEU D4196      64.038 -33.155  20.619  1.00 24.11           C  
+ATOM   8663  CD2 LEU D4196      64.039 -31.632  18.636  1.00 21.76           C  
+ATOM   8664  N   ILE D4197      67.460 -33.443  17.339  1.00 20.03           N  
+ATOM   8665  CA  ILE D4197      67.481 -33.439  15.888  1.00 20.72           C  
+ATOM   8666  C   ILE D4197      66.034 -33.672  15.451  1.00 19.06           C  
+ATOM   8667  O   ILE D4197      65.436 -34.676  15.806  1.00 17.24           O  
+ATOM   8668  CB  ILE D4197      68.393 -34.558  15.320  1.00 21.27           C  
+ATOM   8669  CG1 ILE D4197      69.843 -34.314  15.755  1.00 23.27           C  
+ATOM   8670  CG2 ILE D4197      68.309 -34.580  13.800  1.00 20.27           C  
+ATOM   8671  CD1 ILE D4197      70.809 -35.456  15.398  1.00 19.55           C  
+ATOM   8672  N   LEU D4198      65.480 -32.710  14.717  1.00 19.72           N  
+ATOM   8673  CA  LEU D4198      64.111 -32.779  14.212  1.00 18.24           C  
+ATOM   8674  C   LEU D4198      64.181 -33.028  12.709  1.00 18.83           C  
+ATOM   8675  O   LEU D4198      64.597 -32.163  11.936  1.00 17.84           O  
+ATOM   8676  CB  LEU D4198      63.363 -31.476  14.493  1.00 16.75           C  
+ATOM   8677  CG  LEU D4198      61.889 -31.461  14.064  1.00 20.55           C  
+ATOM   8678  CD1 LEU D4198      61.097 -32.438  14.917  1.00 18.05           C  
+ATOM   8679  CD2 LEU D4198      61.310 -30.054  14.203  1.00 19.79           C  
+ATOM   8680  N   GLU D4199      63.762 -34.219  12.306  1.00 19.58           N  
+ATOM   8681  CA  GLU D4199      63.806 -34.626  10.913  1.00 21.29           C  
+ATOM   8682  C   GLU D4199      62.417 -34.688  10.269  1.00 21.85           C  
+ATOM   8683  O   GLU D4199      61.497 -35.332  10.791  1.00 22.16           O  
+ATOM   8684  CB  GLU D4199      64.517 -35.982  10.821  1.00 25.10           C  
+ATOM   8685  CG  GLU D4199      64.524 -36.586   9.443  1.00 32.55           C  
+ATOM   8686  CD  GLU D4199      63.429 -37.608   9.281  1.00 36.43           C  
+ATOM   8687  OE1 GLU D4199      63.516 -38.666   9.947  1.00 40.00           O  
+ATOM   8688  OE2 GLU D4199      62.481 -37.358   8.500  1.00 38.79           O  
+ATOM   8689  N   GLY D4200      62.269 -34.005   9.134  1.00 21.37           N  
+ATOM   8690  CA  GLY D4200      60.990 -33.986   8.445  1.00 21.08           C  
+ATOM   8691  C   GLY D4200      61.026 -33.126   7.196  1.00 21.91           C  
+ATOM   8692  O   GLY D4200      61.736 -32.119   7.137  1.00 21.66           O  
+ATOM   8693  N   LEU D4201      60.258 -33.519   6.188  1.00 20.45           N  
+ATOM   8694  CA  LEU D4201      60.216 -32.785   4.932  1.00 19.61           C  
+ATOM   8695  C   LEU D4201      59.660 -31.371   5.082  1.00 19.45           C  
+ATOM   8696  O   LEU D4201      59.901 -30.514   4.229  1.00 17.26           O  
+ATOM   8697  CB  LEU D4201      59.361 -33.553   3.926  1.00 20.53           C  
+ATOM   8698  CG  LEU D4201      57.886 -33.716   4.310  1.00 20.80           C  
+ATOM   8699  CD1 LEU D4201      57.109 -32.481   3.869  1.00 20.12           C  
+ATOM   8700  CD2 LEU D4201      57.297 -34.962   3.638  1.00 21.99           C  
+ATOM   8701  N   ASN D4202      58.938 -31.124   6.172  1.00 18.67           N  
+ATOM   8702  CA  ASN D4202      58.298 -29.825   6.380  1.00 20.38           C  
+ATOM   8703  C   ASN D4202      58.884 -28.901   7.447  1.00 20.24           C  
+ATOM   8704  O   ASN D4202      58.249 -27.910   7.802  1.00 19.38           O  
+ATOM   8705  CB  ASN D4202      56.823 -30.059   6.698  1.00 19.29           C  
+ATOM   8706  CG  ASN D4202      56.636 -30.863   7.970  1.00 20.15           C  
+ATOM   8707  OD1 ASN D4202      57.471 -31.701   8.308  1.00 21.70           O  
+ATOM   8708  ND2 ASN D4202      55.535 -30.622   8.675  1.00 18.71           N  
+ATOM   8709  N   VAL D4203      60.080 -29.196   7.952  1.00 19.83           N  
+ATOM   8710  CA  VAL D4203      60.657 -28.356   9.005  1.00 18.57           C  
+ATOM   8711  C   VAL D4203      61.002 -26.921   8.612  1.00 18.67           C  
+ATOM   8712  O   VAL D4203      61.235 -26.076   9.480  1.00 19.17           O  
+ATOM   8713  CB  VAL D4203      61.901 -29.027   9.632  1.00 17.63           C  
+ATOM   8714  CG1 VAL D4203      61.485 -30.335  10.282  1.00 16.14           C  
+ATOM   8715  CG2 VAL D4203      62.979 -29.265   8.578  1.00 15.94           C  
+ATOM   8716  N   LEU D4204      61.037 -26.636   7.314  1.00 18.51           N  
+ATOM   8717  CA  LEU D4204      61.347 -25.284   6.855  1.00 20.68           C  
+ATOM   8718  C   LEU D4204      60.100 -24.537   6.385  1.00 20.27           C  
+ATOM   8719  O   LEU D4204      60.159 -23.354   6.045  1.00 23.27           O  
+ATOM   8720  CB  LEU D4204      62.389 -25.329   5.730  1.00 19.33           C  
+ATOM   8721  CG  LEU D4204      63.811 -25.692   6.175  1.00 20.35           C  
+ATOM   8722  CD1 LEU D4204      64.700 -25.857   4.948  1.00 20.03           C  
+ATOM   8723  CD2 LEU D4204      64.361 -24.609   7.102  1.00 16.34           C  
+ATOM   8724  N   GLN D4205      58.968 -25.226   6.370  1.00 20.52           N  
+ATOM   8725  CA  GLN D4205      57.721 -24.612   5.943  1.00 21.89           C  
+ATOM   8726  C   GLN D4205      57.242 -23.617   6.993  1.00 22.93           C  
+ATOM   8727  O   GLN D4205      57.756 -23.579   8.112  1.00 22.02           O  
+ATOM   8728  CB  GLN D4205      56.660 -25.694   5.682  1.00 20.76           C  
+ATOM   8729  CG  GLN D4205      56.964 -26.502   4.427  1.00 21.02           C  
+ATOM   8730  CD  GLN D4205      56.031 -27.672   4.217  1.00 21.17           C  
+ATOM   8731  OE1 GLN D4205      55.090 -27.891   4.992  1.00 21.71           O  
+ATOM   8732  NE2 GLN D4205      56.288 -28.438   3.158  1.00 19.96           N  
+ATOM   8733  N   SER D4206      56.253 -22.811   6.628  1.00 23.46           N  
+ATOM   8734  CA  SER D4206      55.735 -21.804   7.535  1.00 24.55           C  
+ATOM   8735  C   SER D4206      54.234 -21.566   7.357  1.00 23.82           C  
+ATOM   8736  O   SER D4206      53.534 -22.374   6.747  1.00 24.79           O  
+ATOM   8737  CB  SER D4206      56.498 -20.501   7.313  1.00 24.30           C  
+ATOM   8738  OG  SER D4206      56.371 -20.082   5.967  1.00 25.78           O  
+ATOM   8739  N   GLY D4207      53.754 -20.451   7.893  1.00 24.74           N  
+ATOM   8740  CA  GLY D4207      52.342 -20.120   7.801  1.00 25.73           C  
+ATOM   8741  C   GLY D4207      51.778 -20.088   6.392  1.00 24.62           C  
+ATOM   8742  O   GLY D4207      50.641 -20.508   6.163  1.00 25.80           O  
+ATOM   8743  N   MET D4208      52.562 -19.588   5.443  1.00 24.50           N  
+ATOM   8744  CA  MET D4208      52.104 -19.498   4.062  1.00 26.13           C  
+ATOM   8745  C   MET D4208      51.750 -20.863   3.479  1.00 26.24           C  
+ATOM   8746  O   MET D4208      50.992 -20.957   2.522  1.00 27.11           O  
+ATOM   8747  CB  MET D4208      53.168 -18.823   3.193  1.00 25.96           C  
+ATOM   8748  CG  MET D4208      54.445 -19.638   3.016  1.00 29.20           C  
+ATOM   8749  SD  MET D4208      55.711 -18.752   2.057  1.00 30.54           S  
+ATOM   8750  CE  MET D4208      54.767 -18.386   0.554  1.00 26.87           C  
+ATOM   8751  N   ASP D4209      52.302 -21.922   4.058  1.00 27.33           N  
+ATOM   8752  CA  ASP D4209      52.038 -23.272   3.579  1.00 28.72           C  
+ATOM   8753  C   ASP D4209      50.764 -23.849   4.172  1.00 29.99           C  
+ATOM   8754  O   ASP D4209      50.337 -24.925   3.773  1.00 30.18           O  
+ATOM   8755  CB  ASP D4209      53.211 -24.191   3.920  1.00 31.33           C  
+ATOM   8756  CG  ASP D4209      54.493 -23.769   3.243  1.00 32.18           C  
+ATOM   8757  OD1 ASP D4209      54.542 -23.831   1.995  1.00 32.00           O  
+ATOM   8758  OD2 ASP D4209      55.440 -23.367   3.957  1.00 30.37           O  
+ATOM   8759  N   TYR D4210      50.167 -23.142   5.130  1.00 31.21           N  
+ATOM   8760  CA  TYR D4210      48.944 -23.618   5.767  1.00 31.81           C  
+ATOM   8761  C   TYR D4210      47.864 -22.541   5.757  1.00 32.89           C  
+ATOM   8762  O   TYR D4210      47.350 -22.150   6.802  1.00 34.05           O  
+ATOM   8763  CB  TYR D4210      49.242 -24.073   7.202  1.00 30.81           C  
+ATOM   8764  CG  TYR D4210      50.269 -25.186   7.263  1.00 32.04           C  
+ATOM   8765  CD1 TYR D4210      51.604 -24.944   6.942  1.00 32.01           C  
+ATOM   8766  CD2 TYR D4210      49.892 -26.497   7.564  1.00 31.88           C  
+ATOM   8767  CE1 TYR D4210      52.540 -25.976   6.907  1.00 33.84           C  
+ATOM   8768  CE2 TYR D4210      50.818 -27.543   7.532  1.00 32.05           C  
+ATOM   8769  CZ  TYR D4210      52.142 -27.276   7.200  1.00 35.39           C  
+ATOM   8770  OH  TYR D4210      53.069 -28.301   7.142  1.00 36.84           O  
+ATOM   8771  N   PRO D4211      47.493 -22.059   4.561  1.00 33.55           N  
+ATOM   8772  CA  PRO D4211      46.468 -21.018   4.442  1.00 34.92           C  
+ATOM   8773  C   PRO D4211      45.131 -21.460   5.021  1.00 36.14           C  
+ATOM   8774  O   PRO D4211      44.326 -20.633   5.442  1.00 37.05           O  
+ATOM   8775  CB  PRO D4211      46.401 -20.774   2.936  1.00 33.54           C  
+ATOM   8776  CG  PRO D4211      46.680 -22.144   2.382  1.00 35.27           C  
+ATOM   8777  CD  PRO D4211      47.837 -22.610   3.236  1.00 34.13           C  
+ATOM   8778  N   HIS D4212      44.903 -22.768   5.047  1.00 36.79           N  
+ATOM   8779  CA  HIS D4212      43.659 -23.316   5.571  1.00 37.99           C  
+ATOM   8780  C   HIS D4212      43.583 -23.238   7.095  1.00 38.05           C  
+ATOM   8781  O   HIS D4212      42.494 -23.264   7.666  1.00 39.34           O  
+ATOM   8782  CB  HIS D4212      43.501 -24.775   5.126  1.00 39.51           C  
+ATOM   8783  CG  HIS D4212      44.679 -25.641   5.457  1.00 39.99           C  
+ATOM   8784  ND1 HIS D4212      45.883 -25.545   4.793  1.00 39.60           N  
+ATOM   8785  CD2 HIS D4212      44.846 -26.602   6.399  1.00 38.26           C  
+ATOM   8786  CE1 HIS D4212      46.740 -26.408   5.310  1.00 38.25           C  
+ATOM   8787  NE2 HIS D4212      46.136 -27.059   6.286  1.00 37.33           N  
+ATOM   8788  N   ASP D4213      44.739 -23.135   7.743  1.00 36.96           N  
+ATOM   8789  CA  ASP D4213      44.822 -23.079   9.203  1.00 35.50           C  
+ATOM   8790  C   ASP D4213      46.191 -22.496   9.554  1.00 34.41           C  
+ATOM   8791  O   ASP D4213      47.076 -23.207  10.025  1.00 36.20           O  
+ATOM   8792  CB  ASP D4213      44.698 -24.495   9.757  1.00 35.77           C  
+ATOM   8793  CG  ASP D4213      44.630 -24.526  11.255  1.00 35.35           C  
+ATOM   8794  OD1 ASP D4213      44.652 -25.639  11.826  1.00 37.89           O  
+ATOM   8795  OD2 ASP D4213      44.551 -23.442  11.861  1.00 37.28           O  
+ATOM   8796  N   PRO D4214      46.371 -21.183   9.348  1.00 33.21           N  
+ATOM   8797  CA  PRO D4214      47.617 -20.453   9.605  1.00 32.48           C  
+ATOM   8798  C   PRO D4214      48.197 -20.335  11.013  1.00 30.99           C  
+ATOM   8799  O   PRO D4214      47.471 -20.159  11.993  1.00 32.15           O  
+ATOM   8800  CB  PRO D4214      47.328 -19.082   9.006  1.00 33.56           C  
+ATOM   8801  CG  PRO D4214      45.870 -18.909   9.313  1.00 34.54           C  
+ATOM   8802  CD  PRO D4214      45.302 -20.255   8.929  1.00 33.15           C  
+ATOM   8803  N   HIS D4215      49.523 -20.447  11.093  1.00 28.06           N  
+ATOM   8804  CA  HIS D4215      50.242 -20.269  12.349  1.00 26.71           C  
+ATOM   8805  C   HIS D4215      51.181 -19.098  12.086  1.00 25.27           C  
+ATOM   8806  O   HIS D4215      51.618 -18.890  10.946  1.00 23.52           O  
+ATOM   8807  CB  HIS D4215      51.006 -21.540  12.791  1.00 26.13           C  
+ATOM   8808  CG  HIS D4215      51.933 -22.110  11.758  1.00 26.53           C  
+ATOM   8809  ND1 HIS D4215      51.488 -22.860  10.689  1.00 27.41           N  
+ATOM   8810  CD2 HIS D4215      53.283 -22.096  11.671  1.00 26.31           C  
+ATOM   8811  CE1 HIS D4215      52.526 -23.290   9.994  1.00 26.31           C  
+ATOM   8812  NE2 HIS D4215      53.629 -22.841  10.567  1.00 25.62           N  
+ATOM   8813  N   HIS D4216      51.480 -18.326  13.129  1.00 23.91           N  
+ATOM   8814  CA  HIS D4216      52.303 -17.130  12.974  1.00 24.50           C  
+ATOM   8815  C   HIS D4216      53.723 -17.175  13.510  1.00 23.38           C  
+ATOM   8816  O   HIS D4216      54.483 -16.218  13.366  1.00 23.14           O  
+ATOM   8817  CB  HIS D4216      51.538 -15.951  13.561  1.00 25.87           C  
+ATOM   8818  CG  HIS D4216      50.188 -15.771  12.941  1.00 29.30           C  
+ATOM   8819  ND1 HIS D4216      49.998 -15.094  11.755  1.00 30.43           N  
+ATOM   8820  CD2 HIS D4216      48.979 -16.279  13.280  1.00 29.63           C  
+ATOM   8821  CE1 HIS D4216      48.733 -15.193  11.388  1.00 29.80           C  
+ATOM   8822  NE2 HIS D4216      48.093 -15.909  12.295  1.00 31.28           N  
+ATOM   8823  N   VAL D4217      54.072 -18.284  14.144  1.00 22.79           N  
+ATOM   8824  CA  VAL D4217      55.425 -18.493  14.655  1.00 23.81           C  
+ATOM   8825  C   VAL D4217      55.749 -19.851  14.056  1.00 22.99           C  
+ATOM   8826  O   VAL D4217      55.006 -20.814  14.249  1.00 22.91           O  
+ATOM   8827  CB  VAL D4217      55.480 -18.560  16.196  1.00 25.03           C  
+ATOM   8828  CG1 VAL D4217      56.922 -18.585  16.650  1.00 26.95           C  
+ATOM   8829  CG2 VAL D4217      54.791 -17.347  16.800  1.00 26.27           C  
+ATOM   8830  N   PHE D4218      56.845 -19.928  13.316  1.00 21.06           N  
+ATOM   8831  CA  PHE D4218      57.194 -21.165  12.630  1.00 19.64           C  
+ATOM   8832  C   PHE D4218      58.164 -22.091  13.358  1.00 19.93           C  
+ATOM   8833  O   PHE D4218      58.825 -21.707  14.329  1.00 19.15           O  
+ATOM   8834  CB  PHE D4218      57.755 -20.812  11.250  1.00 18.37           C  
+ATOM   8835  CG  PHE D4218      57.120 -19.592  10.641  1.00 18.95           C  
+ATOM   8836  CD1 PHE D4218      57.904 -18.597  10.065  1.00 18.62           C  
+ATOM   8837  CD2 PHE D4218      55.734 -19.420  10.673  1.00 19.84           C  
+ATOM   8838  CE1 PHE D4218      57.317 -17.447   9.531  1.00 18.06           C  
+ATOM   8839  CE2 PHE D4218      55.139 -18.273  10.140  1.00 17.66           C  
+ATOM   8840  CZ  PHE D4218      55.933 -17.289   9.571  1.00 19.08           C  
+ATOM   8841  N   VAL D4219      58.238 -23.324  12.869  1.00 20.23           N  
+ATOM   8842  CA  VAL D4219      59.138 -24.320  13.421  1.00 20.21           C  
+ATOM   8843  C   VAL D4219      60.558 -23.749  13.423  1.00 19.70           C  
+ATOM   8844  O   VAL D4219      61.279 -23.852  14.415  1.00 20.33           O  
+ATOM   8845  CB  VAL D4219      59.103 -25.627  12.571  1.00 20.66           C  
+ATOM   8846  CG1 VAL D4219      60.286 -26.511  12.913  1.00 18.70           C  
+ATOM   8847  CG2 VAL D4219      57.796 -26.377  12.825  1.00 18.60           C  
+ATOM   8848  N   SER D4220      60.941 -23.132  12.310  1.00 18.06           N  
+ATOM   8849  CA  SER D4220      62.265 -22.556  12.167  1.00 18.76           C  
+ATOM   8850  C   SER D4220      62.582 -21.509  13.245  1.00 17.93           C  
+ATOM   8851  O   SER D4220      63.745 -21.273  13.574  1.00 15.76           O  
+ATOM   8852  CB  SER D4220      62.419 -21.934  10.774  1.00 19.24           C  
+ATOM   8853  OG  SER D4220      61.537 -20.829  10.617  1.00 23.62           O  
+ATOM   8854  N   ASP D4221      61.543 -20.880  13.789  1.00 19.87           N  
+ATOM   8855  CA  ASP D4221      61.733 -19.876  14.837  1.00 19.78           C  
+ATOM   8856  C   ASP D4221      62.197 -20.505  16.149  1.00 19.51           C  
+ATOM   8857  O   ASP D4221      62.578 -19.803  17.084  1.00 20.44           O  
+ATOM   8858  CB  ASP D4221      60.444 -19.078  15.053  1.00 17.99           C  
+ATOM   8859  CG  ASP D4221      60.114 -18.181  13.858  1.00 19.12           C  
+ATOM   8860  OD1 ASP D4221      61.065 -17.607  13.286  1.00 15.55           O  
+ATOM   8861  OD2 ASP D4221      58.921 -18.046  13.497  1.00 18.44           O  
+ATOM   8862  N   PHE D4222      62.177 -21.835  16.206  1.00 20.17           N  
+ATOM   8863  CA  PHE D4222      62.612 -22.563  17.394  1.00 21.26           C  
+ATOM   8864  C   PHE D4222      63.720 -23.555  17.039  1.00 20.50           C  
+ATOM   8865  O   PHE D4222      64.005 -24.493  17.796  1.00 20.39           O  
+ATOM   8866  CB  PHE D4222      61.424 -23.296  18.035  1.00 21.11           C  
+ATOM   8867  CG  PHE D4222      60.299 -22.381  18.434  1.00 22.80           C  
+ATOM   8868  CD1 PHE D4222      59.130 -22.323  17.679  1.00 22.55           C  
+ATOM   8869  CD2 PHE D4222      60.419 -21.555  19.548  1.00 23.63           C  
+ATOM   8870  CE1 PHE D4222      58.099 -21.456  18.024  1.00 24.10           C  
+ATOM   8871  CE2 PHE D4222      59.383 -20.674  19.906  1.00 25.16           C  
+ATOM   8872  CZ  PHE D4222      58.224 -20.628  19.144  1.00 24.18           C  
+ATOM   8873  N   VAL D4223      64.339 -23.350  15.880  1.00 19.05           N  
+ATOM   8874  CA  VAL D4223      65.423 -24.219  15.425  1.00 18.16           C  
+ATOM   8875  C   VAL D4223      66.712 -23.413  15.315  1.00 18.25           C  
+ATOM   8876  O   VAL D4223      66.725 -22.326  14.739  1.00 19.32           O  
+ATOM   8877  CB  VAL D4223      65.084 -24.862  14.047  1.00 18.29           C  
+ATOM   8878  CG1 VAL D4223      66.304 -25.587  13.477  1.00 14.74           C  
+ATOM   8879  CG2 VAL D4223      63.928 -25.845  14.212  1.00 16.31           C  
+ATOM   8880  N   ASP D4224      67.791 -23.941  15.879  1.00 18.48           N  
+ATOM   8881  CA  ASP D4224      69.070 -23.250  15.833  1.00 19.46           C  
+ATOM   8882  C   ASP D4224      69.804 -23.425  14.512  1.00 19.32           C  
+ATOM   8883  O   ASP D4224      70.352 -22.467  13.981  1.00 21.58           O  
+ATOM   8884  CB  ASP D4224      69.971 -23.723  16.973  1.00 18.94           C  
+ATOM   8885  CG  ASP D4224      69.391 -23.412  18.333  1.00 21.92           C  
+ATOM   8886  OD1 ASP D4224      68.725 -24.299  18.922  1.00 21.50           O  
+ATOM   8887  OD2 ASP D4224      69.590 -22.270  18.799  1.00 22.81           O  
+ATOM   8888  N   PHE D4225      69.822 -24.647  13.987  1.00 20.00           N  
+ATOM   8889  CA  PHE D4225      70.520 -24.921  12.731  1.00 19.93           C  
+ATOM   8890  C   PHE D4225      69.657 -25.820  11.850  1.00 19.16           C  
+ATOM   8891  O   PHE D4225      69.118 -26.814  12.319  1.00 22.15           O  
+ATOM   8892  CB  PHE D4225      71.852 -25.627  13.028  1.00 19.44           C  
+ATOM   8893  CG  PHE D4225      72.844 -25.593  11.886  1.00 20.69           C  
+ATOM   8894  CD1 PHE D4225      73.807 -24.578  11.805  1.00 19.17           C  
+ATOM   8895  CD2 PHE D4225      72.827 -26.580  10.899  1.00 17.81           C  
+ATOM   8896  CE1 PHE D4225      74.736 -24.552  10.757  1.00 18.18           C  
+ATOM   8897  CE2 PHE D4225      73.752 -26.563   9.848  1.00 18.33           C  
+ATOM   8898  CZ  PHE D4225      74.709 -25.545   9.778  1.00 17.89           C  
+ATOM   8899  N   SER D4226      69.526 -25.479  10.577  1.00 18.94           N  
+ATOM   8900  CA  SER D4226      68.730 -26.308   9.683  1.00 19.19           C  
+ATOM   8901  C   SER D4226      69.538 -26.790   8.486  1.00 19.11           C  
+ATOM   8902  O   SER D4226      70.339 -26.043   7.920  1.00 20.46           O  
+ATOM   8903  CB  SER D4226      67.480 -25.545   9.209  1.00 18.24           C  
+ATOM   8904  OG  SER D4226      67.816 -24.433   8.404  1.00 15.19           O  
+ATOM   8905  N   ILE D4227      69.311 -28.047   8.113  1.00 20.31           N  
+ATOM   8906  CA  ILE D4227      69.989 -28.678   6.982  1.00 20.15           C  
+ATOM   8907  C   ILE D4227      68.954 -29.156   5.971  1.00 21.34           C  
+ATOM   8908  O   ILE D4227      67.941 -29.748   6.342  1.00 20.59           O  
+ATOM   8909  CB  ILE D4227      70.791 -29.932   7.426  1.00 21.93           C  
+ATOM   8910  CG1 ILE D4227      71.970 -29.532   8.326  1.00 19.39           C  
+ATOM   8911  CG2 ILE D4227      71.270 -30.714   6.198  1.00 18.15           C  
+ATOM   8912  CD1 ILE D4227      72.519 -30.705   9.146  1.00 22.02           C  
+ATOM   8913  N   TYR D4228      69.206 -28.895   4.694  1.00 19.83           N  
+ATOM   8914  CA  TYR D4228      68.306 -29.365   3.658  1.00 19.80           C  
+ATOM   8915  C   TYR D4228      69.081 -30.370   2.803  1.00 18.91           C  
+ATOM   8916  O   TYR D4228      70.071 -30.014   2.165  1.00 18.82           O  
+ATOM   8917  CB  TYR D4228      67.820 -28.202   2.788  1.00 18.21           C  
+ATOM   8918  CG  TYR D4228      66.811 -28.617   1.737  1.00 18.45           C  
+ATOM   8919  CD1 TYR D4228      65.441 -28.470   1.953  1.00 18.57           C  
+ATOM   8920  CD2 TYR D4228      67.231 -29.159   0.521  1.00 20.55           C  
+ATOM   8921  CE1 TYR D4228      64.517 -28.849   0.979  1.00 18.89           C  
+ATOM   8922  CE2 TYR D4228      66.317 -29.543  -0.455  1.00 18.74           C  
+ATOM   8923  CZ  TYR D4228      64.965 -29.385  -0.223  1.00 20.02           C  
+ATOM   8924  OH  TYR D4228      64.067 -29.756  -1.200  1.00 20.05           O  
+ATOM   8925  N   VAL D4229      68.653 -31.629   2.815  1.00 19.83           N  
+ATOM   8926  CA  VAL D4229      69.326 -32.656   2.023  1.00 20.58           C  
+ATOM   8927  C   VAL D4229      68.713 -32.553   0.634  1.00 21.57           C  
+ATOM   8928  O   VAL D4229      67.498 -32.647   0.481  1.00 20.73           O  
+ATOM   8929  CB  VAL D4229      69.105 -34.053   2.626  1.00 21.65           C  
+ATOM   8930  CG1 VAL D4229      70.070 -35.059   1.996  1.00 18.54           C  
+ATOM   8931  CG2 VAL D4229      69.309 -33.990   4.137  1.00 18.95           C  
+ATOM   8932  N   ASP D4230      69.565 -32.352  -0.368  1.00 22.13           N  
+ATOM   8933  CA  ASP D4230      69.115 -32.147  -1.738  1.00 22.84           C  
+ATOM   8934  C   ASP D4230      69.621 -33.185  -2.736  1.00 23.47           C  
+ATOM   8935  O   ASP D4230      70.727 -33.703  -2.594  1.00 22.28           O  
+ATOM   8936  CB  ASP D4230      69.564 -30.742  -2.163  1.00 24.78           C  
+ATOM   8937  CG  ASP D4230      68.831 -30.225  -3.374  1.00 24.60           C  
+ATOM   8938  OD1 ASP D4230      67.638 -30.544  -3.548  1.00 26.48           O  
+ATOM   8939  OD2 ASP D4230      69.450 -29.469  -4.145  1.00 27.66           O  
+ATOM   8940  N   ALA D4231      68.797 -33.482  -3.744  1.00 23.98           N  
+ATOM   8941  CA  ALA D4231      69.156 -34.437  -4.788  1.00 25.87           C  
+ATOM   8942  C   ALA D4231      68.222 -34.314  -5.989  1.00 25.91           C  
+ATOM   8943  O   ALA D4231      67.091 -33.864  -5.861  1.00 27.94           O  
+ATOM   8944  CB  ALA D4231      69.122 -35.861  -4.238  1.00 24.31           C  
+ATOM   8945  N   PRO D4232      68.694 -34.710  -7.180  1.00 27.64           N  
+ATOM   8946  CA  PRO D4232      67.898 -34.647  -8.414  1.00 28.36           C  
+ATOM   8947  C   PRO D4232      66.684 -35.576  -8.363  1.00 28.36           C  
+ATOM   8948  O   PRO D4232      66.704 -36.608  -7.691  1.00 25.01           O  
+ATOM   8949  CB  PRO D4232      68.885 -35.091  -9.495  1.00 29.58           C  
+ATOM   8950  CG  PRO D4232      70.231 -34.776  -8.903  1.00 30.72           C  
+ATOM   8951  CD  PRO D4232      70.064 -35.174  -7.461  1.00 28.36           C  
+ATOM   8952  N   GLU D4233      65.638 -35.209  -9.095  1.00 29.58           N  
+ATOM   8953  CA  GLU D4233      64.412 -35.995  -9.150  1.00 29.93           C  
+ATOM   8954  C   GLU D4233      64.654 -37.434  -9.614  1.00 29.23           C  
+ATOM   8955  O   GLU D4233      64.067 -38.366  -9.068  1.00 28.57           O  
+ATOM   8956  CB  GLU D4233      63.408 -35.307 -10.080  1.00 32.55           C  
+ATOM   8957  CG  GLU D4233      62.004 -35.903 -10.094  1.00 36.44           C  
+ATOM   8958  CD  GLU D4233      61.908 -37.202 -10.879  1.00 39.47           C  
+ATOM   8959  OE1 GLU D4233      62.571 -37.312 -11.934  1.00 40.78           O  
+ATOM   8960  OE2 GLU D4233      61.154 -38.105 -10.449  1.00 40.94           O  
+ATOM   8961  N   ASP D4234      65.522 -37.616 -10.607  1.00 28.44           N  
+ATOM   8962  CA  ASP D4234      65.813 -38.954 -11.119  1.00 29.26           C  
+ATOM   8963  C   ASP D4234      66.434 -39.877 -10.065  1.00 28.00           C  
+ATOM   8964  O   ASP D4234      66.156 -41.078 -10.045  1.00 28.83           O  
+ATOM   8965  CB  ASP D4234      66.731 -38.886 -12.350  1.00 31.79           C  
+ATOM   8966  CG  ASP D4234      68.114 -38.353 -12.028  1.00 36.68           C  
+ATOM   8967  OD1 ASP D4234      68.225 -37.168 -11.647  1.00 40.16           O  
+ATOM   8968  OD2 ASP D4234      69.096 -39.121 -12.152  1.00 39.37           O  
+ATOM   8969  N   LEU D4235      67.278 -39.331  -9.197  1.00 25.37           N  
+ATOM   8970  CA  LEU D4235      67.901 -40.139  -8.153  1.00 22.78           C  
+ATOM   8971  C   LEU D4235      66.904 -40.401  -7.035  1.00 22.15           C  
+ATOM   8972  O   LEU D4235      66.858 -41.502  -6.479  1.00 23.05           O  
+ATOM   8973  CB  LEU D4235      69.135 -39.437  -7.592  1.00 22.18           C  
+ATOM   8974  CG  LEU D4235      70.343 -39.411  -8.533  1.00 21.66           C  
+ATOM   8975  CD1 LEU D4235      71.451 -38.548  -7.955  1.00 19.99           C  
+ATOM   8976  CD2 LEU D4235      70.819 -40.828  -8.758  1.00 20.14           C  
+ATOM   8977  N   LEU D4236      66.100 -39.391  -6.718  1.00 21.01           N  
+ATOM   8978  CA  LEU D4236      65.096 -39.514  -5.669  1.00 21.78           C  
+ATOM   8979  C   LEU D4236      64.097 -40.627  -6.012  1.00 21.91           C  
+ATOM   8980  O   LEU D4236      63.697 -41.412  -5.148  1.00 21.12           O  
+ATOM   8981  CB  LEU D4236      64.359 -38.181  -5.485  1.00 20.48           C  
+ATOM   8982  CG  LEU D4236      65.130 -37.011  -4.860  1.00 20.82           C  
+ATOM   8983  CD1 LEU D4236      64.253 -35.771  -4.854  1.00 21.79           C  
+ATOM   8984  CD2 LEU D4236      65.545 -37.346  -3.439  1.00 17.26           C  
+ATOM   8985  N   GLN D4237      63.706 -40.693  -7.280  1.00 22.37           N  
+ATOM   8986  CA  GLN D4237      62.758 -41.703  -7.734  1.00 24.99           C  
+ATOM   8987  C   GLN D4237      63.341 -43.102  -7.538  1.00 24.38           C  
+ATOM   8988  O   GLN D4237      62.686 -43.998  -7.000  1.00 25.17           O  
+ATOM   8989  CB  GLN D4237      62.412 -41.471  -9.207  1.00 26.12           C  
+ATOM   8990  CG  GLN D4237      61.307 -42.377  -9.730  1.00 29.50           C  
+ATOM   8991  CD  GLN D4237      61.050 -42.200 -11.219  1.00 31.88           C  
+ATOM   8992  OE1 GLN D4237      60.734 -41.104 -11.684  1.00 32.27           O  
+ATOM   8993  NE2 GLN D4237      61.186 -43.284 -11.973  1.00 34.98           N  
+ATOM   8994  N   THR D4238      64.585 -43.278  -7.968  1.00 24.88           N  
+ATOM   8995  CA  THR D4238      65.273 -44.557  -7.825  1.00 24.42           C  
+ATOM   8996  C   THR D4238      65.380 -44.982  -6.355  1.00 24.21           C  
+ATOM   8997  O   THR D4238      65.094 -46.131  -6.006  1.00 25.17           O  
+ATOM   8998  CB  THR D4238      66.688 -44.476  -8.407  1.00 23.71           C  
+ATOM   8999  OG1 THR D4238      66.617 -44.120  -9.795  1.00 26.18           O  
+ATOM   9000  CG2 THR D4238      67.395 -45.807  -8.260  1.00 23.48           C  
+ATOM   9001  N   TRP D4239      65.797 -44.058  -5.497  1.00 23.03           N  
+ATOM   9002  CA  TRP D4239      65.939 -44.354  -4.075  1.00 22.08           C  
+ATOM   9003  C   TRP D4239      64.593 -44.691  -3.445  1.00 21.56           C  
+ATOM   9004  O   TRP D4239      64.496 -45.594  -2.613  1.00 22.26           O  
+ATOM   9005  CB  TRP D4239      66.582 -43.171  -3.346  1.00 22.27           C  
+ATOM   9006  CG  TRP D4239      67.913 -42.791  -3.918  1.00 21.81           C  
+ATOM   9007  CD1 TRP D4239      68.706 -43.562  -4.724  1.00 24.48           C  
+ATOM   9008  CD2 TRP D4239      68.618 -41.557  -3.725  1.00 21.94           C  
+ATOM   9009  NE1 TRP D4239      69.857 -42.885  -5.047  1.00 24.02           N  
+ATOM   9010  CE2 TRP D4239      69.830 -41.651  -4.447  1.00 21.50           C  
+ATOM   9011  CE3 TRP D4239      68.343 -40.380  -3.017  1.00 19.94           C  
+ATOM   9012  CZ2 TRP D4239      70.767 -40.616  -4.478  1.00 21.52           C  
+ATOM   9013  CZ3 TRP D4239      69.278 -39.347  -3.051  1.00 19.74           C  
+ATOM   9014  CH2 TRP D4239      70.472 -39.474  -3.776  1.00 19.80           C  
+ATOM   9015  N   TYR D4240      63.554 -43.967  -3.852  1.00 21.39           N  
+ATOM   9016  CA  TYR D4240      62.213 -44.205  -3.339  1.00 21.18           C  
+ATOM   9017  C   TYR D4240      61.755 -45.613  -3.709  1.00 21.32           C  
+ATOM   9018  O   TYR D4240      61.311 -46.379  -2.856  1.00 19.66           O  
+ATOM   9019  CB  TYR D4240      61.211 -43.201  -3.921  1.00 20.43           C  
+ATOM   9020  CG  TYR D4240      59.796 -43.472  -3.455  1.00 21.04           C  
+ATOM   9021  CD1 TYR D4240      59.375 -43.086  -2.180  1.00 20.82           C  
+ATOM   9022  CD2 TYR D4240      58.907 -44.202  -4.250  1.00 22.02           C  
+ATOM   9023  CE1 TYR D4240      58.110 -43.427  -1.704  1.00 22.01           C  
+ATOM   9024  CE2 TYR D4240      57.638 -44.550  -3.780  1.00 21.56           C  
+ATOM   9025  CZ  TYR D4240      57.251 -44.162  -2.507  1.00 22.80           C  
+ATOM   9026  OH  TYR D4240      56.015 -44.528  -2.028  1.00 23.38           O  
+ATOM   9027  N   ILE D4241      61.860 -45.943  -4.994  1.00 23.41           N  
+ATOM   9028  CA  ILE D4241      61.441 -47.254  -5.488  1.00 24.91           C  
+ATOM   9029  C   ILE D4241      62.211 -48.389  -4.823  1.00 25.82           C  
+ATOM   9030  O   ILE D4241      61.611 -49.358  -4.357  1.00 26.81           O  
+ATOM   9031  CB  ILE D4241      61.617 -47.348  -7.025  1.00 25.90           C  
+ATOM   9032  CG1 ILE D4241      60.649 -46.382  -7.710  1.00 25.42           C  
+ATOM   9033  CG2 ILE D4241      61.370 -48.774  -7.505  1.00 26.92           C  
+ATOM   9034  CD1 ILE D4241      60.852 -46.267  -9.205  1.00 26.49           C  
+ATOM   9035  N   ASN D4242      63.537 -48.272  -4.769  1.00 26.59           N  
+ATOM   9036  CA  ASN D4242      64.338 -49.325  -4.150  1.00 26.57           C  
+ATOM   9037  C   ASN D4242      63.992 -49.493  -2.670  1.00 25.38           C  
+ATOM   9038  O   ASN D4242      64.031 -50.602  -2.144  1.00 24.85           O  
+ATOM   9039  CB  ASN D4242      65.837 -49.050  -4.325  1.00 27.53           C  
+ATOM   9040  CG  ASN D4242      66.279 -49.121  -5.784  1.00 29.20           C  
+ATOM   9041  OD1 ASN D4242      65.691 -49.847  -6.591  1.00 29.12           O  
+ATOM   9042  ND2 ASN D4242      67.330 -48.383  -6.123  1.00 29.50           N  
+ATOM   9043  N   ARG D4243      63.645 -48.401  -1.994  1.00 25.64           N  
+ATOM   9044  CA  ARG D4243      63.282 -48.505  -0.582  1.00 24.76           C  
+ATOM   9045  C   ARG D4243      61.929 -49.215  -0.509  1.00 24.67           C  
+ATOM   9046  O   ARG D4243      61.693 -50.035   0.376  1.00 23.57           O  
+ATOM   9047  CB  ARG D4243      63.183 -47.122   0.074  1.00 23.78           C  
+ATOM   9048  CG  ARG D4243      62.902 -47.194   1.577  1.00 22.92           C  
+ATOM   9049  CD  ARG D4243      62.824 -45.811   2.212  1.00 23.56           C  
+ATOM   9050  NE  ARG D4243      61.696 -45.047   1.693  1.00 23.91           N  
+ATOM   9051  CZ  ARG D4243      61.395 -43.803   2.055  1.00 25.20           C  
+ATOM   9052  NH1 ARG D4243      62.145 -43.162   2.948  1.00 23.29           N  
+ATOM   9053  NH2 ARG D4243      60.340 -43.197   1.516  1.00 23.79           N  
+ATOM   9054  N   PHE D4244      61.054 -48.895  -1.457  1.00 24.35           N  
+ATOM   9055  CA  PHE D4244      59.732 -49.507  -1.529  1.00 24.69           C  
+ATOM   9056  C   PHE D4244      59.877 -51.020  -1.683  1.00 24.96           C  
+ATOM   9057  O   PHE D4244      59.248 -51.798  -0.962  1.00 23.85           O  
+ATOM   9058  CB  PHE D4244      58.964 -48.952  -2.732  1.00 25.01           C  
+ATOM   9059  CG  PHE D4244      57.633 -49.623  -2.971  1.00 26.25           C  
+ATOM   9060  CD1 PHE D4244      56.481 -49.166  -2.337  1.00 27.02           C  
+ATOM   9061  CD2 PHE D4244      57.534 -50.718  -3.833  1.00 26.75           C  
+ATOM   9062  CE1 PHE D4244      55.248 -49.784  -2.555  1.00 27.41           C  
+ATOM   9063  CE2 PHE D4244      56.304 -51.346  -4.058  1.00 26.28           C  
+ATOM   9064  CZ  PHE D4244      55.160 -50.877  -3.417  1.00 27.55           C  
+ATOM   9065  N   LEU D4245      60.707 -51.432  -2.636  1.00 25.67           N  
+ATOM   9066  CA  LEU D4245      60.925 -52.849  -2.890  1.00 26.81           C  
+ATOM   9067  C   LEU D4245      61.411 -53.589  -1.654  1.00 27.93           C  
+ATOM   9068  O   LEU D4245      60.921 -54.671  -1.343  1.00 27.64           O  
+ATOM   9069  CB  LEU D4245      61.907 -53.034  -4.045  1.00 25.55           C  
+ATOM   9070  CG  LEU D4245      61.358 -52.502  -5.378  1.00 24.90           C  
+ATOM   9071  CD1 LEU D4245      62.354 -52.750  -6.492  1.00 24.20           C  
+ATOM   9072  CD2 LEU D4245      60.041 -53.196  -5.694  1.00 26.63           C  
+ATOM   9073  N   LYS D4246      62.367 -53.013  -0.939  1.00 29.44           N  
+ATOM   9074  CA  LYS D4246      62.858 -53.671   0.261  1.00 30.35           C  
+ATOM   9075  C   LYS D4246      61.715 -53.780   1.262  1.00 29.30           C  
+ATOM   9076  O   LYS D4246      61.614 -54.761   1.994  1.00 29.53           O  
+ATOM   9077  CB  LYS D4246      64.042 -52.899   0.844  1.00 33.58           C  
+ATOM   9078  CG  LYS D4246      65.279 -52.987  -0.036  1.00 36.93           C  
+ATOM   9079  CD  LYS D4246      66.430 -52.157   0.504  1.00 40.91           C  
+ATOM   9080  CE  LYS D4246      67.697 -52.354  -0.326  1.00 42.40           C  
+ATOM   9081  NZ  LYS D4246      67.499 -52.033  -1.773  1.00 44.18           N  
+ATOM   9082  N   PHE D4247      60.840 -52.779   1.278  1.00 28.80           N  
+ATOM   9083  CA  PHE D4247      59.685 -52.789   2.173  1.00 28.51           C  
+ATOM   9084  C   PHE D4247      58.724 -53.910   1.777  1.00 27.93           C  
+ATOM   9085  O   PHE D4247      58.157 -54.578   2.644  1.00 27.61           O  
+ATOM   9086  CB  PHE D4247      58.955 -51.439   2.123  1.00 30.58           C  
+ATOM   9087  CG  PHE D4247      59.462 -50.428   3.127  1.00 33.49           C  
+ATOM   9088  CD1 PHE D4247      59.661 -49.101   2.754  1.00 32.74           C  
+ATOM   9089  CD2 PHE D4247      59.682 -50.789   4.454  1.00 34.15           C  
+ATOM   9090  CE1 PHE D4247      60.071 -48.146   3.687  1.00 34.39           C  
+ATOM   9091  CE2 PHE D4247      60.092 -49.843   5.396  1.00 36.05           C  
+ATOM   9092  CZ  PHE D4247      60.286 -48.516   5.009  1.00 34.50           C  
+ATOM   9093  N   ARG D4248      58.543 -54.121   0.474  1.00 25.61           N  
+ATOM   9094  CA  ARG D4248      57.655 -55.180   0.008  1.00 26.26           C  
+ATOM   9095  C   ARG D4248      58.263 -56.534   0.367  1.00 26.22           C  
+ATOM   9096  O   ARG D4248      57.585 -57.404   0.915  1.00 25.80           O  
+ATOM   9097  CB  ARG D4248      57.440 -55.099  -1.514  1.00 26.15           C  
+ATOM   9098  CG  ARG D4248      56.229 -55.921  -2.003  1.00 27.65           C  
+ATOM   9099  CD  ARG D4248      56.035 -55.840  -3.516  1.00 27.45           C  
+ATOM   9100  NE  ARG D4248      57.179 -56.422  -4.203  1.00 30.94           N  
+ATOM   9101  CZ  ARG D4248      57.178 -57.598  -4.822  1.00 28.59           C  
+ATOM   9102  NH1 ARG D4248      56.084 -58.345  -4.868  1.00 26.22           N  
+ATOM   9103  NH2 ARG D4248      58.298 -58.040  -5.369  1.00 31.48           N  
+ATOM   9104  N   GLU D4249      59.541 -56.712   0.054  1.00 26.66           N  
+ATOM   9105  CA  GLU D4249      60.214 -57.968   0.359  1.00 29.52           C  
+ATOM   9106  C   GLU D4249      60.065 -58.303   1.830  1.00 28.11           C  
+ATOM   9107  O   GLU D4249      59.733 -59.430   2.183  1.00 28.48           O  
+ATOM   9108  CB  GLU D4249      61.699 -57.889   0.000  1.00 30.90           C  
+ATOM   9109  CG  GLU D4249      61.996 -58.373  -1.404  1.00 37.83           C  
+ATOM   9110  CD  GLU D4249      63.301 -57.830  -1.959  1.00 40.54           C  
+ATOM   9111  OE1 GLU D4249      64.320 -57.877  -1.241  1.00 42.16           O  
+ATOM   9112  OE2 GLU D4249      63.300 -57.367  -3.125  1.00 42.56           O  
+ATOM   9113  N   GLY D4250      60.291 -57.311   2.682  1.00 28.28           N  
+ATOM   9114  CA  GLY D4250      60.194 -57.525   4.113  1.00 28.11           C  
+ATOM   9115  C   GLY D4250      58.815 -57.925   4.588  1.00 28.91           C  
+ATOM   9116  O   GLY D4250      58.675 -58.458   5.684  1.00 31.31           O  
+ATOM   9117  N   ALA D4251      57.794 -57.697   3.769  1.00 26.87           N  
+ATOM   9118  CA  ALA D4251      56.431 -58.023   4.170  1.00 27.12           C  
+ATOM   9119  C   ALA D4251      55.855 -59.322   3.615  1.00 27.23           C  
+ATOM   9120  O   ALA D4251      54.705 -59.657   3.906  1.00 26.58           O  
+ATOM   9121  CB  ALA D4251      55.504 -56.858   3.812  1.00 27.82           C  
+ATOM   9122  N   PHE D4252      56.648 -60.053   2.833  1.00 26.30           N  
+ATOM   9123  CA  PHE D4252      56.188 -61.304   2.228  1.00 28.33           C  
+ATOM   9124  C   PHE D4252      55.486 -62.259   3.185  1.00 30.29           C  
+ATOM   9125  O   PHE D4252      54.450 -62.830   2.848  1.00 30.64           O  
+ATOM   9126  CB  PHE D4252      57.357 -62.033   1.549  1.00 26.34           C  
+ATOM   9127  CG  PHE D4252      57.781 -61.419   0.233  1.00 25.03           C  
+ATOM   9128  CD1 PHE D4252      58.944 -61.839  -0.402  1.00 24.61           C  
+ATOM   9129  CD2 PHE D4252      57.008 -60.426  -0.377  1.00 24.01           C  
+ATOM   9130  CE1 PHE D4252      59.335 -61.280  -1.615  1.00 23.12           C  
+ATOM   9131  CE2 PHE D4252      57.392 -59.861  -1.594  1.00 20.34           C  
+ATOM   9132  CZ  PHE D4252      58.555 -60.289  -2.212  1.00 22.65           C  
+ATOM   9133  N   THR D4253      56.037 -62.425   4.381  1.00 31.93           N  
+ATOM   9134  CA  THR D4253      55.439 -63.341   5.344  1.00 34.06           C  
+ATOM   9135  C   THR D4253      54.754 -62.637   6.519  1.00 37.27           C  
+ATOM   9136  O   THR D4253      54.417 -63.270   7.520  1.00 36.98           O  
+ATOM   9137  CB  THR D4253      56.503 -64.316   5.894  1.00 32.03           C  
+ATOM   9138  OG1 THR D4253      57.471 -63.586   6.657  1.00 31.89           O  
+ATOM   9139  CG2 THR D4253      57.210 -65.029   4.744  1.00 28.99           C  
+ATOM   9140  N   ASP D4254      54.528 -61.331   6.392  1.00 39.97           N  
+ATOM   9141  CA  ASP D4254      53.888 -60.584   7.463  1.00 42.67           C  
+ATOM   9142  C   ASP D4254      52.522 -60.032   7.057  1.00 45.06           C  
+ATOM   9143  O   ASP D4254      52.419 -58.925   6.528  1.00 45.65           O  
+ATOM   9144  CB  ASP D4254      54.787 -59.437   7.917  1.00 43.20           C  
+ATOM   9145  CG  ASP D4254      54.350 -58.852   9.244  1.00 44.87           C  
+ATOM   9146  OD1 ASP D4254      53.133 -58.857   9.516  1.00 45.69           O  
+ATOM   9147  OD2 ASP D4254      55.218 -58.381  10.011  1.00 45.20           O  
+ATOM   9148  N   PRO D4255      51.455 -60.811   7.289  1.00 47.12           N  
+ATOM   9149  CA  PRO D4255      50.092 -60.389   6.949  1.00 48.83           C  
+ATOM   9150  C   PRO D4255      49.650 -59.200   7.800  1.00 49.73           C  
+ATOM   9151  O   PRO D4255      48.572 -58.644   7.596  1.00 50.94           O  
+ATOM   9152  CB  PRO D4255      49.264 -61.641   7.233  1.00 48.75           C  
+ATOM   9153  CG  PRO D4255      50.230 -62.752   6.941  1.00 47.88           C  
+ATOM   9154  CD  PRO D4255      51.486 -62.248   7.613  1.00 47.96           C  
+ATOM   9155  N   ASP D4256      50.489 -58.827   8.762  1.00 50.45           N  
+ATOM   9156  CA  ASP D4256      50.203 -57.700   9.648  1.00 50.06           C  
+ATOM   9157  C   ASP D4256      51.011 -56.477   9.210  1.00 49.44           C  
+ATOM   9158  O   ASP D4256      51.282 -55.574  10.012  1.00 49.24           O  
+ATOM   9159  CB  ASP D4256      50.545 -58.064  11.096  1.00 49.61           C  
+ATOM   9160  N   SER D4257      51.395 -56.453   7.935  1.00 47.35           N  
+ATOM   9161  CA  SER D4257      52.174 -55.349   7.395  1.00 45.49           C  
+ATOM   9162  C   SER D4257      51.380 -54.611   6.321  1.00 43.81           C  
+ATOM   9163  O   SER D4257      50.577 -55.209   5.600  1.00 44.71           O  
+ATOM   9164  CB  SER D4257      53.491 -55.874   6.808  1.00 46.93           C  
+ATOM   9165  OG  SER D4257      54.399 -54.819   6.518  1.00 45.69           O  
+ATOM   9166  N   TYR D4258      51.595 -53.304   6.232  1.00 40.18           N  
+ATOM   9167  CA  TYR D4258      50.912 -52.485   5.238  1.00 37.78           C  
+ATOM   9168  C   TYR D4258      51.418 -52.883   3.855  1.00 36.18           C  
+ATOM   9169  O   TYR D4258      50.654 -52.929   2.889  1.00 33.78           O  
+ATOM   9170  CB  TYR D4258      51.200 -50.996   5.487  1.00 37.28           C  
+ATOM   9171  CG  TYR D4258      50.779 -50.074   4.360  1.00 35.57           C  
+ATOM   9172  CD1 TYR D4258      49.431 -49.824   4.102  1.00 35.97           C  
+ATOM   9173  CD2 TYR D4258      51.729 -49.462   3.541  1.00 35.47           C  
+ATOM   9174  CE1 TYR D4258      49.040 -48.985   3.049  1.00 36.31           C  
+ATOM   9175  CE2 TYR D4258      51.351 -48.625   2.485  1.00 34.73           C  
+ATOM   9176  CZ  TYR D4258      50.005 -48.394   2.246  1.00 36.13           C  
+ATOM   9177  OH  TYR D4258      49.615 -47.580   1.203  1.00 37.04           O  
+ATOM   9178  N   PHE D4259      52.712 -53.179   3.775  1.00 33.89           N  
+ATOM   9179  CA  PHE D4259      53.322 -53.559   2.514  1.00 33.75           C  
+ATOM   9180  C   PHE D4259      53.026 -54.972   2.042  1.00 33.28           C  
+ATOM   9181  O   PHE D4259      53.491 -55.382   0.981  1.00 32.44           O  
+ATOM   9182  CB  PHE D4259      54.832 -53.343   2.572  1.00 34.47           C  
+ATOM   9183  CG  PHE D4259      55.234 -51.907   2.408  1.00 34.67           C  
+ATOM   9184  CD1 PHE D4259      55.160 -51.022   3.481  1.00 34.94           C  
+ATOM   9185  CD2 PHE D4259      55.651 -51.432   1.169  1.00 33.04           C  
+ATOM   9186  CE1 PHE D4259      55.492 -49.679   3.318  1.00 34.96           C  
+ATOM   9187  CE2 PHE D4259      55.986 -50.094   0.994  1.00 32.58           C  
+ATOM   9188  CZ  PHE D4259      55.907 -49.216   2.069  1.00 33.85           C  
+ATOM   9189  N   HIS D4260      52.254 -55.722   2.815  1.00 32.76           N  
+ATOM   9190  CA  HIS D4260      51.919 -57.067   2.391  1.00 34.20           C  
+ATOM   9191  C   HIS D4260      51.003 -56.930   1.181  1.00 33.71           C  
+ATOM   9192  O   HIS D4260      51.059 -57.736   0.252  1.00 32.22           O  
+ATOM   9193  CB  HIS D4260      51.217 -57.823   3.514  1.00 36.21           C  
+ATOM   9194  CG  HIS D4260      50.878 -59.240   3.171  1.00 40.11           C  
+ATOM   9195  ND1 HIS D4260      49.834 -59.576   2.334  1.00 41.49           N  
+ATOM   9196  CD2 HIS D4260      51.445 -60.410   3.550  1.00 40.84           C  
+ATOM   9197  CE1 HIS D4260      49.774 -60.891   2.213  1.00 41.80           C  
+ATOM   9198  NE2 HIS D4260      50.740 -61.420   2.941  1.00 41.61           N  
+ATOM   9199  N   ASN D4261      50.175 -55.887   1.193  1.00 32.99           N  
+ATOM   9200  CA  ASN D4261      49.253 -55.623   0.094  1.00 32.85           C  
+ATOM   9201  C   ASN D4261      49.986 -55.633  -1.249  1.00 32.44           C  
+ATOM   9202  O   ASN D4261      49.427 -56.029  -2.272  1.00 31.27           O  
+ATOM   9203  CB  ASN D4261      48.570 -54.259   0.279  1.00 34.71           C  
+ATOM   9204  CG  ASN D4261      47.651 -54.210   1.499  1.00 36.98           C  
+ATOM   9205  OD1 ASN D4261      46.694 -54.986   1.608  1.00 36.26           O  
+ATOM   9206  ND2 ASN D4261      47.941 -53.292   2.421  1.00 36.24           N  
+ATOM   9207  N   TYR D4262      51.239 -55.191  -1.244  1.00 31.12           N  
+ATOM   9208  CA  TYR D4262      52.024 -55.140  -2.475  1.00 30.07           C  
+ATOM   9209  C   TYR D4262      52.686 -56.464  -2.851  1.00 29.50           C  
+ATOM   9210  O   TYR D4262      53.154 -56.627  -3.981  1.00 30.88           O  
+ATOM   9211  CB  TYR D4262      53.078 -54.032  -2.376  1.00 30.39           C  
+ATOM   9212  CG  TYR D4262      52.479 -52.648  -2.243  1.00 30.47           C  
+ATOM   9213  CD1 TYR D4262      52.592 -51.925  -1.057  1.00 31.23           C  
+ATOM   9214  CD2 TYR D4262      51.788 -52.065  -3.303  1.00 31.68           C  
+ATOM   9215  CE1 TYR D4262      52.032 -50.652  -0.929  1.00 31.39           C  
+ATOM   9216  CE2 TYR D4262      51.224 -50.794  -3.186  1.00 32.81           C  
+ATOM   9217  CZ  TYR D4262      51.352 -50.095  -1.998  1.00 32.38           C  
+ATOM   9218  OH  TYR D4262      50.806 -48.837  -1.890  1.00 34.50           O  
+ATOM   9219  N   ALA D4263      52.720 -57.403  -1.908  1.00 28.05           N  
+ATOM   9220  CA  ALA D4263      53.311 -58.721  -2.140  1.00 28.91           C  
+ATOM   9221  C   ALA D4263      52.449 -59.503  -3.132  1.00 28.53           C  
+ATOM   9222  O   ALA D4263      52.921 -60.445  -3.779  1.00 26.73           O  
+ATOM   9223  CB  ALA D4263      53.413 -59.492  -0.822  1.00 29.48           C  
+ATOM   9224  N   LYS D4264      51.184 -59.100  -3.236  1.00 27.27           N  
+ATOM   9225  CA  LYS D4264      50.227 -59.721  -4.140  1.00 25.93           C  
+ATOM   9226  C   LYS D4264      50.488 -59.302  -5.589  1.00 25.80           C  
+ATOM   9227  O   LYS D4264      50.008 -59.934  -6.528  1.00 26.68           O  
+ATOM   9228  CB  LYS D4264      48.809 -59.335  -3.731  1.00 25.37           C  
+ATOM   9229  N   LEU D4265      51.253 -58.232  -5.778  1.00 24.75           N  
+ATOM   9230  CA  LEU D4265      51.539 -57.761  -7.131  1.00 24.17           C  
+ATOM   9231  C   LEU D4265      52.854 -58.338  -7.630  1.00 24.16           C  
+ATOM   9232  O   LEU D4265      53.747 -58.642  -6.831  1.00 23.46           O  
+ATOM   9233  CB  LEU D4265      51.619 -56.234  -7.154  1.00 21.74           C  
+ATOM   9234  CG  LEU D4265      50.437 -55.425  -6.599  1.00 23.70           C  
+ATOM   9235  CD1 LEU D4265      50.798 -53.944  -6.641  1.00 20.80           C  
+ATOM   9236  CD2 LEU D4265      49.165 -55.688  -7.410  1.00 21.20           C  
+ATOM   9237  N   THR D4266      52.977 -58.512  -8.944  1.00 22.81           N  
+ATOM   9238  CA  THR D4266      54.230 -59.021  -9.483  1.00 24.69           C  
+ATOM   9239  C   THR D4266      55.244 -57.909  -9.231  1.00 26.17           C  
+ATOM   9240  O   THR D4266      54.873 -56.736  -9.130  1.00 26.71           O  
+ATOM   9241  CB  THR D4266      54.154 -59.288 -11.001  1.00 23.50           C  
+ATOM   9242  OG1 THR D4266      53.871 -58.061 -11.694  1.00 24.90           O  
+ATOM   9243  CG2 THR D4266      53.068 -60.317 -11.303  1.00 21.37           C  
+ATOM   9244  N   LYS D4267      56.518 -58.263  -9.119  1.00 25.84           N  
+ATOM   9245  CA  LYS D4267      57.520 -57.242  -8.868  1.00 26.75           C  
+ATOM   9246  C   LYS D4267      57.383 -56.102  -9.877  1.00 24.24           C  
+ATOM   9247  O   LYS D4267      57.412 -54.936  -9.504  1.00 22.54           O  
+ATOM   9248  CB  LYS D4267      58.928 -57.842  -8.943  1.00 28.66           C  
+ATOM   9249  CG  LYS D4267      60.014 -56.898  -8.454  1.00 31.81           C  
+ATOM   9250  CD  LYS D4267      61.382 -57.506  -8.681  1.00 38.43           C  
+ATOM   9251  CE  LYS D4267      62.485 -56.511  -8.385  1.00 40.94           C  
+ATOM   9252  NZ  LYS D4267      63.788 -56.991  -8.928  1.00 45.27           N  
+ATOM   9253  N   GLU D4268      57.218 -56.452 -11.150  1.00 23.85           N  
+ATOM   9254  CA  GLU D4268      57.096 -55.464 -12.217  1.00 23.68           C  
+ATOM   9255  C   GLU D4268      55.973 -54.463 -11.982  1.00 22.79           C  
+ATOM   9256  O   GLU D4268      56.166 -53.263 -12.138  1.00 21.85           O  
+ATOM   9257  CB  GLU D4268      56.887 -56.162 -13.569  1.00 24.80           C  
+ATOM   9258  N   GLU D4269      54.794 -54.946 -11.614  1.00 22.63           N  
+ATOM   9259  CA  GLU D4269      53.696 -54.028 -11.382  1.00 22.58           C  
+ATOM   9260  C   GLU D4269      53.892 -53.292 -10.068  1.00 21.02           C  
+ATOM   9261  O   GLU D4269      53.422 -52.166  -9.910  1.00 21.96           O  
+ATOM   9262  CB  GLU D4269      52.347 -54.752 -11.393  1.00 21.60           C  
+ATOM   9263  CG  GLU D4269      51.177 -53.816 -11.086  1.00 23.99           C  
+ATOM   9264  CD  GLU D4269      49.809 -54.408 -11.408  1.00 25.85           C  
+ATOM   9265  OE1 GLU D4269      49.543 -55.576 -11.043  1.00 22.12           O  
+ATOM   9266  OE2 GLU D4269      48.993 -53.690 -12.019  1.00 26.46           O  
+ATOM   9267  N   ALA D4270      54.596 -53.932  -9.137  1.00 21.46           N  
+ATOM   9268  CA  ALA D4270      54.886 -53.338  -7.830  1.00 21.20           C  
+ATOM   9269  C   ALA D4270      55.773 -52.120  -8.033  1.00 20.42           C  
+ATOM   9270  O   ALA D4270      55.631 -51.124  -7.342  1.00 21.16           O  
+ATOM   9271  CB  ALA D4270      55.590 -54.351  -6.925  1.00 18.79           C  
+ATOM   9272  N   ILE D4271      56.684 -52.208  -8.996  1.00 20.63           N  
+ATOM   9273  CA  ILE D4271      57.578 -51.104  -9.304  1.00 20.46           C  
+ATOM   9274  C   ILE D4271      56.791 -49.934  -9.909  1.00 21.42           C  
+ATOM   9275  O   ILE D4271      56.980 -48.776  -9.515  1.00 18.87           O  
+ATOM   9276  CB  ILE D4271      58.676 -51.560 -10.276  1.00 19.41           C  
+ATOM   9277  CG1 ILE D4271      59.654 -52.483  -9.543  1.00 18.87           C  
+ATOM   9278  CG2 ILE D4271      59.386 -50.368 -10.879  1.00 19.72           C  
+ATOM   9279  CD1 ILE D4271      60.662 -53.172 -10.466  1.00 17.04           C  
+ATOM   9280  N   LYS D4272      55.903 -50.240 -10.854  1.00 21.04           N  
+ATOM   9281  CA  LYS D4272      55.090 -49.203 -11.484  1.00 23.83           C  
+ATOM   9282  C   LYS D4272      54.192 -48.550 -10.449  1.00 22.44           C  
+ATOM   9283  O   LYS D4272      53.972 -47.344 -10.486  1.00 22.57           O  
+ATOM   9284  CB  LYS D4272      54.261 -49.785 -12.638  1.00 27.79           C  
+ATOM   9285  CG  LYS D4272      55.114 -50.087 -13.881  1.00 34.75           C  
+ATOM   9286  CD  LYS D4272      54.334 -50.788 -14.990  1.00 39.85           C  
+ATOM   9287  CE  LYS D4272      55.267 -51.233 -16.122  1.00 41.82           C  
+ATOM   9288  NZ  LYS D4272      54.616 -52.214 -17.043  1.00 42.91           N  
+ATOM   9289  N   THR D4273      53.681 -49.345  -9.518  1.00 22.92           N  
+ATOM   9290  CA  THR D4273      52.834 -48.809  -8.460  1.00 24.80           C  
+ATOM   9291  C   THR D4273      53.663 -47.822  -7.635  1.00 25.44           C  
+ATOM   9292  O   THR D4273      53.241 -46.696  -7.377  1.00 26.40           O  
+ATOM   9293  CB  THR D4273      52.337 -49.928  -7.531  1.00 24.62           C  
+ATOM   9294  OG1 THR D4273      51.599 -50.878  -8.300  1.00 25.58           O  
+ATOM   9295  CG2 THR D4273      51.444 -49.358  -6.429  1.00 25.30           C  
+ATOM   9296  N   ALA D4274      54.852 -48.258  -7.229  1.00 26.39           N  
+ATOM   9297  CA  ALA D4274      55.750 -47.423  -6.440  1.00 27.06           C  
+ATOM   9298  C   ALA D4274      56.072 -46.151  -7.209  1.00 27.24           C  
+ATOM   9299  O   ALA D4274      56.048 -45.051  -6.656  1.00 27.23           O  
+ATOM   9300  CB  ALA D4274      57.047 -48.181  -6.135  1.00 26.13           C  
+ATOM   9301  N   MET D4275      56.375 -46.313  -8.490  1.00 26.98           N  
+ATOM   9302  CA  MET D4275      56.715 -45.186  -9.333  1.00 29.22           C  
+ATOM   9303  C   MET D4275      55.571 -44.175  -9.362  1.00 29.36           C  
+ATOM   9304  O   MET D4275      55.800 -42.967  -9.429  1.00 29.48           O  
+ATOM   9305  CB  MET D4275      57.023 -45.676 -10.748  1.00 30.61           C  
+ATOM   9306  CG  MET D4275      57.773 -44.669 -11.598  1.00 36.25           C  
+ATOM   9307  SD  MET D4275      58.038 -45.266 -13.280  1.00 42.56           S  
+ATOM   9308  CE  MET D4275      59.003 -46.756 -12.944  1.00 38.22           C  
+ATOM   9309  N   THR D4276      54.339 -44.675  -9.299  1.00 28.41           N  
+ATOM   9310  CA  THR D4276      53.161 -43.815  -9.329  1.00 28.39           C  
+ATOM   9311  C   THR D4276      52.983 -43.047  -8.020  1.00 28.35           C  
+ATOM   9312  O   THR D4276      52.589 -41.880  -8.029  1.00 28.42           O  
+ATOM   9313  CB  THR D4276      51.894 -44.632  -9.647  1.00 27.82           C  
+ATOM   9314  OG1 THR D4276      51.980 -45.105 -10.995  1.00 28.82           O  
+ATOM   9315  CG2 THR D4276      50.633 -43.785  -9.489  1.00 25.98           C  
+ATOM   9316  N   LEU D4277      53.270 -43.703  -6.900  1.00 27.67           N  
+ATOM   9317  CA  LEU D4277      53.175 -43.040  -5.611  1.00 28.63           C  
+ATOM   9318  C   LEU D4277      54.186 -41.890  -5.654  1.00 28.98           C  
+ATOM   9319  O   LEU D4277      53.910 -40.782  -5.202  1.00 28.53           O  
+ATOM   9320  CB  LEU D4277      53.526 -44.007  -4.481  1.00 27.49           C  
+ATOM   9321  CG  LEU D4277      52.561 -45.171  -4.217  1.00 29.35           C  
+ATOM   9322  CD1 LEU D4277      53.197 -46.160  -3.243  1.00 26.28           C  
+ATOM   9323  CD2 LEU D4277      51.243 -44.642  -3.657  1.00 27.46           C  
+ATOM   9324  N   TRP D4278      55.354 -42.156  -6.230  1.00 28.40           N  
+ATOM   9325  CA  TRP D4278      56.389 -41.138  -6.324  1.00 28.20           C  
+ATOM   9326  C   TRP D4278      55.928 -39.906  -7.095  1.00 28.59           C  
+ATOM   9327  O   TRP D4278      55.791 -38.812  -6.538  1.00 27.80           O  
+ATOM   9328  CB  TRP D4278      57.649 -41.709  -6.990  1.00 26.20           C  
+ATOM   9329  CG  TRP D4278      58.663 -40.644  -7.255  1.00 25.33           C  
+ATOM   9330  CD1 TRP D4278      59.005 -40.117  -8.470  1.00 24.50           C  
+ATOM   9331  CD2 TRP D4278      59.350 -39.861  -6.272  1.00 23.86           C  
+ATOM   9332  NE1 TRP D4278      59.846 -39.047  -8.303  1.00 21.80           N  
+ATOM   9333  CE2 TRP D4278      60.075 -38.866  -6.964  1.00 24.21           C  
+ATOM   9334  CE3 TRP D4278      59.414 -39.899  -4.873  1.00 22.68           C  
+ATOM   9335  CZ2 TRP D4278      60.860 -37.908  -6.300  1.00 23.32           C  
+ATOM   9336  CZ3 TRP D4278      60.193 -38.949  -4.212  1.00 23.86           C  
+ATOM   9337  CH2 TRP D4278      60.904 -37.965  -4.931  1.00 23.74           C  
+ATOM   9338  N   LYS D4279      55.690 -40.096  -8.385  1.00 29.85           N  
+ATOM   9339  CA  LYS D4279      55.268 -39.015  -9.263  1.00 31.29           C  
+ATOM   9340  C   LYS D4279      54.026 -38.232  -8.853  1.00 30.74           C  
+ATOM   9341  O   LYS D4279      54.066 -37.005  -8.786  1.00 32.22           O  
+ATOM   9342  CB  LYS D4279      55.083 -39.552 -10.684  1.00 32.02           C  
+ATOM   9343  CG  LYS D4279      56.392 -39.948 -11.345  1.00 35.34           C  
+ATOM   9344  CD  LYS D4279      56.153 -40.613 -12.688  1.00 39.26           C  
+ATOM   9345  CE  LYS D4279      57.466 -41.006 -13.353  1.00 41.48           C  
+ATOM   9346  NZ  LYS D4279      57.235 -41.857 -14.560  1.00 44.10           N  
+ATOM   9347  N   GLU D4280      52.936 -38.926  -8.560  1.00 29.91           N  
+ATOM   9348  CA  GLU D4280      51.684 -38.252  -8.214  1.00 31.42           C  
+ATOM   9349  C   GLU D4280      51.546 -37.724  -6.791  1.00 29.39           C  
+ATOM   9350  O   GLU D4280      50.721 -36.843  -6.545  1.00 29.48           O  
+ATOM   9351  CB  GLU D4280      50.499 -39.175  -8.548  1.00 33.27           C  
+ATOM   9352  CG  GLU D4280      50.421 -39.526 -10.033  1.00 38.05           C  
+ATOM   9353  CD  GLU D4280      49.319 -40.524 -10.371  1.00 41.50           C  
+ATOM   9354  OE1 GLU D4280      49.148 -40.828 -11.574  1.00 42.35           O  
+ATOM   9355  OE2 GLU D4280      48.628 -41.008  -9.446  1.00 43.46           O  
+ATOM   9356  N   ILE D4281      52.336 -38.247  -5.857  1.00 27.50           N  
+ATOM   9357  CA  ILE D4281      52.251 -37.776  -4.476  1.00 25.86           C  
+ATOM   9358  C   ILE D4281      53.531 -37.122  -3.949  1.00 25.54           C  
+ATOM   9359  O   ILE D4281      53.555 -35.920  -3.700  1.00 24.00           O  
+ATOM   9360  CB  ILE D4281      51.856 -38.911  -3.506  1.00 22.94           C  
+ATOM   9361  CG1 ILE D4281      50.528 -39.535  -3.944  1.00 24.24           C  
+ATOM   9362  CG2 ILE D4281      51.730 -38.355  -2.094  1.00 21.53           C  
+ATOM   9363  CD1 ILE D4281      50.081 -40.711  -3.077  1.00 26.38           C  
+ATOM   9364  N   ASN D4282      54.596 -37.900  -3.786  1.00 25.44           N  
+ATOM   9365  CA  ASN D4282      55.841 -37.352  -3.247  1.00 25.05           C  
+ATOM   9366  C   ASN D4282      56.559 -36.316  -4.093  1.00 25.33           C  
+ATOM   9367  O   ASN D4282      57.053 -35.319  -3.563  1.00 25.96           O  
+ATOM   9368  CB  ASN D4282      56.811 -38.476  -2.899  1.00 24.52           C  
+ATOM   9369  CG  ASN D4282      56.263 -39.383  -1.827  1.00 25.83           C  
+ATOM   9370  OD1 ASN D4282      55.730 -38.915  -0.819  1.00 24.60           O  
+ATOM   9371  ND2 ASN D4282      56.389 -40.690  -2.031  1.00 25.78           N  
+ATOM   9372  N   TRP D4283      56.628 -36.543  -5.398  1.00 25.49           N  
+ATOM   9373  CA  TRP D4283      57.302 -35.598  -6.276  1.00 24.70           C  
+ATOM   9374  C   TRP D4283      56.505 -34.302  -6.390  1.00 25.58           C  
+ATOM   9375  O   TRP D4283      57.077 -33.214  -6.446  1.00 23.93           O  
+ATOM   9376  CB  TRP D4283      57.501 -36.209  -7.661  1.00 25.62           C  
+ATOM   9377  CG  TRP D4283      58.200 -35.298  -8.607  1.00 30.38           C  
+ATOM   9378  CD1 TRP D4283      59.270 -34.492  -8.333  1.00 30.46           C  
+ATOM   9379  CD2 TRP D4283      57.905 -35.114  -9.992  1.00 32.07           C  
+ATOM   9380  NE1 TRP D4283      59.657 -33.818  -9.463  1.00 32.84           N  
+ATOM   9381  CE2 TRP D4283      58.834 -34.182 -10.498  1.00 33.56           C  
+ATOM   9382  CE3 TRP D4283      56.942 -35.647 -10.857  1.00 35.34           C  
+ATOM   9383  CZ2 TRP D4283      58.834 -33.769 -11.833  1.00 37.55           C  
+ATOM   9384  CZ3 TRP D4283      56.937 -35.237 -12.192  1.00 38.82           C  
+ATOM   9385  CH2 TRP D4283      57.880 -34.304 -12.665  1.00 39.10           C  
+ATOM   9386  N   LEU D4284      55.184 -34.423  -6.425  1.00 25.78           N  
+ATOM   9387  CA  LEU D4284      54.322 -33.255  -6.522  1.00 26.09           C  
+ATOM   9388  C   LEU D4284      54.522 -32.444  -5.255  1.00 24.03           C  
+ATOM   9389  O   LEU D4284      54.601 -31.216  -5.293  1.00 24.01           O  
+ATOM   9390  CB  LEU D4284      52.855 -33.680  -6.635  1.00 28.03           C  
+ATOM   9391  CG  LEU D4284      51.862 -32.557  -6.943  1.00 31.29           C  
+ATOM   9392  CD1 LEU D4284      52.133 -32.033  -8.355  1.00 32.49           C  
+ATOM   9393  CD2 LEU D4284      50.426 -33.072  -6.827  1.00 32.01           C  
+ATOM   9394  N   ASN D4285      54.604 -33.151  -4.133  1.00 22.60           N  
+ATOM   9395  CA  ASN D4285      54.792 -32.514  -2.840  1.00 23.47           C  
+ATOM   9396  C   ASN D4285      56.134 -31.794  -2.816  1.00 23.27           C  
+ATOM   9397  O   ASN D4285      56.253 -30.707  -2.261  1.00 22.34           O  
+ATOM   9398  CB  ASN D4285      54.733 -33.556  -1.719  1.00 21.97           C  
+ATOM   9399  CG  ASN D4285      54.736 -32.928  -0.336  1.00 22.25           C  
+ATOM   9400  OD1 ASN D4285      54.480 -31.733  -0.188  1.00 23.72           O  
+ATOM   9401  ND2 ASN D4285      55.007 -33.736   0.687  1.00 20.25           N  
+ATOM   9402  N   LEU D4286      57.142 -32.404  -3.432  1.00 23.02           N  
+ATOM   9403  CA  LEU D4286      58.470 -31.812  -3.479  1.00 23.17           C  
+ATOM   9404  C   LEU D4286      58.445 -30.483  -4.220  1.00 23.58           C  
+ATOM   9405  O   LEU D4286      58.953 -29.480  -3.718  1.00 23.59           O  
+ATOM   9406  CB  LEU D4286      59.458 -32.766  -4.166  1.00 23.21           C  
+ATOM   9407  CG  LEU D4286      60.853 -32.200  -4.479  1.00 23.54           C  
+ATOM   9408  CD1 LEU D4286      61.526 -31.745  -3.188  1.00 22.96           C  
+ATOM   9409  CD2 LEU D4286      61.702 -33.264  -5.176  1.00 22.93           C  
+ATOM   9410  N   LYS D4287      57.850 -30.482  -5.408  1.00 24.28           N  
+ATOM   9411  CA  LYS D4287      57.772 -29.284  -6.238  1.00 25.84           C  
+ATOM   9412  C   LYS D4287      56.916 -28.158  -5.660  1.00 26.03           C  
+ATOM   9413  O   LYS D4287      57.313 -26.990  -5.687  1.00 24.46           O  
+ATOM   9414  CB  LYS D4287      57.247 -29.658  -7.627  1.00 28.02           C  
+ATOM   9415  CG  LYS D4287      58.258 -30.381  -8.492  1.00 30.30           C  
+ATOM   9416  CD  LYS D4287      57.592 -31.411  -9.388  1.00 33.88           C  
+ATOM   9417  CE  LYS D4287      56.646 -30.788 -10.391  1.00 37.63           C  
+ATOM   9418  NZ  LYS D4287      55.912 -31.847 -11.155  1.00 37.77           N  
+ATOM   9419  N   GLN D4288      55.747 -28.505  -5.134  1.00 24.98           N  
+ATOM   9420  CA  GLN D4288      54.856 -27.487  -4.594  1.00 26.59           C  
+ATOM   9421  C   GLN D4288      55.130 -27.022  -3.172  1.00 26.17           C  
+ATOM   9422  O   GLN D4288      54.879 -25.862  -2.857  1.00 26.68           O  
+ATOM   9423  CB  GLN D4288      53.401 -27.960  -4.641  1.00 28.87           C  
+ATOM   9424  CG  GLN D4288      52.912 -28.433  -5.985  1.00 30.71           C  
+ATOM   9425  CD  GLN D4288      51.448 -28.823  -5.941  1.00 33.48           C  
+ATOM   9426  OE1 GLN D4288      50.954 -29.328  -4.928  1.00 34.47           O  
+ATOM   9427  NE2 GLN D4288      50.745 -28.604  -7.047  1.00 34.52           N  
+ATOM   9428  N   ASN D4289      55.650 -27.903  -2.318  1.00 24.26           N  
+ATOM   9429  CA  ASN D4289      55.853 -27.535  -0.916  1.00 23.45           C  
+ATOM   9430  C   ASN D4289      57.229 -27.676  -0.277  1.00 22.27           C  
+ATOM   9431  O   ASN D4289      57.564 -26.934   0.647  1.00 23.73           O  
+ATOM   9432  CB  ASN D4289      54.869 -28.318  -0.047  1.00 22.42           C  
+ATOM   9433  CG  ASN D4289      53.459 -28.267  -0.587  1.00 23.55           C  
+ATOM   9434  OD1 ASN D4289      52.891 -27.188  -0.741  1.00 21.35           O  
+ATOM   9435  ND2 ASN D4289      52.883 -29.437  -0.883  1.00 21.24           N  
+ATOM   9436  N   ILE D4290      58.019 -28.631  -0.741  1.00 20.38           N  
+ATOM   9437  CA  ILE D4290      59.312 -28.864  -0.125  1.00 19.77           C  
+ATOM   9438  C   ILE D4290      60.476 -28.095  -0.737  1.00 19.62           C  
+ATOM   9439  O   ILE D4290      61.156 -27.340  -0.043  1.00 20.07           O  
+ATOM   9440  CB  ILE D4290      59.635 -30.381  -0.112  1.00 18.27           C  
+ATOM   9441  CG1 ILE D4290      58.480 -31.150   0.544  1.00 17.03           C  
+ATOM   9442  CG2 ILE D4290      60.915 -30.631   0.655  1.00 15.45           C  
+ATOM   9443  CD1 ILE D4290      58.595 -32.670   0.457  1.00 16.81           C  
+ATOM   9444  N   LEU D4291      60.695 -28.269  -2.034  1.00 18.76           N  
+ATOM   9445  CA  LEU D4291      61.798 -27.601  -2.707  1.00 19.63           C  
+ATOM   9446  C   LEU D4291      61.856 -26.084  -2.518  1.00 20.42           C  
+ATOM   9447  O   LEU D4291      62.941 -25.507  -2.407  1.00 21.01           O  
+ATOM   9448  CB  LEU D4291      61.772 -27.937  -4.196  1.00 19.58           C  
+ATOM   9449  CG  LEU D4291      62.972 -27.465  -5.014  1.00 21.52           C  
+ATOM   9450  CD1 LEU D4291      64.269 -27.928  -4.350  1.00 21.36           C  
+ATOM   9451  CD2 LEU D4291      62.859 -28.014  -6.431  1.00 21.60           C  
+ATOM   9452  N   PRO D4292      60.693 -25.413  -2.480  1.00 20.78           N  
+ATOM   9453  CA  PRO D4292      60.691 -23.957  -2.303  1.00 20.79           C  
+ATOM   9454  C   PRO D4292      61.254 -23.459  -0.972  1.00 21.09           C  
+ATOM   9455  O   PRO D4292      61.617 -22.281  -0.858  1.00 20.87           O  
+ATOM   9456  CB  PRO D4292      59.216 -23.587  -2.473  1.00 21.08           C  
+ATOM   9457  CG  PRO D4292      58.721 -24.630  -3.420  1.00 20.87           C  
+ATOM   9458  CD  PRO D4292      59.349 -25.887  -2.863  1.00 20.01           C  
+ATOM   9459  N   THR D4293      61.319 -24.341   0.026  1.00 19.05           N  
+ATOM   9460  CA  THR D4293      61.837 -23.970   1.342  1.00 17.43           C  
+ATOM   9461  C   THR D4293      63.342 -24.159   1.448  1.00 18.82           C  
+ATOM   9462  O   THR D4293      63.949 -23.792   2.456  1.00 19.40           O  
+ATOM   9463  CB  THR D4293      61.203 -24.810   2.474  1.00 17.27           C  
+ATOM   9464  OG1 THR D4293      61.661 -26.168   2.372  1.00 15.78           O  
+ATOM   9465  CG2 THR D4293      59.680 -24.781   2.395  1.00 14.70           C  
+ATOM   9466  N   ARG D4294      63.951 -24.721   0.411  1.00 19.68           N  
+ATOM   9467  CA  ARG D4294      65.388 -24.984   0.439  1.00 20.10           C  
+ATOM   9468  C   ARG D4294      66.304 -23.818   0.813  1.00 19.27           C  
+ATOM   9469  O   ARG D4294      67.249 -24.004   1.583  1.00 19.10           O  
+ATOM   9470  CB  ARG D4294      65.853 -25.565  -0.901  1.00 19.83           C  
+ATOM   9471  CG  ARG D4294      67.318 -26.001  -0.894  1.00 22.79           C  
+ATOM   9472  CD  ARG D4294      67.734 -26.614  -2.216  1.00 23.22           C  
+ATOM   9473  NE  ARG D4294      67.593 -25.665  -3.312  1.00 26.92           N  
+ATOM   9474  CZ  ARG D4294      67.843 -25.952  -4.585  1.00 30.44           C  
+ATOM   9475  NH1 ARG D4294      68.245 -27.170  -4.927  1.00 32.40           N  
+ATOM   9476  NH2 ARG D4294      67.694 -25.023  -5.519  1.00 33.32           N  
+ATOM   9477  N   GLU D4295      66.047 -22.629   0.275  1.00 18.35           N  
+ATOM   9478  CA  GLU D4295      66.910 -21.488   0.572  1.00 19.72           C  
+ATOM   9479  C   GLU D4295      66.746 -20.909   1.973  1.00 19.64           C  
+ATOM   9480  O   GLU D4295      67.368 -19.905   2.306  1.00 19.53           O  
+ATOM   9481  CB  GLU D4295      66.725 -20.390  -0.477  1.00 23.56           C  
+ATOM   9482  CG  GLU D4295      67.418 -20.711  -1.805  1.00 26.98           C  
+ATOM   9483  CD  GLU D4295      66.850 -21.956  -2.462  1.00 26.49           C  
+ATOM   9484  OE1 GLU D4295      67.621 -22.702  -3.093  1.00 29.43           O  
+ATOM   9485  OE2 GLU D4295      65.629 -22.183  -2.349  1.00 30.84           O  
+ATOM   9486  N   ARG D4296      65.908 -21.534   2.791  1.00 18.49           N  
+ATOM   9487  CA  ARG D4296      65.733 -21.075   4.162  1.00 18.22           C  
+ATOM   9488  C   ARG D4296      66.652 -21.871   5.097  1.00 18.50           C  
+ATOM   9489  O   ARG D4296      66.747 -21.573   6.289  1.00 17.99           O  
+ATOM   9490  CB  ARG D4296      64.285 -21.253   4.624  1.00 17.20           C  
+ATOM   9491  CG  ARG D4296      63.255 -20.413   3.882  1.00 17.63           C  
+ATOM   9492  CD  ARG D4296      62.004 -20.275   4.742  1.00 16.39           C  
+ATOM   9493  NE  ARG D4296      62.280 -19.503   5.952  1.00 17.39           N  
+ATOM   9494  CZ  ARG D4296      61.850 -19.819   7.171  1.00 17.76           C  
+ATOM   9495  NH1 ARG D4296      61.114 -20.900   7.354  1.00 16.85           N  
+ATOM   9496  NH2 ARG D4296      62.173 -19.053   8.214  1.00 17.49           N  
+ATOM   9497  N   ALA D4297      67.328 -22.883   4.555  1.00 17.25           N  
+ATOM   9498  CA  ALA D4297      68.222 -23.720   5.360  1.00 16.80           C  
+ATOM   9499  C   ALA D4297      69.571 -23.079   5.652  1.00 17.59           C  
+ATOM   9500  O   ALA D4297      70.069 -22.263   4.874  1.00 18.54           O  
+ATOM   9501  CB  ALA D4297      68.434 -25.067   4.672  1.00 16.77           C  
+ATOM   9502  N   SER D4298      70.153 -23.459   6.786  1.00 17.33           N  
+ATOM   9503  CA  SER D4298      71.455 -22.948   7.184  1.00 16.74           C  
+ATOM   9504  C   SER D4298      72.485 -23.609   6.289  1.00 17.26           C  
+ATOM   9505  O   SER D4298      73.465 -22.983   5.885  1.00 18.71           O  
+ATOM   9506  CB  SER D4298      71.764 -23.311   8.634  1.00 15.47           C  
+ATOM   9507  OG  SER D4298      70.757 -22.857   9.506  1.00 16.38           O  
+ATOM   9508  N   LEU D4299      72.248 -24.882   5.976  1.00 18.16           N  
+ATOM   9509  CA  LEU D4299      73.165 -25.646   5.145  1.00 17.86           C  
+ATOM   9510  C   LEU D4299      72.448 -26.575   4.180  1.00 19.68           C  
+ATOM   9511  O   LEU D4299      71.489 -27.249   4.547  1.00 21.22           O  
+ATOM   9512  CB  LEU D4299      74.109 -26.457   6.041  1.00 17.40           C  
+ATOM   9513  CG  LEU D4299      75.126 -27.409   5.406  1.00 17.31           C  
+ATOM   9514  CD1 LEU D4299      76.309 -27.556   6.336  1.00 17.34           C  
+ATOM   9515  CD2 LEU D4299      74.492 -28.760   5.125  1.00 14.49           C  
+ATOM   9516  N   ILE D4300      72.927 -26.600   2.942  1.00 20.38           N  
+ATOM   9517  CA  ILE D4300      72.356 -27.452   1.914  1.00 20.27           C  
+ATOM   9518  C   ILE D4300      73.355 -28.548   1.574  1.00 21.11           C  
+ATOM   9519  O   ILE D4300      74.483 -28.270   1.158  1.00 22.12           O  
+ATOM   9520  CB  ILE D4300      72.034 -26.659   0.633  1.00 20.98           C  
+ATOM   9521  CG1 ILE D4300      71.076 -25.516   0.957  1.00 20.62           C  
+ATOM   9522  CG2 ILE D4300      71.402 -27.587  -0.405  1.00 20.05           C  
+ATOM   9523  CD1 ILE D4300      70.843 -24.561  -0.205  1.00 23.29           C  
+ATOM   9524  N   LEU D4301      72.928 -29.790   1.768  1.00 21.48           N  
+ATOM   9525  CA  LEU D4301      73.752 -30.965   1.494  1.00 21.64           C  
+ATOM   9526  C   LEU D4301      73.204 -31.596   0.208  1.00 23.50           C  
+ATOM   9527  O   LEU D4301      72.097 -32.139   0.206  1.00 23.98           O  
+ATOM   9528  CB  LEU D4301      73.632 -31.944   2.668  1.00 20.74           C  
+ATOM   9529  CG  LEU D4301      74.730 -32.987   2.861  1.00 21.71           C  
+ATOM   9530  CD1 LEU D4301      76.010 -32.306   3.305  1.00 18.70           C  
+ATOM   9531  CD2 LEU D4301      74.291 -34.001   3.894  1.00 21.70           C  
+ATOM   9532  N   THR D4302      73.963 -31.501  -0.884  1.00 24.05           N  
+ATOM   9533  CA  THR D4302      73.541 -32.047  -2.178  1.00 24.63           C  
+ATOM   9534  C   THR D4302      74.154 -33.407  -2.493  1.00 25.38           C  
+ATOM   9535  O   THR D4302      75.373 -33.536  -2.640  1.00 24.78           O  
+ATOM   9536  CB  THR D4302      73.907 -31.098  -3.323  1.00 25.25           C  
+ATOM   9537  OG1 THR D4302      73.350 -29.807  -3.061  1.00 27.70           O  
+ATOM   9538  CG2 THR D4302      73.361 -31.617  -4.648  1.00 23.18           C  
+ATOM   9539  N   LYS D4303      73.300 -34.417  -2.614  1.00 24.53           N  
+ATOM   9540  CA  LYS D4303      73.746 -35.776  -2.908  1.00 24.88           C  
+ATOM   9541  C   LYS D4303      73.632 -36.107  -4.393  1.00 25.45           C  
+ATOM   9542  O   LYS D4303      72.895 -35.456  -5.130  1.00 25.71           O  
+ATOM   9543  CB  LYS D4303      72.919 -36.771  -2.102  1.00 23.43           C  
+ATOM   9544  CG  LYS D4303      73.065 -36.591  -0.615  1.00 24.78           C  
+ATOM   9545  CD  LYS D4303      72.025 -37.383   0.147  1.00 21.69           C  
+ATOM   9546  CE  LYS D4303      72.278 -38.861   0.064  1.00 22.64           C  
+ATOM   9547  NZ  LYS D4303      71.316 -39.599   0.920  1.00 24.31           N  
+ATOM   9548  N   SER D4304      74.380 -37.114  -4.829  1.00 27.25           N  
+ATOM   9549  CA  SER D4304      74.352 -37.547  -6.223  1.00 28.42           C  
+ATOM   9550  C   SER D4304      74.349 -39.070  -6.233  1.00 28.18           C  
+ATOM   9551  O   SER D4304      74.038 -39.695  -5.217  1.00 28.72           O  
+ATOM   9552  CB  SER D4304      75.565 -37.005  -6.991  1.00 27.77           C  
+ATOM   9553  OG  SER D4304      76.775 -37.553  -6.489  1.00 32.49           O  
+ATOM   9554  N   ALA D4305      74.701 -39.666  -7.368  1.00 28.42           N  
+ATOM   9555  CA  ALA D4305      74.707 -41.122  -7.506  1.00 28.46           C  
+ATOM   9556  C   ALA D4305      75.221 -41.897  -6.290  1.00 28.73           C  
+ATOM   9557  O   ALA D4305      76.225 -41.530  -5.684  1.00 29.90           O  
+ATOM   9558  CB  ALA D4305      75.510 -41.514  -8.735  1.00 28.63           C  
+ATOM   9559  N   ASN D4306      74.528 -42.974  -5.934  1.00 28.18           N  
+ATOM   9560  CA  ASN D4306      74.938 -43.800  -4.804  1.00 28.82           C  
+ATOM   9561  C   ASN D4306      74.962 -43.029  -3.493  1.00 27.91           C  
+ATOM   9562  O   ASN D4306      75.650 -43.427  -2.552  1.00 26.21           O  
+ATOM   9563  CB  ASN D4306      76.324 -44.394  -5.059  1.00 32.14           C  
+ATOM   9564  CG  ASN D4306      76.382 -45.194  -6.338  1.00 33.42           C  
+ATOM   9565  OD1 ASN D4306      75.637 -46.163  -6.510  1.00 34.44           O  
+ATOM   9566  ND2 ASN D4306      77.270 -44.791  -7.252  1.00 34.17           N  
+ATOM   9567  N   HIS D4307      74.225 -41.921  -3.449  1.00 26.60           N  
+ATOM   9568  CA  HIS D4307      74.124 -41.094  -2.254  1.00 25.85           C  
+ATOM   9569  C   HIS D4307      75.378 -40.312  -1.890  1.00 25.89           C  
+ATOM   9570  O   HIS D4307      75.465 -39.751  -0.796  1.00 26.24           O  
+ATOM   9571  CB  HIS D4307      73.712 -41.964  -1.071  1.00 25.78           C  
+ATOM   9572  CG  HIS D4307      72.314 -42.478  -1.169  1.00 26.94           C  
+ATOM   9573  ND1 HIS D4307      71.218 -41.725  -0.816  1.00 26.36           N  
+ATOM   9574  CD2 HIS D4307      71.830 -43.669  -1.600  1.00 27.33           C  
+ATOM   9575  CE1 HIS D4307      70.119 -42.428  -1.024  1.00 27.23           C  
+ATOM   9576  NE2 HIS D4307      70.465 -43.611  -1.499  1.00 25.70           N  
+ATOM   9577  N   ALA D4308      76.343 -40.272  -2.800  1.00 24.77           N  
+ATOM   9578  CA  ALA D4308      77.582 -39.549  -2.553  1.00 24.56           C  
+ATOM   9579  C   ALA D4308      77.319 -38.049  -2.538  1.00 23.44           C  
+ATOM   9580  O   ALA D4308      76.662 -37.521  -3.432  1.00 23.77           O  
+ATOM   9581  CB  ALA D4308      78.611 -39.887  -3.635  1.00 23.56           C  
+ATOM   9582  N   VAL D4309      77.820 -37.363  -1.517  1.00 23.19           N  
+ATOM   9583  CA  VAL D4309      77.641 -35.923  -1.428  1.00 23.22           C  
+ATOM   9584  C   VAL D4309      78.605 -35.278  -2.415  1.00 24.14           C  
+ATOM   9585  O   VAL D4309      79.781 -35.628  -2.449  1.00 25.35           O  
+ATOM   9586  CB  VAL D4309      77.941 -35.413  -0.008  1.00 22.78           C  
+ATOM   9587  CG1 VAL D4309      77.977 -33.886   0.005  1.00 21.79           C  
+ATOM   9588  CG2 VAL D4309      76.881 -35.929   0.957  1.00 23.49           C  
+ATOM   9589  N   GLU D4310      78.110 -34.343  -3.220  1.00 25.55           N  
+ATOM   9590  CA  GLU D4310      78.957 -33.684  -4.207  1.00 28.55           C  
+ATOM   9591  C   GLU D4310      79.118 -32.202  -3.946  1.00 28.51           C  
+ATOM   9592  O   GLU D4310      80.005 -31.565  -4.521  1.00 28.56           O  
+ATOM   9593  CB  GLU D4310      78.400 -33.878  -5.624  1.00 31.65           C  
+ATOM   9594  CG  GLU D4310      77.026 -33.270  -5.859  1.00 37.63           C  
+ATOM   9595  CD  GLU D4310      76.688 -33.149  -7.339  1.00 40.95           C  
+ATOM   9596  OE1 GLU D4310      76.939 -34.116  -8.091  1.00 45.15           O  
+ATOM   9597  OE2 GLU D4310      76.170 -32.087  -7.750  1.00 42.73           O  
+ATOM   9598  N   GLU D4311      78.267 -31.650  -3.086  1.00 26.39           N  
+ATOM   9599  CA  GLU D4311      78.338 -30.232  -2.775  1.00 26.05           C  
+ATOM   9600  C   GLU D4311      77.763 -29.901  -1.405  1.00 26.04           C  
+ATOM   9601  O   GLU D4311      76.802 -30.530  -0.947  1.00 23.84           O  
+ATOM   9602  CB  GLU D4311      77.591 -29.421  -3.838  1.00 28.49           C  
+ATOM   9603  CG  GLU D4311      77.602 -27.928  -3.585  1.00 32.71           C  
+ATOM   9604  CD  GLU D4311      76.871 -27.151  -4.655  1.00 36.98           C  
+ATOM   9605  OE1 GLU D4311      75.642 -27.326  -4.794  1.00 38.96           O  
+ATOM   9606  OE2 GLU D4311      77.527 -26.359  -5.360  1.00 40.15           O  
+ATOM   9607  N   VAL D4312      78.363 -28.907  -0.759  1.00 22.96           N  
+ATOM   9608  CA  VAL D4312      77.909 -28.465   0.541  1.00 23.80           C  
+ATOM   9609  C   VAL D4312      77.870 -26.943   0.526  1.00 25.20           C  
+ATOM   9610  O   VAL D4312      78.865 -26.288   0.200  1.00 27.19           O  
+ATOM   9611  CB  VAL D4312      78.849 -28.922   1.680  1.00 22.51           C  
+ATOM   9612  CG1 VAL D4312      78.278 -28.493   3.020  1.00 23.14           C  
+ATOM   9613  CG2 VAL D4312      79.020 -30.423   1.653  1.00 20.14           C  
+ATOM   9614  N   ARG D4313      76.710 -26.385   0.852  1.00 23.56           N  
+ATOM   9615  CA  ARG D4313      76.550 -24.947   0.903  1.00 21.86           C  
+ATOM   9616  C   ARG D4313      76.141 -24.514   2.305  1.00 21.56           C  
+ATOM   9617  O   ARG D4313      75.177 -25.031   2.879  1.00 21.62           O  
+ATOM   9618  CB  ARG D4313      75.525 -24.489  -0.137  1.00 23.18           C  
+ATOM   9619  CG  ARG D4313      76.125 -24.399  -1.538  1.00 25.66           C  
+ATOM   9620  CD  ARG D4313      75.177 -23.715  -2.495  1.00 27.67           C  
+ATOM   9621  NE  ARG D4313      74.080 -24.589  -2.876  1.00 30.74           N  
+ATOM   9622  CZ  ARG D4313      72.876 -24.153  -3.233  1.00 32.70           C  
+ATOM   9623  NH1 ARG D4313      72.629 -22.848  -3.248  1.00 32.06           N  
+ATOM   9624  NH2 ARG D4313      71.925 -25.020  -3.579  1.00 31.68           N  
+ATOM   9625  N   LEU D4314      76.890 -23.562   2.852  1.00 19.49           N  
+ATOM   9626  CA  LEU D4314      76.660 -23.055   4.196  1.00 17.74           C  
+ATOM   9627  C   LEU D4314      76.421 -21.544   4.195  1.00 17.78           C  
+ATOM   9628  O   LEU D4314      77.165 -20.803   3.565  1.00 16.59           O  
+ATOM   9629  CB  LEU D4314      77.876 -23.387   5.067  1.00 17.89           C  
+ATOM   9630  CG  LEU D4314      77.939 -22.790   6.472  1.00 17.66           C  
+ATOM   9631  CD1 LEU D4314      76.779 -23.319   7.303  1.00 17.84           C  
+ATOM   9632  CD2 LEU D4314      79.278 -23.139   7.124  1.00 16.32           C  
+ATOM   9633  N   ARG D4315      75.380 -21.097   4.901  1.00 16.58           N  
+ATOM   9634  CA  ARG D4315      75.066 -19.668   4.971  1.00 17.18           C  
+ATOM   9635  C   ARG D4315      76.263 -18.890   5.508  1.00 18.72           C  
+ATOM   9636  O   ARG D4315      76.879 -19.278   6.503  1.00 19.20           O  
+ATOM   9637  CB  ARG D4315      73.843 -19.420   5.869  1.00 16.87           C  
+ATOM   9638  CG  ARG D4315      72.477 -19.609   5.183  1.00 16.71           C  
+ATOM   9639  CD  ARG D4315      72.251 -18.598   4.047  1.00 15.53           C  
+ATOM   9640  NE  ARG D4315      72.376 -17.217   4.503  1.00 17.51           N  
+ATOM   9641  CZ  ARG D4315      71.460 -16.575   5.226  1.00 19.60           C  
+ATOM   9642  NH1 ARG D4315      70.335 -17.185   5.569  1.00 17.54           N  
+ATOM   9643  NH2 ARG D4315      71.684 -15.327   5.629  1.00 17.74           N  
+ATOM   9644  N   LYS D4316      76.593 -17.790   4.844  1.00 19.84           N  
+ATOM   9645  CA  LYS D4316      77.721 -16.970   5.249  1.00 21.31           C  
+ATOM   9646  C   LYS D4316      77.448 -16.280   6.580  1.00 23.64           C  
+ATOM   9647  O   LYS D4316      78.390 -16.213   7.398  1.00 24.25           O  
+ATOM   9648  CB  LYS D4316      78.024 -15.929   4.175  1.00 20.37           C  
+ATOM   9649  CG  LYS D4316      78.489 -16.520   2.860  1.00 21.03           C  
+ATOM   9650  CD  LYS D4316      78.695 -15.436   1.816  1.00 20.74           C  
+ATOM   9651  CE  LYS D4316      79.189 -16.028   0.504  1.00 22.74           C  
+ATOM   9652  NZ  LYS D4316      79.379 -14.988  -0.545  1.00 25.33           N  
+ATOM   9653  OXT LYS D4316      76.308 -15.809   6.786  1.00 23.35           O  
+TER    9654      LYS D4316                                                      
+HETATM 9823  O   HOH A7009      50.548   0.343  13.376  1.00 20.72           O  
+HETATM 9824  O   HOH A7017      53.965  -2.120  18.481  1.00 13.98           O  
+HETATM 9825  O   HOH A7018      63.443  -9.543  11.005  1.00 15.26           O  
+HETATM 9826  O   HOH A7021      73.198 -13.439  17.052  1.00 20.36           O  
+HETATM 9827  O   HOH A7027      49.221  21.135  14.887  1.00 18.40           O  
+HETATM 9828  O   HOH A7028      60.853 -15.366  18.604  1.00 23.05           O  
+HETATM 9829  O   HOH A7037      59.767 -11.411   4.782  1.00 17.42           O  
+HETATM 9830  O   HOH A7038      42.593  25.907  15.001  1.00 18.80           O  
+HETATM 9831  O   HOH A7040      38.654  22.782   9.727  1.00 21.66           O  
+HETATM 9832  O   HOH A7043      49.805   1.374   8.010  1.00 17.22           O  
+HETATM 9833  O   HOH A7049      63.948 -11.671  12.818  1.00 23.06           O  
+HETATM 9834  O   HOH A7051      51.820  -4.624   7.308  1.00 22.57           O  
+HETATM 9835  O   HOH A7053      62.006   4.113  26.269  1.00 25.37           O  
+HETATM 9836  O   HOH A7062      63.750 -16.608   9.863  1.00 20.58           O  
+HETATM 9837  O   HOH A7064      51.285 -10.904   9.741  1.00 19.15           O  
+HETATM 9838  O   HOH A7067      55.123   5.942  -1.540  1.00 19.14           O  
+HETATM 9839  O   HOH A7069      60.754 -11.348   8.417  1.00 24.37           O  
+HETATM 9840  O   HOH A7072      57.885   0.884   6.585  1.00 20.51           O  
+HETATM 9841  O   HOH A7074      60.318   2.051  -3.192  1.00 19.21           O  
+HETATM 9842  O   HOH A7078      57.488   0.972   9.258  1.00 25.65           O  
+HETATM 9843  O   HOH A7079      56.830  -7.357  11.211  1.00 15.52           O  
+HETATM 9844  O   HOH A7082      56.537 -10.999  -1.890  1.00 26.12           O  
+HETATM 9845  O   HOH A7089      52.067  10.755  13.264  1.00 21.10           O  
+HETATM 9846  O   HOH A7090      48.617 -10.741   6.801  1.00 25.98           O  
+HETATM 9847  O   HOH A7097      55.613 -13.694   9.568  1.00 31.69           O  
+HETATM 9848  O   HOH A7100      54.472  11.656  19.763  1.00 15.07           O  
+HETATM 9849  O   HOH A7102      41.818  11.092   7.967  1.00 35.58           O  
+HETATM 9850  O   HOH A7103      69.804  -4.911  -3.050  1.00 33.77           O  
+HETATM 9851  O   HOH A7104      67.112  -4.633  -3.211  1.00 16.20           O  
+HETATM 9852  O   HOH A7114      58.287  -7.397  26.574  1.00 30.54           O  
+HETATM 9853  O   HOH A7117      54.000   8.321   5.183  1.00 29.20           O  
+HETATM 9854  O   HOH A7118      55.114  10.874  22.388  1.00 23.12           O  
+HETATM 9855  O   HOH A7119      62.404 -14.223  -1.329  1.00 22.44           O  
+HETATM 9856  O   HOH A7121      76.022 -20.774  17.168  1.00 19.24           O  
+HETATM 9857  O   HOH A7124      67.294  -2.006  -2.900  1.00 20.19           O  
+HETATM 9858  O   HOH A7129      62.249 -13.821  13.490  1.00 17.94           O  
+HETATM 9859  O   HOH A7130      81.937 -13.108   7.670  1.00 31.90           O  
+HETATM 9860  O   HOH A7131      71.831   7.732  15.624  1.00 32.48           O  
+HETATM 9861  O   HOH A7137      66.208 -13.549  12.671  1.00 19.65           O  
+HETATM 9862  O   HOH A7142      66.630   4.278   4.936  1.00 21.47           O  
+HETATM 9863  O   HOH A7144      77.900  -7.034   2.325  1.00 30.62           O  
+HETATM 9864  O   HOH A7151      54.329  -6.263  25.679  1.00 41.97           O  
+HETATM 9865  O   HOH A7153      38.677  14.259   9.486  1.00 29.96           O  
+HETATM 9866  O   HOH A7156      63.911 -10.844  -3.661  1.00 26.27           O  
+HETATM 9867  O   HOH A7157      77.272 -17.588  18.937  1.00 27.02           O  
+HETATM 9868  O   HOH A7158      42.919   0.733   5.544  1.00 36.98           O  
+HETATM 9869  O   HOH A7162      73.744 -17.366  12.062  1.00 32.19           O  
+HETATM 9870  O   HOH A7178      59.288  -2.830  41.903  1.00 30.95           O  
+HETATM 9871  O   HOH A7181      83.995 -17.788   8.665  1.00 29.71           O  
+HETATM 9872  O   HOH A7185      49.720  27.624   6.182  1.00 34.32           O  
+HETATM 9873  O   HOH A7194      45.128 -10.792  12.725  1.00 29.58           O  
+HETATM 9874  O   HOH A7197      52.346  17.663  19.612  1.00 32.39           O  
+HETATM 9875  O   HOH A7203      59.728 -21.115   2.159  1.00 24.87           O  
+HETATM 9876  O   HOH A7206      64.977   3.488   3.266  1.00 28.50           O  
+HETATM 9877  O   HOH A7213      51.956 -15.357  17.617  1.00 47.33           O  
+HETATM 9878  O   HOH A7215      51.296 -16.571   0.944  1.00 31.66           O  
+HETATM 9879  O   HOH A7216      88.627 -23.673  14.052  1.00 21.97           O  
+HETATM 9880  O   HOH A7223      53.001  12.067  23.370  1.00 27.83           O  
+HETATM 9881  O   HOH A7230      50.666  -4.165  -4.828  1.00 27.61           O  
+HETATM 9882  O   HOH A7233      58.279  -2.666  35.451  1.00 35.82           O  
+HETATM 9883  O   HOH A7237      60.879 -16.111  -2.729  1.00 23.83           O  
+HETATM 9884  O   HOH A7245      81.986 -14.948   3.409  1.00 34.23           O  
+HETATM 9885  O   HOH A7246      63.613   5.965   3.801  1.00 28.36           O  
+HETATM 9886  O   HOH A7250      53.780  -6.584  -1.953  1.00 44.56           O  
+HETATM 9887  O   HOH A7255      57.414  11.908  23.123  1.00 21.84           O  
+HETATM 9888  O   HOH A7265      61.879   3.971  22.029  1.00 30.87           O  
+HETATM 9889  O   HOH A7275      49.836  -3.313  20.448  1.00 26.59           O  
+HETATM 9890  O   HOH A7278      52.107   8.166   9.646  1.00 25.16           O  
+HETATM 9891  O   HOH A7281      56.371   3.220  11.433  1.00 20.49           O  
+HETATM 9892  O   HOH A7282      65.000 -15.873  12.129  1.00 17.10           O  
+HETATM 9893  O   HOH A7286      58.799 -18.508  30.746  1.00 31.54           O  
+HETATM 9894  O   HOH A7287      61.043   3.327  -5.503  1.00 38.12           O  
+HETATM 9895  O   HOH A7295      64.672   6.786  -3.245  1.00 22.86           O  
+HETATM 9896  O   HOH A7297      61.672 -12.331  -2.892  1.00 37.33           O  
+HETATM 9897  O   HOH A7299      68.266 -15.515  22.462  1.00 25.26           O  
+HETATM 9898  O   HOH A7309      69.150 -15.711  25.626  1.00 29.64           O  
+HETATM 9899  O   HOH A7315      52.108  -3.939  19.388  1.00 28.82           O  
+HETATM 9900  O   HOH A7318      70.594 -16.018  14.730  1.00 34.69           O  
+HETATM 9901  O   HOH A7320      39.004  17.175  17.778  1.00 36.22           O  
+HETATM 9902  O   HOH A7321      79.725 -12.591  24.111  1.00 29.48           O  
+HETATM 9903  O   HOH A7322      51.091 -11.321  19.099  1.00 25.15           O  
+HETATM 9904  O   HOH A7329      56.390 -14.493  26.816  1.00 28.42           O  
+HETATM 9905  O   HOH A7330      55.962  -8.437  -3.350  1.00 34.42           O  
+HETATM 9906  O   HOH A7338      89.495 -25.729  12.820  1.00 34.55           O  
+HETATM 9907  O   HOH A7340      55.582   5.095  32.641  1.00 42.45           O  
+HETATM 9908  O   HOH A7344      92.135 -23.234  17.184  1.00 36.66           O  
+HETATM 9909  O   HOH A7347      58.009  -6.982  -4.466  1.00 37.88           O  
+HETATM 9910  O   HOH A7349      52.620  11.378  26.187  1.00 30.38           O  
+HETATM 9911  O   HOH A7356      52.215   8.914  26.953  1.00 32.21           O  
+HETATM 9912  O   HOH A7359      51.952  11.320  10.631  1.00 36.00           O  
+HETATM 9913  O   HOH A7360      70.842 -11.931  -3.051  1.00 35.05           O  
+HETATM 9914  O   HOH A7365      35.415  20.459  12.999  1.00 38.65           O  
+HETATM 9915  O   HOH A7367      52.376  -1.001  28.414  1.00 25.23           O  
+HETATM 9916  O   HOH A7368      39.685  23.786  16.940  1.00 31.29           O  
+HETATM 9917  O   HOH A7370      70.339 -14.245  17.784  1.00 49.88           O  
+HETATM 9918  O   HOH A7372      81.089  -6.253   8.103  1.00 35.70           O  
+HETATM 9919  O   HOH A7373      48.598  -9.790   4.227  1.00 40.41           O  
+HETATM 9920  O   HOH A7374      89.947 -27.933   8.354  1.00 27.90           O  
+HETATM 9921  O   HOH A7375      54.786   8.596  -6.891  1.00 32.01           O  
+HETATM 9922  O   HOH A7381      59.795   0.303  38.394  1.00 40.89           O  
+HETATM 9923  O   HOH A7382      78.892  -6.285  25.503  1.00 28.74           O  
+HETATM 9924  O   HOH A7385      50.140  -4.952  22.294  1.00 33.49           O  
+HETATM 9925  O   HOH A7387      80.446  -6.967   3.019  1.00 32.84           O  
+HETATM 9926  O   HOH A7388      73.020 -14.685  14.398  1.00 26.32           O  
+HETATM 9927  O   HOH A7399      72.380  13.517  16.970  1.00 35.35           O  
+HETATM 9928  O   HOH A7401      69.846 -17.019  27.779  1.00 36.41           O  
+HETATM 9929  O   HOH A7403      53.682  11.108   5.934  1.00 35.43           O  
+HETATM 9930  O   HOH A7404      46.974  13.729  22.132  1.00 38.36           O  
+HETATM 9931  O   HOH A7409      35.929  17.992  13.329  1.00 38.50           O  
+HETATM 9932  O   HOH A7411      63.914  10.549   3.909  1.00 29.59           O  
+HETATM 9933  O   HOH A7412      64.873   5.395  11.599  1.00 39.72           O  
+HETATM 9934  O   HOH A7415      59.999  -2.453  37.469  1.00 45.26           O  
+HETATM 9935  O   HOH A7416      36.896  22.738  15.030  1.00 38.73           O  
+HETATM 9936  O   HOH A7417      62.039 -15.310  33.314  1.00 33.68           O  
+HETATM 9937  O   HOH A7419      55.592 -15.495  -6.235  1.00 40.75           O  
+HETATM 9938  O   HOH A7429      63.097 -15.605  16.825  1.00 36.66           O  
+HETATM 9939  O   HOH A7453      63.818 -19.865  23.209  1.00 25.88           O  
+HETATM 9940  O   HOH A7459      74.954 -19.328  18.890  1.00 28.12           O  
+HETATM 9941  O   HOH A7463      53.982  10.881   9.147  1.00 36.32           O  
+HETATM 9942  O   HOH A7471      48.393 -12.327   9.966  1.00 33.82           O  
+HETATM 9943  O   HOH A7473      55.993   9.602  10.384  1.00 29.39           O  
+HETATM 9944  O   HOH A7475      45.585  -6.773   5.886  1.00 43.86           O  
+HETATM 9945  O   HOH A7478      53.726  -8.404  25.082  1.00 79.26           O  
+HETATM 9946  O   HOH A7480      63.371  -7.091  -6.409  1.00 32.43           O  
+HETATM 9947  O   HOH A7482      81.759 -11.249  25.148  1.00 25.93           O  
+HETATM 9948  O   HOH A7483      86.469 -15.444  10.426  1.00 93.24           O  
+HETATM 9949  O   HOH A7485      49.678   8.783  28.056  1.00 35.92           O  
+HETATM 9950  O   HOH A7491      49.961  11.395   9.095  1.00 26.35           O  
+HETATM 9951  O   HOH A7496      57.880  13.276  20.712  1.00 30.92           O  
+HETATM 9952  O   HOH A7525      51.373   1.505  30.486  1.00 57.69           O  
+HETATM 9953  O   HOH A7528      61.204  10.786   6.612  1.00 37.46           O  
+HETATM 9954  O   HOH A7533      59.089   6.773  11.689  1.00 35.44           O  
+HETATM 9955  O   HOH A7541      46.310   8.866   0.990  1.00 32.07           O  
+HETATM 9956  O   HOH A7545      67.835 -18.343  21.941  1.00 48.83           O  
+HETATM 9957  O   HOH A7546      52.956 -13.346   9.086  1.00 45.36           O  
+HETATM 9958  O   HOH A7548      49.358  14.006  24.912  1.00 31.54           O  
+HETATM 9959  O   HOH A7551      82.344  -5.786  20.699  1.00 33.09           O  
+HETATM 9960  O   HOH A7555      57.569   1.558  33.494  1.00 43.97           O  
+HETATM 9961  O   HOH A7556      61.407 -10.857  -7.748  1.00 35.03           O  
+HETATM 9962  O   HOH A7557      78.698   4.756  11.933  1.00 45.33           O  
+HETATM 9963  O   HOH A7564      57.184  21.242  14.282  1.00 37.96           O  
+HETATM 9964  O   HOH A7567      75.632   0.804  32.267  1.00 50.53           O  
+HETATM 9965  O   HOH A7569      36.521  15.794   9.441  1.00 25.11           O  
+HETATM 9966  O   HOH A7575      60.782  12.156  16.837  1.00 30.18           O  
+HETATM 9967  O   HOH A7585      60.829  -9.555  39.444  1.00 33.42           O  
+HETATM 9968  O   HOH A7587      45.161  15.267  21.396  1.00 37.20           O  
+HETATM 9969  O   HOH A7588      55.631   6.466  10.589  1.00 27.22           O  
+HETATM 9970  O   HOH A7590      54.095 -14.480  16.138  1.00 42.98           O  
+HETATM 9971  O   HOH A7595      56.452 -22.122  -4.653  1.00 34.01           O  
+HETATM 9972  O   HOH A7601      50.839  10.624   6.578  1.00 38.87           O  
+HETATM 9973  O   HOH A7602      47.237  -9.244   0.018  1.00 41.52           O  
+HETATM 9974  O   HOH A7605      61.668  -5.924  40.131  1.00 37.61           O  
+HETATM 9975  O   HOH A7611      46.192  -8.468  16.265  1.00 31.93           O  
+HETATM 9976  O   HOH A7618      49.281 -17.823   2.338  1.00 43.69           O  
+HETATM 9977  O   HOH A7619      53.834  25.965  16.823  1.00 48.01           O  
+HETATM 9978  O   HOH A7622      57.448  -0.067  35.352  1.00 36.44           O  
+HETATM 9979  O   HOH A7633      68.467 -15.549  10.447  1.00 38.55           O  
+HETATM 9980  O   HOH A7638      92.787 -23.205   7.298  1.00 39.63           O  
+HETATM 9981  O   HOH A7640      63.761 -22.149  31.312  1.00 39.31           O  
+HETATM 9982  O   HOH A7643      46.865  -3.618  20.469  1.00 36.33           O  
+HETATM 9983  O   HOH A7645      43.296   2.655  -0.917  1.00 41.03           O  
+HETATM 9984  O   HOH A7646      91.399 -19.735   7.025  1.00 39.71           O  
+HETATM 9985  O   HOH A7647      50.616  22.641   8.407  1.00 47.61           O  
+HETATM 9986  O   HOH A7650      58.589   3.173   9.894  1.00 49.49           O  
+HETATM 9987  O   HOH A7651      59.816 -10.451  34.859  1.00 43.27           O  
+HETATM 9988  O   HOH A7653      58.228 -17.045  20.444  1.00 25.44           O  
+HETATM 9989  O   HOH A7655      78.487  -3.308  -4.961  1.00 47.67           O  
+HETATM 9990  O   HOH A7658      75.114  -0.851  30.590  1.00 40.01           O  
+HETATM 9991  O   HOH A7661      48.833  17.228  21.671  1.00 66.55           O  
+HETATM 9992  O   HOH A7665      61.288  -0.175  -4.967  1.00 45.88           O  
+HETATM 9993  O   HOH A7671      55.036  14.118  20.395  1.00 25.43           O  
+HETATM 9994  O   HOH A7672      61.823   8.736  27.206  1.00 35.95           O  
+HETATM 9995  O   HOH A7677      69.932 -19.030  14.889  1.00 42.37           O  
+HETATM 9996  O   HOH A7678      63.863  -9.699  -6.337  1.00 48.01           O  
+HETATM 9997  O   HOH A7683      61.744   6.839  32.113  1.00 42.43           O  
+HETATM 9998  O   HOH A7692      37.618  11.108  14.641  1.00 40.17           O  
+HETATM 9999  O   HOH A7693      81.302  -5.215  14.618  1.00 35.50           O  
+HETATM10000  O   HOH A7696      62.301   9.821  12.537  1.00 36.39           O  
+HETATM10001  O   HOH A7697      55.125 -16.275  24.365  1.00 51.24           O  
+HETATM10002  O   HOH A7704      61.317  17.213  26.371  1.00 45.56           O  
+HETATM10003  O   HOH A7705      37.253  12.267  11.047  1.00 49.66           O  
+HETATM10004  O   HOH A7706      91.863 -16.630   9.717  1.00 37.17           O  
+HETATM10005  O   HOH A7707      65.191 -14.461  -2.245  1.00 34.95           O  
+HETATM10006  O   HOH A7711      62.514  -3.167  -7.408  1.00 44.73           O  
+HETATM10007  O   HOH A7715      77.790   4.268   3.530  1.00 45.51           O  
+HETATM10008  O   HOH A7725      81.006 -15.364  23.659  1.00 29.20           O  
+HETATM10009  O   HOH A7726      80.162   3.238  14.235  1.00 40.60           O  
+HETATM10010  O   HOH A7728      67.859 -17.465  13.380  1.00 39.73           O  
+HETATM10011  O   HOH A7732      50.061  -0.163  29.516  1.00 41.43           O  
+HETATM10012  O   HOH A7736      92.552 -19.028   9.206  1.00 44.78           O  
+HETATM10013  O   HOH A7739      50.965  -6.373  -9.322  1.00 38.86           O  
+HETATM10014  O   HOH A7740      50.409   3.919  30.488  1.00 52.43           O  
+HETATM10015  O   HOH A7743      41.318  -6.486  12.400  1.00 37.78           O  
+HETATM10016  O   HOH A7745      57.919  -0.137  -7.652  1.00 40.23           O  
+HETATM10017  O   HOH A7755      54.719  26.253  14.439  1.00 47.44           O  
+HETATM10018  O   HOH A7758      63.988   1.448  37.014  1.00 39.07           O  
+HETATM10019  O   HOH A7763      68.828 -14.770  -1.871  1.00 43.84           O  
+HETATM10020  O   HOH A7772      79.646  -7.412  13.322  1.00 30.79           O  
+HETATM10021  O   HOH A7777      43.396  12.558   5.641  1.00 46.45           O  
+HETATM10022  O   HOH A7778      58.915   3.716  34.803  1.00 42.34           O  
+HETATM10023  O   HOH A7779      44.103   7.466  23.593  1.00 37.53           O  
+HETATM10024  O   HOH A7780      44.447  -4.934   3.287  1.00 35.37           O  
+HETATM10025  O   HOH A7785      55.778 -17.793  21.464  1.00 30.66           O  
+HETATM10026  O   HOH A7787      60.100 -17.067  33.117  1.00 55.10           O  
+HETATM10027  O   HOH A7789      79.533 -16.449  12.611  1.00 34.72           O  
+HETATM10028  O   HOH A7799      63.742   4.164  -6.144  1.00 30.74           O  
+HETATM10029  O   HOH A7805      64.731 -13.705  15.814  1.00 51.03           O  
+HETATM10030  O   HOH A7807      43.311  25.900  17.506  1.00 35.26           O  
+HETATM10031  O   HOH A7808      71.868 -14.893  11.024  1.00 40.67           O  
+HETATM10032  O   HOH A7809      66.739  14.688  14.656  1.00 41.87           O  
+HETATM10033  O   HOH A7814      58.261  18.489  11.265  1.00 33.46           O  
+HETATM10034  O   HOH A7815      82.366  14.485  28.571  1.00 39.50           O  
+HETATM10035  O   HOH A7818      74.510  -2.921  31.905  1.00 51.56           O  
+HETATM10036  O   HOH A7819      95.262 -25.501   8.134  1.00 49.15           O  
+HETATM10037  O   HOH A7826      57.454 -21.575   0.860  1.00 29.30           O  
+HETATM10038  O   HOH A7830      67.821  10.518  -0.189  1.00 40.31           O  
+HETATM10039  O   HOH A7831      60.277  22.830  12.027  1.00 40.38           O  
+HETATM10040  O   HOH A7839      41.812   4.911  -1.901  1.00 44.55           O  
+HETATM10041  O   HOH A7841      59.054  20.641  12.071  1.00 50.54           O  
+HETATM10042  O   HOH A7844      83.546   2.597  16.397  1.00 49.33           O  
+HETATM10043  O   HOH A7848      48.445  -8.127  22.209  1.00 39.91           O  
+HETATM10044  O   HOH A7849      58.238  10.173  11.407  1.00 44.80           O  
+HETATM10045  O   HOH A7855      79.486  -1.081  -6.531  1.00 37.35           O  
+HETATM10046  O   HOH A7856      47.581  11.561   0.685  1.00 48.60           O  
+HETATM10047  O   HOH A7858      52.355 -10.317  26.498  1.00 36.94           O  
+HETATM10048  O   HOH A7860      56.593  25.781   8.204  1.00 46.73           O  
+HETATM10049  O   HOH A7865      65.035  17.957  29.166  1.00 51.12           O  
+HETATM10050  O   HOH A7872      76.010 -13.972  11.285  1.00 33.74           O  
+HETATM10051  O   HOH A7873      80.937   0.168  33.294  1.00 50.36           O  
+HETATM10052  O   HOH A7875      74.984  -7.555  35.039  1.00 53.70           O  
+HETATM10053  O   HOH A7877      91.644 -23.229   1.948  1.00 43.35           O  
+HETATM10054  O   HOH A7878      43.785   8.923  -0.576  1.00 51.89           O  
+HETATM10055  O   HOH A7879      56.821   8.192  -8.733  1.00 36.37           O  
+HETATM10056  O   HOH A7883      58.207  23.952  13.274  1.00 44.33           O  
+HETATM10057  O   HOH A7886      76.657   1.486  24.544  1.00 51.78           O  
+HETATM10058  O   HOH B7003      90.675  73.352  12.213  1.00 10.32           O  
+HETATM10059  O   HOH B7004      77.370  49.248  19.218  1.00 15.80           O  
+HETATM10060  O   HOH B7008      80.798  42.780  16.965  1.00 16.38           O  
+HETATM10061  O   HOH B7012      65.322  44.610  24.885  1.00 21.42           O  
+HETATM10062  O   HOH B7026      81.221  62.973  21.990  1.00 19.89           O  
+HETATM10063  O   HOH B7029      65.212  71.182  20.948  1.00 22.31           O  
+HETATM10064  O   HOH B7030      69.140  41.987  12.913  1.00 21.00           O  
+HETATM10065  O   HOH B7033      79.474  45.365  19.498  1.00 20.79           O  
+HETATM10066  O   HOH B7034      65.851  35.736  17.157  1.00 19.37           O  
+HETATM10067  O   HOH B7042      80.528  60.439  21.380  1.00 16.85           O  
+HETATM10068  O   HOH B7044      72.001  69.636  21.988  1.00 29.33           O  
+HETATM10069  O   HOH B7047      56.129  40.315  15.559  1.00 18.12           O  
+HETATM10070  O   HOH B7058      84.044  48.678  21.572  1.00 20.78           O  
+HETATM10071  O   HOH B7060      67.433  52.375  32.140  1.00 23.85           O  
+HETATM10072  O   HOH B7065      81.403  47.464   3.542  1.00 23.80           O  
+HETATM10073  O   HOH B7075      71.929  37.089  18.810  1.00 26.84           O  
+HETATM10074  O   HOH B7087      83.715  62.864  21.079  1.00 23.58           O  
+HETATM10075  O   HOH B7088      73.990  43.472  21.076  1.00 16.24           O  
+HETATM10076  O   HOH B7095      52.783  47.535  20.926  1.00 17.36           O  
+HETATM10077  O   HOH B7098      79.818  49.040  23.537  1.00 22.30           O  
+HETATM10078  O   HOH B7101      43.808  27.062  12.945  1.00 21.67           O  
+HETATM10079  O   HOH B7107      80.595  52.249  21.329  1.00 22.50           O  
+HETATM10080  O   HOH B7108      78.539  50.566  29.111  1.00 35.27           O  
+HETATM10081  O   HOH B7109      67.728  42.886  15.132  1.00 28.03           O  
+HETATM10082  O   HOH B7116      80.733  45.293   4.141  1.00 19.57           O  
+HETATM10083  O   HOH B7122      68.715  48.702   6.536  1.00 25.50           O  
+HETATM10084  O   HOH B7126      73.359  33.883  28.808  1.00 32.65           O  
+HETATM10085  O   HOH B7134      82.528  36.753  13.020  1.00 27.36           O  
+HETATM10086  O   HOH B7136      51.306  26.932  16.675  1.00 25.71           O  
+HETATM10087  O   HOH B7141      73.033  39.403   3.795  1.00 28.33           O  
+HETATM10088  O   HOH B7143      66.126  43.419  27.386  1.00 18.58           O  
+HETATM10089  O   HOH B7147      62.857  58.558  10.497  1.00 27.62           O  
+HETATM10090  O   HOH B7160      56.537  39.003  13.209  1.00 31.72           O  
+HETATM10091  O   HOH B7166      51.878  47.298  26.634  1.00 26.38           O  
+HETATM10092  O   HOH B7173      50.856  46.252  22.049  1.00 29.88           O  
+HETATM10093  O   HOH B7175      97.076  73.326  11.024  1.00 39.23           O  
+HETATM10094  O   HOH B7177      77.862  61.272  30.665  1.00 23.25           O  
+HETATM10095  O   HOH B7184      82.720  57.455   5.197  1.00 30.19           O  
+HETATM10096  O   HOH B7189      80.452  58.480  23.006  1.00 34.38           O  
+HETATM10097  O   HOH B7191      86.648  42.168  12.784  1.00 29.33           O  
+HETATM10098  O   HOH B7202      76.645  30.250  10.106  1.00 30.42           O  
+HETATM10099  O   HOH B7204      64.349  42.079  28.999  1.00 18.90           O  
+HETATM10100  O   HOH B7207      67.539  32.675  -0.102  1.00 34.50           O  
+HETATM10101  O   HOH B7211      59.731  48.416  32.904  1.00 31.65           O  
+HETATM10102  O   HOH B7212      76.436  33.979  22.459  1.00 30.61           O  
+HETATM10103  O   HOH B7218      73.191  50.704  36.742  1.00 28.89           O  
+HETATM10104  O   HOH B7220      72.623  59.145  39.252  1.00 32.93           O  
+HETATM10105  O   HOH B7229      94.365  72.676  17.536  1.00 31.75           O  
+HETATM10106  O   HOH B7235      56.939  56.042  32.737  1.00 35.83           O  
+HETATM10107  O   HOH B7239      66.951  24.725   8.773  1.00 34.86           O  
+HETATM10108  O   HOH B7240      84.364  53.092  19.283  1.00 27.84           O  
+HETATM10109  O   HOH B7244      85.212  41.992   8.278  1.00 32.23           O  
+HETATM10110  O   HOH B7247      90.401  41.453  19.730  1.00 22.21           O  
+HETATM10111  O   HOH B7252      52.985  45.746  18.899  1.00 19.05           O  
+HETATM10112  O   HOH B7258      52.178  49.913  19.904  1.00 23.47           O  
+HETATM10113  O   HOH B7264      58.513  55.336  24.245  1.00 28.73           O  
+HETATM10114  O   HOH B7267      60.509  53.414  21.520  1.00 28.77           O  
+HETATM10115  O   HOH B7268      53.152  47.196  14.561  1.00 30.48           O  
+HETATM10116  O   HOH B7276      82.792  50.895  22.401  1.00 29.21           O  
+HETATM10117  O   HOH B7277      61.737  42.288  14.098  1.00 27.85           O  
+HETATM10118  O   HOH B7285      78.750  50.285  21.193  1.00 21.73           O  
+HETATM10119  O   HOH B7293      64.358  43.385  16.065  1.00 23.86           O  
+HETATM10120  O   HOH B7301      66.073  66.268  36.168  1.00 26.44           O  
+HETATM10121  O   HOH B7303      81.054  63.987  10.891  1.00 34.52           O  
+HETATM10122  O   HOH B7308      72.832  31.284  21.506  1.00 35.01           O  
+HETATM10123  O   HOH B7311      62.260  37.990   9.666  1.00 32.04           O  
+HETATM10124  O   HOH B7316      75.997  34.459   2.989  1.00 40.02           O  
+HETATM10125  O   HOH B7319      72.137  42.271  31.465  1.00 27.40           O  
+HETATM10126  O   HOH B7326      59.905  38.648  14.187  1.00 26.13           O  
+HETATM10127  O   HOH B7327      82.940  59.293  20.067  1.00 30.12           O  
+HETATM10128  O   HOH B7333      47.782  25.218  19.457  1.00 34.46           O  
+HETATM10129  O   HOH B7335      84.017  54.308  29.140  1.00 31.65           O  
+HETATM10130  O   HOH B7337      69.834  43.278  -0.396  1.00 31.48           O  
+HETATM10131  O   HOH B7339      48.618  47.380  20.784  1.00 41.68           O  
+HETATM10132  O   HOH B7348      76.032  35.587  26.391  1.00 27.69           O  
+HETATM10133  O   HOH B7351      78.607  69.519  23.252  1.00 31.74           O  
+HETATM10134  O   HOH B7353      79.770  41.183  23.663  1.00 28.91           O  
+HETATM10135  O   HOH B7354      78.689  64.232  12.151  1.00 28.63           O  
+HETATM10136  O   HOH B7362      76.183  42.085  31.461  1.00 49.85           O  
+HETATM10137  O   HOH B7363      50.843  45.689  28.797  1.00 36.90           O  
+HETATM10138  O   HOH B7364      64.574  38.854  21.330  1.00 23.57           O  
+HETATM10139  O   HOH B7366      58.301  40.188  11.523  1.00 37.82           O  
+HETATM10140  O   HOH B7369      80.398  48.295   0.880  1.00 48.16           O  
+HETATM10141  O   HOH B7383      62.426  45.366  13.331  1.00 38.69           O  
+HETATM10142  O   HOH B7386      45.267  31.511  21.543  1.00 38.41           O  
+HETATM10143  O   HOH B7390      92.871  73.614  10.423  1.00 32.60           O  
+HETATM10144  O   HOH B7392      90.948  65.744  12.963  1.00 38.99           O  
+HETATM10145  O   HOH B7395      97.112  72.969  17.636  1.00 35.47           O  
+HETATM10146  O   HOH B7405      78.330  58.838  28.364  1.00 33.74           O  
+HETATM10147  O   HOH B7420      73.664  56.222  40.017  1.00 55.15           O  
+HETATM10148  O   HOH B7432      78.530  63.066  32.450  1.00 35.37           O  
+HETATM10149  O   HOH B7434      65.646  28.737  18.825  1.00 32.02           O  
+HETATM10150  O   HOH B7437      67.597  55.958   6.266  1.00 37.36           O  
+HETATM10151  O   HOH B7441      50.569  46.175  17.552  1.00 30.57           O  
+HETATM10152  O   HOH B7442      53.642  74.219  12.630  1.00 35.70           O  
+HETATM10153  O   HOH B7451      80.966  51.243  26.491  1.00 40.99           O  
+HETATM10154  O   HOH B7457      76.167  37.869  24.244  1.00 23.84           O  
+HETATM10155  O   HOH B7461      90.812  73.121   9.287  1.00 36.59           O  
+HETATM10156  O   HOH B7464      66.870  48.451  32.342  1.00 41.75           O  
+HETATM10157  O   HOH B7469      77.230  72.196  22.103  1.00 33.10           O  
+HETATM10158  O   HOH B7470      79.103  52.931  27.273  1.00 98.97           O  
+HETATM10159  O   HOH B7477      49.034  25.164  17.234  1.00 27.89           O  
+HETATM10160  O   HOH B7479      90.827  38.868  20.096  1.00 27.88           O  
+HETATM10161  O   HOH B7481      75.655  39.288   3.198  1.00 37.22           O  
+HETATM10162  O   HOH B7498      50.023  47.622  24.471  1.00 41.45           O  
+HETATM10163  O   HOH B7501      59.355  37.991   9.249  1.00 34.04           O  
+HETATM10164  O   HOH B7502      55.736  49.707  13.757  1.00 24.85           O  
+HETATM10165  O   HOH B7508      57.882  39.766  32.823  1.00 33.82           O  
+HETATM10166  O   HOH B7509      67.380  35.486   5.611  1.00 30.90           O  
+HETATM10167  O   HOH B7523      79.180  52.532  24.287  1.00 31.66           O  
+HETATM10168  O   HOH B7526      78.581  49.332  32.009  1.00 33.78           O  
+HETATM10169  O   HOH B7527      88.545  40.336  12.801  1.00 37.69           O  
+HETATM10170  O   HOH B7531      65.952  41.502  -5.562  1.00 62.52           O  
+HETATM10171  O   HOH B7538      78.619  32.925   9.681  1.00 44.16           O  
+HETATM10172  O   HOH B7544      76.863  74.801  22.268  1.00 46.24           O  
+HETATM10173  O   HOH B7547      52.815  38.225  27.976  1.00 35.29           O  
+HETATM10174  O   HOH B7549      74.491  70.510  15.813  1.00 40.69           O  
+HETATM10175  O   HOH B7550      70.138  36.587  30.083  1.00 30.91           O  
+HETATM10176  O   HOH B7552      48.676  40.050  22.825  1.00 38.89           O  
+HETATM10177  O   HOH B7553      65.180  56.211  40.637  1.00 44.17           O  
+HETATM10178  O   HOH B7554      59.958  68.708  24.630  1.00 34.91           O  
+HETATM10179  O   HOH B7561      55.282  53.835   8.768  1.00 48.38           O  
+HETATM10180  O   HOH B7570      65.121  50.489  11.726  1.00 35.64           O  
+HETATM10181  O   HOH B7574      50.728  61.138   9.293  1.00 33.48           O  
+HETATM10182  O   HOH B7576      64.350  31.656  31.801  1.00 49.84           O  
+HETATM10183  O   HOH B7578      73.217  38.427   1.437  1.00 35.94           O  
+HETATM10184  O   HOH B7580      85.063  33.367  20.134  1.00 33.26           O  
+HETATM10185  O   HOH B7581      66.266  71.635  33.367  1.00 34.14           O  
+HETATM10186  O   HOH B7583      53.311  52.842  31.612  1.00 48.29           O  
+HETATM10187  O   HOH B7586      88.825  46.849   9.861  1.00 36.14           O  
+HETATM10188  O   HOH B7596      79.405  56.645  24.723  1.00 34.25           O  
+HETATM10189  O   HOH B7597      45.420  26.406  19.337  1.00 50.56           O  
+HETATM10190  O   HOH B7607      72.807  40.775  -0.640  1.00 41.95           O  
+HETATM10191  O   HOH B7608      67.203  60.695  42.435  1.00 59.20           O  
+HETATM10192  O   HOH B7614      52.988  45.202  12.822  1.00 41.56           O  
+HETATM10193  O   HOH B7617      69.016  64.705   7.589  1.00 36.89           O  
+HETATM10194  O   HOH B7631      51.833  41.270   3.783  1.00 44.25           O  
+HETATM10195  O   HOH B7634      52.244  26.192  19.452  1.00 36.19           O  
+HETATM10196  O   HOH B7635      62.991  45.822   3.582  1.00 43.98           O  
+HETATM10197  O   HOH B7637      69.845  46.314   5.941  1.00 49.88           O  
+HETATM10198  O   HOH B7642      70.858  53.330  -2.928  1.00 45.17           O  
+HETATM10199  O   HOH B7644      86.743  29.926  18.877  1.00 44.24           O  
+HETATM10200  O   HOH B7662      58.507  36.054  11.180  1.00 42.42           O  
+HETATM10201  O   HOH B7666      79.496  57.218   3.011  1.00 57.19           O  
+HETATM10202  O   HOH B7667      99.479  72.206   9.342  1.00 44.06           O  
+HETATM10203  O   HOH B7684      48.719  49.959  21.060  1.00 56.22           O  
+HETATM10204  O   HOH B7688      70.424  27.861  21.313  1.00 54.65           O  
+HETATM10205  O   HOH B7690      65.413  67.338  17.950  1.00 38.85           O  
+HETATM10206  O   HOH B7691      56.695  56.606  35.527  1.00 37.86           O  
+HETATM10207  O   HOH B7708      80.560  35.709  10.633  1.00 39.97           O  
+HETATM10208  O   HOH B7712      47.570  43.638  16.737  1.00 38.47           O  
+HETATM10209  O   HOH B7713      55.876  28.715  15.672  1.00 32.23           O  
+HETATM10210  O   HOH B7719      77.720  45.403   3.193  1.00 31.99           O  
+HETATM10211  O   HOH B7722      81.338  55.480  33.248  1.00 33.28           O  
+HETATM10212  O   HOH B7723      63.375  69.654  24.819  1.00 38.24           O  
+HETATM10213  O   HOH B7727      80.720  36.739   8.241  1.00 40.45           O  
+HETATM10214  O   HOH B7731      85.460  57.995  14.448  1.00 27.98           O  
+HETATM10215  O   HOH B7738      67.927  36.043  31.445  1.00 31.11           O  
+HETATM10216  O   HOH B7741      87.373  63.847  16.379  1.00 37.26           O  
+HETATM10217  O   HOH B7748      65.353  43.225  31.118  1.00 31.71           O  
+HETATM10218  O   HOH B7750      75.133  54.139  40.181  1.00 36.47           O  
+HETATM10219  O   HOH B7751      46.928  37.853  22.578  1.00 42.77           O  
+HETATM10220  O   HOH B7752      74.903  75.309  20.751  1.00 31.65           O  
+HETATM10221  O   HOH B7759      61.435  32.404  12.392  1.00 40.17           O  
+HETATM10222  O   HOH B7760      55.802  59.101  35.778  1.00 35.23           O  
+HETATM10223  O   HOH B7762      79.906  62.416  34.744  1.00 45.82           O  
+HETATM10224  O   HOH B7770      56.691  59.469   8.547  1.00 29.06           O  
+HETATM10225  O   HOH B7773      66.134  52.738   2.068  1.00 31.90           O  
+HETATM10226  O   HOH B7776      75.710  35.083  29.168  1.00 35.38           O  
+HETATM10227  O   HOH B7781      54.367  55.540  22.945  1.00 49.87           O  
+HETATM10228  O   HOH B7796      68.095  30.244  28.092  1.00 37.87           O  
+HETATM10229  O   HOH B7803      79.766  64.510   4.991  1.00 42.06           O  
+HETATM10230  O   HOH B7804      58.605  28.172  13.677  1.00 43.80           O  
+HETATM10231  O   HOH B7813      82.892  57.140  21.853  1.00 33.14           O  
+HETATM10232  O   HOH B7817      54.336  70.957  19.613  1.00 48.42           O  
+HETATM10233  O   HOH B7828      61.093  72.736  14.774  1.00 45.30           O  
+HETATM10234  O   HOH B7829      55.514  61.261  40.341  1.00 51.72           O  
+HETATM10235  O   HOH B7837      78.704  59.794  40.224  1.00 41.20           O  
+HETATM10236  O   HOH B7838      68.949  62.325   5.965  1.00 43.12           O  
+HETATM10237  O   HOH B7843      65.949  44.533  13.554  1.00 49.66           O  
+HETATM10238  O   HOH B7846      55.502  28.798  13.074  1.00 51.17           O  
+HETATM10239  O   HOH B7850      88.492  39.067  10.421  1.00 40.75           O  
+HETATM10240  O   HOH B7857      63.657  24.644   8.335  1.00 42.30           O  
+HETATM10241  O   HOH B7859      68.060  70.791  31.169  1.00 49.47           O  
+HETATM10242  O   HOH B7862      61.374  71.247  32.680  1.00 44.49           O  
+HETATM10243  O   HOH B7864      73.035  57.809   1.231  1.00 55.77           O  
+HETATM10244  O   HOH B7868      49.893  38.909  25.230  1.00 40.10           O  
+HETATM10245  O   HOH B7869      62.221  69.505  11.760  1.00 42.24           O  
+HETATM10246  O   HOH B7874      47.396  44.034  24.396  1.00 46.53           O  
+HETATM10247  O   HOH B7876      58.201  27.764  16.401  1.00 33.36           O  
+HETATM10248  O   HOH B7884      69.462  61.477  39.825  1.00 45.21           O  
+HETATM10249  O   HOH C7001      13.952  11.064  -5.158  1.00 10.23           O  
+HETATM10250  O   HOH C7005       6.707   3.230  -3.630  1.00 15.00           O  
+HETATM10251  O   HOH C7006      12.878   6.437 -18.745  1.00 14.87           O  
+HETATM10252  O   HOH C7007      11.706  10.214 -20.421  1.00 16.00           O  
+HETATM10253  O   HOH C7011       9.496  -4.705 -20.438  1.00 16.00           O  
+HETATM10254  O   HOH C7013      13.102  12.734 -22.777  1.00 15.42           O  
+HETATM10255  O   HOH C7014       8.627  -7.349 -20.653  1.00 16.53           O  
+HETATM10256  O   HOH C7015       3.975   5.045 -14.736  1.00 15.97           O  
+HETATM10257  O   HOH C7019      36.289  22.715  11.407  1.00 22.08           O  
+HETATM10258  O   HOH C7020      13.123  12.128 -14.742  1.00 13.01           O  
+HETATM10259  O   HOH C7023      20.351  19.976  -9.707  1.00 14.09           O  
+HETATM10260  O   HOH C7025       9.343   3.609 -20.528  1.00 18.56           O  
+HETATM10261  O   HOH C7035      26.544  15.433  -1.724  1.00 15.17           O  
+HETATM10262  O   HOH C7045       7.489   7.014 -23.129  1.00 22.48           O  
+HETATM10263  O   HOH C7050      10.703  13.768  -2.493  1.00 20.43           O  
+HETATM10264  O   HOH C7054       4.968  13.273  -8.250  1.00 20.27           O  
+HETATM10265  O   HOH C7057       7.944   6.669 -18.730  1.00 19.01           O  
+HETATM10266  O   HOH C7063      21.435  12.666 -12.064  1.00 22.21           O  
+HETATM10267  O   HOH C7071      11.297  12.414  -4.722  1.00 20.92           O  
+HETATM10268  O   HOH C7076      22.207  -1.674 -30.275  1.00 22.46           O  
+HETATM10269  O   HOH C7080      13.095 -13.898 -12.650  1.00 26.26           O  
+HETATM10270  O   HOH C7081      24.489  10.357 -28.699  1.00 17.25           O  
+HETATM10271  O   HOH C7084      10.401  21.411 -15.997  1.00 22.59           O  
+HETATM10272  O   HOH C7085       5.967  14.105 -29.628  1.00 17.88           O  
+HETATM10273  O   HOH C7091       4.027 -10.802  -0.441  1.00 21.15           O  
+HETATM10274  O   HOH C7094      10.287   5.176 -18.631  1.00 18.43           O  
+HETATM10275  O   HOH C7105      24.415   8.006 -29.657  1.00 24.41           O  
+HETATM10276  O   HOH C7106      15.821  18.433 -14.148  1.00 21.36           O  
+HETATM10277  O   HOH C7110      15.639  18.960 -26.111  1.00 28.68           O  
+HETATM10278  O   HOH C7111      18.101   0.107   0.203  1.00 23.31           O  
+HETATM10279  O   HOH C7113      29.614  20.411 -16.469  1.00 14.74           O  
+HETATM10280  O   HOH C7115       8.075  13.888 -18.397  1.00 27.11           O  
+HETATM10281  O   HOH C7125      13.963  13.566 -29.660  1.00 20.03           O  
+HETATM10282  O   HOH C7127       2.842  -5.766 -13.299  1.00 26.18           O  
+HETATM10283  O   HOH C7128       9.171  17.752 -15.030  1.00 26.29           O  
+HETATM10284  O   HOH C7132      27.907  -2.787 -10.287  1.00 26.43           O  
+HETATM10285  O   HOH C7133      23.613   8.290   3.475  1.00 17.43           O  
+HETATM10286  O   HOH C7138       8.125  -7.152 -23.283  1.00 28.38           O  
+HETATM10287  O   HOH C7140      21.367  25.503 -22.541  1.00 21.87           O  
+HETATM10288  O   HOH C7145       7.451   4.877 -21.435  1.00 19.24           O  
+HETATM10289  O   HOH C7146      32.920  23.953  12.977  1.00 35.72           O  
+HETATM10290  O   HOH C7148      28.103   6.731 -17.352  1.00 20.17           O  
+HETATM10291  O   HOH C7152       6.596 -14.900 -19.707  1.00 32.62           O  
+HETATM10292  O   HOH C7154      43.622  20.958   2.312  1.00 25.67           O  
+HETATM10293  O   HOH C7164      17.323  16.654  -6.447  1.00 22.34           O  
+HETATM10294  O   HOH C7165       6.512  21.659 -10.081  1.00 30.99           O  
+HETATM10295  O   HOH C7174       8.542 -13.961 -17.409  1.00 29.23           O  
+HETATM10296  O   HOH C7179      28.324  16.398 -22.215  1.00 21.65           O  
+HETATM10297  O   HOH C7180       7.379  19.779 -13.960  1.00 32.76           O  
+HETATM10298  O   HOH C7183      13.134   2.997   8.203  1.00 40.82           O  
+HETATM10299  O   HOH C7196      18.751  26.987  -8.551  1.00 44.77           O  
+HETATM10300  O   HOH C7199       6.947  18.798  -7.035  1.00 30.44           O  
+HETATM10301  O   HOH C7205      18.253  13.422 -30.501  1.00 29.48           O  
+HETATM10302  O   HOH C7208      18.909  21.528 -22.912  1.00 46.24           O  
+HETATM10303  O   HOH C7210       8.471  12.576  -2.423  1.00 27.73           O  
+HETATM10304  O   HOH C7214       5.697 -16.987 -34.068  1.00 31.71           O  
+HETATM10305  O   HOH C7225      23.540   9.439   6.290  1.00 31.78           O  
+HETATM10306  O   HOH C7226       9.390  15.595   1.191  1.00 33.94           O  
+HETATM10307  O   HOH C7227      27.814  13.336  -6.307  1.00 22.47           O  
+HETATM10308  O   HOH C7231      25.675   9.128 -11.199  1.00 40.91           O  
+HETATM10309  O   HOH C7232      26.831  24.145  10.391  1.00 34.60           O  
+HETATM10310  O   HOH C7236      15.775  -7.871 -31.706  1.00 36.83           O  
+HETATM10311  O   HOH C7238       4.172  -3.113 -15.362  1.00 26.11           O  
+HETATM10312  O   HOH C7241      12.621  15.444 -31.499  1.00 27.28           O  
+HETATM10313  O   HOH C7248      33.196   9.690 -13.725  1.00 32.39           O  
+HETATM10314  O   HOH C7253      25.241  10.123   2.401  1.00 19.47           O  
+HETATM10315  O   HOH C7256      34.031  16.763   5.987  1.00 18.21           O  
+HETATM10316  O   HOH C7257      28.730  17.883  -9.939  1.00 21.53           O  
+HETATM10317  O   HOH C7260       9.936 -16.242 -16.916  1.00 27.26           O  
+HETATM10318  O   HOH C7261       5.365  16.940 -29.986  1.00 19.36           O  
+HETATM10319  O   HOH C7262      26.006  17.137  -5.960  1.00 23.23           O  
+HETATM10320  O   HOH C7263      25.180  13.358  -7.479  1.00 20.61           O  
+HETATM10321  O   HOH C7266      20.884  19.036 -26.899  1.00 21.86           O  
+HETATM10322  O   HOH C7271      19.256   2.424  -2.656  1.00 27.93           O  
+HETATM10323  O   HOH C7273      29.094   8.739  -0.034  1.00 29.92           O  
+HETATM10324  O   HOH C7274      33.725  12.418 -21.616  1.00 28.05           O  
+HETATM10325  O   HOH C7279      21.548  -0.156   3.059  1.00 27.30           O  
+HETATM10326  O   HOH C7280      27.997   9.305 -18.726  1.00 20.88           O  
+HETATM10327  O   HOH C7283      21.593   8.271   7.741  1.00 36.53           O  
+HETATM10328  O   HOH C7284      27.387   7.524 -29.951  1.00 32.96           O  
+HETATM10329  O   HOH C7289      39.344  12.388   7.226  1.00 36.31           O  
+HETATM10330  O   HOH C7290      28.556  16.901  -3.383  1.00 28.80           O  
+HETATM10331  O   HOH C7291      22.055  12.417  -8.935  1.00 33.75           O  
+HETATM10332  O   HOH C7292      25.592   5.155 -11.521  1.00 32.60           O  
+HETATM10333  O   HOH C7296      30.662  17.052 -23.992  1.00 31.57           O  
+HETATM10334  O   HOH C7300      24.991   5.977   3.609  1.00 27.71           O  
+HETATM10335  O   HOH C7304      12.722 -15.685 -38.665  1.00 26.00           O  
+HETATM10336  O   HOH C7306      23.336  11.150 -11.207  1.00 52.93           O  
+HETATM10337  O   HOH C7317      -0.554   1.891  -5.188  1.00 28.68           O  
+HETATM10338  O   HOH C7325       4.877  20.671 -11.855  1.00 30.88           O  
+HETATM10339  O   HOH C7328       1.092   6.270 -13.079  1.00 29.58           O  
+HETATM10340  O   HOH C7331      28.305   6.156  -2.524  1.00 22.86           O  
+HETATM10341  O   HOH C7332       5.837  13.159  -2.740  1.00 36.84           O  
+HETATM10342  O   HOH C7336      38.528  19.149   1.097  1.00 42.00           O  
+HETATM10343  O   HOH C7341      23.551  29.823 -12.832  1.00 30.53           O  
+HETATM10344  O   HOH C7343       6.878  19.748  -4.374  1.00 36.67           O  
+HETATM10345  O   HOH C7355       9.785   7.547   3.074  1.00 39.87           O  
+HETATM10346  O   HOH C7358      -4.219   0.920  -5.895  1.00 43.00           O  
+HETATM10347  O   HOH C7361      25.297  24.085 -10.273  1.00 41.19           O  
+HETATM10348  O   HOH C7371      27.606  16.607 -25.148  1.00 45.31           O  
+HETATM10349  O   HOH C7379      36.005  10.232   2.385  1.00 36.48           O  
+HETATM10350  O   HOH C7384      19.417   0.279   4.295  1.00 40.68           O  
+HETATM10351  O   HOH C7394      18.942   8.295   7.275  1.00 30.15           O  
+HETATM10352  O   HOH C7396       0.562   1.149 -19.470  1.00 27.66           O  
+HETATM10353  O   HOH C7398      26.599  28.496 -25.560  1.00 45.95           O  
+HETATM10354  O   HOH C7407      27.553   9.686   3.987  1.00 45.26           O  
+HETATM10355  O   HOH C7410      33.651  -0.945  -6.709  1.00 33.13           O  
+HETATM10356  O   HOH C7413      29.720  -0.150 -12.569  1.00 26.81           O  
+HETATM10357  O   HOH C7421      25.274   9.267 -36.084  1.00 30.97           O  
+HETATM10358  O   HOH C7424      10.441 -17.758 -39.833  1.00 45.05           O  
+HETATM10359  O   HOH C7425       9.678  -3.621 -23.057  1.00 39.72           O  
+HETATM10360  O   HOH C7427      20.419  14.777 -31.789  1.00 41.59           O  
+HETATM10361  O   HOH C7428      26.579  10.252 -27.035  1.00 37.01           O  
+HETATM10362  O   HOH C7436      27.260  30.790 -15.009  1.00 39.67           O  
+HETATM10363  O   HOH C7438      19.132   7.512 -33.343  1.00 31.86           O  
+HETATM10364  O   HOH C7440      25.740   8.333   6.803  1.00 38.83           O  
+HETATM10365  O   HOH C7447       0.651  -5.138   4.428  1.00 32.78           O  
+HETATM10366  O   HOH C7448       4.365  -4.026   6.939  1.00 46.75           O  
+HETATM10367  O   HOH C7452      22.303  13.577 -14.451  1.00 14.67           O  
+HETATM10368  O   HOH C7456      -1.048   0.123 -15.028  1.00 20.47           O  
+HETATM10369  O   HOH C7458       0.174   4.568  -5.981  1.00 29.61           O  
+HETATM10370  O   HOH C7462      14.717 -13.243  -4.508  1.00 30.31           O  
+HETATM10371  O   HOH C7465       6.907   7.064  -2.691  1.00 29.26           O  
+HETATM10372  O   HOH C7467      12.993  -2.609 -27.734  1.00 31.86           O  
+HETATM10373  O   HOH C7468      13.149  24.371 -13.190  1.00 30.01           O  
+HETATM10374  O   HOH C7474      -6.274   0.229  -7.097  1.00 82.69           O  
+HETATM10375  O   HOH C7484      15.447  -6.152 -40.149  1.00 48.75           O  
+HETATM10376  O   HOH C7486      15.708 -14.613  -2.847  1.00 38.32           O  
+HETATM10377  O   HOH C7490      30.274  17.704  -7.360  1.00 30.36           O  
+HETATM10378  O   HOH C7494      25.796  10.183  -8.092  1.00 48.65           O  
+HETATM10379  O   HOH C7495      33.874  15.039   7.963  1.00 35.47           O  
+HETATM10380  O   HOH C7500       9.706  16.131  -1.501  1.00 28.57           O  
+HETATM10381  O   HOH C7503      19.763 -10.485 -21.765  1.00 36.34           O  
+HETATM10382  O   HOH C7504      29.569  10.033 -16.636  1.00 45.11           O  
+HETATM10383  O   HOH C7510      -0.710   8.329 -12.034  1.00 26.96           O  
+HETATM10384  O   HOH C7512      18.225  29.349 -16.107  1.00 37.01           O  
+HETATM10385  O   HOH C7515       7.888  16.481 -18.007  1.00 44.23           O  
+HETATM10386  O   HOH C7524      14.718  19.989   5.734  1.00 52.60           O  
+HETATM10387  O   HOH C7529       1.001  -7.423 -13.188  1.00 38.85           O  
+HETATM10388  O   HOH C7532      27.677  20.867 -25.303  1.00 37.12           O  
+HETATM10389  O   HOH C7534      18.926  19.716 -25.606  1.00 28.39           O  
+HETATM10390  O   HOH C7537       7.950  -0.904 -22.611  1.00 43.95           O  
+HETATM10391  O   HOH C7542      17.850  10.180   9.302  1.00 36.08           O  
+HETATM10392  O   HOH C7543       6.785   5.002 -26.125  1.00 32.21           O  
+HETATM10393  O   HOH C7560      36.510  13.759  -2.340  1.00 29.58           O  
+HETATM10394  O   HOH C7562      28.397   7.530  -7.846  1.00 46.40           O  
+HETATM10395  O   HOH C7565      34.481  23.175 -19.262  1.00 26.31           O  
+HETATM10396  O   HOH C7566      11.648 -13.014 -44.237  1.00 45.45           O  
+HETATM10397  O   HOH C7571       9.963 -18.702 -16.162  1.00 48.93           O  
+HETATM10398  O   HOH C7572      29.818  12.188   6.197  1.00 41.30           O  
+HETATM10399  O   HOH C7577      26.011  11.432 -30.639  1.00 41.36           O  
+HETATM10400  O   HOH C7592      34.852  -5.526  -0.569  1.00 43.13           O  
+HETATM10401  O   HOH C7598      18.305  -8.481 -22.945  1.00 27.47           O  
+HETATM10402  O   HOH C7599      30.136  -0.977  -9.602  1.00 37.38           O  
+HETATM10403  O   HOH C7604      27.440   4.955  -5.936  1.00 50.88           O  
+HETATM10404  O   HOH C7609      16.461  14.859 -29.712  1.00 41.65           O  
+HETATM10405  O   HOH C7612       7.544  -2.958 -19.287  1.00 37.67           O  
+HETATM10406  O   HOH C7613      30.587  -2.172 -23.337  1.00 31.07           O  
+HETATM10407  O   HOH C7615      11.980   7.261   7.612  1.00 66.22           O  
+HETATM10408  O   HOH C7620      28.608  19.349  -3.144  1.00 36.18           O  
+HETATM10409  O   HOH C7621      30.441 -11.551  -7.865  1.00 45.70           O  
+HETATM10410  O   HOH C7627      13.592  -9.461 -34.471  1.00 39.21           O  
+HETATM10411  O   HOH C7628       7.407  14.023   1.686  1.00 36.32           O  
+HETATM10412  O   HOH C7630       8.197  22.266 -24.700  1.00 37.83           O  
+HETATM10413  O   HOH C7639      31.571  11.018 -11.012  1.00 29.69           O  
+HETATM10414  O   HOH C7641      26.424  16.879 -29.009  1.00 39.40           O  
+HETATM10415  O   HOH C7648      27.943   5.206 -12.926  1.00 30.32           O  
+HETATM10416  O   HOH C7649       7.703   3.041 -17.991  1.00 43.54           O  
+HETATM10417  O   HOH C7652      35.449  10.942   9.315  1.00 47.70           O  
+HETATM10418  O   HOH C7654      10.694  16.136   4.741  1.00 52.38           O  
+HETATM10419  O   HOH C7656      15.462  18.519   7.710  1.00 57.87           O  
+HETATM10420  O   HOH C7659      42.670  13.648   1.276  1.00 42.98           O  
+HETATM10421  O   HOH C7660      25.039  27.715  -3.509  1.00 43.82           O  
+HETATM10422  O   HOH C7668       9.226  18.125   2.014  1.00 44.36           O  
+HETATM10423  O   HOH C7670      27.126   6.659   2.354  1.00 36.16           O  
+HETATM10424  O   HOH C7675      28.537  10.638  -6.659  1.00 27.56           O  
+HETATM10425  O   HOH C7676      17.533  13.454   8.814  1.00 39.35           O  
+HETATM10426  O   HOH C7679      15.257   8.707 -33.225  1.00 37.72           O  
+HETATM10427  O   HOH C7680      25.607   6.272 -33.810  1.00 40.95           O  
+HETATM10428  O   HOH C7685      27.413   8.137 -33.850  1.00 41.27           O  
+HETATM10429  O   HOH C7686      10.163  -8.265 -28.406  1.00 33.10           O  
+HETATM10430  O   HOH C7694      23.040  16.973 -29.662  1.00 46.50           O  
+HETATM10431  O   HOH C7699      28.723  15.854  -5.621  1.00 47.82           O  
+HETATM10432  O   HOH C7700       6.523  15.968  -1.732  1.00 52.38           O  
+HETATM10433  O   HOH C7701      23.608  15.716   8.113  1.00 39.42           O  
+HETATM10434  O   HOH C7710      15.514   1.544   8.964  1.00 39.52           O  
+HETATM10435  O   HOH C7717      28.952   4.422 -15.655  1.00 40.55           O  
+HETATM10436  O   HOH C7724      14.901 -10.713 -36.701  1.00 60.34           O  
+HETATM10437  O   HOH C7729      29.087  19.667  -6.038  1.00 39.15           O  
+HETATM10438  O   HOH C7730      -6.821  -2.680  -5.994  1.00 46.75           O  
+HETATM10439  O   HOH C7733      12.416 -19.497 -15.324  1.00 39.80           O  
+HETATM10440  O   HOH C7734       5.553 -13.008 -21.846  1.00 28.73           O  
+HETATM10441  O   HOH C7737      14.795 -10.908 -43.401  1.00 42.23           O  
+HETATM10442  O   HOH C7742      16.408   8.239 -36.283  1.00 43.52           O  
+HETATM10443  O   HOH C7746      35.377   2.536 -23.500  1.00 41.08           O  
+HETATM10444  O   HOH C7747      29.478  18.922 -25.437  1.00 28.78           O  
+HETATM10445  O   HOH C7756      16.141   2.902  11.336  1.00 52.06           O  
+HETATM10446  O   HOH C7757      35.271  15.716  11.949  1.00 37.16           O  
+HETATM10447  O   HOH C7764      30.533   5.264 -17.479  1.00 64.12           O  
+HETATM10448  O   HOH C7765      25.949  -5.541   6.128  1.00 43.80           O  
+HETATM10449  O   HOH C7768      27.524  -8.440 -16.921  1.00 40.99           O  
+HETATM10450  O   HOH C7769      15.917 -20.151  -2.175  1.00 38.05           O  
+HETATM10451  O   HOH C7771       1.771  13.797 -11.846  1.00 46.44           O  
+HETATM10452  O   HOH C7775      19.797 -14.378   2.151  1.00 44.63           O  
+HETATM10453  O   HOH C7782      15.795  -8.345 -28.564  1.00 47.54           O  
+HETATM10454  O   HOH C7784      29.002  27.832 -24.856  1.00 64.45           O  
+HETATM10455  O   HOH C7788      19.740  31.112 -14.740  1.00 38.86           O  
+HETATM10456  O   HOH C7792      32.044   2.450  -0.200  1.00 34.07           O  
+HETATM10457  O   HOH C7798      35.238  22.190 -21.739  1.00 45.66           O  
+HETATM10458  O   HOH C7801      -1.325  -6.312 -13.317  1.00 37.83           O  
+HETATM10459  O   HOH C7810       7.612   1.046 -20.110  1.00 43.88           O  
+HETATM10460  O   HOH C7811      27.800  29.029  15.384  1.00 51.51           O  
+HETATM10461  O   HOH C7820      22.807  29.247  -5.155  1.00 41.59           O  
+HETATM10462  O   HOH C7822      15.605  26.832 -14.044  1.00 31.67           O  
+HETATM10463  O   HOH C7825      29.306  -0.305 -16.720  1.00 33.20           O  
+HETATM10464  O   HOH C7827       3.450  18.518 -10.943  1.00 39.72           O  
+HETATM10465  O   HOH C7832      35.800   5.604   1.672  1.00 46.40           O  
+HETATM10466  O   HOH C7836      17.353  17.194   6.465  1.00 49.30           O  
+HETATM10467  O   HOH C7845      -8.719   7.198  -9.348  1.00 53.65           O  
+HETATM10468  O   HOH C7851       4.075  17.646  -3.844  1.00 50.65           O  
+HETATM10469  O   HOH C7852      44.351  12.258  -1.910  1.00 49.74           O  
+HETATM10470  O   HOH C7854      27.655  -8.759  -6.576  1.00 30.28           O  
+HETATM10471  O   HOH C7861      15.293  22.370   6.535  1.00 49.54           O  
+HETATM10472  O   HOH C7866      33.017   2.045  -4.988  1.00 45.92           O  
+HETATM10473  O   HOH C7867      -1.005   7.633  -9.057  1.00 39.03           O  
+HETATM10474  O   HOH C7870      24.027   4.884   6.294  1.00 55.34           O  
+HETATM10475  O   HOH C7880       3.776  10.888  -1.990  1.00 43.08           O  
+HETATM10476  O   HOH C7881      23.655  11.782   9.610  1.00 32.79           O  
+HETATM10477  O   HOH C7882      34.500  -0.645 -24.457  1.00 47.42           O  
+HETATM10478  O   HOH C7885      34.588  13.146  12.618  1.00 37.12           O  
+HETATM10479  O   HOH D7002      78.391 -17.438  33.634  1.00 13.21           O  
+HETATM10480  O   HOH D7010      65.302 -33.319  -1.384  1.00 22.38           O  
+HETATM10481  O   HOH D7016      73.671 -21.814  16.165  1.00 19.70           O  
+HETATM10482  O   HOH D7022      66.594 -21.814  12.128  1.00 24.49           O  
+HETATM10483  O   HOH D7024      63.886 -25.653  10.593  1.00 18.51           O  
+HETATM10484  O   HOH D7031      62.647 -18.656  11.363  1.00 20.09           O  
+HETATM10485  O   HOH D7032      60.710 -27.825   4.731  1.00 15.96           O  
+HETATM10486  O   HOH D7036      44.864 -52.136 -12.771  1.00 18.43           O  
+HETATM10487  O   HOH D7039      49.653 -37.206  15.090  1.00 26.66           O  
+HETATM10488  O   HOH D7041      60.085 -56.181  -3.601  1.00 22.92           O  
+HETATM10489  O   HOH D7046      50.514 -57.793 -10.529  1.00 21.68           O  
+HETATM10490  O   HOH D7048      78.958 -11.632  30.965  1.00 19.20           O  
+HETATM10491  O   HOH D7052      46.981 -64.428 -10.233  1.00 26.98           O  
+HETATM10492  O   HOH D7055      60.192 -23.697   9.350  1.00 22.77           O  
+HETATM10493  O   HOH D7056      76.237 -39.425   1.775  1.00 24.06           O  
+HETATM10494  O   HOH D7059      56.315 -23.878  10.731  1.00 18.95           O  
+HETATM10495  O   HOH D7061      48.943 -59.497  -8.844  1.00 30.75           O  
+HETATM10496  O   HOH D7066      74.105 -20.726  -3.624  1.00 33.39           O  
+HETATM10497  O   HOH D7068      55.130 -17.731   5.924  1.00 18.16           O  
+HETATM10498  O   HOH D7070      49.117 -63.041  -6.679  1.00 21.36           O  
+HETATM10499  O   HOH D7073      55.701 -62.082  -7.464  1.00 21.74           O  
+HETATM10500  O   HOH D7077      53.364 -61.628  -6.400  1.00 18.34           O  
+HETATM10501  O   HOH D7083      50.861 -57.764 -13.257  1.00 23.65           O  
+HETATM10502  O   HOH D7086      59.388 -35.584  -1.616  1.00 27.31           O  
+HETATM10503  O   HOH D7092      74.668 -27.796  -1.707  1.00 24.95           O  
+HETATM10504  O   HOH D7093      75.157 -14.348  18.527  1.00 20.78           O  
+HETATM10505  O   HOH D7096      56.988 -35.869   8.102  1.00 17.80           O  
+HETATM10506  O   HOH D7099      48.672 -41.122   9.386  1.00 22.28           O  
+HETATM10507  O   HOH D7112      69.038 -19.684   4.772  1.00 32.14           O  
+HETATM10508  O   HOH D7120      53.152 -30.389  21.249  1.00 26.78           O  
+HETATM10509  O   HOH D7123      56.922 -61.072  -9.557  1.00 21.69           O  
+HETATM10510  O   HOH D7135      81.056 -17.671  19.983  1.00 30.78           O  
+HETATM10511  O   HOH D7139      71.579 -42.575  15.547  1.00 38.56           O  
+HETATM10512  O   HOH D7149      61.816 -64.497   9.720  1.00 38.24           O  
+HETATM10513  O   HOH D7150      62.901 -61.846  -3.045  1.00 28.12           O  
+HETATM10514  O   HOH D7155      58.278 -21.221   4.611  1.00 31.73           O  
+HETATM10515  O   HOH D7159      54.252 -36.526   0.371  1.00 18.92           O  
+HETATM10516  O   HOH D7161      63.190 -28.032  27.420  1.00 23.00           O  
+HETATM10517  O   HOH D7163      61.899 -59.972  -4.800  1.00 25.83           O  
+HETATM10518  O   HOH D7167      51.025 -24.224  18.207  1.00 31.87           O  
+HETATM10519  O   HOH D7168      72.043 -17.374  29.581  1.00 30.84           O  
+HETATM10520  O   HOH D7169      46.526 -56.195  -2.749  1.00 31.07           O  
+HETATM10521  O   HOH D7170      71.082 -47.277  -0.568  1.00 23.40           O  
+HETATM10522  O   HOH D7171      57.477 -41.273  13.940  1.00 34.79           O  
+HETATM10523  O   HOH D7172      65.183 -31.959  -6.076  1.00 24.19           O  
+HETATM10524  O   HOH D7176      69.267 -46.147  -2.226  1.00 20.83           O  
+HETATM10525  O   HOH D7182      82.218 -19.594  -1.789  1.00 32.02           O  
+HETATM10526  O   HOH D7186      54.535 -30.458   2.614  1.00 24.77           O  
+HETATM10527  O   HOH D7187      52.741 -62.707   0.790  1.00 31.59           O  
+HETATM10528  O   HOH D7188      52.685 -24.658   0.063  1.00 32.85           O  
+HETATM10529  O   HOH D7190      52.446 -20.971  15.733  1.00 32.35           O  
+HETATM10530  O   HOH D7192      82.429 -32.639  -6.041  1.00 26.47           O  
+HETATM10531  O   HOH D7193      50.541 -58.661 -17.173  1.00 36.60           O  
+HETATM10532  O   HOH D7195      57.945 -52.245 -14.002  1.00 26.99           O  
+HETATM10533  O   HOH D7198      42.869 -54.326  -6.424  1.00 35.00           O  
+HETATM10534  O   HOH D7200      67.458 -21.268  21.918  1.00 25.08           O  
+HETATM10535  O   HOH D7201      65.230 -31.398  -3.159  1.00 21.85           O  
+HETATM10536  O   HOH D7209      75.522 -12.048  37.557  1.00 50.06           O  
+HETATM10537  O   HOH D7217      64.329 -23.821  -4.131  1.00 27.48           O  
+HETATM10538  O   HOH D7219      88.796 -27.022   1.955  1.00 29.34           O  
+HETATM10539  O   HOH D7221      72.972 -20.843  13.662  1.00 29.28           O  
+HETATM10540  O   HOH D7222      44.388 -35.139  14.869  1.00 34.11           O  
+HETATM10541  O   HOH D7224      48.477 -34.883  17.007  1.00 46.25           O  
+HETATM10542  O   HOH D7228      72.041 -44.023  -6.939  1.00 25.09           O  
+HETATM10543  O   HOH D7234      69.302 -47.191  -4.707  1.00 29.39           O  
+HETATM10544  O   HOH D7242      65.407 -61.239  -3.230  1.00 34.06           O  
+HETATM10545  O   HOH D7243      85.007 -32.846  -5.571  1.00 33.04           O  
+HETATM10546  O   HOH D7249      56.172 -24.314  -6.205  1.00 43.99           O  
+HETATM10547  O   HOH D7251      76.311 -15.911  17.049  1.00 28.80           O  
+HETATM10548  O   HOH D7254      66.755 -46.809  -1.279  1.00 18.68           O  
+HETATM10549  O   HOH D7259      51.328 -66.641  -7.543  1.00 22.57           O  
+HETATM10550  O   HOH D7269      54.567 -46.293   4.091  1.00 44.67           O  
+HETATM10551  O   HOH D7270      65.439 -23.633  10.204  1.00 31.89           O  
+HETATM10552  O   HOH D7272      63.460 -61.671  -0.535  1.00 24.38           O  
+HETATM10553  O   HOH D7288      87.816 -35.354  10.758  1.00 33.70           O  
+HETATM10554  O   HOH D7294      63.491 -60.355  -6.999  1.00 31.43           O  
+HETATM10555  O   HOH D7298      71.816 -28.304  -4.412  1.00 38.34           O  
+HETATM10556  O   HOH D7302      72.510 -39.185   3.669  1.00 28.14           O  
+HETATM10557  O   HOH D7305      57.484 -46.590   0.686  1.00 30.99           O  
+HETATM10558  O   HOH D7307      63.388 -20.418  -2.658  1.00 47.91           O  
+HETATM10559  O   HOH D7310      54.212 -32.455  24.810  1.00 34.39           O  
+HETATM10560  O   HOH D7312      58.981 -36.244   6.339  1.00 32.40           O  
+HETATM10561  O   HOH D7313      64.907 -21.235   8.471  1.00 21.78           O  
+HETATM10562  O   HOH D7314      67.037 -30.307  -6.668  1.00 32.64           O  
+HETATM10563  O   HOH D7323      66.117 -48.952   2.867  1.00 41.52           O  
+HETATM10564  O   HOH D7324      55.445 -23.225  -1.593  1.00 46.54           O  
+HETATM10565  O   HOH D7334      60.078 -45.855  -0.405  1.00 23.08           O  
+HETATM10566  O   HOH D7342      54.116 -14.053  12.000  1.00 26.61           O  
+HETATM10567  O   HOH D7345      65.217 -19.427  11.313  1.00 36.54           O  
+HETATM10568  O   HOH D7346      79.007 -16.543  -3.126  1.00 32.30           O  
+HETATM10569  O   HOH D7350      73.205 -61.634   5.216  1.00 30.74           O  
+HETATM10570  O   HOH D7352      58.306 -28.191  15.235  1.00112.18           O  
+HETATM10571  O   HOH D7357      54.913 -23.656  24.039  1.00 31.31           O  
+HETATM10572  O   HOH D7376      65.532 -32.377 -10.120  1.00 34.88           O  
+HETATM10573  O   HOH D7377      45.207 -48.733  -2.978  1.00 47.10           O  
+HETATM10574  O   HOH D7378      60.031 -39.468  16.473  1.00 20.81           O  
+HETATM10575  O   HOH D7380      57.454 -45.785   3.529  1.00 38.97           O  
+HETATM10576  O   HOH D7389      69.335 -18.056   1.493  1.00 30.65           O  
+HETATM10577  O   HOH D7391      60.471 -38.496   4.547  1.00 24.49           O  
+HETATM10578  O   HOH D7393      57.752 -38.442  15.770  1.00 32.59           O  
+HETATM10579  O   HOH D7397      59.773 -26.421  -6.813  1.00 36.57           O  
+HETATM10580  O   HOH D7400      46.578 -13.014  12.321  1.00 31.00           O  
+HETATM10581  O   HOH D7402      71.389 -44.047  -9.664  1.00 38.05           O  
+HETATM10582  O   HOH D7406      59.571 -44.837   4.711  1.00 26.98           O  
+HETATM10583  O   HOH D7408      87.278 -37.727   9.185  1.00 39.06           O  
+HETATM10584  O   HOH D7414      81.547 -35.252  -6.636  1.00 38.52           O  
+HETATM10585  O   HOH D7418      46.946 -48.473   8.629  1.00 38.13           O  
+HETATM10586  O   HOH D7422      43.444 -37.799  -0.747  1.00 33.38           O  
+HETATM10587  O   HOH D7423      68.605 -19.884   7.672  1.00 31.66           O  
+HETATM10588  O   HOH D7426      66.716 -40.438  19.712  1.00 48.11           O  
+HETATM10589  O   HOH D7430      61.244 -40.691   9.331  1.00 45.09           O  
+HETATM10590  O   HOH D7431      60.112 -38.072   7.554  1.00 49.59           O  
+HETATM10591  O   HOH D7433      71.163 -20.418  17.361  1.00 36.46           O  
+HETATM10592  O   HOH D7435      47.944 -38.316  17.031  1.00 47.18           O  
+HETATM10593  O   HOH D7439      60.705 -68.198   5.372  1.00 47.32           O  
+HETATM10594  O   HOH D7443      64.184 -63.874   1.431  1.00 37.39           O  
+HETATM10595  O   HOH D7444      49.284 -47.730  -4.229  1.00 41.86           O  
+HETATM10596  O   HOH D7445      64.713 -40.907  11.483  1.00 34.89           O  
+HETATM10597  O   HOH D7446      76.858 -44.265   1.108  1.00 38.92           O  
+HETATM10598  O   HOH D7449      56.885 -43.367   1.597  1.00 26.80           O  
+HETATM10599  O   HOH D7450      50.097 -49.275 -10.575  1.00 42.45           O  
+HETATM10600  O   HOH D7454      74.362 -15.189   5.083  1.00 19.38           O  
+HETATM10601  O   HOH D7455      56.509 -24.122   0.765  1.00 29.23           O  
+HETATM10602  O   HOH D7460      69.618 -21.465  29.193  1.00 39.42           O  
+HETATM10603  O   HOH D7466      47.376 -28.376  13.917  1.00 32.23           O  
+HETATM10604  O   HOH D7472      76.633 -10.086  -6.446  1.00 39.07           O  
+HETATM10605  O   HOH D7476      54.669 -30.014  23.095  1.00 36.01           O  
+HETATM10606  O   HOH D7487      59.495 -41.662   4.172  1.00 29.98           O  
+HETATM10607  O   HOH D7488      68.963 -17.477  -1.022  1.00 32.12           O  
+HETATM10608  O   HOH D7489      60.009 -27.842  -8.950  1.00 30.23           O  
+HETATM10609  O   HOH D7492      49.089 -51.045 -12.374  1.00 33.74           O  
+HETATM10610  O   HOH D7493      53.776 -43.614   5.529  1.00 23.54           O  
+HETATM10611  O   HOH D7497      47.601 -28.990   8.522  1.00 37.37           O  
+HETATM10612  O   HOH D7499      48.361 -47.889  -8.505  1.00 33.24           O  
+HETATM10613  O   HOH D7505      48.821 -36.276  -8.135  1.00 50.75           O  
+HETATM10614  O   HOH D7506      73.181 -34.259  -7.334  1.00 33.82           O  
+HETATM10615  O   HOH D7507      50.714 -19.064  15.381  1.00 34.05           O  
+HETATM10616  O   HOH D7511      50.880 -47.386 -12.134  1.00 43.92           O  
+HETATM10617  O   HOH D7513      47.605 -30.448  -2.434  1.00 37.34           O  
+HETATM10618  O   HOH D7514      43.092 -45.301  -9.661  1.00 39.55           O  
+HETATM10619  O   HOH D7516      48.683 -18.660   5.233  1.00 35.98           O  
+HETATM10620  O   HOH D7517      75.853 -19.977   8.893  1.00 27.18           O  
+HETATM10621  O   HOH D7518      66.558 -35.419 -12.475  1.00 36.70           O  
+HETATM10622  O   HOH D7519      78.097 -43.089  -0.947  1.00 53.53           O  
+HETATM10623  O   HOH D7520      81.380 -18.067   7.844  1.00 32.62           O  
+HETATM10624  O   HOH D7521      41.135 -40.047   1.929  1.00 34.41           O  
+HETATM10625  O   HOH D7522      50.160 -28.496  -2.206  1.00 41.82           O  
+HETATM10626  O   HOH D7530      58.321 -45.474  14.034  1.00 44.09           O  
+HETATM10627  O   HOH D7535      52.578 -24.363  -2.633  1.00 40.82           O  
+HETATM10628  O   HOH D7536      90.500 -31.168  15.803  1.00 60.82           O  
+HETATM10629  O   HOH D7539      72.805 -42.621 -11.527  1.00 37.65           O  
+HETATM10630  O   HOH D7540      54.638 -46.263   0.464  1.00 48.97           O  
+HETATM10631  O   HOH D7558      51.816 -55.633 -14.688  1.00 39.76           O  
+HETATM10632  O   HOH D7559      63.432 -16.599  14.481  1.00 32.17           O  
+HETATM10633  O   HOH D7563      49.009 -24.287  11.152  1.00 31.72           O  
+HETATM10634  O   HOH D7568      50.925 -21.302  -0.040  1.00 52.15           O  
+HETATM10635  O   HOH D7573      58.119 -63.533 -12.194  1.00 43.02           O  
+HETATM10636  O   HOH D7579      51.323 -62.489  -8.706  1.00 45.08           O  
+HETATM10637  O   HOH D7582      59.800 -61.339 -10.303  1.00 43.64           O  
+HETATM10638  O   HOH D7584      67.644 -49.443  -1.661  1.00 37.29           O  
+HETATM10639  O   HOH D7589      80.037 -36.560  -5.122  1.00 49.12           O  
+HETATM10640  O   HOH D7591      71.148 -14.521   8.429  1.00 36.19           O  
+HETATM10641  O   HOH D7593      53.296 -33.195  20.963  1.00 29.68           O  
+HETATM10642  O   HOH D7594      65.270 -42.101 -12.623  1.00 46.69           O  
+HETATM10643  O   HOH D7600      69.109 -48.787   0.980  1.00 35.68           O  
+HETATM10644  O   HOH D7603      66.429 -20.352  30.432  1.00 38.83           O  
+HETATM10645  O   HOH D7606      81.835 -49.153   3.905  1.00 35.79           O  
+HETATM10646  O   HOH D7616      46.486 -67.861   5.036  1.00 43.34           O  
+HETATM10647  O   HOH D7623      48.794 -36.167  -4.634  1.00 47.30           O  
+HETATM10648  O   HOH D7624      42.809 -30.271  12.706  1.00 45.28           O  
+HETATM10649  O   HOH D7625      64.338 -44.876   8.985  1.00 39.25           O  
+HETATM10650  O   HOH D7626      71.986 -23.720  31.849  1.00 50.03           O  
+HETATM10651  O   HOH D7629      48.190 -20.711  16.166  1.00 52.67           O  
+HETATM10652  O   HOH D7632      52.059 -41.746  19.158  1.00 33.32           O  
+HETATM10653  O   HOH D7636      65.413 -52.915  -3.199  1.00 51.77           O  
+HETATM10654  O   HOH D7657      71.538 -46.680  -6.344  1.00 30.51           O  
+HETATM10655  O   HOH D7663      88.661 -38.946   6.691  1.00 70.42           O  
+HETATM10656  O   HOH D7664      49.127 -40.506   0.671  1.00 40.37           O  
+HETATM10657  O   HOH D7669      62.895 -64.669   7.145  1.00 55.35           O  
+HETATM10658  O   HOH D7673      54.279 -58.094 -14.579  1.00 34.31           O  
+HETATM10659  O   HOH D7674      47.311 -26.942  11.391  1.00 55.88           O  
+HETATM10660  O   HOH D7681      81.874 -29.409  22.345  1.00 49.11           O  
+HETATM10661  O   HOH D7682      61.556 -64.088   2.852  1.00 42.56           O  
+HETATM10662  O   HOH D7687      75.383 -29.855  24.477  1.00 29.69           O  
+HETATM10663  O   HOH D7689      78.705 -39.833  -7.217  1.00 34.81           O  
+HETATM10664  O   HOH D7695      68.691 -49.358  -8.581  1.00 39.36           O  
+HETATM10665  O   HOH D7698      73.229 -48.813  15.329  1.00 40.17           O  
+HETATM10666  O   HOH D7702      48.233 -41.726  -6.752  1.00 44.72           O  
+HETATM10667  O   HOH D7703      88.037 -28.215  -5.946  1.00 43.32           O  
+HETATM10668  O   HOH D7709      51.051 -28.152  27.848  1.00 40.91           O  
+HETATM10669  O   HOH D7714      63.604 -32.642 -12.595  1.00 49.27           O  
+HETATM10670  O   HOH D7716      59.443 -42.425  26.231  1.00 41.34           O  
+HETATM10671  O   HOH D7718      57.663 -58.885 -12.992  1.00 46.58           O  
+HETATM10672  O   HOH D7720      83.395 -19.873  19.260  1.00 23.82           O  
+HETATM10673  O   HOH D7721      51.622 -13.390  11.089  1.00 34.49           O  
+HETATM10674  O   HOH D7735      72.689 -18.081  24.449  1.00 38.04           O  
+HETATM10675  O   HOH D7744      79.448 -19.682   8.638  1.00 45.09           O  
+HETATM10676  O   HOH D7749      61.959 -61.301   1.456  1.00 40.26           O  
+HETATM10677  O   HOH D7753      50.672 -51.071 -14.313  1.00 26.76           O  
+HETATM10678  O   HOH D7754      44.897 -29.296  10.235  1.00 45.05           O  
+HETATM10679  O   HOH D7761      71.551 -15.689  -4.669  1.00 31.83           O  
+HETATM10680  O   HOH D7766      62.023 -39.718   7.005  1.00 67.72           O  
+HETATM10681  O   HOH D7767      46.616 -50.613 -13.827  1.00 37.60           O  
+HETATM10682  O   HOH D7774      80.784 -15.756   6.765  1.00 33.31           O  
+HETATM10683  O   HOH D7783      73.929 -27.756  23.545  1.00 36.27           O  
+HETATM10684  O   HOH D7786      43.503 -43.883  12.225  1.00 34.66           O  
+HETATM10685  O   HOH D7790      72.632 -39.080  23.041  1.00 45.14           O  
+HETATM10686  O   HOH D7791      44.200 -47.115   8.944  1.00 43.11           O  
+HETATM10687  O   HOH D7793      42.229 -33.362  -1.423  1.00 40.75           O  
+HETATM10688  O   HOH D7794      86.435 -30.272  15.893  1.00 37.88           O  
+HETATM10689  O   HOH D7795      46.070 -25.883   2.367  1.00 32.84           O  
+HETATM10690  O   HOH D7797      35.388 -39.905   4.022  1.00 45.83           O  
+HETATM10691  O   HOH D7800      54.282 -33.724 -13.369  1.00 44.98           O  
+HETATM10692  O   HOH D7802      77.368 -29.236  26.644  1.00 57.13           O  
+HETATM10693  O   HOH D7806      49.403 -62.726 -10.283  1.00 62.99           O  
+HETATM10694  O   HOH D7812      52.128 -53.061 -18.136  1.00 54.68           O  
+HETATM10695  O   HOH D7816      60.126 -40.212 -14.717  1.00 59.07           O  
+HETATM10696  O   HOH D7821      69.899 -18.114  19.643  1.00 45.83           O  
+HETATM10697  O   HOH D7823      65.624 -19.632  15.077  1.00 45.61           O  
+HETATM10698  O   HOH D7824      44.850 -16.037  11.259  1.00 51.71           O  
+HETATM10699  O   HOH D7833      81.626 -36.703  15.398  1.00 46.48           O  
+HETATM10700  O   HOH D7834      86.311 -22.340  27.755  1.00 40.79           O  
+HETATM10701  O   HOH D7835      45.200 -29.641  -3.398  1.00 37.90           O  
+HETATM10702  O   HOH D7840      62.069 -61.703  -8.969  1.00 34.28           O  
+HETATM10703  O   HOH D7842      43.846 -30.699   7.413  1.00 40.99           O  
+HETATM10704  O   HOH D7847      70.889 -18.621  -3.232  1.00 52.69           O  
+HETATM10705  O   HOH D7853      75.715 -24.337  -6.352  1.00 52.02           O  
+HETATM10706  O   HOH D7863      74.594 -32.322 -10.502  1.00 34.30           O  
+HETATM10707  O   HOH D7871      61.669 -45.258   6.121  1.00 30.61           O  
+CONECT 9655 9657                                                                
+CONECT 9656 9657 9658 9659 9660                                                 
+CONECT 9657 9655 9656                                                           
+CONECT 9658 9656                                                                
+CONECT 9659 9656                                                                
+CONECT 9660 9656 9661 9662                                                      
+CONECT 9661 9660                                                                
+CONECT 9662 9660 9663 9664                                                      
+CONECT 9663 9662                                                                
+CONECT 9664 9662 9665                                                           
+CONECT 9665 9664 9666                                                           
+CONECT 9666 9665 9667                                                           
+CONECT 9667 9666 9668 9669                                                      
+CONECT 9668 9667                                                                
+CONECT 9669 9667                                                                
+CONECT 9670 9671 9672 9673 9677                                                 
+CONECT 9671 9670                                                                
+CONECT 9672 9670                                                                
+CONECT 9673 9670                                                                
+CONECT 9674 9675 9676 9677 9678                                                 
+CONECT 9675 9674                                                                
+CONECT 9676 9674                                                                
+CONECT 9677 9670 9674                                                           
+CONECT 9678 9674 9679                                                           
+CONECT 9679 9678 9680                                                           
+CONECT 9680 9679 9681 9682                                                      
+CONECT 9681 9680 9686                                                           
+CONECT 9682 9680 9683 9684                                                      
+CONECT 9683 9682                                                                
+CONECT 9684 9682 9685 9686                                                      
+CONECT 9685 9684                                                                
+CONECT 9686 9681 9684 9687                                                      
+CONECT 9687 9686 9688 9696                                                      
+CONECT 9688 9687 9689                                                           
+CONECT 9689 9688 9690                                                           
+CONECT 9690 9689 9691 9696                                                      
+CONECT 9691 9690 9692 9693                                                      
+CONECT 9692 9691                                                                
+CONECT 9693 9691 9694                                                           
+CONECT 9694 9693 9695                                                           
+CONECT 9695 9694 9696                                                           
+CONECT 9696 9687 9690 9695                                                      
+CONECT 9697 9699                                                                
+CONECT 9698 9699 9700 9701 9702                                                 
+CONECT 9699 9697 9698                                                           
+CONECT 9700 9698                                                                
+CONECT 9701 9698                                                                
+CONECT 9702 9698 9703 9704                                                      
+CONECT 9703 9702                                                                
+CONECT 9704 9702 9705 9706                                                      
+CONECT 9705 9704                                                                
+CONECT 9706 9704 9707                                                           
+CONECT 9707 9706 9708                                                           
+CONECT 9708 9707 9709                                                           
+CONECT 9709 9708 9710 9711                                                      
+CONECT 9710 9709                                                                
+CONECT 9711 9709                                                                
+CONECT 9712 9713 9714 9715 9719                                                 
+CONECT 9713 9712                                                                
+CONECT 9714 9712                                                                
+CONECT 9715 9712                                                                
+CONECT 9716 9717 9718 9719 9720                                                 
+CONECT 9717 9716                                                                
+CONECT 9718 9716                                                                
+CONECT 9719 9712 9716                                                           
+CONECT 9720 9716 9721                                                           
+CONECT 9721 9720 9722                                                           
+CONECT 9722 9721 9723 9724                                                      
+CONECT 9723 9722 9728                                                           
+CONECT 9724 9722 9725 9726                                                      
+CONECT 9725 9724                                                                
+CONECT 9726 9724 9727 9728                                                      
+CONECT 9727 9726                                                                
+CONECT 9728 9723 9726 9729                                                      
+CONECT 9729 9728 9730 9738                                                      
+CONECT 9730 9729 9731                                                           
+CONECT 9731 9730 9732                                                           
+CONECT 9732 9731 9733 9738                                                      
+CONECT 9733 9732 9734 9735                                                      
+CONECT 9734 9733                                                                
+CONECT 9735 9733 9736                                                           
+CONECT 9736 9735 9737                                                           
+CONECT 9737 9736 9738                                                           
+CONECT 9738 9729 9732 9737                                                      
+CONECT 9739 9741                                                                
+CONECT 9740 9741 9742 9743 9744                                                 
+CONECT 9741 9739 9740                                                           
+CONECT 9742 9740                                                                
+CONECT 9743 9740                                                                
+CONECT 9744 9740 9745 9746                                                      
+CONECT 9745 9744                                                                
+CONECT 9746 9744 9747 9748                                                      
+CONECT 9747 9746                                                                
+CONECT 9748 9746 9749                                                           
+CONECT 9749 9748 9750                                                           
+CONECT 9750 9749 9751                                                           
+CONECT 9751 9750 9752 9753                                                      
+CONECT 9752 9751                                                                
+CONECT 9753 9751                                                                
+CONECT 9754 9755 9756 9757 9761                                                 
+CONECT 9755 9754                                                                
+CONECT 9756 9754                                                                
+CONECT 9757 9754                                                                
+CONECT 9758 9759 9760 9761 9762                                                 
+CONECT 9759 9758                                                                
+CONECT 9760 9758                                                                
+CONECT 9761 9754 9758                                                           
+CONECT 9762 9758 9763                                                           
+CONECT 9763 9762 9764                                                           
+CONECT 9764 9763 9765 9766                                                      
+CONECT 9765 9764 9770                                                           
+CONECT 9766 9764 9767 9768                                                      
+CONECT 9767 9766                                                                
+CONECT 9768 9766 9769 9770                                                      
+CONECT 9769 9768                                                                
+CONECT 9770 9765 9768 9771                                                      
+CONECT 9771 9770 9772 9780                                                      
+CONECT 9772 9771 9773                                                           
+CONECT 9773 9772 9774                                                           
+CONECT 9774 9773 9775 9780                                                      
+CONECT 9775 9774 9776 9777                                                      
+CONECT 9776 9775                                                                
+CONECT 9777 9775 9778                                                           
+CONECT 9778 9777 9779                                                           
+CONECT 9779 9778 9780                                                           
+CONECT 9780 9771 9774 9779                                                      
+CONECT 9781 9783                                                                
+CONECT 9782 9783 9784 9785 9786                                                 
+CONECT 9783 9781 9782                                                           
+CONECT 9784 9782                                                                
+CONECT 9785 9782                                                                
+CONECT 9786 9782 9787 9788                                                      
+CONECT 9787 9786                                                                
+CONECT 9788 9786 9789 9790                                                      
+CONECT 9789 9788                                                                
+CONECT 9790 9788 9791                                                           
+CONECT 9791 9790 9792                                                           
+CONECT 9792 9791 9793                                                           
+CONECT 9793 9792 9794 9795                                                      
+CONECT 9794 9793                                                                
+CONECT 9795 9793                                                                
+CONECT 9796 9797 9798 9799 9803                                                 
+CONECT 9797 9796                                                                
+CONECT 9798 9796                                                                
+CONECT 9799 9796                                                                
+CONECT 9800 9801 9802 9803 9804                                                 
+CONECT 9801 9800                                                                
+CONECT 9802 9800                                                                
+CONECT 9803 9796 9800                                                           
+CONECT 9804 9800 9805                                                           
+CONECT 9805 9804 9806                                                           
+CONECT 9806 9805 9807 9808                                                      
+CONECT 9807 9806 9812                                                           
+CONECT 9808 9806 9809 9810                                                      
+CONECT 9809 9808                                                                
+CONECT 9810 9808 9811 9812                                                      
+CONECT 9811 9810                                                                
+CONECT 9812 9807 9810 9813                                                      
+CONECT 9813 9812 9814 9822                                                      
+CONECT 9814 9813 9815                                                           
+CONECT 9815 9814 9816                                                           
+CONECT 9816 9815 9817 9822                                                      
+CONECT 9817 9816 9818 9819                                                      
+CONECT 9818 9817                                                                
+CONECT 9819 9817 9820                                                           
+CONECT 9820 9819 9821                                                           
+CONECT 9821 9820 9822                                                           
+CONECT 9822 9813 9816 9821                                                      
+MASTER      400    0    8   68   44    0   34    610703    4  168   96          
+END                                                                             

--- a/ops/gates/configs/legacy_runtime_receptors/1YGC_apo.pdb
+++ b/ops/gates/configs/legacy_runtime_receptors/1YGC_apo.pdb
@@ -1,0 +1,3334 @@
+HEADER    HYDROLASE                               04-JAN-05   1YGC              
+TITLE     SHORT FACTOR VIIA WITH A SMALL MOLECULE INHIBITOR                     
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: COAGULATION FACTOR VII;                                    
+COMPND   3 CHAIN: H;                                                            
+COMPND   4 FRAGMENT: HEAVY CHAIN (RESIDUES 213-466);                            
+COMPND   5 SYNONYM: SERUM PROTHROMBIN CONVERSION ACCELERATOR, SPCA,             
+COMPND   6 PROCONVERTIN, EPTACOG ALFA;                                          
+COMPND   7 EC: 3.4.21.21;                                                       
+COMPND   8 ENGINEERED: YES;                                                     
+COMPND   9 MOL_ID: 2;                                                           
+COMPND  10 MOLECULE: COAGULATION FACTOR VII;                                    
+COMPND  11 CHAIN: L;                                                            
+COMPND  12 FRAGMENT: LIGHT CHAIN, DEL 1-149 FROM FULL LENGTH (RESIDUES 150-212);
+COMPND  13 SYNONYM: SERUM PROTHROMBIN CONVERSION ACCELERATOR, SPCA,             
+COMPND  14 PROCONVERTIN, EPTACOG ALFA;                                          
+COMPND  15 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE   3 ORGANISM_COMMON: HUMAN;                                              
+SOURCE   4 ORGANISM_TAXID: 9606;                                                
+SOURCE   5 GENE: F7;                                                            
+SOURCE   6 EXPRESSION_SYSTEM: SPODOPTERA FRUGIPERDA;                            
+SOURCE   7 EXPRESSION_SYSTEM_COMMON: FALL ARMYWORM;                             
+SOURCE   8 EXPRESSION_SYSTEM_TAXID: 7108;                                       
+SOURCE   9 EXPRESSION_SYSTEM_STRAIN: HIGH FIVE;                                 
+SOURCE  10 EXPRESSION_SYSTEM_VECTOR_TYPE: VIRUS;                                
+SOURCE  11 EXPRESSION_SYSTEM_PLASMID: GP67SSFVII;                               
+SOURCE  12 MOL_ID: 2;                                                           
+SOURCE  13 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE  14 ORGANISM_COMMON: HUMAN;                                              
+SOURCE  15 ORGANISM_TAXID: 9606;                                                
+SOURCE  16 GENE: F7;                                                            
+SOURCE  17 EXPRESSION_SYSTEM: SPODOPTERA FRUGIPERDA;                            
+SOURCE  18 EXPRESSION_SYSTEM_COMMON: FALL ARMYWORM;                             
+SOURCE  19 EXPRESSION_SYSTEM_TAXID: 7108;                                       
+SOURCE  20 EXPRESSION_SYSTEM_STRAIN: HIGH FIVE;                                 
+SOURCE  21 EXPRESSION_SYSTEM_VECTOR_TYPE: VIRUS;                                
+SOURCE  22 EXPRESSION_SYSTEM_PLASMID: GP67SSFVII                                
+KEYWDS    INVERTED OXY-ANION HOLE, HYDROLASE                                    
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    A.G.OLIVERO,C.EIGENBROT,R.GOLDSMITH,K.ROBARGE,D.R.ARTIS,J.FLYGARE,    
+AUTHOR   2 T.RAWSON,C.REFINO,S.BUNTING,D.KIRCHHOFER                             
+REVDAT   4   09-OCT-24 1YGC    1       REMARK LINK                              
+REVDAT   3   24-FEB-09 1YGC    1       VERSN                                    
+REVDAT   2   13-DEC-05 1YGC    1       JRNL                                     
+REVDAT   1   18-JAN-05 1YGC    0                                                
+JRNL        AUTH   A.G.OLIVERO,C.EIGENBROT,R.GOLDSMITH,K.ROBARGE,D.R.ARTIS,     
+JRNL        AUTH 2 J.FLYGARE,T.RAWSON,D.P.SUTHERLIN,S.KADKHODAYAN,M.BERESINI,   
+JRNL        AUTH 3 L.O.ELLIOTT,G.G.DEGUZMAN,D.W.BANNER,M.ULTSCH,U.MARZEC,       
+JRNL        AUTH 4 S.R.HANSON,C.REFINO,S.BUNTING,D.KIRCHHOFER                   
+JRNL        TITL   A SELECTIVE, SLOW BINDING INHIBITOR OF FACTOR VIIA BINDS TO  
+JRNL        TITL 2 A NONSTANDARD ACTIVE SITE CONFORMATION AND ATTENUATES        
+JRNL        TITL 3 THROMBUS FORMATION IN VIVO.                                  
+JRNL        REF    J.BIOL.CHEM.                  V. 280  9160 2005              
+JRNL        REFN                   ISSN 0021-9258                               
+JRNL        PMID   15632123                                                     
+JRNL        DOI    10.1074/JBC.M409068200                                       
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    2.00 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : CNX 2000.1                                           
+REMARK   3   AUTHORS     : BRUNGER,ADAMS,CLORE,DELANO,GROS,GROSSE-              
+REMARK   3               : KUNSTLEVE,JIANG,KUSZEWSKI,NILGES,PANNU,              
+REMARK   3               : READ,RICE,SIMONSON,WARREN,MOLECULAR                  
+REMARK   3               : SIMULATIONS (BADGER,BERARD,KUMAR,SZALMA,             
+REMARK   3               : YIP,DZAKULA)                                         
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 2.00                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 29.15                          
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : 0.000                          
+REMARK   3   DATA CUTOFF HIGH         (ABS(F)) : 2203986.800                    
+REMARK   3   DATA CUTOFF LOW          (ABS(F)) : 0.0000                         
+REMARK   3   COMPLETENESS (WORKING+TEST)   (%) : 94.9                           
+REMARK   3   NUMBER OF REFLECTIONS             : 34943                          
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   CROSS-VALIDATION METHOD          : THROUGHOUT                      
+REMARK   3   FREE R VALUE TEST SET SELECTION  : RANDOM                          
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.189                           
+REMARK   3   R VALUE            (WORKING SET) : 0.188                           
+REMARK   3   FREE R VALUE                     : 0.205                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 2.500                           
+REMARK   3   FREE R VALUE TEST SET COUNT      : 878                             
+REMARK   3   ESTIMATED ERROR OF FREE R VALUE  : 0.007                           
+REMARK   3                                                                      
+REMARK   3  FIT/AGREEMENT OF MODEL WITH ALL DATA.                               
+REMARK   3   R VALUE     (WORKING + TEST SET, NO CUTOFF) : NULL                 
+REMARK   3   R VALUE            (WORKING SET, NO CUTOFF) : NULL                 
+REMARK   3   FREE R VALUE                    (NO CUTOFF) : NULL                 
+REMARK   3   FREE R VALUE TEST SET SIZE   (%, NO CUTOFF) : NULL                 
+REMARK   3   FREE R VALUE TEST SET COUNT     (NO CUTOFF) : NULL                 
+REMARK   3   ESTIMATED ERROR OF FREE R VALUE (NO CUTOFF) : NULL                 
+REMARK   3   TOTAL NUMBER OF REFLECTIONS     (NO CUTOFF) : 34943                
+REMARK   3                                                                      
+REMARK   3  FIT IN THE HIGHEST RESOLUTION BIN.                                  
+REMARK   3   TOTAL NUMBER OF BINS USED           : 6                            
+REMARK   3   BIN RESOLUTION RANGE HIGH       (A) : 2.00                         
+REMARK   3   BIN RESOLUTION RANGE LOW        (A) : 2.13                         
+REMARK   3   BIN COMPLETENESS (WORKING+TEST) (%) : 94.00                        
+REMARK   3   REFLECTIONS IN BIN    (WORKING SET) : 5598                         
+REMARK   3   BIN R VALUE           (WORKING SET) : 0.2010                       
+REMARK   3   BIN FREE R VALUE                    : 0.3050                       
+REMARK   3   BIN FREE R VALUE TEST SET SIZE  (%) : 0.90                         
+REMARK   3   BIN FREE R VALUE TEST SET COUNT     : 49                           
+REMARK   3   ESTIMATED ERROR OF BIN FREE R VALUE : 0.044                        
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 2368                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 75                                      
+REMARK   3   SOLVENT ATOMS            : 260                                     
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : 10.80                          
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : 21.70                          
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : -1.32000                                             
+REMARK   3    B22 (A**2) : -1.32000                                             
+REMARK   3    B33 (A**2) : 2.64000                                              
+REMARK   3    B12 (A**2) : 0.00000                                              
+REMARK   3    B13 (A**2) : 0.00000                                              
+REMARK   3    B23 (A**2) : 0.00000                                              
+REMARK   3                                                                      
+REMARK   3  ESTIMATED COORDINATE ERROR.                                         
+REMARK   3   ESD FROM LUZZATI PLOT        (A) : 0.20                            
+REMARK   3   ESD FROM SIGMAA              (A) : 0.08                            
+REMARK   3   LOW RESOLUTION CUTOFF        (A) : 5.00                            
+REMARK   3                                                                      
+REMARK   3  CROSS-VALIDATED ESTIMATED COORDINATE ERROR.                         
+REMARK   3   ESD FROM C-V LUZZATI PLOT    (A) : 0.23                            
+REMARK   3   ESD FROM C-V SIGMAA          (A) : 0.17                            
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.                                   
+REMARK   3   BOND LENGTHS                 (A) : 0.008                           
+REMARK   3   BOND ANGLES            (DEGREES) : 1.500                           
+REMARK   3   DIHEDRAL ANGLES        (DEGREES) : 26.00                           
+REMARK   3   IMPROPER ANGLES        (DEGREES) : 1.260                           
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL MODEL : RESTRAINED                                
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL FACTOR RESTRAINTS.    RMS    SIGMA                
+REMARK   3   MAIN-CHAIN BOND              (A**2) : 2.270 ; 3.000                
+REMARK   3   MAIN-CHAIN ANGLE             (A**2) : 2.860 ; 4.000                
+REMARK   3   SIDE-CHAIN BOND              (A**2) : 4.220 ; 4.000                
+REMARK   3   SIDE-CHAIN ANGLE             (A**2) : 5.350 ; 6.000                
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELING.                                              
+REMARK   3   METHOD USED : FLAT MODEL                                           
+REMARK   3   KSOL        : 0.36                                                 
+REMARK   3   BSOL        : 47.74                                                
+REMARK   3                                                                      
+REMARK   3  NCS MODEL : NULL                                                    
+REMARK   3                                                                      
+REMARK   3  NCS RESTRAINTS.                         RMS   SIGMA/WEIGHT          
+REMARK   3   GROUP  1  POSITIONAL            (A) : NULL  ; NULL                 
+REMARK   3   GROUP  1  B-FACTOR           (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  PARAMETER FILE  1  : PROTEIN_REP.PARAM                              
+REMARK   3  PARAMETER FILE  2  : PARWAT.PRO                                     
+REMARK   3  PARAMETER FILE  3  : PARAM.CALCIUM                                  
+REMARK   3  PARAMETER FILE  4  : 905.PAR                                        
+REMARK   3  PARAMETER FILE  5  : PARAM.SO4                                      
+REMARK   3  PARAMETER FILE  6  : NULL                                           
+REMARK   3  TOPOLOGY FILE  1   : PROTEIN.TOP                                    
+REMARK   3  TOPOLOGY FILE  2   : TOPWAT.PRO                                     
+REMARK   3  TOPOLOGY FILE  3   : TOP.CALCIUM                                    
+REMARK   3  TOPOLOGY FILE  4   : 905.TOP                                        
+REMARK   3  TOPOLOGY FILE  5   : TOP.SO4                                        
+REMARK   3  TOPOLOGY FILE  6   : NULL                                           
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 1YGC COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY RCSB ON 06-JAN-05.                  
+REMARK 100 THE DEPOSITION ID IS D_1000031482.                                   
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 13-JUN-01                          
+REMARK 200  TEMPERATURE           (KELVIN) : 100                                
+REMARK 200  PH                             : 7.5                                
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : SSRL                               
+REMARK 200  BEAMLINE                       : BL9-2                              
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 1.0                                
+REMARK 200  MONOCHROMATOR                  : NULL                               
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : CCD                                
+REMARK 200  DETECTOR MANUFACTURER          : ADSC QUANTUM 4                     
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : DENZO                              
+REMARK 200  DATA SCALING SOFTWARE          : SCALEPACK                          
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 34943                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 2.000                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 30.000                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : -2.000                             
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 95.0                               
+REMARK 200  DATA REDUNDANCY                : 3.500                              
+REMARK 200  R MERGE                    (I) : 0.06600                            
+REMARK 200  R SYM                      (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 7.3000                             
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : NULL                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : NULL                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : NULL                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : NULL                               
+REMARK 200  R MERGE FOR SHELL          (I) : NULL                               
+REMARK 200  R SYM FOR SHELL            (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : NULL                               
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MOLECULAR REPLACEMENT        
+REMARK 200 SOFTWARE USED: AMORE                                                 
+REMARK 200 STARTING MODEL: NULL                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 67.37                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 3.77                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: AMMONIUM SULFATE, GLYCEROL, PEG 400,     
+REMARK 280  CALCIUM ION, PH 7.5, VAPOR DIFFUSION, HANGING DROP, TEMPERATURE     
+REMARK 280  292K                                                                
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 41 21 2                        
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X,-Y,Z+1/2                                             
+REMARK 290       3555   -Y+1/2,X+1/2,Z+1/4                                      
+REMARK 290       4555   Y+1/2,-X+1/2,Z+3/4                                      
+REMARK 290       5555   -X+1/2,Y+1/2,-Z+1/4                                     
+REMARK 290       6555   X+1/2,-Y+1/2,-Z+3/4                                     
+REMARK 290       7555   Y,X,-Z                                                  
+REMARK 290       8555   -Y,-X,-Z+1/2                                            
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000       58.16000            
+REMARK 290   SMTRY1   3  0.000000 -1.000000  0.000000       47.61000            
+REMARK 290   SMTRY2   3  1.000000  0.000000  0.000000       47.61000            
+REMARK 290   SMTRY3   3  0.000000  0.000000  1.000000       29.08000            
+REMARK 290   SMTRY1   4  0.000000  1.000000  0.000000       47.61000            
+REMARK 290   SMTRY2   4 -1.000000  0.000000  0.000000       47.61000            
+REMARK 290   SMTRY3   4  0.000000  0.000000  1.000000       87.24000            
+REMARK 290   SMTRY1   5 -1.000000  0.000000  0.000000       47.61000            
+REMARK 290   SMTRY2   5  0.000000  1.000000  0.000000       47.61000            
+REMARK 290   SMTRY3   5  0.000000  0.000000 -1.000000       29.08000            
+REMARK 290   SMTRY1   6  1.000000  0.000000  0.000000       47.61000            
+REMARK 290   SMTRY2   6  0.000000 -1.000000  0.000000       47.61000            
+REMARK 290   SMTRY3   6  0.000000  0.000000 -1.000000       87.24000            
+REMARK 290   SMTRY1   7  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   7  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   7  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1   8  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   8 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   8  0.000000  0.000000 -1.000000       58.16000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1, 2                                                    
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: DIMERIC                           
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: DIMERIC                    
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 4340 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 13590 ANGSTROM**2                       
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -119.0 KCAL/MOL                       
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: H, L                                  
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 2                                                       
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: TETRAMERIC                 
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 9680 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 26270 ANGSTROM**2                       
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -252.0 KCAL/MOL                       
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: H, L                                  
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   2  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   2  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   2  0.000000  0.000000 -1.000000      116.32000            
+REMARK 375                                                                      
+REMARK 375 SPECIAL POSITION                                                     
+REMARK 375 THE FOLLOWING ATOMS ARE FOUND TO BE WITHIN 0.15 ANGSTROMS            
+REMARK 375 OF A SYMMETRY RELATED ATOM AND ARE ASSUMED TO BE ON SPECIAL          
+REMARK 375 POSITIONS.                                                           
+REMARK 375                                                                      
+REMARK 375 ATOM RES CSSEQI                                                      
+REMARK 375 CA    CA H 538  LIES ON A SPECIAL POSITION.                          
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465     LYS L   143                                                      
+REMARK 465     ARG L   144                                                      
+REMARK 465     ASN L   145                                                      
+REMARK 465     ALA L   146                                                      
+REMARK 465     SER L   147                                                      
+REMARK 465     LYS L   148                                                      
+REMARK 465     PRO L   149                                                      
+REMARK 465     GLN L   150                                                      
+REMARK 465     GLY L   151                                                      
+REMARK 465     ARG L   152                                                      
+REMARK 475                                                                      
+REMARK 475 ZERO OCCUPANCY RESIDUES                                              
+REMARK 475 THE FOLLOWING RESIDUES WERE MODELED WITH ZERO OCCUPANCY.             
+REMARK 475 THE LOCATION AND PROPERTIES OF THESE RESIDUES MAY NOT                
+REMARK 475 BE RELIABLE. (M=MODEL NUMBER; RES=RESIDUE NAME;                      
+REMARK 475 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE)          
+REMARK 475   M RES C  SSEQI                                                     
+REMARK 475     LYS H   170D                                                     
+REMARK 475     GLY L   107                                                      
+REMARK 480                                                                      
+REMARK 480 ZERO OCCUPANCY ATOM                                                  
+REMARK 480 THE FOLLOWING RESIDUES HAVE ATOMS MODELED WITH ZERO                  
+REMARK 480 OCCUPANCY. THE LOCATION AND PROPERTIES OF THESE ATOMS                
+REMARK 480 MAY NOT BE RELIABLE. (M=MODEL NUMBER; RES=RESIDUE NAME;              
+REMARK 480 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):         
+REMARK 480   M RES C SSEQI ATOMS                                                
+REMARK 480     ARG H   84   NE   CZ   NH1  NH2                                  
+REMARK 480     GLN H  170   CG   CD   OE1  NE2                                  
+REMARK 480     THR L  108   CB   OG1  CG2                                       
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND ANGLES                                       
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,3(1X,A4,2X),12X,F5.1)              
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   ATM2   ATM3                                     
+REMARK 500    LEU H  68   CA  -  CB  -  CG  ANGL. DEV. = -13.9 DEGREES          
+REMARK 500    HIS H 199   N   -  CA  -  C   ANGL. DEV. = -16.4 DEGREES          
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    HIS H  71      -62.21   -142.32                                   
+REMARK 500    THR H 129C     -54.33   -125.58                                   
+REMARK 500    GLN L 100     -105.48   -121.80                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 620                                                                      
+REMARK 620 METAL COORDINATION                                                   
+REMARK 620 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 620 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                             
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              CA H 300  CA                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 GLU H  70   OE1                                                    
+REMARK 620 2 ASP H  72   O    88.7                                              
+REMARK 620 3 GLU H  75   O   161.3  78.8                                        
+REMARK 620 4 GLU H  80   OE2 103.8 166.4  90.2                                  
+REMARK 620 5 HOH H 454   O    81.8  97.7  86.0  89.4                            
+REMARK 620 6 HOH H 541   O    86.6  85.2 106.0  90.2 168.0                      
+REMARK 620 N                    1     2     3     4     5                       
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              CA H 538  CA                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 HOH H 438   O                                                      
+REMARK 620 2 HOH H 438   O   106.3                                              
+REMARK 620 3 HOH H 553   O    94.6 118.3                                        
+REMARK 620 4 HOH H 553   O   118.1  94.7 125.1                                  
+REMARK 620 N                    1     2     3                                   
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE CA H 300                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE CA H 538                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC3                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE SO4 H 301                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC4                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE SO4 L 302                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC5                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE SO4 H 304                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC6                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE SO4 H 308                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC7                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE SO4 H 310                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC8                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE SO4 H 311                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC9                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE SO4 H 312                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: BC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE 905 H 1                   
+REMARK 900                                                                      
+REMARK 900 RELATED ENTRIES                                                      
+REMARK 900 RELATED ID: 1JBU   RELATED DB: PDB                                   
+REMARK 900 SHORT FACTOR VII ZYMOGEN WITH INHIBITORY PEPTIDE A183                
+REMARK 900 RELATED ID: 1KLI   RELATED DB: PDB                                   
+REMARK 900 SHORT FACTOR VIIA WITH BENZAMIDINE                                   
+REMARK 900 RELATED ID: 1KLJ   RELATED DB: PDB                                   
+REMARK 900 SHORT FACTOR VIIA UNINHIBITED                                        
+REMARK 900 RELATED ID: 1DAN   RELATED DB: PDB                                   
+REMARK 900 FACTOR VIIA COMPLEX WITH TISSUE FACTOR                               
+DBREF  1YGC H   16   257  UNP    P08709   FA7_HUMAN      213    466             
+DBREF  1YGC L   90   152  UNP    P08709   FA7_HUMAN      150    212             
+SEQRES   1 H  254  ILE VAL GLY GLY LYS VAL CYS PRO LYS GLY GLU CYS PRO          
+SEQRES   2 H  254  TRP GLN VAL LEU LEU LEU VAL ASN GLY ALA GLN LEU CYS          
+SEQRES   3 H  254  GLY GLY THR LEU ILE ASN THR ILE TRP VAL VAL SER ALA          
+SEQRES   4 H  254  ALA HIS CYS PHE ASP LYS ILE LYS ASN TRP ARG ASN LEU          
+SEQRES   5 H  254  ILE ALA VAL LEU GLY GLU HIS ASP LEU SER GLU HIS ASP          
+SEQRES   6 H  254  GLY ASP GLU GLN SER ARG ARG VAL ALA GLN VAL ILE ILE          
+SEQRES   7 H  254  PRO SER THR TYR VAL PRO GLY THR THR ASN HIS ASP ILE          
+SEQRES   8 H  254  ALA LEU LEU ARG LEU HIS GLN PRO VAL VAL LEU THR ASP          
+SEQRES   9 H  254  HIS VAL VAL PRO LEU CYS LEU PRO GLU ARG THR PHE SER          
+SEQRES  10 H  254  GLU ARG THR LEU ALA PHE VAL ARG PHE SER LEU VAL SER          
+SEQRES  11 H  254  GLY TRP GLY GLN LEU LEU ASP ARG GLY ALA THR ALA LEU          
+SEQRES  12 H  254  GLU LEU MET VAL LEU ASN VAL PRO ARG LEU MET THR GLN          
+SEQRES  13 H  254  ASP CYS LEU GLN GLN SER ARG LYS VAL GLY ASP SER PRO          
+SEQRES  14 H  254  ASN ILE THR GLU TYR MET PHE CYS ALA GLY TYR SER ASP          
+SEQRES  15 H  254  GLY SER LYS ASP SER CYS LYS GLY ASP SER GLY GLY PRO          
+SEQRES  16 H  254  HIS ALA THR HIS TYR ARG GLY THR TRP TYR LEU THR GLY          
+SEQRES  17 H  254  ILE VAL SER TRP GLY GLN GLY CYS ALA THR VAL GLY HIS          
+SEQRES  18 H  254  PHE GLY VAL TYR THR ARG VAL SER GLN TYR ILE GLU TRP          
+SEQRES  19 H  254  LEU GLN LYS LEU MET ARG SER GLU PRO ARG PRO GLY VAL          
+SEQRES  20 H  254  LEU LEU ARG ALA PRO PHE PRO                                  
+SEQRES   1 L   63  ILE CYS VAL ASN GLU ASN GLY GLY CYS GLU GLN TYR CYS          
+SEQRES   2 L   63  SER ASP HIS THR GLY THR LYS ARG SER CYS ARG CYS HIS          
+SEQRES   3 L   63  GLU GLY TYR SER LEU LEU ALA ASP GLY VAL SER CYS THR          
+SEQRES   4 L   63  PRO THR VAL GLU TYR PRO CYS GLY LYS ILE PRO ILE LEU          
+SEQRES   5 L   63  GLU LYS ARG ASN ALA SER LYS PRO GLN GLY ARG                  
+HET     CA  H 300       1                                                       
+HET     CA  H 538       1                                                       
+HET    SO4  H 301       5                                                       
+HET    SO4  H 304       5                                                       
+HET    SO4  H 308       5                                                       
+HET    SO4  H 310       5                                                       
+HET    SO4  H 311       5                                                       
+HET    SO4  H 312       5                                                       
+HET    905  H   1      38                                                       
+HET    SO4  L 302       5                                                       
+HETNAM      CA CALCIUM ION                                                      
+HETNAM     SO4 SULFATE ION                                                      
+HETNAM     905 (R)-4-[2-(3-AMINO-BENZENESULFONYLAMINO)-1-(3,5-                  
+HETNAM   2 905  DIETHOXY-2-FLUOROPHENYL)-2-OXO-ETHYLAMINO]-2-HYDROXY-           
+HETNAM   3 905  BENZAMIDINE                                                     
+FORMUL   3   CA    2(CA 2+)                                                     
+FORMUL   5  SO4    7(O4 S 2-)                                                   
+FORMUL  11  905    C25 H28 F N5 O6 S                                            
+FORMUL  13  HOH   *260(H2 O)                                                    
+HELIX    1   1 ALA H   55  ASP H   60  5                                   6    
+HELIX    2   2 ASN H   60D ARG H   62  5                                   3    
+HELIX    3   3 GLU H  125  THR H  129C 1                                   8    
+HELIX    4   4 LEU H  129D VAL H  129G 5                                   4    
+HELIX    5   5 MET H  164  SER H  170B 1                                   9    
+HELIX    6   6 CYS H  191  SER H  195  5                                   5    
+HELIX    7   7 TYR H  234  ARG H  243  1                                  10    
+HELIX    8   8 ASN L   93  CYS L   98  5                                   6    
+SHEET    1   A 8 LYS H  20  VAL H  21  0                                        
+SHEET    2   A 8 MET H 156  LEU H 163 -1  O  VAL H 157   N  LYS H  20           
+SHEET    3   A 8 MET H 180  ALA H 183 -1  O  CYS H 182   N  LEU H 163           
+SHEET    4   A 8 GLY H 226  ARG H 230 -1  O  TYR H 228   N  PHE H 181           
+SHEET    5   A 8 THR H 206  TRP H 215 -1  N  TRP H 215   O  VAL H 227           
+SHEET    6   A 8 PRO H 198  TYR H 203 -1  N  THR H 201   O  TYR H 208           
+SHEET    7   A 8 PHE H 135  GLY H 140 -1  N  LEU H 137   O  ALA H 200           
+SHEET    8   A 8 MET H 156  LEU H 163 -1  O  VAL H 160   N  SER H 136           
+SHEET    1   B 8 LEU H 251  ALA H 254  0                                        
+SHEET    2   B 8 GLN H  81  PRO H  91  1  N  VAL H  88   O  LEU H 252           
+SHEET    3   B 8 ALA H 104  LEU H 108 -1  O  LEU H 105   N  ILE H  89           
+SHEET    4   B 8 TRP H  51  SER H  54 -1  N  VAL H  52   O  LEU H 106           
+SHEET    5   B 8 ALA H  39  LEU H  46 -1  N  THR H  45   O  VAL H  53           
+SHEET    6   B 8 GLN H  30  VAL H  35 -1  N  LEU H  33   O  CYS H  42           
+SHEET    7   B 8 LEU H  64  LEU H  68 -1  O  ILE H  65   N  LEU H  34           
+SHEET    8   B 8 GLN H  81  PRO H  91 -1  O  GLN H  81   N  LEU H  68           
+SHEET    1   C 2 TYR L 101  ASP L 104  0                                        
+SHEET    2   C 2 ARG L 110  ARG L 113 -1  O  SER L 111   N  SER L 103           
+SHEET    1   D 2 TYR L 118  LEU L 120  0                                        
+SHEET    2   D 2 CYS L 127  PRO L 129 -1  O  THR L 128   N  SER L 119           
+SSBOND   1 CYS H   22    CYS H   27                          1555   1555  2.04  
+SSBOND   2 CYS H   42    CYS H   58                          1555   1555  2.04  
+SSBOND   3 CYS H  122    CYS L  135                          1555   1555  2.02  
+SSBOND   4 CYS H  168    CYS H  182                          1555   1555  2.04  
+SSBOND   5 CYS H  191    CYS H  220                          1555   1555  2.03  
+SSBOND   6 CYS L   91    CYS L  102                          1555   1555  2.04  
+SSBOND   7 CYS L   98    CYS L  112                          1555   1555  2.03  
+SSBOND   8 CYS L  114    CYS L  127                          1555   1555  2.03  
+LINK         OE1 GLU H  70                CA    CA H 300     1555   1555  2.43  
+LINK         O   ASP H  72                CA    CA H 300     1555   1555  2.45  
+LINK         O   GLU H  75                CA    CA H 300     1555   1555  2.32  
+LINK         OE2 GLU H  80                CA    CA H 300     1555   1555  2.45  
+LINK        CA    CA H 300                 O   HOH H 454     1555   1555  2.45  
+LINK        CA    CA H 300                 O   HOH H 541     1555   1555  2.51  
+LINK         O   HOH H 438                CA    CA H 538     1555   1555  2.87  
+LINK         O   HOH H 438                CA    CA H 538     7556   1555  2.87  
+LINK        CA    CA H 538                 O   HOH H 553     1555   1555  2.74  
+LINK        CA    CA H 538                 O   HOH H 553     1555   7556  2.74  
+CISPEP   1 PHE H  256    PRO H  257          0         0.18                     
+SITE     1 AC1  6 GLU H  70  ASP H  72  GLU H  75  GLU H  80                    
+SITE     2 AC1  6 HOH H 454  HOH H 541                                          
+SITE     1 AC2  2 HOH H 438  HOH H 553                                          
+SITE     1 AC3  7 MET H 164  THR H 165  ARG H 230  HOH H 537                    
+SITE     2 AC3  7 HOH H 612  HOH H 720  HOH H 789                               
+SITE     1 AC4  4 ARG H 129B SER L 103  ASP L 104  HOH L 447                    
+SITE     1 AC5  4 SER H 244  GLU H 245  HOH H 562  HOH L 516                    
+SITE     1 AC6  5 SER H  82  ARG H  83  ARG H  84  HIS H 109                    
+SITE     2 AC6  5 GLN H 110                                                     
+SITE     1 AC7  4 THR H  98  THR H  99  PRO H 170I HOH H 605                    
+SITE     1 AC8  6 SER H 170B GLN H 217  HIS H 224  PHE H 225                    
+SITE     2 AC8  6 VAL H 227  HOH H 634                                          
+SITE     1 AC9  5 THR H 115  ASP H 116  HIS H 117  HOH H 621                    
+SITE     2 AC9  5 TYR L 133                                                     
+SITE     1 BC1 19 HIS H  57  ASP H  60  THR H  98  ASP H 102                    
+SITE     2 BC1 19 ASP H 189  SER H 190  LYS H 192  SER H 195                    
+SITE     3 BC1 19 SER H 214  TRP H 215  GLY H 216  GLY H 219                    
+SITE     4 BC1 19 CYS H 220  GLY H 226  HOH H 449  HOH H 463                    
+SITE     5 BC1 19 HOH H 536  HOH H 867  HOH H1013                               
+CRYST1   95.220   95.220  116.320  90.00  90.00  90.00 P 41 21 2     8          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.010502  0.000000  0.000000        0.00000                         
+SCALE2      0.000000  0.010502  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.008597        0.00000                         
+ATOM      1  N   ILE H  16      12.190  28.931  29.880  1.00 13.01           N  
+ATOM      2  CA  ILE H  16      13.341  28.768  28.929  1.00 10.73           C  
+ATOM      3  C   ILE H  16      12.770  28.350  27.570  1.00 14.33           C  
+ATOM      4  O   ILE H  16      12.018  27.383  27.488  1.00 12.16           O  
+ATOM      5  CB  ILE H  16      14.317  27.663  29.422  1.00 11.26           C  
+ATOM      6  CG1 ILE H  16      14.916  28.036  30.788  1.00 12.55           C  
+ATOM      7  CG2 ILE H  16      15.440  27.428  28.406  1.00 10.05           C  
+ATOM      8  CD1 ILE H  16      15.809  29.289  30.750  1.00 13.60           C  
+ATOM      9  N   VAL H  17      13.085  29.113  26.526  1.00 14.43           N  
+ATOM     10  CA  VAL H  17      12.619  28.801  25.172  1.00 13.67           C  
+ATOM     11  C   VAL H  17      13.744  28.140  24.360  1.00 15.77           C  
+ATOM     12  O   VAL H  17      14.870  28.632  24.328  1.00 19.12           O  
+ATOM     13  CB  VAL H  17      12.165  30.076  24.405  1.00 13.69           C  
+ATOM     14  CG1 VAL H  17      11.562  29.697  23.041  1.00 16.99           C  
+ATOM     15  CG2 VAL H  17      11.157  30.879  25.223  1.00 17.59           C  
+ATOM     16  N   GLY H  18      13.445  27.001  23.744  1.00 15.74           N  
+ATOM     17  CA  GLY H  18      14.432  26.330  22.908  1.00 18.06           C  
+ATOM     18  C   GLY H  18      15.570  25.586  23.581  1.00 20.86           C  
+ATOM     19  O   GLY H  18      16.586  25.307  22.944  1.00 17.46           O  
+ATOM     20  N   GLY H  19      15.426  25.280  24.864  1.00 19.48           N  
+ATOM     21  CA  GLY H  19      16.470  24.553  25.561  1.00 19.26           C  
+ATOM     22  C   GLY H  19      16.059  23.105  25.733  1.00 20.96           C  
+ATOM     23  O   GLY H  19      15.365  22.539  24.889  1.00 17.25           O  
+ATOM     24  N   LYS H  20      16.457  22.505  26.846  1.00 16.74           N  
+ATOM     25  CA  LYS H  20      16.109  21.118  27.111  1.00 15.53           C  
+ATOM     26  C   LYS H  20      15.985  20.909  28.610  1.00 14.95           C  
+ATOM     27  O   LYS H  20      16.356  21.780  29.391  1.00 15.63           O  
+ATOM     28  CB  LYS H  20      17.183  20.180  26.539  1.00 23.57           C  
+ATOM     29  CG  LYS H  20      18.546  20.303  27.203  1.00 31.11           C  
+ATOM     30  CD  LYS H  20      19.614  19.451  26.509  1.00 41.61           C  
+ATOM     31  CE  LYS H  20      20.045  20.030  25.159  1.00 46.34           C  
+ATOM     32  NZ  LYS H  20      18.983  19.976  24.107  1.00 52.13           N  
+ATOM     33  N   VAL H  21      15.452  19.763  29.011  1.00 13.67           N  
+ATOM     34  CA  VAL H  21      15.315  19.452  30.432  1.00 18.53           C  
+ATOM     35  C   VAL H  21      16.714  19.301  31.052  1.00 19.58           C  
+ATOM     36  O   VAL H  21      17.593  18.666  30.458  1.00 18.73           O  
+ATOM     37  CB  VAL H  21      14.529  18.125  30.634  1.00 19.97           C  
+ATOM     38  CG1 VAL H  21      14.564  17.682  32.108  1.00 21.41           C  
+ATOM     39  CG2 VAL H  21      13.084  18.290  30.168  1.00 19.72           C  
+ATOM     40  N   CYS H  22      16.960  19.984  32.169  1.00 16.36           N  
+ATOM     41  CA  CYS H  22      18.243  19.852  32.864  1.00 14.92           C  
+ATOM     42  C   CYS H  22      18.104  18.513  33.584  1.00 12.52           C  
+ATOM     43  O   CYS H  22      17.222  18.362  34.437  1.00 14.78           O  
+ATOM     44  CB  CYS H  22      18.444  20.967  33.909  1.00 12.50           C  
+ATOM     45  SG  CYS H  22      20.087  20.831  34.701  1.00 15.14           S  
+ATOM     46  N   PRO H  23      18.937  17.509  33.235  1.00 16.88           N  
+ATOM     47  CA  PRO H  23      18.821  16.206  33.906  1.00 17.28           C  
+ATOM     48  C   PRO H  23      18.826  16.393  35.421  1.00 20.46           C  
+ATOM     49  O   PRO H  23      19.645  17.151  35.948  1.00 15.70           O  
+ATOM     50  CB  PRO H  23      20.069  15.460  33.424  1.00 20.25           C  
+ATOM     51  CG  PRO H  23      20.302  16.043  32.055  1.00 20.03           C  
+ATOM     52  CD  PRO H  23      20.095  17.524  32.321  1.00 15.45           C  
+ATOM     53  N   LYS H  24      17.883  15.750  36.104  1.00 15.58           N  
+ATOM     54  CA  LYS H  24      17.763  15.876  37.557  1.00 16.54           C  
+ATOM     55  C   LYS H  24      19.109  15.829  38.286  1.00 18.15           C  
+ATOM     56  O   LYS H  24      19.861  14.851  38.178  1.00 18.44           O  
+ATOM     57  CB  LYS H  24      16.845  14.788  38.103  1.00 19.66           C  
+ATOM     58  CG  LYS H  24      16.551  14.910  39.604  1.00 17.85           C  
+ATOM     59  CD  LYS H  24      16.367  13.534  40.195  1.00 27.31           C  
+ATOM     60  CE  LYS H  24      15.515  13.521  41.435  1.00 22.42           C  
+ATOM     61  NZ  LYS H  24      15.799  14.508  42.513  1.00 17.60           N  
+ATOM     62  N   GLY H  25      19.414  16.897  39.017  1.00 17.18           N  
+ATOM     63  CA  GLY H  25      20.665  16.950  39.758  1.00 16.14           C  
+ATOM     64  C   GLY H  25      21.801  17.652  39.034  1.00 16.55           C  
+ATOM     65  O   GLY H  25      22.841  17.918  39.634  1.00 14.18           O  
+ATOM     66  N   GLU H  26      21.624  17.952  37.750  1.00 11.79           N  
+ATOM     67  CA  GLU H  26      22.676  18.632  36.997  1.00 13.80           C  
+ATOM     68  C   GLU H  26      22.643  20.156  37.077  1.00 15.14           C  
+ATOM     69  O   GLU H  26      23.535  20.816  36.563  1.00 13.62           O  
+ATOM     70  CB  GLU H  26      22.715  18.157  35.542  1.00 16.15           C  
+ATOM     71  CG  GLU H  26      23.190  16.719  35.410  1.00 15.00           C  
+ATOM     72  CD  GLU H  26      23.450  16.305  33.969  1.00 19.49           C  
+ATOM     73  OE1 GLU H  26      23.661  17.176  33.108  1.00 18.36           O  
+ATOM     74  OE2 GLU H  26      23.437  15.096  33.709  1.00 23.23           O  
+ATOM     75  N   CYS H  27      21.622  20.711  37.732  1.00 12.11           N  
+ATOM     76  CA  CYS H  27      21.509  22.164  37.929  1.00 13.67           C  
+ATOM     77  C   CYS H  27      21.208  22.286  39.427  1.00  9.70           C  
+ATOM     78  O   CYS H  27      20.268  22.967  39.820  1.00 13.29           O  
+ATOM     79  CB  CYS H  27      20.321  22.710  37.113  1.00 16.69           C  
+ATOM     80  SG  CYS H  27      20.553  22.725  35.307  1.00 18.04           S  
+ATOM     81  N   PRO H  28      22.069  21.706  40.285  1.00 11.99           N  
+ATOM     82  CA  PRO H  28      21.886  21.712  41.738  1.00 11.91           C  
+ATOM     83  C   PRO H  28      21.799  23.038  42.494  1.00 12.00           C  
+ATOM     84  O   PRO H  28      21.315  23.064  43.618  1.00  8.54           O  
+ATOM     85  CB  PRO H  28      23.034  20.824  42.217  1.00 12.72           C  
+ATOM     86  CG  PRO H  28      24.145  21.237  41.300  1.00 10.96           C  
+ATOM     87  CD  PRO H  28      23.444  21.281  39.943  1.00 12.77           C  
+ATOM     88  N   TRP H  29      22.265  24.122  41.883  1.00 10.49           N  
+ATOM     89  CA  TRP H  29      22.213  25.440  42.516  1.00 13.38           C  
+ATOM     90  C   TRP H  29      20.927  26.202  42.196  1.00 12.08           C  
+ATOM     91  O   TRP H  29      20.692  27.276  42.737  1.00 10.36           O  
+ATOM     92  CB  TRP H  29      23.419  26.281  42.101  1.00 10.32           C  
+ATOM     93  CG  TRP H  29      23.902  25.978  40.719  1.00 15.45           C  
+ATOM     94  CD1 TRP H  29      23.352  26.389  39.543  1.00 13.44           C  
+ATOM     95  CD2 TRP H  29      25.027  25.157  40.378  1.00 14.67           C  
+ATOM     96  NE1 TRP H  29      24.065  25.873  38.484  1.00 15.92           N  
+ATOM     97  CE2 TRP H  29      25.097  25.112  38.969  1.00 15.06           C  
+ATOM     98  CE3 TRP H  29      25.981  24.452  41.133  1.00 17.72           C  
+ATOM     99  CZ2 TRP H  29      26.086  24.385  38.286  1.00 16.59           C  
+ATOM    100  CZ3 TRP H  29      26.971  23.725  40.457  1.00 19.92           C  
+ATOM    101  CH2 TRP H  29      27.012  23.701  39.047  1.00 15.09           C  
+ATOM    102  N   GLN H  30      20.105  25.646  41.309  1.00  8.96           N  
+ATOM    103  CA  GLN H  30      18.842  26.297  40.933  1.00 11.13           C  
+ATOM    104  C   GLN H  30      17.869  26.392  42.104  1.00  8.95           C  
+ATOM    105  O   GLN H  30      17.681  25.434  42.857  1.00 11.79           O  
+ATOM    106  CB  GLN H  30      18.156  25.542  39.783  1.00 12.86           C  
+ATOM    107  CG  GLN H  30      16.783  26.117  39.381  1.00 11.98           C  
+ATOM    108  CD  GLN H  30      16.877  27.418  38.580  1.00 10.84           C  
+ATOM    109  OE1 GLN H  30      17.627  27.508  37.607  1.00 12.61           O  
+ATOM    110  NE2 GLN H  30      16.090  28.417  38.969  1.00  9.39           N  
+ATOM    111  N   VAL H  31      17.265  27.563  42.253  1.00 11.79           N  
+ATOM    112  CA  VAL H  31      16.295  27.799  43.311  1.00  9.62           C  
+ATOM    113  C   VAL H  31      14.953  28.164  42.674  1.00  9.69           C  
+ATOM    114  O   VAL H  31      14.911  28.804  41.624  1.00  9.98           O  
+ATOM    115  CB  VAL H  31      16.727  28.984  44.229  1.00 11.02           C  
+ATOM    116  CG1 VAL H  31      15.694  29.206  45.332  1.00 11.93           C  
+ATOM    117  CG2 VAL H  31      18.140  28.726  44.853  1.00  8.19           C  
+ATOM    118  N   LEU H  32      13.868  27.713  43.303  1.00 11.10           N  
+ATOM    119  CA  LEU H  32      12.517  28.043  42.867  1.00 10.96           C  
+ATOM    120  C   LEU H  32      11.932  28.903  43.997  1.00 10.78           C  
+ATOM    121  O   LEU H  32      11.944  28.499  45.160  1.00 11.42           O  
+ATOM    122  CB  LEU H  32      11.654  26.774  42.698  1.00 12.66           C  
+ATOM    123  CG  LEU H  32      10.159  27.022  42.441  1.00 15.77           C  
+ATOM    124  CD1 LEU H  32       9.957  27.854  41.184  1.00 14.41           C  
+ATOM    125  CD2 LEU H  32       9.395  25.693  42.325  1.00 15.61           C  
+ATOM    126  N   LEU H  33      11.481  30.107  43.661  1.00  9.50           N  
+ATOM    127  CA  LEU H  33      10.884  30.992  44.659  1.00 10.99           C  
+ATOM    128  C   LEU H  33       9.378  30.913  44.461  1.00 13.44           C  
+ATOM    129  O   LEU H  33       8.893  30.978  43.331  1.00 11.79           O  
+ATOM    130  CB  LEU H  33      11.367  32.442  44.479  1.00 10.90           C  
+ATOM    131  CG  LEU H  33      12.865  32.715  44.712  1.00 13.46           C  
+ATOM    132  CD1 LEU H  33      13.186  34.173  44.403  1.00 10.18           C  
+ATOM    133  CD2 LEU H  33      13.247  32.393  46.161  1.00  9.48           C  
+ATOM    134  N   LEU H  34       8.658  30.781  45.570  1.00 12.05           N  
+ATOM    135  CA  LEU H  34       7.203  30.655  45.573  1.00 16.35           C  
+ATOM    136  C   LEU H  34       6.578  31.693  46.493  1.00 17.69           C  
+ATOM    137  O   LEU H  34       7.147  32.029  47.528  1.00 17.98           O  
+ATOM    138  CB  LEU H  34       6.810  29.273  46.124  1.00 13.64           C  
+ATOM    139  CG  LEU H  34       7.350  28.005  45.453  1.00 13.41           C  
+ATOM    140  CD1 LEU H  34       6.985  26.775  46.294  1.00 17.17           C  
+ATOM    141  CD2 LEU H  34       6.781  27.878  44.061  1.00 10.07           C  
+ATOM    142  N   VAL H  35       5.403  32.190  46.112  1.00 18.49           N  
+ATOM    143  CA  VAL H  35       4.654  33.136  46.941  1.00 15.57           C  
+ATOM    144  C   VAL H  35       3.261  32.521  47.046  1.00 17.57           C  
+ATOM    145  O   VAL H  35       2.595  32.326  46.029  1.00 15.83           O  
+ATOM    146  CB  VAL H  35       4.586  34.546  46.318  1.00 20.14           C  
+ATOM    147  CG1 VAL H  35       3.689  35.456  47.167  1.00 26.09           C  
+ATOM    148  CG2 VAL H  35       5.976  35.145  46.246  1.00 23.82           C  
+ATOM    149  N   ASN H  37       2.851  32.153  48.261  1.00 18.41           N  
+ATOM    150  CA  ASN H  37       1.554  31.506  48.462  1.00 21.62           C  
+ATOM    151  C   ASN H  37       1.454  30.226  47.620  1.00 19.20           C  
+ATOM    152  O   ASN H  37       0.406  29.927  47.044  1.00 17.30           O  
+ATOM    153  CB  ASN H  37       0.399  32.457  48.110  1.00 24.88           C  
+ATOM    154  CG  ASN H  37       0.251  33.587  49.110  1.00 30.90           C  
+ATOM    155  OD1 ASN H  37       0.061  34.746  48.734  1.00 37.07           O  
+ATOM    156  ND2 ASN H  37       0.341  33.256  50.393  1.00 31.65           N  
+ATOM    157  N   GLY H  38       2.569  29.504  47.512  1.00 16.60           N  
+ATOM    158  CA  GLY H  38       2.591  28.267  46.744  1.00 14.32           C  
+ATOM    159  C   GLY H  38       2.705  28.402  45.232  1.00 14.81           C  
+ATOM    160  O   GLY H  38       2.893  27.400  44.539  1.00 15.12           O  
+ATOM    161  N   ALA H  39       2.571  29.622  44.713  1.00 12.94           N  
+ATOM    162  CA  ALA H  39       2.672  29.868  43.272  1.00 12.43           C  
+ATOM    163  C   ALA H  39       4.090  30.261  42.867  1.00 13.36           C  
+ATOM    164  O   ALA H  39       4.762  30.998  43.576  1.00 15.32           O  
+ATOM    165  CB  ALA H  39       1.706  30.972  42.852  1.00 14.32           C  
+ATOM    166  N   GLN H  40       4.496  29.807  41.689  1.00 14.39           N  
+ATOM    167  CA  GLN H  40       5.810  30.089  41.136  1.00 15.38           C  
+ATOM    168  C   GLN H  40       5.980  31.596  40.952  1.00 14.80           C  
+ATOM    169  O   GLN H  40       5.142  32.251  40.338  1.00 10.62           O  
+ATOM    170  CB  GLN H  40       5.908  29.373  39.794  1.00 18.88           C  
+ATOM    171  CG  GLN H  40       7.212  29.476  39.058  1.00 29.43           C  
+ATOM    172  CD  GLN H  40       7.144  28.745  37.713  1.00 27.98           C  
+ATOM    173  OE1 GLN H  40       6.329  27.835  37.525  1.00 32.31           O  
+ATOM    174  NE2 GLN H  40       7.992  29.141  36.784  1.00 28.52           N  
+ATOM    175  N   LEU H  41       7.054  32.147  41.511  1.00 12.45           N  
+ATOM    176  CA  LEU H  41       7.318  33.579  41.400  1.00 11.42           C  
+ATOM    177  C   LEU H  41       8.514  33.893  40.507  1.00 14.65           C  
+ATOM    178  O   LEU H  41       8.437  34.732  39.595  1.00 11.29           O  
+ATOM    179  CB  LEU H  41       7.598  34.176  42.784  1.00 12.73           C  
+ATOM    180  CG  LEU H  41       8.123  35.626  42.784  1.00 14.70           C  
+ATOM    181  CD1 LEU H  41       6.967  36.603  42.602  1.00 15.56           C  
+ATOM    182  CD2 LEU H  41       8.871  35.927  44.096  1.00 16.94           C  
+ATOM    183  N   CYS H  42       9.621  33.210  40.785  1.00 10.32           N  
+ATOM    184  CA  CYS H  42      10.877  33.450  40.089  1.00  8.65           C  
+ATOM    185  C   CYS H  42      11.889  32.356  40.382  1.00  9.99           C  
+ATOM    186  O   CYS H  42      11.642  31.452  41.181  1.00  9.85           O  
+ATOM    187  CB  CYS H  42      11.482  34.756  40.631  1.00 11.33           C  
+ATOM    188  SG  CYS H  42      10.984  36.321  39.835  1.00 15.50           S  
+ATOM    189  N   GLY H  43      13.053  32.488  39.757  1.00 12.66           N  
+ATOM    190  CA  GLY H  43      14.139  31.563  39.988  1.00  9.32           C  
+ATOM    191  C   GLY H  43      15.140  32.254  40.909  1.00 13.37           C  
+ATOM    192  O   GLY H  43      14.947  33.420  41.312  1.00 10.37           O  
+ATOM    193  N   GLY H  44      16.206  31.532  41.236  1.00  9.44           N  
+ATOM    194  CA  GLY H  44      17.253  32.058  42.093  1.00 10.89           C  
+ATOM    195  C   GLY H  44      18.479  31.163  42.011  1.00 12.35           C  
+ATOM    196  O   GLY H  44      18.424  30.090  41.395  1.00  9.37           O  
+ATOM    197  N   THR H  45      19.567  31.580  42.659  1.00 10.68           N  
+ATOM    198  CA  THR H  45      20.810  30.816  42.660  1.00  9.94           C  
+ATOM    199  C   THR H  45      21.355  30.678  44.068  1.00 10.25           C  
+ATOM    200  O   THR H  45      21.595  31.673  44.750  1.00 12.14           O  
+ATOM    201  CB  THR H  45      21.909  31.508  41.814  1.00 13.03           C  
+ATOM    202  OG1 THR H  45      21.442  31.673  40.473  1.00 14.06           O  
+ATOM    203  CG2 THR H  45      23.198  30.672  41.801  1.00 10.49           C  
+ATOM    204  N   LEU H  46      21.565  29.446  44.505  1.00  8.10           N  
+ATOM    205  CA  LEU H  46      22.129  29.214  45.833  1.00  8.71           C  
+ATOM    206  C   LEU H  46      23.641  29.472  45.725  1.00  8.68           C  
+ATOM    207  O   LEU H  46      24.281  28.948  44.805  1.00  9.27           O  
+ATOM    208  CB  LEU H  46      21.901  27.759  46.241  1.00  9.47           C  
+ATOM    209  CG  LEU H  46      22.383  27.388  47.645  1.00 10.40           C  
+ATOM    210  CD1 LEU H  46      21.397  27.965  48.693  1.00 10.07           C  
+ATOM    211  CD2 LEU H  46      22.474  25.853  47.764  1.00 11.18           C  
+ATOM    212  N   ILE H  47      24.192  30.338  46.577  1.00  9.79           N  
+ATOM    213  CA  ILE H  47      25.634  30.592  46.541  1.00 10.01           C  
+ATOM    214  C   ILE H  47      26.393  30.050  47.753  1.00 11.36           C  
+ATOM    215  O   ILE H  47      27.620  30.049  47.781  1.00 12.30           O  
+ATOM    216  CB  ILE H  47      26.007  32.052  46.232  1.00 10.28           C  
+ATOM    217  CG1 ILE H  47      25.387  33.020  47.234  1.00  9.47           C  
+ATOM    218  CG2 ILE H  47      25.605  32.381  44.801  1.00 10.19           C  
+ATOM    219  CD1 ILE H  47      25.980  34.449  47.116  1.00 12.46           C  
+ATOM    220  N   ASN H  48      25.646  29.667  48.779  1.00 10.21           N  
+ATOM    221  CA  ASN H  48      26.190  28.989  49.962  1.00 13.43           C  
+ATOM    222  C   ASN H  48      24.989  28.401  50.680  1.00 15.79           C  
+ATOM    223  O   ASN H  48      23.878  28.497  50.151  1.00 17.72           O  
+ATOM    224  CB  ASN H  48      27.082  29.862  50.852  1.00 21.42           C  
+ATOM    225  CG  ASN H  48      26.408  31.105  51.308  1.00 18.81           C  
+ATOM    226  OD1 ASN H  48      25.332  31.057  51.898  1.00 22.81           O  
+ATOM    227  ND2 ASN H  48      27.041  32.244  51.052  1.00 24.78           N  
+ATOM    228  N   THR H  49      25.166  27.822  51.866  1.00  9.06           N  
+ATOM    229  CA  THR H  49      24.032  27.187  52.528  1.00 13.19           C  
+ATOM    230  C   THR H  49      22.883  28.063  52.993  1.00 14.17           C  
+ATOM    231  O   THR H  49      21.789  27.561  53.204  1.00 14.59           O  
+ATOM    232  CB  THR H  49      24.462  26.231  53.670  1.00 11.27           C  
+ATOM    233  OG1 THR H  49      25.008  26.978  54.764  1.00 11.71           O  
+ATOM    234  CG2 THR H  49      25.498  25.228  53.160  1.00 11.10           C  
+ATOM    235  N   ILE H  50      23.083  29.368  53.103  1.00 14.37           N  
+ATOM    236  CA  ILE H  50      21.974  30.192  53.556  1.00 14.00           C  
+ATOM    237  C   ILE H  50      21.696  31.415  52.685  1.00 12.43           C  
+ATOM    238  O   ILE H  50      20.751  32.156  52.930  1.00 15.31           O  
+ATOM    239  CB  ILE H  50      22.166  30.570  55.063  1.00 20.63           C  
+ATOM    240  CG1 ILE H  50      20.809  30.794  55.743  1.00 26.71           C  
+ATOM    241  CG2 ILE H  50      23.088  31.770  55.210  1.00 19.18           C  
+ATOM    242  CD1 ILE H  50      20.892  30.966  57.280  1.00 33.48           C  
+ATOM    243  N   TRP H  51      22.490  31.592  51.636  1.00 11.52           N  
+ATOM    244  CA  TRP H  51      22.326  32.740  50.757  1.00 13.01           C  
+ATOM    245  C   TRP H  51      21.932  32.371  49.327  1.00 12.14           C  
+ATOM    246  O   TRP H  51      22.505  31.459  48.721  1.00 10.55           O  
+ATOM    247  CB  TRP H  51      23.608  33.579  50.748  1.00 11.84           C  
+ATOM    248  CG  TRP H  51      23.931  34.208  52.077  1.00 12.15           C  
+ATOM    249  CD1 TRP H  51      24.879  33.799  52.987  1.00 14.54           C  
+ATOM    250  CD2 TRP H  51      23.327  35.383  52.625  1.00 11.93           C  
+ATOM    251  NE1 TRP H  51      24.903  34.666  54.063  1.00 11.86           N  
+ATOM    252  CE2 TRP H  51      23.962  35.646  53.865  1.00 17.57           C  
+ATOM    253  CE3 TRP H  51      22.311  36.248  52.186  1.00 11.82           C  
+ATOM    254  CZ2 TRP H  51      23.614  36.742  54.668  1.00 17.03           C  
+ATOM    255  CZ3 TRP H  51      21.966  37.341  52.986  1.00 13.44           C  
+ATOM    256  CH2 TRP H  51      22.620  37.575  54.213  1.00 13.55           C  
+ATOM    257  N   VAL H  52      20.971  33.126  48.797  1.00 15.39           N  
+ATOM    258  CA  VAL H  52      20.447  32.943  47.445  1.00 12.61           C  
+ATOM    259  C   VAL H  52      20.475  34.281  46.700  1.00 11.15           C  
+ATOM    260  O   VAL H  52      20.137  35.313  47.261  1.00 11.45           O  
+ATOM    261  CB  VAL H  52      18.971  32.455  47.491  1.00  7.90           C  
+ATOM    262  CG1 VAL H  52      18.330  32.526  46.085  1.00 12.73           C  
+ATOM    263  CG2 VAL H  52      18.893  31.011  48.040  1.00  7.71           C  
+ATOM    264  N   VAL H  53      20.893  34.265  45.438  1.00  9.91           N  
+ATOM    265  CA  VAL H  53      20.904  35.484  44.645  1.00  7.29           C  
+ATOM    266  C   VAL H  53      19.737  35.373  43.662  1.00  9.71           C  
+ATOM    267  O   VAL H  53      19.541  34.328  43.026  1.00 12.65           O  
+ATOM    268  CB  VAL H  53      22.228  35.644  43.828  1.00  9.73           C  
+ATOM    269  CG1 VAL H  53      22.117  36.831  42.885  1.00  7.29           C  
+ATOM    270  CG2 VAL H  53      23.432  35.833  44.769  1.00  8.63           C  
+ATOM    271  N   SER H  54      18.966  36.446  43.548  1.00 12.08           N  
+ATOM    272  CA  SER H  54      17.842  36.472  42.621  1.00  9.53           C  
+ATOM    273  C   SER H  54      17.800  37.864  41.991  1.00 12.37           C  
+ATOM    274  O   SER H  54      18.785  38.609  42.061  1.00 10.44           O  
+ATOM    275  CB  SER H  54      16.542  36.162  43.364  1.00 10.91           C  
+ATOM    276  OG  SER H  54      15.487  35.955  42.433  1.00 11.78           O  
+ATOM    277  N   ALA H  55      16.665  38.217  41.391  1.00  8.48           N  
+ATOM    278  CA  ALA H  55      16.512  39.519  40.753  1.00  7.32           C  
+ATOM    279  C   ALA H  55      15.626  40.396  41.611  1.00  8.97           C  
+ATOM    280  O   ALA H  55      14.604  39.938  42.122  1.00 10.35           O  
+ATOM    281  CB  ALA H  55      15.883  39.351  39.368  1.00  9.25           C  
+ATOM    282  N   ALA H  56      15.999  41.665  41.750  1.00 10.09           N  
+ATOM    283  CA  ALA H  56      15.202  42.605  42.547  1.00 12.73           C  
+ATOM    284  C   ALA H  56      13.756  42.748  42.054  1.00 14.43           C  
+ATOM    285  O   ALA H  56      12.826  42.819  42.862  1.00 13.68           O  
+ATOM    286  CB  ALA H  56      15.881  43.990  42.565  1.00 11.42           C  
+ATOM    287  N   HIS H  57      13.550  42.747  40.736  1.00 14.44           N  
+ATOM    288  CA  HIS H  57      12.194  42.942  40.212  1.00 13.07           C  
+ATOM    289  C   HIS H  57      11.207  41.852  40.611  1.00 13.33           C  
+ATOM    290  O   HIS H  57       9.995  42.058  40.544  1.00 12.54           O  
+ATOM    291  CB  HIS H  57      12.191  43.172  38.690  1.00 12.68           C  
+ATOM    292  CG  HIS H  57      12.249  41.916  37.876  1.00 12.59           C  
+ATOM    293  ND1 HIS H  57      13.417  41.448  37.317  1.00 12.85           N  
+ATOM    294  CD2 HIS H  57      11.273  41.064  37.474  1.00 13.52           C  
+ATOM    295  CE1 HIS H  57      13.164  40.367  36.601  1.00 12.96           C  
+ATOM    296  NE2 HIS H  57      11.869  40.111  36.682  1.00 14.89           N  
+ATOM    297  N   CYS H  58      11.733  40.711  41.052  1.00 11.59           N  
+ATOM    298  CA  CYS H  58      10.903  39.597  41.498  1.00 12.86           C  
+ATOM    299  C   CYS H  58      10.093  39.978  42.739  1.00 13.84           C  
+ATOM    300  O   CYS H  58       9.075  39.358  43.037  1.00 11.55           O  
+ATOM    301  CB  CYS H  58      11.779  38.384  41.848  1.00 14.44           C  
+ATOM    302  SG  CYS H  58      12.514  37.543  40.407  1.00 13.91           S  
+ATOM    303  N   PHE H  59      10.538  41.007  43.453  1.00  9.65           N  
+ATOM    304  CA  PHE H  59       9.866  41.413  44.683  1.00 11.75           C  
+ATOM    305  C   PHE H  59       9.060  42.713  44.634  1.00 15.23           C  
+ATOM    306  O   PHE H  59       8.564  43.177  45.667  1.00 15.93           O  
+ATOM    307  CB  PHE H  59      10.894  41.427  45.818  1.00 14.10           C  
+ATOM    308  CG  PHE H  59      11.734  40.172  45.855  1.00 10.69           C  
+ATOM    309  CD1 PHE H  59      11.230  39.000  46.411  1.00 15.21           C  
+ATOM    310  CD2 PHE H  59      12.976  40.132  45.211  1.00 15.65           C  
+ATOM    311  CE1 PHE H  59      11.943  37.788  46.315  1.00 13.98           C  
+ATOM    312  CE2 PHE H  59      13.700  38.929  45.109  1.00 11.66           C  
+ATOM    313  CZ  PHE H  59      13.180  37.758  45.659  1.00 13.05           C  
+ATOM    314  N   ASP H  60       8.861  43.248  43.432  1.00 15.18           N  
+ATOM    315  CA  ASP H  60       8.118  44.502  43.271  1.00 21.17           C  
+ATOM    316  C   ASP H  60       6.687  44.479  43.812  1.00 23.56           C  
+ATOM    317  O   ASP H  60       6.203  45.484  44.348  1.00 22.09           O  
+ATOM    318  CB  ASP H  60       8.054  44.911  41.790  1.00 15.47           C  
+ATOM    319  CG  ASP H  60       9.329  45.587  41.289  1.00 16.06           C  
+ATOM    320  OD1 ASP H  60      10.340  45.637  42.019  1.00 17.64           O  
+ATOM    321  OD2 ASP H  60       9.315  46.063  40.133  1.00 16.48           O  
+ATOM    322  N   LYS H  60A      6.025  43.331  43.693  1.00 22.68           N  
+ATOM    323  CA  LYS H  60A      4.622  43.202  44.104  1.00 28.67           C  
+ATOM    324  C   LYS H  60A      4.329  42.416  45.378  1.00 30.78           C  
+ATOM    325  O   LYS H  60A      3.178  42.051  45.628  1.00 34.08           O  
+ATOM    326  CB  LYS H  60A      3.817  42.595  42.948  1.00 32.15           C  
+ATOM    327  CG  LYS H  60A      4.130  43.217  41.594  1.00 41.07           C  
+ATOM    328  CD  LYS H  60A      3.591  42.374  40.450  1.00 47.56           C  
+ATOM    329  CE  LYS H  60A      3.992  42.958  39.104  1.00 52.26           C  
+ATOM    330  NZ  LYS H  60A      3.383  42.185  37.988  1.00 54.60           N  
+ATOM    331  N   ILE H  60B      5.347  42.153  46.187  1.00 28.10           N  
+ATOM    332  CA  ILE H  60B      5.124  41.409  47.418  1.00 30.94           C  
+ATOM    333  C   ILE H  60B      4.358  42.283  48.418  1.00 33.94           C  
+ATOM    334  O   ILE H  60B      4.679  43.459  48.594  1.00 31.90           O  
+ATOM    335  CB  ILE H  60B      6.452  40.957  48.067  1.00 29.62           C  
+ATOM    336  CG1 ILE H  60B      7.266  40.087  47.098  1.00 30.04           C  
+ATOM    337  CG2 ILE H  60B      6.168  40.174  49.348  1.00 32.93           C  
+ATOM    338  CD1 ILE H  60B      6.638  38.745  46.774  1.00 33.67           C  
+ATOM    339  N   LYS H  60C      3.327  41.715  49.041  1.00 35.57           N  
+ATOM    340  CA  LYS H  60C      2.542  42.450  50.038  1.00 40.71           C  
+ATOM    341  C   LYS H  60C      2.871  41.936  51.436  1.00 38.93           C  
+ATOM    342  O   LYS H  60C      2.954  42.703  52.397  1.00 42.07           O  
+ATOM    343  CB  LYS H  60C      1.047  42.285  49.770  1.00 44.89           C  
+ATOM    344  CG  LYS H  60C      0.258  43.600  49.723  1.00 54.38           C  
+ATOM    345  CD  LYS H  60C      0.446  44.356  48.398  1.00 58.31           C  
+ATOM    346  CE  LYS H  60C      1.790  45.081  48.315  1.00 61.05           C  
+ATOM    347  NZ  LYS H  60C      1.957  45.817  47.026  1.00 61.75           N  
+ATOM    348  N   ASN H  60D      3.074  40.626  51.524  1.00 36.78           N  
+ATOM    349  CA  ASN H  60D      3.397  39.960  52.775  1.00 37.13           C  
+ATOM    350  C   ASN H  60D      4.580  39.008  52.542  1.00 34.35           C  
+ATOM    351  O   ASN H  60D      4.437  37.949  51.927  1.00 30.53           O  
+ATOM    352  CB  ASN H  60D      2.173  39.187  53.264  1.00 42.99           C  
+ATOM    353  CG  ASN H  60D      2.341  38.660  54.668  1.00 48.80           C  
+ATOM    354  OD1 ASN H  60D      2.845  37.557  54.871  1.00 53.76           O  
+ATOM    355  ND2 ASN H  60D      1.905  39.442  55.651  1.00 56.19           N  
+ATOM    356  N   TRP H  61       5.738  39.395  53.067  1.00 32.99           N  
+ATOM    357  CA  TRP H  61       6.986  38.646  52.934  1.00 34.91           C  
+ATOM    358  C   TRP H  61       6.988  37.235  53.512  1.00 34.59           C  
+ATOM    359  O   TRP H  61       7.783  36.384  53.111  1.00 34.83           O  
+ATOM    360  CB  TRP H  61       8.111  39.454  53.580  1.00 38.40           C  
+ATOM    361  CG  TRP H  61       8.279  40.797  52.949  1.00 40.08           C  
+ATOM    362  CD1 TRP H  61       7.752  41.982  53.378  1.00 42.66           C  
+ATOM    363  CD2 TRP H  61       8.967  41.080  51.729  1.00 38.68           C  
+ATOM    364  NE1 TRP H  61       8.061  42.986  52.489  1.00 43.36           N  
+ATOM    365  CE2 TRP H  61       8.807  42.458  51.468  1.00 40.91           C  
+ATOM    366  CE3 TRP H  61       9.701  40.300  50.825  1.00 33.15           C  
+ATOM    367  CZ2 TRP H  61       9.352  43.073  50.339  1.00 38.92           C  
+ATOM    368  CZ3 TRP H  61      10.241  40.912  49.706  1.00 26.23           C  
+ATOM    369  CH2 TRP H  61      10.063  42.285  49.473  1.00 30.36           C  
+ATOM    370  N   ARG H  62       6.058  36.986  54.420  1.00 30.87           N  
+ATOM    371  CA  ARG H  62       5.940  35.706  55.106  1.00 32.64           C  
+ATOM    372  C   ARG H  62       5.419  34.596  54.196  1.00 30.93           C  
+ATOM    373  O   ARG H  62       5.488  33.417  54.536  1.00 33.04           O  
+ATOM    374  CB  ARG H  62       5.047  35.879  56.344  1.00 38.20           C  
+ATOM    375  CG  ARG H  62       5.443  37.096  57.232  1.00 41.51           C  
+ATOM    376  CD  ARG H  62       5.064  38.447  56.582  1.00 45.96           C  
+ATOM    377  NE  ARG H  62       5.669  39.624  57.209  1.00 51.01           N  
+ATOM    378  CZ  ARG H  62       5.723  40.828  56.642  1.00 50.52           C  
+ATOM    379  NH1 ARG H  62       5.219  41.030  55.431  1.00 49.22           N  
+ATOM    380  NH2 ARG H  62       6.255  41.848  57.300  1.00 57.09           N  
+ATOM    381  N   ASN H  63       4.917  34.986  53.030  1.00 25.10           N  
+ATOM    382  CA  ASN H  63       4.392  34.051  52.042  1.00 29.26           C  
+ATOM    383  C   ASN H  63       5.481  33.609  51.050  1.00 21.25           C  
+ATOM    384  O   ASN H  63       5.215  32.823  50.145  1.00 22.43           O  
+ATOM    385  CB  ASN H  63       3.258  34.717  51.248  1.00 30.25           C  
+ATOM    386  CG  ASN H  63       2.121  35.212  52.135  1.00 39.35           C  
+ATOM    387  OD1 ASN H  63       1.926  34.725  53.249  1.00 39.05           O  
+ATOM    388  ND2 ASN H  63       1.354  36.176  51.630  1.00 38.12           N  
+ATOM    389  N   LEU H  64       6.693  34.127  51.216  1.00 19.71           N  
+ATOM    390  CA  LEU H  64       7.793  33.802  50.310  1.00 18.88           C  
+ATOM    391  C   LEU H  64       8.577  32.567  50.744  1.00 18.46           C  
+ATOM    392  O   LEU H  64       9.118  32.531  51.846  1.00 17.36           O  
+ATOM    393  CB  LEU H  64       8.724  35.008  50.202  1.00 19.25           C  
+ATOM    394  CG  LEU H  64       9.937  34.951  49.277  1.00 27.54           C  
+ATOM    395  CD1 LEU H  64       9.496  34.704  47.829  1.00 25.86           C  
+ATOM    396  CD2 LEU H  64      10.708  36.275  49.405  1.00 24.06           C  
+ATOM    397  N   ILE H  65       8.679  31.583  49.850  1.00 14.93           N  
+ATOM    398  CA  ILE H  65       9.394  30.337  50.129  1.00 14.58           C  
+ATOM    399  C   ILE H  65      10.431  30.029  49.050  1.00 15.05           C  
+ATOM    400  O   ILE H  65      10.190  30.261  47.872  1.00 14.63           O  
+ATOM    401  CB  ILE H  65       8.399  29.134  50.197  1.00 17.74           C  
+ATOM    402  CG1 ILE H  65       7.443  29.294  51.387  1.00 20.74           C  
+ATOM    403  CG2 ILE H  65       9.151  27.798  50.257  1.00 18.03           C  
+ATOM    404  CD1 ILE H  65       8.108  29.184  52.753  1.00 23.53           C  
+ATOM    405  N   ALA H  66      11.595  29.532  49.462  1.00 12.23           N  
+ATOM    406  CA  ALA H  66      12.636  29.151  48.517  1.00 11.76           C  
+ATOM    407  C   ALA H  66      12.741  27.634  48.555  1.00 10.15           C  
+ATOM    408  O   ALA H  66      12.814  27.039  49.627  1.00 13.71           O  
+ATOM    409  CB  ALA H  66      13.976  29.779  48.900  1.00 10.65           C  
+ATOM    410  N   VAL H  67      12.780  27.018  47.379  1.00 13.84           N  
+ATOM    411  CA  VAL H  67      12.884  25.578  47.286  1.00 11.63           C  
+ATOM    412  C   VAL H  67      14.149  25.169  46.534  1.00 12.69           C  
+ATOM    413  O   VAL H  67      14.392  25.636  45.419  1.00  9.56           O  
+ATOM    414  CB  VAL H  67      11.664  24.958  46.536  1.00 14.79           C  
+ATOM    415  CG1 VAL H  67      11.735  23.436  46.598  1.00 10.44           C  
+ATOM    416  CG2 VAL H  67      10.328  25.456  47.160  1.00  9.48           C  
+ATOM    417  N   LEU H  68      14.949  24.307  47.169  1.00 12.83           N  
+ATOM    418  CA  LEU H  68      16.172  23.759  46.568  1.00 10.64           C  
+ATOM    419  C   LEU H  68      15.992  22.267  46.287  1.00 13.71           C  
+ATOM    420  O   LEU H  68      15.144  21.620  46.897  1.00 12.75           O  
+ATOM    421  CB  LEU H  68      17.382  24.000  47.479  1.00 10.97           C  
+ATOM    422  CG  LEU H  68      17.799  25.405  47.060  1.00 24.63           C  
+ATOM    423  CD1 LEU H  68      17.544  26.404  48.142  1.00 15.75           C  
+ATOM    424  CD2 LEU H  68      19.201  25.407  46.538  1.00 19.52           C  
+ATOM    425  N   GLY H  69      16.766  21.741  45.335  1.00  9.25           N  
+ATOM    426  CA  GLY H  69      16.670  20.332  44.987  1.00  9.57           C  
+ATOM    427  C   GLY H  69      15.408  20.019  44.200  1.00 11.87           C  
+ATOM    428  O   GLY H  69      15.025  18.857  44.056  1.00 10.76           O  
+ATOM    429  N   GLU H  70      14.760  21.063  43.692  1.00 14.57           N  
+ATOM    430  CA  GLU H  70      13.539  20.910  42.912  1.00 13.19           C  
+ATOM    431  C   GLU H  70      13.862  20.516  41.470  1.00 13.04           C  
+ATOM    432  O   GLU H  70      14.904  20.894  40.925  1.00 12.53           O  
+ATOM    433  CB  GLU H  70      12.732  22.217  42.939  1.00 12.78           C  
+ATOM    434  CG  GLU H  70      11.381  22.146  42.250  1.00 13.35           C  
+ATOM    435  CD  GLU H  70      10.493  21.071  42.849  1.00 16.78           C  
+ATOM    436  OE1 GLU H  70      10.655  19.905  42.455  1.00 12.72           O  
+ATOM    437  OE2 GLU H  70       9.670  21.377  43.735  1.00 17.41           O  
+ATOM    438  N   HIS H  71      12.992  19.711  40.867  1.00 11.72           N  
+ATOM    439  CA  HIS H  71      13.187  19.302  39.482  1.00 10.55           C  
+ATOM    440  C   HIS H  71      11.864  19.230  38.724  1.00 12.84           C  
+ATOM    441  O   HIS H  71      11.648  19.974  37.770  1.00 12.07           O  
+ATOM    442  CB  HIS H  71      13.905  17.952  39.394  1.00 12.44           C  
+ATOM    443  CG  HIS H  71      14.022  17.440  37.993  1.00 15.14           C  
+ATOM    444  ND1 HIS H  71      14.805  18.058  37.042  1.00 14.04           N  
+ATOM    445  CD2 HIS H  71      13.397  16.417  37.358  1.00 16.87           C  
+ATOM    446  CE1 HIS H  71      14.658  17.442  35.882  1.00 20.26           C  
+ATOM    447  NE2 HIS H  71      13.809  16.443  36.046  1.00 18.89           N  
+ATOM    448  N   ASP H  72      10.982  18.347  39.181  1.00 11.92           N  
+ATOM    449  CA  ASP H  72       9.671  18.129  38.566  1.00 13.19           C  
+ATOM    450  C   ASP H  72       8.594  18.696  39.494  1.00 11.49           C  
+ATOM    451  O   ASP H  72       8.375  18.189  40.585  1.00 13.67           O  
+ATOM    452  CB  ASP H  72       9.471  16.620  38.362  1.00 14.27           C  
+ATOM    453  CG  ASP H  72       8.214  16.281  37.564  1.00 24.94           C  
+ATOM    454  OD1 ASP H  72       7.245  17.063  37.556  1.00 19.41           O  
+ATOM    455  OD2 ASP H  72       8.196  15.199  36.952  1.00 22.48           O  
+ATOM    456  N   LEU H  73       7.911  19.739  39.044  1.00 14.05           N  
+ATOM    457  CA  LEU H  73       6.876  20.391  39.847  1.00 14.67           C  
+ATOM    458  C   LEU H  73       5.611  19.558  40.096  1.00 14.78           C  
+ATOM    459  O   LEU H  73       4.809  19.885  40.970  1.00 15.38           O  
+ATOM    460  CB  LEU H  73       6.493  21.727  39.195  1.00 11.18           C  
+ATOM    461  CG  LEU H  73       7.672  22.676  38.908  1.00 12.07           C  
+ATOM    462  CD1 LEU H  73       7.155  24.024  38.373  1.00 11.24           C  
+ATOM    463  CD2 LEU H  73       8.483  22.884  40.181  1.00  9.72           C  
+ATOM    464  N   SER H  74       5.449  18.470  39.357  1.00 15.92           N  
+ATOM    465  CA  SER H  74       4.259  17.640  39.498  1.00 17.94           C  
+ATOM    466  C   SER H  74       4.361  16.569  40.582  1.00 20.15           C  
+ATOM    467  O   SER H  74       3.345  16.030  41.015  1.00 22.22           O  
+ATOM    468  CB  SER H  74       3.921  16.980  38.156  1.00 17.60           C  
+ATOM    469  OG  SER H  74       4.807  15.898  37.894  1.00 22.73           O  
+ATOM    470  N   GLU H  75       5.572  16.270  41.042  1.00 19.16           N  
+ATOM    471  CA  GLU H  75       5.728  15.229  42.053  1.00 18.31           C  
+ATOM    472  C   GLU H  75       6.751  15.567  43.119  1.00 21.45           C  
+ATOM    473  O   GLU H  75       7.669  16.322  42.868  1.00 21.72           O  
+ATOM    474  CB  GLU H  75       6.145  13.908  41.388  1.00 21.68           C  
+ATOM    475  CG  GLU H  75       7.452  13.976  40.595  1.00 25.53           C  
+ATOM    476  CD  GLU H  75       7.966  12.602  40.151  1.00 34.43           C  
+ATOM    477  OE1 GLU H  75       9.199  12.389  40.181  1.00 34.82           O  
+ATOM    478  OE2 GLU H  75       7.150  11.738  39.763  1.00 36.17           O  
+ATOM    479  N   HIS H  76       6.591  14.981  44.299  1.00 17.46           N  
+ATOM    480  CA  HIS H  76       7.535  15.171  45.395  1.00 18.83           C  
+ATOM    481  C   HIS H  76       8.384  13.908  45.436  1.00 19.30           C  
+ATOM    482  O   HIS H  76       7.834  12.816  45.551  1.00 16.66           O  
+ATOM    483  CB  HIS H  76       6.799  15.308  46.728  1.00 20.80           C  
+ATOM    484  CG  HIS H  76       7.714  15.440  47.908  1.00 21.52           C  
+ATOM    485  ND1 HIS H  76       7.988  14.390  48.760  1.00 26.19           N  
+ATOM    486  CD2 HIS H  76       8.414  16.498  48.380  1.00 19.42           C  
+ATOM    487  CE1 HIS H  76       8.814  14.797  49.707  1.00 23.37           C  
+ATOM    488  NE2 HIS H  76       9.087  16.073  49.499  1.00 23.00           N  
+ATOM    489  N   ASP H  77       9.705  14.041  45.324  1.00 17.94           N  
+ATOM    490  CA  ASP H  77      10.564  12.858  45.365  1.00 16.89           C  
+ATOM    491  C   ASP H  77      11.491  12.779  46.583  1.00 19.63           C  
+ATOM    492  O   ASP H  77      12.297  11.860  46.695  1.00 18.60           O  
+ATOM    493  CB  ASP H  77      11.335  12.665  44.041  1.00 15.91           C  
+ATOM    494  CG  ASP H  77      12.358  13.780  43.751  1.00 14.42           C  
+ATOM    495  OD1 ASP H  77      12.679  14.603  44.637  1.00 16.18           O  
+ATOM    496  OD2 ASP H  77      12.854  13.815  42.608  1.00 14.54           O  
+ATOM    497  N   GLY H  78      11.350  13.726  47.507  1.00 18.29           N  
+ATOM    498  CA  GLY H  78      12.175  13.715  48.704  1.00 19.63           C  
+ATOM    499  C   GLY H  78      13.490  14.486  48.660  1.00 19.73           C  
+ATOM    500  O   GLY H  78      14.148  14.629  49.692  1.00 13.96           O  
+ATOM    501  N   ASP H  79      13.896  14.964  47.490  1.00 16.12           N  
+ATOM    502  CA  ASP H  79      15.142  15.731  47.395  1.00 15.74           C  
+ATOM    503  C   ASP H  79      14.924  17.229  47.567  1.00 16.66           C  
+ATOM    504  O   ASP H  79      15.880  17.993  47.741  1.00 14.24           O  
+ATOM    505  CB  ASP H  79      15.846  15.462  46.068  1.00  9.89           C  
+ATOM    506  CG  ASP H  79      16.338  14.036  45.961  1.00 16.91           C  
+ATOM    507  OD1 ASP H  79      16.326  13.489  44.852  1.00 15.27           O  
+ATOM    508  OD2 ASP H  79      16.725  13.462  46.996  1.00 13.39           O  
+ATOM    509  N   GLU H  80      13.662  17.640  47.514  1.00 14.76           N  
+ATOM    510  CA  GLU H  80      13.301  19.045  47.666  1.00 16.31           C  
+ATOM    511  C   GLU H  80      13.474  19.507  49.100  1.00 15.86           C  
+ATOM    512  O   GLU H  80      13.126  18.792  50.028  1.00 11.87           O  
+ATOM    513  CB  GLU H  80      11.833  19.278  47.262  1.00 17.61           C  
+ATOM    514  CG  GLU H  80      11.466  18.777  45.865  1.00 12.47           C  
+ATOM    515  CD  GLU H  80      10.961  17.337  45.855  1.00 15.76           C  
+ATOM    516  OE1 GLU H  80      11.192  16.592  46.826  1.00 13.78           O  
+ATOM    517  OE2 GLU H  80      10.316  16.947  44.873  1.00 14.21           O  
+ATOM    518  N   GLN H  81      13.990  20.722  49.271  1.00 13.52           N  
+ATOM    519  CA  GLN H  81      14.168  21.318  50.593  1.00 11.58           C  
+ATOM    520  C   GLN H  81      13.586  22.721  50.506  1.00 12.06           C  
+ATOM    521  O   GLN H  81      14.022  23.527  49.686  1.00 11.83           O  
+ATOM    522  CB  GLN H  81      15.650  21.399  50.965  1.00 11.79           C  
+ATOM    523  CG  GLN H  81      16.335  20.043  51.130  1.00 15.25           C  
+ATOM    524  CD  GLN H  81      17.784  20.194  51.551  1.00 14.61           C  
+ATOM    525  OE1 GLN H  81      18.110  21.048  52.371  1.00 14.78           O  
+ATOM    526  NE2 GLN H  81      18.658  19.377  50.986  1.00 12.80           N  
+ATOM    527  N   SER H  82      12.602  23.016  51.342  1.00 14.07           N  
+ATOM    528  CA  SER H  82      11.965  24.329  51.321  1.00 12.84           C  
+ATOM    529  C   SER H  82      12.370  25.128  52.551  1.00 12.85           C  
+ATOM    530  O   SER H  82      12.534  24.570  53.643  1.00 12.15           O  
+ATOM    531  CB  SER H  82      10.439  24.177  51.250  1.00 15.42           C  
+ATOM    532  OG  SER H  82       9.950  23.508  52.398  1.00 24.05           O  
+ATOM    533  N   ARG H  83      12.545  26.432  52.362  1.00 12.81           N  
+ATOM    534  CA  ARG H  83      12.948  27.321  53.442  1.00 15.53           C  
+ATOM    535  C   ARG H  83      12.234  28.664  53.364  1.00 15.11           C  
+ATOM    536  O   ARG H  83      11.974  29.180  52.277  1.00 12.40           O  
+ATOM    537  CB  ARG H  83      14.460  27.598  53.365  1.00 14.32           C  
+ATOM    538  CG  ARG H  83      15.378  26.394  53.579  1.00 11.31           C  
+ATOM    539  CD  ARG H  83      15.303  25.879  55.006  1.00 12.58           C  
+ATOM    540  NE  ARG H  83      16.281  24.827  55.289  1.00 13.01           N  
+ATOM    541  CZ  ARG H  83      16.085  23.529  55.067  1.00 17.30           C  
+ATOM    542  NH1 ARG H  83      14.943  23.094  54.537  1.00 14.08           N  
+ATOM    543  NH2 ARG H  83      17.016  22.653  55.435  1.00 13.35           N  
+ATOM    544  N   ARG H  84      11.924  29.232  54.521  1.00 13.87           N  
+ATOM    545  CA  ARG H  84      11.320  30.558  54.551  1.00 18.89           C  
+ATOM    546  C   ARG H  84      12.450  31.547  54.269  1.00 19.04           C  
+ATOM    547  O   ARG H  84      13.629  31.243  54.476  1.00 16.05           O  
+ATOM    548  CB  ARG H  84      10.722  30.859  55.925  1.00 18.70           C  
+ATOM    549  CG  ARG H  84       9.472  30.060  56.240  1.00 20.06           C  
+ATOM    550  CD  ARG H  84       8.976  30.343  57.660  1.00 29.83           C  
+ATOM    551  NE  ARG H  84       8.524  31.723  57.826  0.00 25.08           N  
+ATOM    552  CZ  ARG H  84       7.435  32.234  57.256  0.00 24.99           C  
+ATOM    553  NH1 ARG H  84       6.670  31.485  56.472  0.00 24.33           N  
+ATOM    554  NH2 ARG H  84       7.109  33.499  57.473  0.00 24.99           N  
+ATOM    555  N   VAL H  85      12.094  32.714  53.756  1.00 23.56           N  
+ATOM    556  CA  VAL H  85      13.086  33.739  53.458  1.00 23.42           C  
+ATOM    557  C   VAL H  85      13.099  34.748  54.606  1.00 24.47           C  
+ATOM    558  O   VAL H  85      12.095  35.395  54.881  1.00 27.48           O  
+ATOM    559  CB  VAL H  85      12.769  34.429  52.114  1.00 21.88           C  
+ATOM    560  CG1 VAL H  85      13.764  35.555  51.849  1.00 20.94           C  
+ATOM    561  CG2 VAL H  85      12.809  33.400  50.983  1.00 19.53           C  
+ATOM    562  N   ALA H  86      14.230  34.851  55.295  1.00 20.95           N  
+ATOM    563  CA  ALA H  86      14.360  35.762  56.431  1.00 23.12           C  
+ATOM    564  C   ALA H  86      14.698  37.204  56.048  1.00 24.97           C  
+ATOM    565  O   ALA H  86      14.442  38.138  56.823  1.00 18.98           O  
+ATOM    566  CB  ALA H  86      15.405  35.238  57.397  1.00 17.17           C  
+ATOM    567  N   GLN H  87      15.292  37.383  54.870  1.00 18.69           N  
+ATOM    568  CA  GLN H  87      15.678  38.716  54.432  1.00 20.28           C  
+ATOM    569  C   GLN H  87      15.829  38.803  52.923  1.00 17.70           C  
+ATOM    570  O   GLN H  87      16.278  37.854  52.278  1.00 14.04           O  
+ATOM    571  CB  GLN H  87      17.012  39.090  55.088  1.00 20.55           C  
+ATOM    572  CG  GLN H  87      17.393  40.559  54.992  1.00 24.16           C  
+ATOM    573  CD  GLN H  87      17.440  41.227  56.350  1.00 33.26           C  
+ATOM    574  OE1 GLN H  87      16.497  41.917  56.755  1.00 31.91           O  
+ATOM    575  NE2 GLN H  87      18.531  41.011  57.073  1.00 33.45           N  
+ATOM    576  N   VAL H  88      15.386  39.925  52.367  1.00 17.23           N  
+ATOM    577  CA  VAL H  88      15.511  40.201  50.946  1.00 16.25           C  
+ATOM    578  C   VAL H  88      16.230  41.546  50.902  1.00 16.72           C  
+ATOM    579  O   VAL H  88      15.694  42.569  51.348  1.00 13.91           O  
+ATOM    580  CB  VAL H  88      14.142  40.316  50.245  1.00 17.96           C  
+ATOM    581  CG1 VAL H  88      14.339  40.763  48.777  1.00 15.45           C  
+ATOM    582  CG2 VAL H  88      13.399  38.979  50.309  1.00 16.19           C  
+ATOM    583  N   ILE H  89      17.461  41.529  50.408  1.00 14.87           N  
+ATOM    584  CA  ILE H  89      18.274  42.734  50.339  1.00 14.41           C  
+ATOM    585  C   ILE H  89      18.396  43.202  48.901  1.00 15.98           C  
+ATOM    586  O   ILE H  89      18.817  42.454  48.020  1.00 15.91           O  
+ATOM    587  CB  ILE H  89      19.683  42.489  50.906  1.00 12.37           C  
+ATOM    588  CG1 ILE H  89      19.592  41.789  52.269  1.00 15.83           C  
+ATOM    589  CG2 ILE H  89      20.416  43.825  51.052  1.00 16.12           C  
+ATOM    590  CD1 ILE H  89      20.949  41.349  52.844  1.00 13.11           C  
+ATOM    591  N   ILE H  90      18.072  44.470  48.691  1.00 12.05           N  
+ATOM    592  CA  ILE H  90      18.092  45.077  47.375  1.00 13.90           C  
+ATOM    593  C   ILE H  90      18.946  46.355  47.363  1.00 13.21           C  
+ATOM    594  O   ILE H  90      18.984  47.092  48.352  1.00 16.06           O  
+ATOM    595  CB  ILE H  90      16.620  45.337  46.960  1.00 20.00           C  
+ATOM    596  CG1 ILE H  90      15.969  43.991  46.577  1.00 17.97           C  
+ATOM    597  CG2 ILE H  90      16.517  46.362  45.851  1.00 24.45           C  
+ATOM    598  CD1 ILE H  90      14.488  44.064  46.364  1.00 21.31           C  
+ATOM    599  N   PRO H  91      19.692  46.600  46.263  1.00 12.71           N  
+ATOM    600  CA  PRO H  91      20.541  47.799  46.154  1.00 13.62           C  
+ATOM    601  C   PRO H  91      19.685  49.059  46.270  1.00 12.74           C  
+ATOM    602  O   PRO H  91      18.574  49.102  45.735  1.00 14.78           O  
+ATOM    603  CB  PRO H  91      21.100  47.713  44.730  1.00 18.35           C  
+ATOM    604  CG  PRO H  91      20.932  46.293  44.330  1.00 18.22           C  
+ATOM    605  CD  PRO H  91      19.657  45.863  44.986  1.00 14.18           C  
+ATOM    606  N   SER H  92      20.238  50.100  46.888  1.00 15.89           N  
+ATOM    607  CA  SER H  92      19.522  51.366  47.063  1.00 17.33           C  
+ATOM    608  C   SER H  92      19.243  52.025  45.717  1.00 17.70           C  
+ATOM    609  O   SER H  92      18.321  52.828  45.580  1.00 18.18           O  
+ATOM    610  CB  SER H  92      20.361  52.326  47.923  1.00 19.67           C  
+ATOM    611  OG  SER H  92      21.599  52.615  47.295  1.00 17.35           O  
+ATOM    612  N   THR H  93      20.053  51.663  44.730  1.00 17.28           N  
+ATOM    613  CA  THR H  93      19.970  52.211  43.385  1.00 17.78           C  
+ATOM    614  C   THR H  93      18.860  51.612  42.511  1.00 17.62           C  
+ATOM    615  O   THR H  93      18.523  52.163  41.458  1.00 18.79           O  
+ATOM    616  CB  THR H  93      21.335  52.081  42.683  1.00 19.76           C  
+ATOM    617  OG1 THR H  93      21.815  50.734  42.806  1.00 18.21           O  
+ATOM    618  CG2 THR H  93      22.356  53.041  43.311  1.00 22.39           C  
+ATOM    619  N   TYR H  94      18.290  50.495  42.954  1.00 17.90           N  
+ATOM    620  CA  TYR H  94      17.211  49.846  42.221  1.00 14.61           C  
+ATOM    621  C   TYR H  94      15.894  50.596  42.412  1.00 16.23           C  
+ATOM    622  O   TYR H  94      15.515  50.911  43.533  1.00 16.25           O  
+ATOM    623  CB  TYR H  94      17.026  48.398  42.692  1.00 12.05           C  
+ATOM    624  CG  TYR H  94      15.800  47.748  42.092  1.00 12.14           C  
+ATOM    625  CD1 TYR H  94      15.765  47.399  40.744  1.00 12.79           C  
+ATOM    626  CD2 TYR H  94      14.653  47.534  42.859  1.00 15.52           C  
+ATOM    627  CE1 TYR H  94      14.613  46.854  40.164  1.00 13.08           C  
+ATOM    628  CE2 TYR H  94      13.495  46.994  42.292  1.00 11.79           C  
+ATOM    629  CZ  TYR H  94      13.485  46.657  40.941  1.00 13.54           C  
+ATOM    630  OH  TYR H  94      12.336  46.141  40.370  1.00 16.94           O  
+ATOM    631  N   VAL H  95      15.188  50.851  41.313  1.00 16.13           N  
+ATOM    632  CA  VAL H  95      13.897  51.533  41.372  1.00 15.46           C  
+ATOM    633  C   VAL H  95      12.832  50.600  40.799  1.00 15.32           C  
+ATOM    634  O   VAL H  95      12.890  50.219  39.630  1.00 15.86           O  
+ATOM    635  CB  VAL H  95      13.927  52.864  40.572  1.00 18.82           C  
+ATOM    636  CG1 VAL H  95      12.542  53.507  40.549  1.00 19.35           C  
+ATOM    637  CG2 VAL H  95      14.935  53.825  41.208  1.00 17.63           C  
+ATOM    638  N   PRO H  96      11.857  50.195  41.623  1.00 17.14           N  
+ATOM    639  CA  PRO H  96      10.803  49.294  41.147  1.00 18.02           C  
+ATOM    640  C   PRO H  96      10.173  49.761  39.838  1.00 21.18           C  
+ATOM    641  O   PRO H  96       9.936  50.948  39.653  1.00 17.08           O  
+ATOM    642  CB  PRO H  96       9.801  49.322  42.295  1.00 20.67           C  
+ATOM    643  CG  PRO H  96      10.704  49.432  43.500  1.00 20.99           C  
+ATOM    644  CD  PRO H  96      11.684  50.502  43.057  1.00 15.35           C  
+ATOM    645  N   GLY H  97       9.960  48.825  38.919  1.00 21.89           N  
+ATOM    646  CA  GLY H  97       9.355  49.165  37.643  1.00 20.35           C  
+ATOM    647  C   GLY H  97      10.353  49.524  36.562  1.00 22.10           C  
+ATOM    648  O   GLY H  97       9.967  49.707  35.411  1.00 22.16           O  
+ATOM    649  N   THR H  98      11.628  49.649  36.933  1.00 20.09           N  
+ATOM    650  CA  THR H  98      12.689  49.975  35.979  1.00 15.74           C  
+ATOM    651  C   THR H  98      13.677  48.805  35.914  1.00 18.66           C  
+ATOM    652  O   THR H  98      13.644  47.911  36.769  1.00 18.73           O  
+ATOM    653  CB  THR H  98      13.408  51.273  36.357  1.00 19.56           C  
+ATOM    654  OG1 THR H  98      14.124  51.082  37.579  1.00 19.18           O  
+ATOM    655  CG2 THR H  98      12.389  52.400  36.549  1.00 24.31           C  
+ATOM    656  N   THR H  99      14.597  48.851  34.953  1.00 15.32           N  
+ATOM    657  CA  THR H  99      15.533  47.746  34.726  1.00 16.24           C  
+ATOM    658  C   THR H  99      16.914  47.716  35.381  1.00 19.36           C  
+ATOM    659  O   THR H  99      17.481  46.640  35.549  1.00 18.97           O  
+ATOM    660  CB  THR H  99      15.776  47.550  33.216  1.00 15.03           C  
+ATOM    661  OG1 THR H  99      16.382  48.735  32.685  1.00 16.37           O  
+ATOM    662  CG2 THR H  99      14.456  47.284  32.474  1.00 15.15           C  
+ATOM    663  N   ASN H 100      17.468  48.873  35.726  1.00 15.55           N  
+ATOM    664  CA  ASN H 100      18.824  48.918  36.280  1.00 16.24           C  
+ATOM    665  C   ASN H 100      18.997  48.342  37.695  1.00 17.77           C  
+ATOM    666  O   ASN H 100      18.083  48.404  38.510  1.00 16.88           O  
+ATOM    667  CB  ASN H 100      19.343  50.358  36.224  1.00 15.80           C  
+ATOM    668  CG  ASN H 100      20.846  50.446  35.962  1.00 17.06           C  
+ATOM    669  OD1 ASN H 100      21.459  51.502  36.175  1.00 24.26           O  
+ATOM    670  ND2 ASN H 100      21.433  49.369  35.443  1.00 15.11           N  
+ATOM    671  N   HIS H 101      20.164  47.746  37.953  1.00 15.59           N  
+ATOM    672  CA  HIS H 101      20.492  47.187  39.272  1.00 13.48           C  
+ATOM    673  C   HIS H 101      19.516  46.099  39.713  1.00 13.04           C  
+ATOM    674  O   HIS H 101      19.057  46.081  40.861  1.00 12.89           O  
+ATOM    675  CB  HIS H 101      20.525  48.322  40.315  1.00 14.00           C  
+ATOM    676  CG  HIS H 101      21.506  49.412  39.996  1.00 18.12           C  
+ATOM    677  ND1 HIS H 101      22.871  49.246  40.103  1.00 18.17           N  
+ATOM    678  CD2 HIS H 101      21.316  50.680  39.555  1.00 17.06           C  
+ATOM    679  CE1 HIS H 101      23.480  50.365  39.743  1.00 14.77           C  
+ATOM    680  NE2 HIS H 101      22.558  51.250  39.406  1.00 13.09           N  
+ATOM    681  N   ASP H 102      19.227  45.178  38.800  1.00 14.71           N  
+ATOM    682  CA  ASP H 102      18.265  44.117  39.058  1.00 14.19           C  
+ATOM    683  C   ASP H 102      18.859  42.908  39.774  1.00 13.78           C  
+ATOM    684  O   ASP H 102      19.054  41.838  39.183  1.00 13.63           O  
+ATOM    685  CB  ASP H 102      17.606  43.704  37.743  1.00 12.99           C  
+ATOM    686  CG  ASP H 102      16.358  42.867  37.954  1.00 12.46           C  
+ATOM    687  OD1 ASP H 102      15.944  42.187  37.003  1.00 16.28           O  
+ATOM    688  OD2 ASP H 102      15.794  42.885  39.063  1.00 12.31           O  
+ATOM    689  N   ILE H 103      19.112  43.077  41.064  1.00 10.90           N  
+ATOM    690  CA  ILE H 103      19.694  42.012  41.861  1.00  9.29           C  
+ATOM    691  C   ILE H 103      19.158  42.059  43.289  1.00 11.37           C  
+ATOM    692  O   ILE H 103      18.806  43.123  43.799  1.00 13.62           O  
+ATOM    693  CB  ILE H 103      21.257  42.111  41.843  1.00 12.39           C  
+ATOM    694  CG1 ILE H 103      21.888  41.003  42.693  1.00 13.08           C  
+ATOM    695  CG2 ILE H 103      21.716  43.493  42.347  1.00 11.48           C  
+ATOM    696  CD1 ILE H 103      23.417  40.842  42.462  1.00  9.82           C  
+ATOM    697  N   ALA H 104      19.021  40.885  43.897  1.00 11.71           N  
+ATOM    698  CA  ALA H 104      18.545  40.778  45.267  1.00 11.34           C  
+ATOM    699  C   ALA H 104      19.308  39.668  45.949  1.00 10.25           C  
+ATOM    700  O   ALA H 104      19.634  38.657  45.327  1.00 12.23           O  
+ATOM    701  CB  ALA H 104      17.048  40.481  45.311  1.00  9.63           C  
+ATOM    702  N   LEU H 105      19.657  39.890  47.207  1.00  9.41           N  
+ATOM    703  CA  LEU H 105      20.354  38.873  47.984  1.00  9.28           C  
+ATOM    704  C   LEU H 105      19.384  38.415  49.063  1.00  9.95           C  
+ATOM    705  O   LEU H 105      18.890  39.227  49.848  1.00 12.51           O  
+ATOM    706  CB  LEU H 105      21.628  39.433  48.605  1.00 11.97           C  
+ATOM    707  CG  LEU H 105      22.365  38.475  49.554  1.00 11.05           C  
+ATOM    708  CD1 LEU H 105      22.855  37.227  48.803  1.00 11.29           C  
+ATOM    709  CD2 LEU H 105      23.547  39.210  50.183  1.00 11.55           C  
+ATOM    710  N   LEU H 106      19.090  37.117  49.069  1.00 11.43           N  
+ATOM    711  CA  LEU H 106      18.158  36.522  50.028  1.00 13.03           C  
+ATOM    712  C   LEU H 106      18.843  35.657  51.069  1.00 13.89           C  
+ATOM    713  O   LEU H 106      19.699  34.837  50.734  1.00  9.32           O  
+ATOM    714  CB  LEU H 106      17.117  35.642  49.306  1.00 11.05           C  
+ATOM    715  CG  LEU H 106      15.956  36.293  48.548  1.00 16.24           C  
+ATOM    716  CD1 LEU H 106      16.489  37.254  47.497  1.00 13.66           C  
+ATOM    717  CD2 LEU H 106      15.104  35.204  47.886  1.00 17.75           C  
+ATOM    718  N   ARG H 107      18.464  35.856  52.331  1.00 12.34           N  
+ATOM    719  CA  ARG H 107      18.985  35.052  53.416  1.00 13.24           C  
+ATOM    720  C   ARG H 107      17.870  34.085  53.820  1.00 12.35           C  
+ATOM    721  O   ARG H 107      16.752  34.507  54.120  1.00 12.55           O  
+ATOM    722  CB  ARG H 107      19.365  35.910  54.625  1.00 13.94           C  
+ATOM    723  CG  ARG H 107      19.905  35.081  55.789  1.00 15.52           C  
+ATOM    724  CD  ARG H 107      19.975  35.886  57.084  1.00 23.61           C  
+ATOM    725  NE  ARG H 107      21.316  36.396  57.322  1.00 40.69           N  
+ATOM    726  CZ  ARG H 107      22.227  35.795  58.088  1.00 43.72           C  
+ATOM    727  NH1 ARG H 107      21.952  34.644  58.696  1.00 43.65           N  
+ATOM    728  NH2 ARG H 107      23.406  36.369  58.280  1.00 39.61           N  
+ATOM    729  N   LEU H 108      18.172  32.790  53.806  1.00  9.92           N  
+ATOM    730  CA  LEU H 108      17.195  31.776  54.188  1.00 11.95           C  
+ATOM    731  C   LEU H 108      17.082  31.743  55.717  1.00 14.23           C  
+ATOM    732  O   LEU H 108      18.025  32.103  56.416  1.00 15.68           O  
+ATOM    733  CB  LEU H 108      17.621  30.418  53.634  1.00 13.01           C  
+ATOM    734  CG  LEU H 108      17.775  30.412  52.105  1.00 13.65           C  
+ATOM    735  CD1 LEU H 108      18.099  29.002  51.608  1.00 10.97           C  
+ATOM    736  CD2 LEU H 108      16.488  30.920  51.454  1.00 10.40           C  
+ATOM    737  N   HIS H 109      15.921  31.342  56.225  1.00 13.75           N  
+ATOM    738  CA  HIS H 109      15.674  31.281  57.674  1.00 18.67           C  
+ATOM    739  C   HIS H 109      16.531  30.210  58.359  1.00 17.11           C  
+ATOM    740  O   HIS H 109      16.919  30.359  59.517  1.00 15.65           O  
+ATOM    741  CB  HIS H 109      14.189  31.005  57.924  1.00 22.86           C  
+ATOM    742  CG  HIS H 109      13.789  31.065  59.366  1.00 34.00           C  
+ATOM    743  ND1 HIS H 109      13.238  29.987  60.029  1.00 39.46           N  
+ATOM    744  CD2 HIS H 109      13.819  32.081  60.261  1.00 39.47           C  
+ATOM    745  CE1 HIS H 109      12.940  30.339  61.268  1.00 36.85           C  
+ATOM    746  NE2 HIS H 109      13.283  31.605  61.434  1.00 42.40           N  
+ATOM    747  N   GLN H 110      16.822  29.143  57.620  1.00 11.90           N  
+ATOM    748  CA  GLN H 110      17.634  28.023  58.090  1.00 14.74           C  
+ATOM    749  C   GLN H 110      18.486  27.593  56.908  1.00 13.33           C  
+ATOM    750  O   GLN H 110      18.033  27.632  55.764  1.00 14.81           O  
+ATOM    751  CB  GLN H 110      16.760  26.811  58.430  1.00 22.37           C  
+ATOM    752  CG  GLN H 110      16.302  26.657  59.850  1.00 35.55           C  
+ATOM    753  CD  GLN H 110      15.811  25.233  60.113  1.00 42.08           C  
+ATOM    754  OE1 GLN H 110      16.309  24.550  61.007  1.00 38.07           O  
+ATOM    755  NE2 GLN H 110      14.863  24.768  59.301  1.00 46.92           N  
+ATOM    756  N   PRO H 111      19.717  27.145  57.163  1.00 13.36           N  
+ATOM    757  CA  PRO H 111      20.514  26.730  56.005  1.00 10.80           C  
+ATOM    758  C   PRO H 111      19.977  25.448  55.352  1.00 14.05           C  
+ATOM    759  O   PRO H 111      19.284  24.652  56.001  1.00 11.04           O  
+ATOM    760  CB  PRO H 111      21.906  26.517  56.608  1.00 14.65           C  
+ATOM    761  CG  PRO H 111      21.635  26.206  58.034  1.00 21.76           C  
+ATOM    762  CD  PRO H 111      20.517  27.143  58.399  1.00 11.21           C  
+ATOM    763  N   VAL H 112      20.200  25.307  54.046  1.00 13.14           N  
+ATOM    764  CA  VAL H 112      19.804  24.078  53.364  1.00 11.42           C  
+ATOM    765  C   VAL H 112      20.940  23.086  53.607  1.00 13.41           C  
+ATOM    766  O   VAL H 112      22.048  23.488  53.971  1.00 12.40           O  
+ATOM    767  CB  VAL H 112      19.602  24.259  51.836  1.00 13.48           C  
+ATOM    768  CG1 VAL H 112      18.391  25.156  51.571  1.00 13.39           C  
+ATOM    769  CG2 VAL H 112      20.866  24.834  51.167  1.00 10.04           C  
+ATOM    770  N   VAL H 113      20.637  21.797  53.458  1.00 12.52           N  
+ATOM    771  CA  VAL H 113      21.615  20.727  53.638  1.00 11.26           C  
+ATOM    772  C   VAL H 113      22.160  20.381  52.259  1.00 14.44           C  
+ATOM    773  O   VAL H 113      21.396  20.083  51.343  1.00 12.64           O  
+ATOM    774  CB  VAL H 113      20.952  19.460  54.251  1.00 12.64           C  
+ATOM    775  CG1 VAL H 113      21.984  18.338  54.436  1.00 12.04           C  
+ATOM    776  CG2 VAL H 113      20.295  19.811  55.597  1.00 12.03           C  
+ATOM    777  N   LEU H 114      23.474  20.479  52.092  1.00 11.77           N  
+ATOM    778  CA  LEU H 114      24.077  20.153  50.807  1.00 13.88           C  
+ATOM    779  C   LEU H 114      24.007  18.642  50.592  1.00 13.99           C  
+ATOM    780  O   LEU H 114      24.263  17.858  51.510  1.00 12.56           O  
+ATOM    781  CB  LEU H 114      25.514  20.672  50.732  1.00 12.48           C  
+ATOM    782  CG  LEU H 114      25.670  22.179  51.004  1.00 16.13           C  
+ATOM    783  CD1 LEU H 114      27.073  22.638  50.598  1.00 10.29           C  
+ATOM    784  CD2 LEU H 114      24.607  22.977  50.241  1.00  8.08           C  
+ATOM    785  N   THR H 115      23.586  18.259  49.388  1.00 13.40           N  
+ATOM    786  CA  THR H 115      23.417  16.867  48.992  1.00 10.50           C  
+ATOM    787  C   THR H 115      23.760  16.790  47.507  1.00 11.52           C  
+ATOM    788  O   THR H 115      24.104  17.803  46.897  1.00 10.29           O  
+ATOM    789  CB  THR H 115      21.919  16.443  49.123  1.00 15.08           C  
+ATOM    790  OG1 THR H 115      21.137  17.220  48.202  1.00  9.48           O  
+ATOM    791  CG2 THR H 115      21.390  16.691  50.545  1.00  8.30           C  
+ATOM    792  N   ASP H 116      23.658  15.597  46.917  1.00 13.59           N  
+ATOM    793  CA  ASP H 116      23.928  15.444  45.487  1.00 10.63           C  
+ATOM    794  C   ASP H 116      23.003  16.337  44.645  1.00 13.19           C  
+ATOM    795  O   ASP H 116      23.324  16.709  43.498  1.00 12.37           O  
+ATOM    796  CB  ASP H 116      23.721  13.985  45.061  1.00 11.72           C  
+ATOM    797  CG  ASP H 116      24.828  13.056  45.562  1.00 19.91           C  
+ATOM    798  OD1 ASP H 116      25.742  13.509  46.280  1.00 15.13           O  
+ATOM    799  OD2 ASP H 116      24.777  11.862  45.226  1.00 17.10           O  
+ATOM    800  N   HIS H 117      21.856  16.680  45.224  1.00 12.88           N  
+ATOM    801  CA  HIS H 117      20.865  17.497  44.537  1.00 12.74           C  
+ATOM    802  C   HIS H 117      20.789  18.962  44.970  1.00 13.79           C  
+ATOM    803  O   HIS H 117      20.041  19.748  44.383  1.00  9.80           O  
+ATOM    804  CB  HIS H 117      19.497  16.807  44.642  1.00 14.68           C  
+ATOM    805  CG  HIS H 117      19.476  15.447  44.013  1.00 11.52           C  
+ATOM    806  ND1 HIS H 117      19.732  14.293  44.724  1.00 14.98           N  
+ATOM    807  CD2 HIS H 117      19.321  15.064  42.723  1.00 14.28           C  
+ATOM    808  CE1 HIS H 117      19.743  13.259  43.902  1.00 14.72           C  
+ATOM    809  NE2 HIS H 117      19.497  13.701  42.680  1.00 14.44           N  
+ATOM    810  N   VAL H 118      21.585  19.347  45.965  1.00 10.21           N  
+ATOM    811  CA  VAL H 118      21.576  20.728  46.453  1.00 11.56           C  
+ATOM    812  C   VAL H 118      23.024  21.163  46.681  1.00 13.18           C  
+ATOM    813  O   VAL H 118      23.658  20.761  47.657  1.00  9.58           O  
+ATOM    814  CB  VAL H 118      20.768  20.858  47.768  1.00 11.08           C  
+ATOM    815  CG1 VAL H 118      20.809  22.301  48.289  1.00 13.25           C  
+ATOM    816  CG2 VAL H 118      19.309  20.410  47.540  1.00  8.50           C  
+ATOM    817  N   VAL H 119      23.538  21.962  45.749  1.00 10.48           N  
+ATOM    818  CA  VAL H 119      24.922  22.442  45.789  1.00 11.66           C  
+ATOM    819  C   VAL H 119      24.979  23.902  45.364  1.00 12.38           C  
+ATOM    820  O   VAL H 119      24.338  24.298  44.389  1.00 10.87           O  
+ATOM    821  CB  VAL H 119      25.814  21.623  44.795  1.00 13.42           C  
+ATOM    822  CG1 VAL H 119      27.272  22.125  44.820  1.00 12.38           C  
+ATOM    823  CG2 VAL H 119      25.759  20.125  45.137  1.00 12.49           C  
+ATOM    824  N   PRO H 120      25.760  24.724  46.081  1.00  8.39           N  
+ATOM    825  CA  PRO H 120      25.844  26.137  45.698  1.00 11.60           C  
+ATOM    826  C   PRO H 120      26.707  26.376  44.460  1.00 11.18           C  
+ATOM    827  O   PRO H 120      27.597  25.587  44.151  1.00 12.12           O  
+ATOM    828  CB  PRO H 120      26.487  26.785  46.927  1.00 13.41           C  
+ATOM    829  CG  PRO H 120      27.405  25.695  47.442  1.00 13.53           C  
+ATOM    830  CD  PRO H 120      26.526  24.455  47.315  1.00 10.46           C  
+ATOM    831  N   LEU H 121      26.388  27.439  43.729  1.00 10.89           N  
+ATOM    832  CA  LEU H 121      27.163  27.858  42.566  1.00 10.30           C  
+ATOM    833  C   LEU H 121      28.229  28.793  43.158  1.00 11.34           C  
+ATOM    834  O   LEU H 121      27.936  29.534  44.099  1.00 10.15           O  
+ATOM    835  CB  LEU H 121      26.273  28.642  41.590  1.00  8.40           C  
+ATOM    836  CG  LEU H 121      26.892  29.097  40.255  1.00 10.68           C  
+ATOM    837  CD1 LEU H 121      27.503  27.901  39.542  1.00 10.87           C  
+ATOM    838  CD2 LEU H 121      25.839  29.766  39.342  1.00 10.29           C  
+ATOM    839  N   CYS H 122      29.460  28.758  42.653  1.00  9.22           N  
+ATOM    840  CA  CYS H 122      30.484  29.653  43.217  1.00 13.03           C  
+ATOM    841  C   CYS H 122      30.291  31.128  42.842  1.00 13.00           C  
+ATOM    842  O   CYS H 122      30.110  31.447  41.672  1.00 13.05           O  
+ATOM    843  CB  CYS H 122      31.898  29.244  42.766  1.00 10.69           C  
+ATOM    844  SG  CYS H 122      32.391  27.526  43.106  1.00 14.62           S  
+ATOM    845  N   LEU H 123      30.310  32.022  43.833  1.00 12.27           N  
+ATOM    846  CA  LEU H 123      30.223  33.460  43.543  1.00 12.64           C  
+ATOM    847  C   LEU H 123      31.697  33.815  43.319  1.00 13.55           C  
+ATOM    848  O   LEU H 123      32.490  33.764  44.246  1.00 11.18           O  
+ATOM    849  CB  LEU H 123      29.673  34.256  44.740  1.00 12.17           C  
+ATOM    850  CG  LEU H 123      29.572  35.767  44.464  1.00 13.36           C  
+ATOM    851  CD1 LEU H 123      28.432  36.042  43.481  1.00 10.64           C  
+ATOM    852  CD2 LEU H 123      29.330  36.543  45.775  1.00 11.49           C  
+ATOM    853  N   PRO H 124      32.079  34.190  42.090  1.00 13.49           N  
+ATOM    854  CA  PRO H 124      33.490  34.516  41.833  1.00 14.36           C  
+ATOM    855  C   PRO H 124      33.995  35.846  42.374  1.00 13.95           C  
+ATOM    856  O   PRO H 124      33.212  36.711  42.749  1.00 13.60           O  
+ATOM    857  CB  PRO H 124      33.552  34.519  40.309  1.00 11.13           C  
+ATOM    858  CG  PRO H 124      32.218  35.149  39.954  1.00 14.13           C  
+ATOM    859  CD  PRO H 124      31.251  34.431  40.892  1.00 13.33           C  
+ATOM    860  N   GLU H 125      35.322  35.982  42.446  1.00 15.44           N  
+ATOM    861  CA  GLU H 125      35.924  37.249  42.854  1.00 15.83           C  
+ATOM    862  C   GLU H 125      35.671  38.174  41.664  1.00 13.62           C  
+ATOM    863  O   GLU H 125      35.587  37.711  40.529  1.00 14.09           O  
+ATOM    864  CB  GLU H 125      37.436  37.101  43.062  1.00 16.65           C  
+ATOM    865  CG  GLU H 125      37.797  36.493  44.394  1.00 18.92           C  
+ATOM    866  CD  GLU H 125      39.298  36.381  44.631  1.00 28.71           C  
+ATOM    867  OE1 GLU H 125      40.117  36.934  43.857  1.00 20.98           O  
+ATOM    868  OE2 GLU H 125      39.659  35.712  45.610  1.00 24.40           O  
+ATOM    869  N   ARG H 126      35.561  39.473  41.912  1.00 17.79           N  
+ATOM    870  CA  ARG H 126      35.317  40.433  40.836  1.00 15.98           C  
+ATOM    871  C   ARG H 126      36.399  40.410  39.744  1.00 17.16           C  
+ATOM    872  O   ARG H 126      36.068  40.378  38.560  1.00 15.98           O  
+ATOM    873  CB  ARG H 126      35.166  41.853  41.411  1.00 19.80           C  
+ATOM    874  CG  ARG H 126      34.888  42.939  40.364  1.00 24.13           C  
+ATOM    875  CD  ARG H 126      34.921  44.343  40.983  1.00 22.71           C  
+ATOM    876  NE  ARG H 126      36.210  44.634  41.614  1.00 40.12           N  
+ATOM    877  CZ  ARG H 126      37.312  45.012  40.967  1.00 40.15           C  
+ATOM    878  NH1 ARG H 126      37.308  45.159  39.647  1.00 43.97           N  
+ATOM    879  NH2 ARG H 126      38.433  45.223  41.643  1.00 39.40           N  
+ATOM    880  N   THR H 127      37.680  40.399  40.124  1.00 16.42           N  
+ATOM    881  CA  THR H 127      38.756  40.386  39.119  1.00 16.97           C  
+ATOM    882  C   THR H 127      38.697  39.166  38.221  1.00 12.86           C  
+ATOM    883  O   THR H 127      38.772  39.278  37.003  1.00 19.93           O  
+ATOM    884  CB  THR H 127      40.167  40.483  39.753  1.00 16.65           C  
+ATOM    885  OG1 THR H 127      40.314  39.479  40.770  1.00 23.65           O  
+ATOM    886  CG2 THR H 127      40.380  41.878  40.358  1.00 21.44           C  
+ATOM    887  N   PHE H 128      38.538  37.997  38.824  1.00 15.17           N  
+ATOM    888  CA  PHE H 128      38.449  36.761  38.069  1.00 12.04           C  
+ATOM    889  C   PHE H 128      37.274  36.812  37.094  1.00 16.39           C  
+ATOM    890  O   PHE H 128      37.397  36.421  35.935  1.00 16.19           O  
+ATOM    891  CB  PHE H 128      38.275  35.593  39.041  1.00 13.34           C  
+ATOM    892  CG  PHE H 128      38.001  34.280  38.371  1.00 13.37           C  
+ATOM    893  CD1 PHE H 128      38.927  33.726  37.493  1.00 15.16           C  
+ATOM    894  CD2 PHE H 128      36.826  33.586  38.641  1.00 12.91           C  
+ATOM    895  CE1 PHE H 128      38.686  32.493  36.891  1.00 15.31           C  
+ATOM    896  CE2 PHE H 128      36.572  32.357  38.052  1.00 14.50           C  
+ATOM    897  CZ  PHE H 128      37.505  31.803  37.172  1.00 18.10           C  
+ATOM    898  N   SER H 129      36.137  37.313  37.562  1.00 14.78           N  
+ATOM    899  CA  SER H 129      34.956  37.405  36.717  1.00 13.83           C  
+ATOM    900  C   SER H 129      35.114  38.381  35.548  1.00 15.19           C  
+ATOM    901  O   SER H 129      34.679  38.091  34.441  1.00 15.79           O  
+ATOM    902  CB  SER H 129      33.731  37.792  37.551  1.00 14.78           C  
+ATOM    903  OG  SER H 129      32.566  37.576  36.784  1.00 15.84           O  
+ATOM    904  N   GLU H 129A     35.727  39.536  35.793  1.00 19.29           N  
+ATOM    905  CA  GLU H 129A     35.928  40.542  34.745  1.00 18.14           C  
+ATOM    906  C   GLU H 129A     37.067  40.202  33.777  1.00 21.08           C  
+ATOM    907  O   GLU H 129A     36.935  40.377  32.568  1.00 20.57           O  
+ATOM    908  CB  GLU H 129A     36.194  41.914  35.369  1.00 20.43           C  
+ATOM    909  CG  GLU H 129A     35.040  42.450  36.219  1.00 21.21           C  
+ATOM    910  CD  GLU H 129A     35.354  43.782  36.881  1.00 25.08           C  
+ATOM    911  OE1 GLU H 129A     36.531  44.190  36.913  1.00 30.99           O  
+ATOM    912  OE2 GLU H 129A     34.421  44.420  37.391  1.00 24.64           O  
+ATOM    913  N   ARG H 129B     38.181  39.718  34.316  1.00 22.02           N  
+ATOM    914  CA  ARG H 129B     39.355  39.369  33.508  1.00 22.90           C  
+ATOM    915  C   ARG H 129B     39.251  38.033  32.800  1.00 21.94           C  
+ATOM    916  O   ARG H 129B     39.850  37.830  31.735  1.00 21.34           O  
+ATOM    917  CB  ARG H 129B     40.610  39.336  34.388  1.00 21.87           C  
+ATOM    918  CG  ARG H 129B     40.992  40.674  34.997  1.00 24.74           C  
+ATOM    919  CD  ARG H 129B     42.070  40.493  36.059  1.00 29.39           C  
+ATOM    920  NE  ARG H 129B     42.469  41.768  36.642  1.00 28.81           N  
+ATOM    921  CZ  ARG H 129B     43.156  41.900  37.773  1.00 30.31           C  
+ATOM    922  NH1 ARG H 129B     43.467  43.112  38.211  1.00 28.92           N  
+ATOM    923  NH2 ARG H 129B     43.527  40.833  38.472  1.00 26.06           N  
+ATOM    924  N   THR H 129C     38.461  37.121  33.356  1.00 19.02           N  
+ATOM    925  CA  THR H 129C     38.380  35.793  32.765  1.00 17.13           C  
+ATOM    926  C   THR H 129C     37.004  35.241  32.389  1.00 19.58           C  
+ATOM    927  O   THR H 129C     36.795  34.829  31.242  1.00 19.03           O  
+ATOM    928  CB  THR H 129C     39.125  34.783  33.680  1.00 15.23           C  
+ATOM    929  OG1 THR H 129C     40.490  35.194  33.815  1.00 19.83           O  
+ATOM    930  CG2 THR H 129C     39.077  33.371  33.111  1.00 17.60           C  
+ATOM    931  N   LEU H 129D     36.071  35.215  33.340  1.00 16.72           N  
+ATOM    932  CA  LEU H 129D     34.743  34.659  33.064  1.00 16.78           C  
+ATOM    933  C   LEU H 129D     33.976  35.418  31.991  1.00 14.65           C  
+ATOM    934  O   LEU H 129D     33.234  34.815  31.223  1.00 16.90           O  
+ATOM    935  CB  LEU H 129D     33.888  34.588  34.340  1.00 13.67           C  
+ATOM    936  CG  LEU H 129D     34.374  33.696  35.482  1.00 19.36           C  
+ATOM    937  CD1 LEU H 129D     33.379  33.798  36.651  1.00 10.21           C  
+ATOM    938  CD2 LEU H 129D     34.507  32.238  35.012  1.00 13.92           C  
+ATOM    939  N   ALA H 129E     34.155  36.737  31.949  1.00 18.22           N  
+ATOM    940  CA  ALA H 129E     33.461  37.584  30.983  1.00 17.56           C  
+ATOM    941  C   ALA H 129E     33.817  37.251  29.542  1.00 19.43           C  
+ATOM    942  O   ALA H 129E     33.102  37.640  28.614  1.00 22.04           O  
+ATOM    943  CB  ALA H 129E     33.732  39.047  31.275  1.00 15.91           C  
+ATOM    944  N   PHE H 129F     34.903  36.501  29.357  1.00 22.27           N  
+ATOM    945  CA  PHE H 129F     35.344  36.113  28.017  1.00 21.27           C  
+ATOM    946  C   PHE H 129F     35.010  34.671  27.639  1.00 19.90           C  
+ATOM    947  O   PHE H 129F     35.310  34.225  26.533  1.00 21.86           O  
+ATOM    948  CB  PHE H 129F     36.827  36.444  27.836  1.00 23.11           C  
+ATOM    949  CG  PHE H 129F     37.121  37.906  28.011  1.00 23.89           C  
+ATOM    950  CD1 PHE H 129F     36.707  38.825  27.051  1.00 25.51           C  
+ATOM    951  CD2 PHE H 129F     37.714  38.380  29.178  1.00 21.29           C  
+ATOM    952  CE1 PHE H 129F     36.868  40.196  27.254  1.00 25.10           C  
+ATOM    953  CE2 PHE H 129F     37.879  39.747  29.389  1.00 24.83           C  
+ATOM    954  CZ  PHE H 129F     37.453  40.657  28.424  1.00 25.31           C  
+ATOM    955  N   VAL H 129G     34.404  33.929  28.562  1.00 17.26           N  
+ATOM    956  CA  VAL H 129G     33.975  32.565  28.247  1.00 15.64           C  
+ATOM    957  C   VAL H 129G     32.718  32.824  27.409  1.00 18.77           C  
+ATOM    958  O   VAL H 129G     31.783  33.476  27.873  1.00 19.05           O  
+ATOM    959  CB  VAL H 129G     33.626  31.752  29.521  1.00 17.73           C  
+ATOM    960  CG1 VAL H 129G     33.059  30.387  29.141  1.00 17.45           C  
+ATOM    961  CG2 VAL H 129G     34.873  31.549  30.364  1.00 18.15           C  
+ATOM    962  N   ARG H 134      32.706  32.361  26.164  1.00 19.91           N  
+ATOM    963  CA  ARG H 134      31.567  32.631  25.291  1.00 18.73           C  
+ATOM    964  C   ARG H 134      30.204  32.116  25.746  1.00 17.43           C  
+ATOM    965  O   ARG H 134      29.255  32.895  25.863  1.00 20.30           O  
+ATOM    966  CB  ARG H 134      31.832  32.163  23.856  1.00 20.70           C  
+ATOM    967  CG  ARG H 134      30.770  32.688  22.892  1.00 23.86           C  
+ATOM    968  CD  ARG H 134      31.066  32.400  21.425  1.00 30.69           C  
+ATOM    969  NE  ARG H 134      29.988  32.947  20.601  1.00 33.46           N  
+ATOM    970  CZ  ARG H 134      29.524  32.390  19.488  1.00 36.40           C  
+ATOM    971  NH1 ARG H 134      28.524  32.968  18.833  1.00 34.62           N  
+ATOM    972  NH2 ARG H 134      30.067  31.274  19.017  1.00 37.86           N  
+ATOM    973  N   PHE H 135      30.109  30.815  26.000  1.00 15.70           N  
+ATOM    974  CA  PHE H 135      28.841  30.223  26.398  1.00 18.22           C  
+ATOM    975  C   PHE H 135      28.667  29.980  27.885  1.00 17.32           C  
+ATOM    976  O   PHE H 135      29.628  29.652  28.592  1.00 17.84           O  
+ATOM    977  CB  PHE H 135      28.614  28.918  25.638  1.00 16.30           C  
+ATOM    978  CG  PHE H 135      28.349  29.112  24.176  1.00 21.55           C  
+ATOM    979  CD1 PHE H 135      27.048  29.227  23.705  1.00 19.86           C  
+ATOM    980  CD2 PHE H 135      29.402  29.154  23.261  1.00 27.29           C  
+ATOM    981  CE1 PHE H 135      26.790  29.380  22.337  1.00 21.62           C  
+ATOM    982  CE2 PHE H 135      29.158  29.308  21.892  1.00 28.74           C  
+ATOM    983  CZ  PHE H 135      27.846  29.420  21.429  1.00 25.42           C  
+ATOM    984  N   SER H 136      27.417  30.104  28.331  1.00 18.00           N  
+ATOM    985  CA  SER H 136      27.027  29.886  29.725  1.00 14.31           C  
+ATOM    986  C   SER H 136      25.615  29.289  29.749  1.00 16.74           C  
+ATOM    987  O   SER H 136      24.876  29.406  28.772  1.00 16.07           O  
+ATOM    988  CB  SER H 136      27.017  31.206  30.497  1.00 18.14           C  
+ATOM    989  OG  SER H 136      28.316  31.756  30.620  1.00 16.47           O  
+ATOM    990  N   LEU H 137      25.247  28.650  30.858  1.00 13.95           N  
+ATOM    991  CA  LEU H 137      23.926  28.039  30.981  1.00 15.14           C  
+ATOM    992  C   LEU H 137      22.926  28.910  31.749  1.00 17.34           C  
+ATOM    993  O   LEU H 137      23.281  29.514  32.761  1.00 13.81           O  
+ATOM    994  CB  LEU H 137      24.038  26.686  31.693  1.00 13.48           C  
+ATOM    995  CG  LEU H 137      24.902  25.578  31.084  1.00 13.99           C  
+ATOM    996  CD1 LEU H 137      24.879  24.353  32.004  1.00 14.99           C  
+ATOM    997  CD2 LEU H 137      24.399  25.205  29.695  1.00 17.23           C  
+ATOM    998  N   VAL H 138      21.697  28.999  31.237  1.00 13.84           N  
+ATOM    999  CA  VAL H 138      20.617  29.742  31.892  1.00 12.51           C  
+ATOM   1000  C   VAL H 138      19.527  28.702  32.125  1.00 12.80           C  
+ATOM   1001  O   VAL H 138      19.289  27.847  31.272  1.00 12.09           O  
+ATOM   1002  CB  VAL H 138      20.071  30.918  31.039  1.00 14.34           C  
+ATOM   1003  CG1 VAL H 138      21.128  32.011  30.912  1.00 15.66           C  
+ATOM   1004  CG2 VAL H 138      19.632  30.435  29.655  1.00 14.74           C  
+ATOM   1005  N   SER H 139      18.861  28.773  33.270  1.00 11.72           N  
+ATOM   1006  CA  SER H 139      17.859  27.774  33.599  1.00 11.81           C  
+ATOM   1007  C   SER H 139      16.653  28.278  34.365  1.00 11.34           C  
+ATOM   1008  O   SER H 139      16.678  29.365  34.948  1.00 12.94           O  
+ATOM   1009  CB  SER H 139      18.528  26.664  34.414  1.00 15.69           C  
+ATOM   1010  OG  SER H 139      19.267  27.240  35.479  1.00 14.05           O  
+ATOM   1011  N   GLY H 140      15.593  27.472  34.355  1.00 14.16           N  
+ATOM   1012  CA  GLY H 140      14.378  27.833  35.069  1.00 13.16           C  
+ATOM   1013  C   GLY H 140      13.138  27.073  34.630  1.00 14.41           C  
+ATOM   1014  O   GLY H 140      13.169  26.274  33.682  1.00 12.59           O  
+ATOM   1015  N   TRP H 141      12.038  27.332  35.333  1.00 12.77           N  
+ATOM   1016  CA  TRP H 141      10.749  26.700  35.040  1.00 13.58           C  
+ATOM   1017  C   TRP H 141       9.828  27.696  34.339  1.00 13.00           C  
+ATOM   1018  O   TRP H 141       8.604  27.586  34.412  1.00 14.50           O  
+ATOM   1019  CB  TRP H 141      10.081  26.227  36.337  1.00 11.32           C  
+ATOM   1020  CG  TRP H 141      10.789  25.095  37.012  1.00 12.81           C  
+ATOM   1021  CD1 TRP H 141      10.559  23.758  36.834  1.00 11.29           C  
+ATOM   1022  CD2 TRP H 141      11.786  25.201  38.034  1.00 12.01           C  
+ATOM   1023  NE1 TRP H 141      11.345  23.029  37.698  1.00 14.52           N  
+ATOM   1024  CE2 TRP H 141      12.107  23.890  38.444  1.00 12.39           C  
+ATOM   1025  CE3 TRP H 141      12.429  26.282  38.653  1.00 13.13           C  
+ATOM   1026  CZ2 TRP H 141      13.050  23.626  39.451  1.00 11.42           C  
+ATOM   1027  CZ3 TRP H 141      13.361  26.024  39.657  1.00 11.86           C  
+ATOM   1028  CH2 TRP H 141      13.661  24.701  40.045  1.00 14.11           C  
+ATOM   1029  N   GLY H 142      10.426  28.679  33.672  1.00 13.15           N  
+ATOM   1030  CA  GLY H 142       9.643  29.686  32.975  1.00 13.48           C  
+ATOM   1031  C   GLY H 142       8.966  29.188  31.708  1.00 11.71           C  
+ATOM   1032  O   GLY H 142       9.024  28.003  31.375  1.00 12.97           O  
+ATOM   1033  N   GLN H 143       8.366  30.129  30.985  1.00 13.89           N  
+ATOM   1034  CA  GLN H 143       7.646  29.861  29.737  1.00 16.95           C  
+ATOM   1035  C   GLN H 143       8.515  29.168  28.698  1.00 16.92           C  
+ATOM   1036  O   GLN H 143       9.638  29.603  28.427  1.00 14.87           O  
+ATOM   1037  CB  GLN H 143       7.123  31.170  29.137  1.00 15.90           C  
+ATOM   1038  CG  GLN H 143       6.000  31.836  29.923  1.00 14.24           C  
+ATOM   1039  CD  GLN H 143       6.483  32.666  31.101  1.00 20.77           C  
+ATOM   1040  OE1 GLN H 143       7.686  32.789  31.359  1.00 16.79           O  
+ATOM   1041  NE2 GLN H 143       5.536  33.250  31.822  1.00 17.59           N  
+ATOM   1042  N   LEU H 144       7.955  28.131  28.078  1.00 16.36           N  
+ATOM   1043  CA  LEU H 144       8.646  27.358  27.053  1.00 13.94           C  
+ATOM   1044  C   LEU H 144       8.596  28.067  25.715  1.00 15.42           C  
+ATOM   1045  O   LEU H 144       9.352  27.740  24.804  1.00 16.01           O  
+ATOM   1046  CB  LEU H 144       8.000  25.975  26.917  1.00 12.93           C  
+ATOM   1047  CG  LEU H 144       8.205  25.111  28.166  1.00 16.81           C  
+ATOM   1048  CD1 LEU H 144       7.231  23.928  28.158  1.00 19.16           C  
+ATOM   1049  CD2 LEU H 144       9.668  24.643  28.220  1.00 15.39           C  
+ATOM   1050  N   LEU H 145       7.685  29.031  25.613  1.00 16.19           N  
+ATOM   1051  CA  LEU H 145       7.482  29.835  24.405  1.00 18.05           C  
+ATOM   1052  C   LEU H 145       6.985  31.193  24.857  1.00 17.45           C  
+ATOM   1053  O   LEU H 145       6.356  31.306  25.917  1.00 19.16           O  
+ATOM   1054  CB  LEU H 145       6.368  29.234  23.531  1.00 20.62           C  
+ATOM   1055  CG  LEU H 145       6.535  27.869  22.867  1.00 30.34           C  
+ATOM   1056  CD1 LEU H 145       5.182  27.379  22.350  1.00 28.51           C  
+ATOM   1057  CD2 LEU H 145       7.537  27.974  21.741  1.00 27.33           C  
+ATOM   1058  N   ASP H 146       7.235  32.221  24.054  1.00 17.43           N  
+ATOM   1059  CA  ASP H 146       6.725  33.546  24.389  1.00 18.55           C  
+ATOM   1060  C   ASP H 146       5.200  33.404  24.379  1.00 20.71           C  
+ATOM   1061  O   ASP H 146       4.632  32.863  23.426  1.00 23.21           O  
+ATOM   1062  CB  ASP H 146       7.152  34.577  23.348  1.00 20.03           C  
+ATOM   1063  CG  ASP H 146       6.783  35.984  23.754  1.00 23.95           C  
+ATOM   1064  OD1 ASP H 146       5.752  36.500  23.286  1.00 22.06           O  
+ATOM   1065  OD2 ASP H 146       7.503  36.566  24.580  1.00 24.01           O  
+ATOM   1066  N   ARG H 147       4.559  33.835  25.463  1.00 19.07           N  
+ATOM   1067  CA  ARG H 147       3.108  33.741  25.623  1.00 18.81           C  
+ATOM   1068  C   ARG H 147       2.626  32.292  25.663  1.00 18.27           C  
+ATOM   1069  O   ARG H 147       1.497  31.980  25.282  1.00 16.06           O  
+ATOM   1070  CB  ARG H 147       2.383  34.563  24.542  1.00 17.10           C  
+ATOM   1071  CG  ARG H 147       2.612  36.065  24.742  1.00 23.90           C  
+ATOM   1072  CD  ARG H 147       1.622  36.921  23.984  1.00 31.88           C  
+ATOM   1073  NE  ARG H 147       1.824  36.852  22.542  1.00 31.64           N  
+ATOM   1074  CZ  ARG H 147       1.112  37.551  21.665  1.00 36.47           C  
+ATOM   1075  NH1 ARG H 147       0.151  38.367  22.089  1.00 35.91           N  
+ATOM   1076  NH2 ARG H 147       1.354  37.431  20.367  1.00 30.35           N  
+ATOM   1077  N   GLY H 149       3.489  31.420  26.179  1.00 16.78           N  
+ATOM   1078  CA  GLY H 149       3.164  30.011  26.283  1.00 17.65           C  
+ATOM   1079  C   GLY H 149       3.169  29.550  27.733  1.00 20.50           C  
+ATOM   1080  O   GLY H 149       3.472  30.321  28.650  1.00 18.61           O  
+ATOM   1081  N   ALA H 150       2.830  28.285  27.943  1.00 15.66           N  
+ATOM   1082  CA  ALA H 150       2.792  27.713  29.286  1.00 19.17           C  
+ATOM   1083  C   ALA H 150       4.201  27.546  29.863  1.00 16.06           C  
+ATOM   1084  O   ALA H 150       5.176  27.440  29.122  1.00 14.44           O  
+ATOM   1085  CB  ALA H 150       2.078  26.362  29.256  1.00 21.13           C  
+ATOM   1086  N   THR H 151       4.286  27.526  31.190  1.00 15.18           N  
+ATOM   1087  CA  THR H 151       5.551  27.345  31.887  1.00 18.15           C  
+ATOM   1088  C   THR H 151       5.905  25.860  31.935  1.00 19.37           C  
+ATOM   1089  O   THR H 151       5.052  24.994  31.708  1.00 17.31           O  
+ATOM   1090  CB  THR H 151       5.482  27.914  33.314  1.00 15.50           C  
+ATOM   1091  OG1 THR H 151       4.383  27.316  34.012  1.00 14.43           O  
+ATOM   1092  CG2 THR H 151       5.296  29.417  33.262  1.00 18.07           C  
+ATOM   1093  N   ALA H 152       7.157  25.566  32.259  1.00 16.89           N  
+ATOM   1094  CA  ALA H 152       7.639  24.186  32.299  1.00 16.16           C  
+ATOM   1095  C   ALA H 152       7.386  23.453  33.604  1.00 16.89           C  
+ATOM   1096  O   ALA H 152       7.459  24.043  34.677  1.00 18.55           O  
+ATOM   1097  CB  ALA H 152       9.140  24.161  31.987  1.00 18.15           C  
+ATOM   1098  N   LEU H 153       7.159  22.145  33.506  1.00 14.53           N  
+ATOM   1099  CA  LEU H 153       6.940  21.306  34.685  1.00 18.07           C  
+ATOM   1100  C   LEU H 153       8.279  20.752  35.178  1.00 14.39           C  
+ATOM   1101  O   LEU H 153       8.434  20.420  36.356  1.00 15.54           O  
+ATOM   1102  CB  LEU H 153       5.980  20.156  34.360  1.00 24.54           C  
+ATOM   1103  CG  LEU H 153       4.484  20.503  34.391  1.00 26.16           C  
+ATOM   1104  CD1 LEU H 153       3.670  19.310  33.909  1.00 33.68           C  
+ATOM   1105  CD2 LEU H 153       4.068  20.897  35.811  1.00 28.18           C  
+ATOM   1106  N   GLU H 154       9.234  20.628  34.261  1.00 14.31           N  
+ATOM   1107  CA  GLU H 154      10.563  20.142  34.604  1.00 15.91           C  
+ATOM   1108  C   GLU H 154      11.560  21.267  34.378  1.00 13.85           C  
+ATOM   1109  O   GLU H 154      11.401  22.065  33.460  1.00 13.79           O  
+ATOM   1110  CB  GLU H 154      10.947  18.942  33.738  1.00 18.35           C  
+ATOM   1111  CG  GLU H 154      10.347  17.617  34.179  1.00 20.71           C  
+ATOM   1112  CD  GLU H 154      10.936  16.453  33.402  1.00 26.79           C  
+ATOM   1113  OE1 GLU H 154      10.616  16.337  32.209  1.00 22.71           O  
+ATOM   1114  OE2 GLU H 154      11.741  15.681  33.970  1.00 30.18           O  
+ATOM   1115  N   LEU H 155      12.589  21.323  35.217  1.00 13.60           N  
+ATOM   1116  CA  LEU H 155      13.610  22.359  35.104  1.00 12.58           C  
+ATOM   1117  C   LEU H 155      14.276  22.311  33.725  1.00 13.40           C  
+ATOM   1118  O   LEU H 155      14.749  21.252  33.295  1.00 11.86           O  
+ATOM   1119  CB  LEU H 155      14.663  22.173  36.209  1.00  8.62           C  
+ATOM   1120  CG  LEU H 155      15.823  23.187  36.203  1.00 12.59           C  
+ATOM   1121  CD1 LEU H 155      15.268  24.599  36.294  1.00  8.60           C  
+ATOM   1122  CD2 LEU H 155      16.742  22.904  37.396  1.00  9.32           C  
+ATOM   1123  N   MET H 156      14.290  23.449  33.035  1.00 12.11           N  
+ATOM   1124  CA  MET H 156      14.895  23.552  31.706  1.00 12.85           C  
+ATOM   1125  C   MET H 156      16.215  24.327  31.756  1.00 16.44           C  
+ATOM   1126  O   MET H 156      16.415  25.200  32.606  1.00 12.72           O  
+ATOM   1127  CB  MET H 156      13.944  24.254  30.730  1.00 14.75           C  
+ATOM   1128  CG  MET H 156      12.517  23.674  30.679  1.00 13.22           C  
+ATOM   1129  SD  MET H 156      12.472  21.928  30.224  1.00 15.80           S  
+ATOM   1130  CE  MET H 156      12.828  22.033  28.475  1.00 18.68           C  
+ATOM   1131  N   VAL H 157      17.093  24.042  30.801  1.00 13.11           N  
+ATOM   1132  CA  VAL H 157      18.388  24.702  30.738  1.00 13.28           C  
+ATOM   1133  C   VAL H 157      18.749  25.008  29.283  1.00 15.75           C  
+ATOM   1134  O   VAL H 157      18.315  24.316  28.363  1.00 15.66           O  
+ATOM   1135  CB  VAL H 157      19.475  23.837  31.423  1.00 13.24           C  
+ATOM   1136  CG1 VAL H 157      19.637  22.512  30.676  1.00 13.21           C  
+ATOM   1137  CG2 VAL H 157      20.803  24.617  31.524  1.00 11.54           C  
+ATOM   1138  N   LEU H 158      19.518  26.071  29.078  1.00 15.41           N  
+ATOM   1139  CA  LEU H 158      19.883  26.490  27.732  1.00 14.83           C  
+ATOM   1140  C   LEU H 158      21.276  27.096  27.684  1.00 16.12           C  
+ATOM   1141  O   LEU H 158      21.642  27.876  28.555  1.00 16.24           O  
+ATOM   1142  CB  LEU H 158      18.869  27.541  27.272  1.00 14.85           C  
+ATOM   1143  CG  LEU H 158      19.137  28.290  25.973  1.00 15.18           C  
+ATOM   1144  CD1 LEU H 158      18.917  27.329  24.799  1.00 13.71           C  
+ATOM   1145  CD2 LEU H 158      18.206  29.500  25.887  1.00 16.35           C  
+ATOM   1146  N   ASN H 159      22.035  26.757  26.647  1.00 15.28           N  
+ATOM   1147  CA  ASN H 159      23.392  27.287  26.453  1.00 15.51           C  
+ATOM   1148  C   ASN H 159      23.244  28.552  25.619  1.00 16.50           C  
+ATOM   1149  O   ASN H 159      22.635  28.515  24.555  1.00 16.76           O  
+ATOM   1150  CB  ASN H 159      24.242  26.254  25.688  1.00 19.71           C  
+ATOM   1151  CG  ASN H 159      25.742  26.366  25.976  1.00 25.32           C  
+ATOM   1152  OD1 ASN H 159      26.560  25.852  25.208  1.00 31.42           O  
+ATOM   1153  ND2 ASN H 159      26.107  27.008  27.080  1.00 20.59           N  
+ATOM   1154  N   VAL H 160      23.750  29.678  26.121  1.00 14.55           N  
+ATOM   1155  CA  VAL H 160      23.665  30.950  25.402  1.00 13.69           C  
+ATOM   1156  C   VAL H 160      25.011  31.658  25.313  1.00 17.60           C  
+ATOM   1157  O   VAL H 160      25.797  31.629  26.257  1.00 15.95           O  
+ATOM   1158  CB  VAL H 160      22.658  31.942  26.066  1.00 16.95           C  
+ATOM   1159  CG1 VAL H 160      21.223  31.445  25.907  1.00 16.36           C  
+ATOM   1160  CG2 VAL H 160      22.990  32.144  27.548  1.00 11.78           C  
+ATOM   1161  N   PRO H 161      25.305  32.284  24.160  1.00 17.43           N  
+ATOM   1162  CA  PRO H 161      26.575  32.995  24.002  1.00 16.39           C  
+ATOM   1163  C   PRO H 161      26.424  34.445  24.464  1.00 17.70           C  
+ATOM   1164  O   PRO H 161      25.371  35.062  24.271  1.00 15.54           O  
+ATOM   1165  CB  PRO H 161      26.837  32.900  22.496  1.00 18.15           C  
+ATOM   1166  CG  PRO H 161      25.429  32.992  21.909  1.00 15.12           C  
+ATOM   1167  CD  PRO H 161      24.609  32.118  22.865  1.00 17.77           C  
+ATOM   1168  N   ARG H 162      27.473  34.972  25.094  1.00 16.00           N  
+ATOM   1169  CA  ARG H 162      27.478  36.345  25.598  1.00 16.47           C  
+ATOM   1170  C   ARG H 162      27.990  37.315  24.536  1.00 21.27           C  
+ATOM   1171  O   ARG H 162      28.880  36.979  23.753  1.00 19.07           O  
+ATOM   1172  CB  ARG H 162      28.372  36.432  26.838  1.00 16.85           C  
+ATOM   1173  CG  ARG H 162      28.444  37.804  27.497  1.00 14.98           C  
+ATOM   1174  CD  ARG H 162      29.105  37.682  28.872  1.00 17.95           C  
+ATOM   1175  NE  ARG H 162      29.355  38.976  29.499  1.00 16.66           N  
+ATOM   1176  CZ  ARG H 162      29.781  39.133  30.752  1.00 17.61           C  
+ATOM   1177  NH1 ARG H 162      30.000  38.071  31.522  1.00 15.45           N  
+ATOM   1178  NH2 ARG H 162      30.008  40.354  31.231  1.00 15.35           N  
+ATOM   1179  N   LEU H 163      27.431  38.520  24.528  1.00 22.12           N  
+ATOM   1180  CA  LEU H 163      27.838  39.553  23.583  1.00 22.99           C  
+ATOM   1181  C   LEU H 163      28.382  40.766  24.312  1.00 25.65           C  
+ATOM   1182  O   LEU H 163      27.959  41.066  25.427  1.00 27.61           O  
+ATOM   1183  CB  LEU H 163      26.647  40.027  22.738  1.00 24.48           C  
+ATOM   1184  CG  LEU H 163      26.070  39.166  21.604  1.00 29.77           C  
+ATOM   1185  CD1 LEU H 163      25.338  37.933  22.141  1.00 29.18           C  
+ATOM   1186  CD2 LEU H 163      25.110  40.026  20.800  1.00 32.54           C  
+ATOM   1187  N   MET H 164      29.355  41.441  23.706  1.00 27.67           N  
+ATOM   1188  CA  MET H 164      29.859  42.681  24.285  1.00 30.42           C  
+ATOM   1189  C   MET H 164      28.696  43.623  23.992  1.00 28.89           C  
+ATOM   1190  O   MET H 164      28.017  43.460  22.974  1.00 21.73           O  
+ATOM   1191  CB  MET H 164      31.122  43.152  23.570  1.00 36.54           C  
+ATOM   1192  CG  MET H 164      32.314  42.253  23.802  1.00 44.96           C  
+ATOM   1193  SD  MET H 164      33.806  42.939  23.066  1.00 57.77           S  
+ATOM   1194  CE  MET H 164      34.461  43.840  24.468  1.00 56.09           C  
+ATOM   1195  N   THR H 165      28.448  44.581  24.880  1.00 28.72           N  
+ATOM   1196  CA  THR H 165      27.311  45.495  24.724  1.00 31.68           C  
+ATOM   1197  C   THR H 165      27.261  46.271  23.408  1.00 30.63           C  
+ATOM   1198  O   THR H 165      26.180  46.490  22.851  1.00 27.58           O  
+ATOM   1199  CB  THR H 165      27.193  46.453  25.934  1.00 35.87           C  
+ATOM   1200  OG1 THR H 165      26.950  45.681  27.121  1.00 37.66           O  
+ATOM   1201  CG2 THR H 165      26.043  47.443  25.743  1.00 39.34           C  
+ATOM   1202  N   GLN H 166      28.430  46.650  22.900  1.00 30.91           N  
+ATOM   1203  CA  GLN H 166      28.512  47.387  21.643  1.00 35.75           C  
+ATOM   1204  C   GLN H 166      27.915  46.521  20.539  1.00 31.77           C  
+ATOM   1205  O   GLN H 166      27.125  46.994  19.725  1.00 32.99           O  
+ATOM   1206  CB  GLN H 166      29.973  47.716  21.319  1.00 38.44           C  
+ATOM   1207  CG  GLN H 166      30.182  48.431  19.993  1.00 50.29           C  
+ATOM   1208  CD  GLN H 166      31.653  48.641  19.670  1.00 56.08           C  
+ATOM   1209  OE1 GLN H 166      32.214  49.709  19.931  1.00 61.35           O  
+ATOM   1210  NE2 GLN H 166      32.286  47.619  19.099  1.00 59.34           N  
+ATOM   1211  N   ASP H 167      28.252  45.235  20.571  1.00 30.99           N  
+ATOM   1212  CA  ASP H 167      27.771  44.283  19.583  1.00 35.97           C  
+ATOM   1213  C   ASP H 167      26.292  43.969  19.759  1.00 36.17           C  
+ATOM   1214  O   ASP H 167      25.587  43.717  18.779  1.00 35.09           O  
+ATOM   1215  CB  ASP H 167      28.600  42.994  19.630  1.00 43.30           C  
+ATOM   1216  CG  ASP H 167      30.077  43.235  19.332  1.00 50.32           C  
+ATOM   1217  OD1 ASP H 167      30.389  44.063  18.446  1.00 53.09           O  
+ATOM   1218  OD2 ASP H 167      30.931  42.593  19.983  1.00 55.17           O  
+ATOM   1219  N   CYS H 168      25.818  43.989  21.002  1.00 32.87           N  
+ATOM   1220  CA  CYS H 168      24.412  43.707  21.268  1.00 32.39           C  
+ATOM   1221  C   CYS H 168      23.536  44.795  20.657  1.00 33.40           C  
+ATOM   1222  O   CYS H 168      22.519  44.510  20.025  1.00 32.95           O  
+ATOM   1223  CB  CYS H 168      24.143  43.623  22.776  1.00 25.80           C  
+ATOM   1224  SG  CYS H 168      22.401  43.250  23.181  1.00 27.98           S  
+ATOM   1225  N   LEU H 169      23.951  46.043  20.839  1.00 38.21           N  
+ATOM   1226  CA  LEU H 169      23.210  47.184  20.315  1.00 41.89           C  
+ATOM   1227  C   LEU H 169      23.226  47.217  18.786  1.00 43.40           C  
+ATOM   1228  O   LEU H 169      22.199  47.484  18.157  1.00 43.53           O  
+ATOM   1229  CB  LEU H 169      23.780  48.480  20.891  1.00 44.58           C  
+ATOM   1230  CG  LEU H 169      23.660  48.589  22.415  1.00 45.42           C  
+ATOM   1231  CD1 LEU H 169      24.512  49.736  22.923  1.00 47.40           C  
+ATOM   1232  CD2 LEU H 169      22.199  48.767  22.815  1.00 47.04           C  
+ATOM   1233  N   GLN H 170      24.387  46.917  18.201  1.00 43.17           N  
+ATOM   1234  CA  GLN H 170      24.551  46.899  16.751  1.00 43.17           C  
+ATOM   1235  C   GLN H 170      23.722  45.789  16.115  1.00 44.19           C  
+ATOM   1236  O   GLN H 170      23.079  45.998  15.086  1.00 45.08           O  
+ATOM   1237  CB  GLN H 170      26.029  46.726  16.379  1.00 40.79           C  
+ATOM   1238  CG  GLN H 170      26.901  47.909  16.773  0.00 35.20           C  
+ATOM   1239  CD  GLN H 170      28.368  47.704  16.442  0.00 31.39           C  
+ATOM   1240  OE1 GLN H 170      28.802  46.594  16.134  0.00 29.18           O  
+ATOM   1241  NE2 GLN H 170      29.142  48.781  16.512  0.00 28.58           N  
+ATOM   1242  N   GLN H 170A     23.713  44.619  16.752  1.00 43.34           N  
+ATOM   1243  CA  GLN H 170A     22.961  43.475  16.244  1.00 44.91           C  
+ATOM   1244  C   GLN H 170A     21.465  43.491  16.578  1.00 44.93           C  
+ATOM   1245  O   GLN H 170A     20.694  42.711  16.009  1.00 45.77           O  
+ATOM   1246  CB  GLN H 170A     23.601  42.164  16.717  1.00 45.52           C  
+ATOM   1247  CG  GLN H 170A     24.986  41.913  16.139  1.00 46.73           C  
+ATOM   1248  CD  GLN H 170A     25.607  40.610  16.622  1.00 45.79           C  
+ATOM   1249  OE1 GLN H 170A     26.813  40.541  16.871  1.00 46.14           O  
+ATOM   1250  NE2 GLN H 170A     24.792  39.567  16.734  1.00 48.75           N  
+ATOM   1251  N   SER H 170B     21.056  44.361  17.500  1.00 44.66           N  
+ATOM   1252  CA  SER H 170B     19.646  44.464  17.880  1.00 45.82           C  
+ATOM   1253  C   SER H 170B     18.906  45.507  17.051  1.00 47.06           C  
+ATOM   1254  O   SER H 170B     19.500  46.483  16.579  1.00 46.28           O  
+ATOM   1255  CB  SER H 170B     19.488  44.815  19.368  1.00 45.56           C  
+ATOM   1256  OG  SER H 170B     19.935  43.764  20.207  1.00 38.47           O  
+ATOM   1257  N   ARG H 170C     17.608  45.280  16.870  1.00 47.58           N  
+ATOM   1258  CA  ARG H 170C     16.752  46.196  16.128  1.00 49.72           C  
+ATOM   1259  C   ARG H 170C     16.294  47.275  17.110  1.00 49.83           C  
+ATOM   1260  O   ARG H 170C     15.925  46.970  18.243  1.00 51.59           O  
+ATOM   1261  CB  ARG H 170C     15.559  45.437  15.533  1.00 51.67           C  
+ATOM   1262  CG  ARG H 170C     15.991  44.280  14.635  1.00 54.38           C  
+ATOM   1263  CD  ARG H 170C     14.984  43.956  13.533  1.00 59.23           C  
+ATOM   1264  NE  ARG H 170C     13.791  43.258  14.012  1.00 63.06           N  
+ATOM   1265  CZ  ARG H 170C     13.085  42.394  13.282  1.00 64.24           C  
+ATOM   1266  NH1 ARG H 170C     13.451  42.114  12.036  1.00 62.03           N  
+ATOM   1267  NH2 ARG H 170C     12.002  41.815  13.793  1.00 64.65           N  
+ATOM   1268  N   LYS H 170D     16.360  48.533  16.689  0.00 47.98           N  
+ATOM   1269  CA  LYS H 170D     15.982  49.651  17.551  0.00 46.80           C  
+ATOM   1270  C   LYS H 170D     14.504  49.792  17.891  0.00 49.79           C  
+ATOM   1271  O   LYS H 170D     13.632  49.677  17.028  0.00 49.34           O  
+ATOM   1272  CB  LYS H 170D     16.526  50.961  16.984  0.00 40.67           C  
+ATOM   1273  CG  LYS H 170D     17.980  51.213  17.348  0.00 32.71           C  
+ATOM   1274  CD  LYS H 170D     18.690  52.042  16.294  0.00 26.20           C  
+ATOM   1275  CE  LYS H 170D     18.865  51.249  15.007  0.00 22.44           C  
+ATOM   1276  NZ  LYS H 170D     19.622  49.984  15.239  0.00 20.83           N  
+ATOM   1277  N   VAL H 170E     14.246  50.040  19.172  1.00 54.52           N  
+ATOM   1278  CA  VAL H 170E     12.893  50.217  19.698  1.00 58.19           C  
+ATOM   1279  C   VAL H 170E     12.805  51.580  20.394  1.00 61.23           C  
+ATOM   1280  O   VAL H 170E     13.771  52.033  21.022  1.00 61.76           O  
+ATOM   1281  CB  VAL H 170E     12.533  49.084  20.707  1.00 58.02           C  
+ATOM   1282  CG1 VAL H 170E     11.183  49.357  21.377  1.00 57.08           C  
+ATOM   1283  CG2 VAL H 170E     12.505  47.736  19.993  1.00 58.19           C  
+ATOM   1284  N   GLY H 170F     11.645  52.224  20.276  1.00 63.21           N  
+ATOM   1285  CA  GLY H 170F     11.443  53.530  20.883  1.00 64.59           C  
+ATOM   1286  C   GLY H 170F     11.585  53.564  22.396  1.00 64.78           C  
+ATOM   1287  O   GLY H 170F     12.543  54.135  22.922  1.00 65.96           O  
+ATOM   1288  N   ASP H 170G     10.636  52.944  23.096  1.00 64.04           N  
+ATOM   1289  CA  ASP H 170G     10.642  52.910  24.561  1.00 62.64           C  
+ATOM   1290  C   ASP H 170G     11.675  51.962  25.174  1.00 60.18           C  
+ATOM   1291  O   ASP H 170G     11.768  51.852  26.402  1.00 62.80           O  
+ATOM   1292  CB  ASP H 170G      9.246  52.550  25.084  1.00 64.42           C  
+ATOM   1293  CG  ASP H 170G      8.248  53.675  24.901  1.00 66.23           C  
+ATOM   1294  OD1 ASP H 170G      8.058  54.458  25.859  1.00 68.44           O  
+ATOM   1295  OD2 ASP H 170G      7.652  53.776  23.805  1.00 66.38           O  
+ATOM   1296  N   SER H 170H     12.449  51.294  24.320  1.00 55.86           N  
+ATOM   1297  CA  SER H 170H     13.471  50.339  24.749  1.00 49.16           C  
+ATOM   1298  C   SER H 170H     14.402  50.824  25.861  1.00 44.16           C  
+ATOM   1299  O   SER H 170H     15.059  51.858  25.723  1.00 43.52           O  
+ATOM   1300  CB  SER H 170H     14.313  49.912  23.545  1.00 46.94           C  
+ATOM   1301  OG  SER H 170H     15.328  49.002  23.929  1.00 54.92           O  
+ATOM   1302  N   PRO H 170I     14.452  50.092  26.992  1.00 39.42           N  
+ATOM   1303  CA  PRO H 170I     15.342  50.527  28.070  1.00 34.89           C  
+ATOM   1304  C   PRO H 170I     16.811  50.368  27.679  1.00 33.71           C  
+ATOM   1305  O   PRO H 170I     17.161  49.525  26.846  1.00 31.43           O  
+ATOM   1306  CB  PRO H 170I     14.937  49.629  29.250  1.00 36.29           C  
+ATOM   1307  CG  PRO H 170I     14.311  48.438  28.612  1.00 34.87           C  
+ATOM   1308  CD  PRO H 170I     13.569  48.998  27.439  1.00 38.70           C  
+ATOM   1309  N   ASN H 175      17.655  51.232  28.234  1.00 31.32           N  
+ATOM   1310  CA  ASN H 175      19.088  51.206  27.953  1.00 31.48           C  
+ATOM   1311  C   ASN H 175      19.805  50.020  28.585  1.00 30.34           C  
+ATOM   1312  O   ASN H 175      19.410  49.544  29.654  1.00 28.30           O  
+ATOM   1313  CB  ASN H 175      19.744  52.494  28.455  1.00 33.14           C  
+ATOM   1314  CG  ASN H 175      19.369  53.704  27.620  1.00 40.80           C  
+ATOM   1315  OD1 ASN H 175      20.119  54.115  26.738  1.00 46.90           O  
+ATOM   1316  ND2 ASN H 175      18.201  54.274  27.892  1.00 44.32           N  
+ATOM   1317  N   ILE H 176      20.847  49.544  27.904  1.00 29.93           N  
+ATOM   1318  CA  ILE H 176      21.677  48.449  28.398  1.00 29.38           C  
+ATOM   1319  C   ILE H 176      22.809  49.179  29.116  1.00 28.31           C  
+ATOM   1320  O   ILE H 176      23.629  49.847  28.480  1.00 30.25           O  
+ATOM   1321  CB  ILE H 176      22.319  47.613  27.254  1.00 29.53           C  
+ATOM   1322  CG1 ILE H 176      21.270  47.161  26.232  1.00 34.79           C  
+ATOM   1323  CG2 ILE H 176      23.033  46.396  27.840  1.00 26.80           C  
+ATOM   1324  CD1 ILE H 176      20.251  46.206  26.766  1.00 36.30           C  
+ATOM   1325  N   THR H 177      22.850  49.066  30.436  1.00 25.74           N  
+ATOM   1326  CA  THR H 177      23.870  49.747  31.223  1.00 18.49           C  
+ATOM   1327  C   THR H 177      25.061  48.836  31.508  1.00 20.16           C  
+ATOM   1328  O   THR H 177      25.087  47.671  31.099  1.00 16.50           O  
+ATOM   1329  CB  THR H 177      23.291  50.192  32.561  1.00 21.07           C  
+ATOM   1330  OG1 THR H 177      23.103  49.031  33.380  1.00 16.92           O  
+ATOM   1331  CG2 THR H 177      21.943  50.909  32.359  1.00 22.03           C  
+ATOM   1332  N   GLU H 178      26.026  49.356  32.257  1.00 16.71           N  
+ATOM   1333  CA  GLU H 178      27.216  48.587  32.606  1.00 19.80           C  
+ATOM   1334  C   GLU H 178      26.867  47.536  33.668  1.00 18.08           C  
+ATOM   1335  O   GLU H 178      27.675  46.676  33.999  1.00 17.78           O  
+ATOM   1336  CB  GLU H 178      28.317  49.527  33.113  1.00 24.75           C  
+ATOM   1337  CG  GLU H 178      27.988  50.195  34.435  1.00 33.30           C  
+ATOM   1338  CD  GLU H 178      29.012  51.239  34.852  1.00 44.15           C  
+ATOM   1339  OE1 GLU H 178      28.667  52.441  34.829  1.00 48.16           O  
+ATOM   1340  OE2 GLU H 178      30.151  50.859  35.214  1.00 50.43           O  
+ATOM   1341  N   TYR H 179      25.647  47.603  34.181  1.00 16.53           N  
+ATOM   1342  CA  TYR H 179      25.184  46.660  35.189  1.00 17.10           C  
+ATOM   1343  C   TYR H 179      24.395  45.521  34.557  1.00 15.13           C  
+ATOM   1344  O   TYR H 179      23.741  44.747  35.254  1.00 13.14           O  
+ATOM   1345  CB  TYR H 179      24.356  47.399  36.235  1.00 14.51           C  
+ATOM   1346  CG  TYR H 179      25.177  48.463  36.936  1.00 18.46           C  
+ATOM   1347  CD1 TYR H 179      26.071  48.114  37.947  1.00 16.61           C  
+ATOM   1348  CD2 TYR H 179      25.106  49.805  36.549  1.00 18.92           C  
+ATOM   1349  CE1 TYR H 179      26.886  49.065  38.562  1.00 16.36           C  
+ATOM   1350  CE2 TYR H 179      25.925  50.779  37.161  1.00 20.30           C  
+ATOM   1351  CZ  TYR H 179      26.811  50.391  38.165  1.00 23.16           C  
+ATOM   1352  OH  TYR H 179      27.643  51.307  38.761  1.00 22.18           O  
+ATOM   1353  N   MET H 180      24.517  45.401  33.237  1.00 14.77           N  
+ATOM   1354  CA  MET H 180      23.828  44.376  32.467  1.00 13.68           C  
+ATOM   1355  C   MET H 180      24.725  43.856  31.352  1.00 16.24           C  
+ATOM   1356  O   MET H 180      25.782  44.423  31.063  1.00 14.36           O  
+ATOM   1357  CB  MET H 180      22.593  44.972  31.769  1.00 16.23           C  
+ATOM   1358  CG  MET H 180      21.630  45.760  32.622  1.00 17.34           C  
+ATOM   1359  SD  MET H 180      20.461  46.681  31.555  1.00 17.17           S  
+ATOM   1360  CE  MET H 180      19.704  47.761  32.770  1.00 13.59           C  
+ATOM   1361  N   PHE H 181      24.277  42.778  30.719  1.00 16.29           N  
+ATOM   1362  CA  PHE H 181      24.959  42.212  29.555  1.00 16.73           C  
+ATOM   1363  C   PHE H 181      23.957  41.392  28.766  1.00 19.02           C  
+ATOM   1364  O   PHE H 181      22.963  40.917  29.317  1.00 11.58           O  
+ATOM   1365  CB  PHE H 181      26.231  41.404  29.908  1.00 16.03           C  
+ATOM   1366  CG  PHE H 181      25.970  40.076  30.564  1.00 15.46           C  
+ATOM   1367  CD1 PHE H 181      25.622  38.957  29.799  1.00 12.48           C  
+ATOM   1368  CD2 PHE H 181      26.100  39.936  31.940  1.00 11.77           C  
+ATOM   1369  CE1 PHE H 181      25.408  37.712  30.404  1.00 14.19           C  
+ATOM   1370  CE2 PHE H 181      25.889  38.695  32.561  1.00 12.01           C  
+ATOM   1371  CZ  PHE H 181      25.543  37.583  31.791  1.00 10.77           C  
+ATOM   1372  N   CYS H 182      24.176  41.308  27.457  1.00 17.19           N  
+ATOM   1373  CA  CYS H 182      23.302  40.552  26.588  1.00 16.99           C  
+ATOM   1374  C   CYS H 182      23.850  39.174  26.359  1.00 15.41           C  
+ATOM   1375  O   CYS H 182      25.068  38.979  26.307  1.00 18.31           O  
+ATOM   1376  CB  CYS H 182      23.187  41.213  25.216  1.00 18.93           C  
+ATOM   1377  SG  CYS H 182      22.480  42.879  25.186  1.00 21.36           S  
+ATOM   1378  N   ALA H 183      22.938  38.218  26.212  1.00 15.51           N  
+ATOM   1379  CA  ALA H 183      23.307  36.846  25.915  1.00 16.68           C  
+ATOM   1380  C   ALA H 183      22.142  36.153  25.212  1.00 15.96           C  
+ATOM   1381  O   ALA H 183      20.978  36.417  25.509  1.00 19.05           O  
+ATOM   1382  CB  ALA H 183      23.705  36.097  27.183  1.00 14.35           C  
+ATOM   1383  N   GLY H 184A     22.454  35.319  24.227  1.00 16.58           N  
+ATOM   1384  CA  GLY H 184A     21.394  34.613  23.539  1.00 16.31           C  
+ATOM   1385  C   GLY H 184A     21.537  34.560  22.034  1.00 23.66           C  
+ATOM   1386  O   GLY H 184A     22.647  34.544  21.501  1.00 18.78           O  
+ATOM   1387  N   TYR H 184      20.393  34.554  21.357  1.00 21.86           N  
+ATOM   1388  CA  TYR H 184      20.324  34.462  19.902  1.00 21.74           C  
+ATOM   1389  C   TYR H 184      19.284  35.438  19.382  1.00 23.31           C  
+ATOM   1390  O   TYR H 184      18.301  35.724  20.067  1.00 21.14           O  
+ATOM   1391  CB  TYR H 184      19.908  33.045  19.512  1.00 21.67           C  
+ATOM   1392  CG  TYR H 184      20.867  31.988  19.980  1.00 19.78           C  
+ATOM   1393  CD1 TYR H 184      20.798  31.475  21.273  1.00 19.40           C  
+ATOM   1394  CD2 TYR H 184      21.857  31.504  19.126  1.00 21.69           C  
+ATOM   1395  CE1 TYR H 184      21.693  30.499  21.705  1.00 20.45           C  
+ATOM   1396  CE2 TYR H 184      22.759  30.532  19.549  1.00 22.16           C  
+ATOM   1397  CZ  TYR H 184      22.670  30.035  20.831  1.00 20.31           C  
+ATOM   1398  OH  TYR H 184      23.549  29.058  21.234  1.00 27.20           O  
+ATOM   1399  N   SER H 185      19.484  35.934  18.165  1.00 22.15           N  
+ATOM   1400  CA  SER H 185      18.542  36.890  17.579  1.00 24.92           C  
+ATOM   1401  C   SER H 185      17.621  36.295  16.500  1.00 25.34           C  
+ATOM   1402  O   SER H 185      16.841  37.020  15.878  1.00 25.50           O  
+ATOM   1403  CB  SER H 185      19.299  38.099  17.017  1.00 23.96           C  
+ATOM   1404  OG  SER H 185      20.219  37.707  16.011  1.00 26.82           O  
+ATOM   1405  N   ASP H 186      17.686  34.982  16.298  1.00 26.21           N  
+ATOM   1406  CA  ASP H 186      16.858  34.325  15.282  1.00 26.19           C  
+ATOM   1407  C   ASP H 186      15.493  33.860  15.797  1.00 27.59           C  
+ATOM   1408  O   ASP H 186      14.771  33.137  15.104  1.00 23.42           O  
+ATOM   1409  CB  ASP H 186      17.624  33.154  14.642  1.00 28.46           C  
+ATOM   1410  CG  ASP H 186      17.861  31.990  15.607  1.00 29.96           C  
+ATOM   1411  OD1 ASP H 186      17.629  32.138  16.825  1.00 32.89           O  
+ATOM   1412  OD2 ASP H 186      18.283  30.911  15.142  1.00 24.42           O  
+ATOM   1413  N   GLY H 187      15.171  34.232  17.036  1.00 25.58           N  
+ATOM   1414  CA  GLY H 187      13.892  33.869  17.629  1.00 24.43           C  
+ATOM   1415  C   GLY H 187      13.720  32.415  18.035  1.00 25.43           C  
+ATOM   1416  O   GLY H 187      12.589  31.940  18.183  1.00 26.44           O  
+ATOM   1417  N   SER H 188A     14.827  31.723  18.288  1.00 20.89           N  
+ATOM   1418  CA  SER H 188A     14.764  30.309  18.652  1.00 20.14           C  
+ATOM   1419  C   SER H 188A     15.083  29.927  20.099  1.00 18.77           C  
+ATOM   1420  O   SER H 188A     14.543  28.944  20.610  1.00 16.79           O  
+ATOM   1421  CB  SER H 188A     15.706  29.505  17.747  1.00 24.79           C  
+ATOM   1422  OG  SER H 188A     17.065  29.765  18.081  1.00 22.86           O  
+ATOM   1423  N   LYS H 188      15.980  30.670  20.743  1.00 20.98           N  
+ATOM   1424  CA  LYS H 188      16.417  30.332  22.106  1.00 20.94           C  
+ATOM   1425  C   LYS H 188      16.599  31.553  22.999  1.00 15.93           C  
+ATOM   1426  O   LYS H 188      17.263  32.511  22.612  1.00 15.08           O  
+ATOM   1427  CB  LYS H 188      17.762  29.597  22.033  1.00 21.62           C  
+ATOM   1428  CG  LYS H 188      17.801  28.378  21.115  1.00 24.91           C  
+ATOM   1429  CD  LYS H 188      19.238  27.863  20.983  1.00 26.34           C  
+ATOM   1430  CE  LYS H 188      19.471  27.215  19.636  1.00 37.58           C  
+ATOM   1431  NZ  LYS H 188      19.173  28.153  18.516  1.00 20.47           N  
+ATOM   1432  N   ASP H 189      16.084  31.479  24.224  1.00 14.19           N  
+ATOM   1433  CA  ASP H 189      16.187  32.606  25.151  1.00 12.80           C  
+ATOM   1434  C   ASP H 189      15.594  32.166  26.479  1.00 15.19           C  
+ATOM   1435  O   ASP H 189      15.011  31.084  26.579  1.00 12.23           O  
+ATOM   1436  CB  ASP H 189      15.345  33.776  24.587  1.00 12.63           C  
+ATOM   1437  CG  ASP H 189      15.584  35.113  25.295  1.00 18.01           C  
+ATOM   1438  OD1 ASP H 189      16.431  35.221  26.205  1.00 15.70           O  
+ATOM   1439  OD2 ASP H 189      14.898  36.092  24.924  1.00 15.42           O  
+ATOM   1440  N   SER H 190      15.855  32.934  27.528  1.00 12.66           N  
+ATOM   1441  CA  SER H 190      15.218  32.666  28.810  1.00 13.76           C  
+ATOM   1442  C   SER H 190      13.912  33.493  28.709  1.00 13.84           C  
+ATOM   1443  O   SER H 190      13.701  34.205  27.713  1.00 13.35           O  
+ATOM   1444  CB  SER H 190      16.107  33.125  29.980  1.00 10.46           C  
+ATOM   1445  OG  SER H 190      16.534  34.468  29.843  1.00 15.83           O  
+ATOM   1446  N   CYS H 191      13.033  33.409  29.708  1.00 14.22           N  
+ATOM   1447  CA  CYS H 191      11.772  34.152  29.641  1.00 17.70           C  
+ATOM   1448  C   CYS H 191      11.356  34.677  31.016  1.00 16.18           C  
+ATOM   1449  O   CYS H 191      12.073  34.493  32.006  1.00 14.26           O  
+ATOM   1450  CB  CYS H 191      10.668  33.278  28.992  1.00 14.12           C  
+ATOM   1451  SG  CYS H 191       9.214  34.170  28.301  1.00 18.20           S  
+ATOM   1452  N   LYS H 192      10.218  35.362  31.057  1.00 17.88           N  
+ATOM   1453  CA  LYS H 192       9.682  35.973  32.282  1.00 16.64           C  
+ATOM   1454  C   LYS H 192       9.724  35.119  33.547  1.00 15.86           C  
+ATOM   1455  O   LYS H 192      10.196  35.577  34.589  1.00 16.22           O  
+ATOM   1456  CB  LYS H 192       8.246  36.452  32.028  1.00 21.09           C  
+ATOM   1457  CG  LYS H 192       8.167  37.573  31.003  1.00 35.33           C  
+ATOM   1458  CD  LYS H 192       6.800  37.676  30.338  1.00 37.99           C  
+ATOM   1459  CE  LYS H 192       5.682  37.862  31.346  1.00 42.57           C  
+ATOM   1460  NZ  LYS H 192       4.403  38.203  30.650  1.00 45.48           N  
+ATOM   1461  N   GLY H 193       9.215  33.892  33.456  1.00 13.05           N  
+ATOM   1462  CA  GLY H 193       9.188  32.992  34.598  1.00 15.54           C  
+ATOM   1463  C   GLY H 193      10.551  32.494  35.053  1.00 13.13           C  
+ATOM   1464  O   GLY H 193      10.655  31.850  36.097  1.00 13.97           O  
+ATOM   1465  N   ASP H 194      11.586  32.755  34.256  1.00  9.81           N  
+ATOM   1466  CA  ASP H 194      12.948  32.350  34.608  1.00 15.60           C  
+ATOM   1467  C   ASP H 194      13.650  33.462  35.375  1.00 11.45           C  
+ATOM   1468  O   ASP H 194      14.746  33.253  35.894  1.00 14.42           O  
+ATOM   1469  CB  ASP H 194      13.760  32.012  33.355  1.00 10.68           C  
+ATOM   1470  CG  ASP H 194      13.135  30.899  32.545  1.00 14.90           C  
+ATOM   1471  OD1 ASP H 194      12.842  29.840  33.121  1.00 11.81           O  
+ATOM   1472  OD2 ASP H 194      12.919  31.085  31.334  1.00 13.02           O  
+ATOM   1473  N   SER H 195      13.014  34.639  35.420  1.00 11.73           N  
+ATOM   1474  CA  SER H 195      13.542  35.824  36.115  1.00 12.20           C  
+ATOM   1475  C   SER H 195      14.182  35.468  37.444  1.00 13.14           C  
+ATOM   1476  O   SER H 195      13.571  34.771  38.256  1.00 12.53           O  
+ATOM   1477  CB  SER H 195      12.413  36.840  36.395  1.00 14.01           C  
+ATOM   1478  OG  SER H 195      12.007  37.532  35.217  1.00 11.72           O  
+ATOM   1479  N   GLY H 196      15.395  35.976  37.674  1.00 11.52           N  
+ATOM   1480  CA  GLY H 196      16.095  35.711  38.924  1.00  8.17           C  
+ATOM   1481  C   GLY H 196      16.993  34.487  38.893  1.00 13.42           C  
+ATOM   1482  O   GLY H 196      17.851  34.322  39.767  1.00 11.22           O  
+ATOM   1483  N   GLY H 197      16.794  33.631  37.888  1.00 11.60           N  
+ATOM   1484  CA  GLY H 197      17.575  32.411  37.757  1.00 11.49           C  
+ATOM   1485  C   GLY H 197      19.025  32.638  37.374  1.00 15.05           C  
+ATOM   1486  O   GLY H 197      19.406  33.741  36.955  1.00 10.32           O  
+ATOM   1487  N   PRO H 198      19.858  31.588  37.449  1.00 11.35           N  
+ATOM   1488  CA  PRO H 198      21.276  31.722  37.108  1.00 14.07           C  
+ATOM   1489  C   PRO H 198      21.678  31.745  35.645  1.00 14.05           C  
+ATOM   1490  O   PRO H 198      21.019  31.150  34.784  1.00 12.79           O  
+ATOM   1491  CB  PRO H 198      21.892  30.477  37.761  1.00 11.89           C  
+ATOM   1492  CG  PRO H 198      20.820  29.449  37.540  1.00 14.74           C  
+ATOM   1493  CD  PRO H 198      19.563  30.228  37.939  1.00 11.58           C  
+ATOM   1494  N   HIS H 199      22.772  32.464  35.395  1.00 12.80           N  
+ATOM   1495  CA  HIS H 199      23.453  32.504  34.101  1.00 11.95           C  
+ATOM   1496  C   HIS H 199      24.807  32.031  34.659  1.00 12.45           C  
+ATOM   1497  O   HIS H 199      25.506  32.788  35.355  1.00 11.56           O  
+ATOM   1498  CB  HIS H 199      23.550  33.920  33.522  1.00 13.35           C  
+ATOM   1499  CG  HIS H 199      24.462  34.029  32.336  1.00 16.71           C  
+ATOM   1500  ND1 HIS H 199      25.829  34.184  32.460  1.00 12.77           N  
+ATOM   1501  CD2 HIS H 199      24.203  34.049  31.005  1.00 17.80           C  
+ATOM   1502  CE1 HIS H 199      26.371  34.304  31.259  1.00 13.51           C  
+ATOM   1503  NE2 HIS H 199      25.407  34.223  30.359  1.00 13.72           N  
+ATOM   1504  N   ALA H 200      25.076  30.737  34.495  1.00 11.34           N  
+ATOM   1505  CA  ALA H 200      26.279  30.088  35.028  1.00 15.26           C  
+ATOM   1506  C   ALA H 200      27.387  29.828  34.011  1.00 15.16           C  
+ATOM   1507  O   ALA H 200      27.143  29.285  32.937  1.00 15.53           O  
+ATOM   1508  CB  ALA H 200      25.886  28.787  35.726  1.00 11.46           C  
+ATOM   1509  N   THR H 201      28.619  30.146  34.402  1.00 13.65           N  
+ATOM   1510  CA  THR H 201      29.771  30.010  33.521  1.00 13.17           C  
+ATOM   1511  C   THR H 201      30.813  29.003  33.984  1.00 13.31           C  
+ATOM   1512  O   THR H 201      31.297  29.048  35.117  1.00 12.39           O  
+ATOM   1513  CB  THR H 201      30.436  31.374  33.328  1.00 14.13           C  
+ATOM   1514  OG1 THR H 201      29.448  32.305  32.877  1.00 18.07           O  
+ATOM   1515  CG2 THR H 201      31.554  31.301  32.295  1.00 14.86           C  
+ATOM   1516  N   HIS H 202      31.170  28.105  33.080  1.00 14.51           N  
+ATOM   1517  CA  HIS H 202      32.155  27.081  33.372  1.00 16.11           C  
+ATOM   1518  C   HIS H 202      33.570  27.564  33.080  1.00 15.65           C  
+ATOM   1519  O   HIS H 202      33.811  28.241  32.079  1.00 15.67           O  
+ATOM   1520  CB  HIS H 202      31.865  25.838  32.525  1.00 18.08           C  
+ATOM   1521  CG  HIS H 202      32.931  24.792  32.598  1.00 22.83           C  
+ATOM   1522  ND1 HIS H 202      32.949  23.813  33.569  1.00 29.20           N  
+ATOM   1523  CD2 HIS H 202      34.007  24.558  31.807  1.00 20.63           C  
+ATOM   1524  CE1 HIS H 202      33.987  23.019  33.371  1.00 22.42           C  
+ATOM   1525  NE2 HIS H 202      34.644  23.450  32.309  1.00 25.58           N  
+ATOM   1526  N   TYR H 203      34.496  27.217  33.971  1.00 16.66           N  
+ATOM   1527  CA  TYR H 203      35.895  27.560  33.789  1.00 17.24           C  
+ATOM   1528  C   TYR H 203      36.777  26.570  34.524  1.00 17.85           C  
+ATOM   1529  O   TYR H 203      36.750  26.479  35.758  1.00 14.63           O  
+ATOM   1530  CB  TYR H 203      36.231  28.976  34.245  1.00 16.16           C  
+ATOM   1531  CG  TYR H 203      37.654  29.344  33.880  1.00 16.56           C  
+ATOM   1532  CD1 TYR H 203      37.983  29.699  32.571  1.00 18.43           C  
+ATOM   1533  CD2 TYR H 203      38.674  29.297  34.830  1.00 17.04           C  
+ATOM   1534  CE1 TYR H 203      39.294  30.000  32.216  1.00 20.58           C  
+ATOM   1535  CE2 TYR H 203      39.992  29.596  34.488  1.00 17.26           C  
+ATOM   1536  CZ  TYR H 203      40.291  29.948  33.180  1.00 21.16           C  
+ATOM   1537  OH  TYR H 203      41.585  30.256  32.838  1.00 20.60           O  
+ATOM   1538  N   ARG H 204      37.546  25.820  33.738  1.00 17.34           N  
+ATOM   1539  CA  ARG H 204      38.469  24.821  34.252  1.00 19.49           C  
+ATOM   1540  C   ARG H 204      37.867  23.854  35.274  1.00 18.84           C  
+ATOM   1541  O   ARG H 204      38.408  23.676  36.365  1.00 19.95           O  
+ATOM   1542  CB  ARG H 204      39.743  25.494  34.792  1.00 18.17           C  
+ATOM   1543  CG  ARG H 204      40.553  26.205  33.691  1.00 23.63           C  
+ATOM   1544  CD  ARG H 204      41.949  26.633  34.161  1.00 35.42           C  
+ATOM   1545  NE  ARG H 204      42.667  27.390  33.131  1.00 49.64           N  
+ATOM   1546  CZ  ARG H 204      43.798  28.069  33.333  1.00 54.17           C  
+ATOM   1547  NH1 ARG H 204      44.364  28.098  34.530  1.00 56.18           N  
+ATOM   1548  NH2 ARG H 204      44.372  28.723  32.329  1.00 58.94           N  
+ATOM   1549  N   GLY H 205      36.734  23.251  34.909  1.00 17.13           N  
+ATOM   1550  CA  GLY H 205      36.083  22.268  35.763  1.00 19.28           C  
+ATOM   1551  C   GLY H 205      35.165  22.760  36.868  1.00 20.53           C  
+ATOM   1552  O   GLY H 205      34.629  21.949  37.629  1.00 19.07           O  
+ATOM   1553  N   THR H 206      34.970  24.071  36.961  1.00 20.31           N  
+ATOM   1554  CA  THR H 206      34.112  24.627  38.002  1.00 17.27           C  
+ATOM   1555  C   THR H 206      33.143  25.665  37.433  1.00 14.99           C  
+ATOM   1556  O   THR H 206      33.465  26.365  36.474  1.00 13.70           O  
+ATOM   1557  CB  THR H 206      34.971  25.230  39.135  1.00 17.98           C  
+ATOM   1558  OG1 THR H 206      35.824  24.203  39.663  1.00 17.30           O  
+ATOM   1559  CG2 THR H 206      34.098  25.773  40.267  1.00 15.63           C  
+ATOM   1560  N   TRP H 207      31.947  25.740  38.017  1.00 12.81           N  
+ATOM   1561  CA  TRP H 207      30.918  26.683  37.562  1.00 13.52           C  
+ATOM   1562  C   TRP H 207      30.774  27.895  38.480  1.00 15.27           C  
+ATOM   1563  O   TRP H 207      30.762  27.752  39.702  1.00 12.27           O  
+ATOM   1564  CB  TRP H 207      29.573  25.965  37.425  1.00 11.69           C  
+ATOM   1565  CG  TRP H 207      29.566  24.916  36.340  1.00 16.72           C  
+ATOM   1566  CD1 TRP H 207      29.988  23.619  36.446  1.00 19.94           C  
+ATOM   1567  CD2 TRP H 207      29.107  25.079  34.994  1.00 15.96           C  
+ATOM   1568  NE1 TRP H 207      29.818  22.970  35.249  1.00 17.04           N  
+ATOM   1569  CE2 TRP H 207      29.279  23.840  34.340  1.00 17.26           C  
+ATOM   1570  CE3 TRP H 207      28.563  26.154  34.277  1.00 13.29           C  
+ATOM   1571  CZ2 TRP H 207      28.928  23.644  33.006  1.00 19.33           C  
+ATOM   1572  CZ3 TRP H 207      28.212  25.961  32.946  1.00 14.25           C  
+ATOM   1573  CH2 TRP H 207      28.397  24.713  32.324  1.00 17.17           C  
+ATOM   1574  N   TYR H 208      30.577  29.069  37.871  1.00 10.81           N  
+ATOM   1575  CA  TYR H 208      30.456  30.331  38.596  1.00 12.30           C  
+ATOM   1576  C   TYR H 208      29.228  31.157  38.200  1.00 11.72           C  
+ATOM   1577  O   TYR H 208      28.760  31.083  37.053  1.00 12.09           O  
+ATOM   1578  CB  TYR H 208      31.698  31.197  38.315  1.00  9.73           C  
+ATOM   1579  CG  TYR H 208      32.996  30.536  38.703  1.00 13.30           C  
+ATOM   1580  CD1 TYR H 208      33.671  29.692  37.812  1.00 13.44           C  
+ATOM   1581  CD2 TYR H 208      33.532  30.720  39.977  1.00 12.28           C  
+ATOM   1582  CE1 TYR H 208      34.851  29.044  38.187  1.00 10.84           C  
+ATOM   1583  CE2 TYR H 208      34.708  30.080  40.361  1.00 12.78           C  
+ATOM   1584  CZ  TYR H 208      35.361  29.243  39.457  1.00 12.90           C  
+ATOM   1585  OH  TYR H 208      36.519  28.607  39.836  1.00 17.05           O  
+ATOM   1586  N   LEU H 209      28.760  31.997  39.120  1.00 10.03           N  
+ATOM   1587  CA  LEU H 209      27.622  32.862  38.837  1.00 11.91           C  
+ATOM   1588  C   LEU H 209      28.104  34.147  38.150  1.00 13.02           C  
+ATOM   1589  O   LEU H 209      28.859  34.928  38.739  1.00 11.29           O  
+ATOM   1590  CB  LEU H 209      26.873  33.231  40.123  1.00 11.43           C  
+ATOM   1591  CG  LEU H 209      25.661  34.165  39.919  1.00 14.58           C  
+ATOM   1592  CD1 LEU H 209      24.565  33.457  39.120  1.00 12.83           C  
+ATOM   1593  CD2 LEU H 209      25.118  34.631  41.275  1.00 10.26           C  
+ATOM   1594  N   THR H 210      27.633  34.374  36.925  1.00 12.15           N  
+ATOM   1595  CA  THR H 210      28.007  35.555  36.164  1.00 10.29           C  
+ATOM   1596  C   THR H 210      26.817  36.442  35.808  1.00 13.33           C  
+ATOM   1597  O   THR H 210      26.985  37.623  35.512  1.00 14.55           O  
+ATOM   1598  CB  THR H 210      28.721  35.171  34.856  1.00 13.76           C  
+ATOM   1599  OG1 THR H 210      27.988  34.128  34.195  1.00 14.51           O  
+ATOM   1600  CG2 THR H 210      30.145  34.700  35.138  1.00 13.43           C  
+ATOM   1601  N   GLY H 211      25.614  35.884  35.842  1.00 12.61           N  
+ATOM   1602  CA  GLY H 211      24.459  36.691  35.499  1.00 14.57           C  
+ATOM   1603  C   GLY H 211      23.175  36.245  36.159  1.00 14.25           C  
+ATOM   1604  O   GLY H 211      23.121  35.197  36.799  1.00 11.91           O  
+ATOM   1605  N   ILE H 212      22.160  37.089  36.030  1.00 11.56           N  
+ATOM   1606  CA  ILE H 212      20.840  36.832  36.575  1.00 10.04           C  
+ATOM   1607  C   ILE H 212      19.824  37.147  35.471  1.00 10.12           C  
+ATOM   1608  O   ILE H 212      19.908  38.210  34.850  1.00 12.18           O  
+ATOM   1609  CB  ILE H 212      20.532  37.770  37.755  1.00  9.11           C  
+ATOM   1610  CG1 ILE H 212      21.619  37.666  38.840  1.00  8.90           C  
+ATOM   1611  CG2 ILE H 212      19.161  37.419  38.344  1.00  6.41           C  
+ATOM   1612  CD1 ILE H 212      21.600  38.814  39.821  1.00  8.90           C  
+ATOM   1613  N   VAL H 213      18.892  36.221  35.214  1.00 10.39           N  
+ATOM   1614  CA  VAL H 213      17.838  36.441  34.207  1.00  9.98           C  
+ATOM   1615  C   VAL H 213      17.115  37.716  34.629  1.00 11.26           C  
+ATOM   1616  O   VAL H 213      16.532  37.779  35.707  1.00 10.61           O  
+ATOM   1617  CB  VAL H 213      16.821  35.271  34.164  1.00 11.96           C  
+ATOM   1618  CG1 VAL H 213      15.713  35.581  33.144  1.00 13.28           C  
+ATOM   1619  CG2 VAL H 213      17.526  33.974  33.771  1.00 14.09           C  
+ATOM   1620  N   SER H 214      17.152  38.735  33.780  1.00 13.43           N  
+ATOM   1621  CA  SER H 214      16.547  40.007  34.155  1.00 15.24           C  
+ATOM   1622  C   SER H 214      15.419  40.514  33.287  1.00 14.09           C  
+ATOM   1623  O   SER H 214      14.297  40.697  33.764  1.00 12.90           O  
+ATOM   1624  CB  SER H 214      17.641  41.077  34.257  1.00 16.01           C  
+ATOM   1625  OG  SER H 214      17.115  42.306  34.727  1.00 15.51           O  
+ATOM   1626  N   TRP H 215      15.705  40.751  32.012  1.00 14.84           N  
+ATOM   1627  CA  TRP H 215      14.679  41.279  31.137  1.00 13.01           C  
+ATOM   1628  C   TRP H 215      14.942  41.067  29.661  1.00 14.03           C  
+ATOM   1629  O   TRP H 215      15.972  40.524  29.260  1.00 11.78           O  
+ATOM   1630  CB  TRP H 215      14.444  42.778  31.429  1.00 10.23           C  
+ATOM   1631  CG  TRP H 215      15.598  43.683  31.108  1.00 16.14           C  
+ATOM   1632  CD1 TRP H 215      16.664  43.970  31.920  1.00 16.64           C  
+ATOM   1633  CD2 TRP H 215      15.789  44.452  29.907  1.00 18.61           C  
+ATOM   1634  NE1 TRP H 215      17.499  44.869  31.300  1.00 15.32           N  
+ATOM   1635  CE2 TRP H 215      16.988  45.182  30.065  1.00 15.08           C  
+ATOM   1636  CE3 TRP H 215      15.064  44.592  28.712  1.00 21.54           C  
+ATOM   1637  CZ2 TRP H 215      17.484  46.043  29.072  1.00 20.26           C  
+ATOM   1638  CZ3 TRP H 215      15.560  45.450  27.718  1.00 24.87           C  
+ATOM   1639  CH2 TRP H 215      16.758  46.162  27.908  1.00 19.72           C  
+ATOM   1640  N   GLY H 216      13.955  41.450  28.865  1.00 15.02           N  
+ATOM   1641  CA  GLY H 216      14.060  41.325  27.427  1.00 14.67           C  
+ATOM   1642  C   GLY H 216      12.860  42.008  26.805  1.00 19.63           C  
+ATOM   1643  O   GLY H 216      11.914  42.368  27.506  1.00 18.71           O  
+ATOM   1644  N   GLN H 217      12.921  42.216  25.495  1.00 20.54           N  
+ATOM   1645  CA  GLN H 217      11.834  42.838  24.741  1.00 23.69           C  
+ATOM   1646  C   GLN H 217      11.124  41.615  24.156  1.00 23.96           C  
+ATOM   1647  O   GLN H 217      11.278  41.287  22.979  1.00 23.11           O  
+ATOM   1648  CB  GLN H 217      12.428  43.719  23.631  1.00 30.89           C  
+ATOM   1649  CG  GLN H 217      11.768  45.078  23.484  1.00 45.13           C  
+ATOM   1650  CD  GLN H 217      12.748  46.243  23.608  1.00 44.68           C  
+ATOM   1651  OE1 GLN H 217      13.879  46.193  23.108  1.00 42.31           O  
+ATOM   1652  NE2 GLN H 217      12.304  47.308  24.261  1.00 47.64           N  
+ATOM   1653  N   GLY H 219      10.378  40.921  25.012  1.00 22.27           N  
+ATOM   1654  CA  GLY H 219       9.709  39.698  24.606  1.00 17.29           C  
+ATOM   1655  C   GLY H 219      10.732  38.567  24.732  1.00 18.99           C  
+ATOM   1656  O   GLY H 219      11.936  38.820  24.869  1.00 14.50           O  
+ATOM   1657  N   CYS H 220      10.262  37.324  24.686  1.00 16.81           N  
+ATOM   1658  CA  CYS H 220      11.141  36.156  24.797  1.00 18.49           C  
+ATOM   1659  C   CYS H 220      11.445  35.567  23.425  1.00 19.17           C  
+ATOM   1660  O   CYS H 220      10.531  35.201  22.696  1.00 16.74           O  
+ATOM   1661  CB  CYS H 220      10.485  35.091  25.685  1.00 17.22           C  
+ATOM   1662  SG  CYS H 220      10.032  35.750  27.318  1.00 17.99           S  
+ATOM   1663  N   ALA H 221A     12.729  35.449  23.095  1.00 16.94           N  
+ATOM   1664  CA  ALA H 221A     13.165  34.910  21.802  1.00 19.45           C  
+ATOM   1665  C   ALA H 221A     12.531  35.691  20.653  1.00 20.43           C  
+ATOM   1666  O   ALA H 221A     11.987  35.116  19.704  1.00 20.33           O  
+ATOM   1667  CB  ALA H 221A     12.834  33.413  21.691  1.00 12.89           C  
+ATOM   1668  N   THR H 221      12.573  37.013  20.777  1.00 21.51           N  
+ATOM   1669  CA  THR H 221      12.023  37.896  19.759  1.00 21.60           C  
+ATOM   1670  C   THR H 221      13.085  38.051  18.683  1.00 21.46           C  
+ATOM   1671  O   THR H 221      14.248  38.314  18.992  1.00 21.83           O  
+ATOM   1672  CB  THR H 221      11.704  39.288  20.344  1.00 16.38           C  
+ATOM   1673  OG1 THR H 221      10.783  39.150  21.433  1.00 17.43           O  
+ATOM   1674  CG2 THR H 221      11.081  40.206  19.270  1.00 21.24           C  
+ATOM   1675  N   VAL H 222      12.704  37.841  17.427  1.00 21.61           N  
+ATOM   1676  CA  VAL H 222      13.654  37.992  16.324  1.00 20.08           C  
+ATOM   1677  C   VAL H 222      14.271  39.390  16.382  1.00 19.51           C  
+ATOM   1678  O   VAL H 222      13.568  40.377  16.592  1.00 22.00           O  
+ATOM   1679  CB  VAL H 222      12.965  37.775  14.949  1.00 24.79           C  
+ATOM   1680  CG1 VAL H 222      13.950  38.043  13.806  1.00 25.94           C  
+ATOM   1681  CG2 VAL H 222      12.422  36.347  14.864  1.00 20.10           C  
+ATOM   1682  N   GLY H 223      15.595  39.452  16.259  1.00 20.36           N  
+ATOM   1683  CA  GLY H 223      16.302  40.717  16.304  1.00 22.85           C  
+ATOM   1684  C   GLY H 223      16.719  41.154  17.701  1.00 24.71           C  
+ATOM   1685  O   GLY H 223      17.387  42.179  17.851  1.00 22.17           O  
+ATOM   1686  N   HIS H 224      16.353  40.375  18.721  1.00 19.55           N  
+ATOM   1687  CA  HIS H 224      16.690  40.730  20.097  1.00 21.16           C  
+ATOM   1688  C   HIS H 224      17.357  39.625  20.903  1.00 21.03           C  
+ATOM   1689  O   HIS H 224      17.266  38.444  20.562  1.00 19.02           O  
+ATOM   1690  CB  HIS H 224      15.450  41.228  20.834  1.00 25.20           C  
+ATOM   1691  CG  HIS H 224      14.878  42.482  20.254  1.00 29.32           C  
+ATOM   1692  ND1 HIS H 224      15.309  43.736  20.627  1.00 26.40           N  
+ATOM   1693  CD2 HIS H 224      13.935  42.675  19.302  1.00 30.46           C  
+ATOM   1694  CE1 HIS H 224      14.655  44.649  19.931  1.00 31.91           C  
+ATOM   1695  NE2 HIS H 224      13.817  44.031  19.120  1.00 27.93           N  
+ATOM   1696  N   PHE H 225      17.984  40.030  22.007  1.00 15.90           N  
+ATOM   1697  CA  PHE H 225      18.701  39.120  22.896  1.00 17.77           C  
+ATOM   1698  C   PHE H 225      18.185  39.216  24.333  1.00 17.15           C  
+ATOM   1699  O   PHE H 225      17.567  40.204  24.709  1.00 16.24           O  
+ATOM   1700  CB  PHE H 225      20.185  39.504  22.912  1.00 19.70           C  
+ATOM   1701  CG  PHE H 225      20.873  39.323  21.593  1.00 22.33           C  
+ATOM   1702  CD1 PHE H 225      21.415  38.096  21.246  1.00 18.99           C  
+ATOM   1703  CD2 PHE H 225      20.959  40.371  20.688  1.00 19.76           C  
+ATOM   1704  CE1 PHE H 225      22.035  37.911  20.006  1.00 20.92           C  
+ATOM   1705  CE2 PHE H 225      21.575  40.198  19.448  1.00 22.35           C  
+ATOM   1706  CZ  PHE H 225      22.111  38.967  19.109  1.00 21.41           C  
+ATOM   1707  N   GLY H 226      18.484  38.198  25.136  1.00 16.53           N  
+ATOM   1708  CA  GLY H 226      18.099  38.226  26.536  1.00 12.38           C  
+ATOM   1709  C   GLY H 226      19.061  39.167  27.248  1.00 16.08           C  
+ATOM   1710  O   GLY H 226      20.204  39.315  26.817  1.00 16.50           O  
+ATOM   1711  N   VAL H 227      18.589  39.865  28.278  1.00 14.95           N  
+ATOM   1712  CA  VAL H 227      19.453  40.784  29.032  1.00 13.74           C  
+ATOM   1713  C   VAL H 227      19.559  40.277  30.461  1.00 16.35           C  
+ATOM   1714  O   VAL H 227      18.552  39.939  31.097  1.00 11.52           O  
+ATOM   1715  CB  VAL H 227      18.935  42.231  29.018  1.00 14.25           C  
+ATOM   1716  CG1 VAL H 227      19.967  43.156  29.646  1.00 16.23           C  
+ATOM   1717  CG2 VAL H 227      18.656  42.664  27.580  1.00 16.93           C  
+ATOM   1718  N   TYR H 228      20.791  40.263  30.957  1.00 16.85           N  
+ATOM   1719  CA  TYR H 228      21.108  39.734  32.273  1.00 17.92           C  
+ATOM   1720  C   TYR H 228      21.841  40.727  33.169  1.00 16.74           C  
+ATOM   1721  O   TYR H 228      22.572  41.587  32.689  1.00 16.23           O  
+ATOM   1722  CB  TYR H 228      21.987  38.487  32.086  1.00 15.80           C  
+ATOM   1723  CG  TYR H 228      21.332  37.395  31.254  1.00 16.56           C  
+ATOM   1724  CD1 TYR H 228      21.284  37.473  29.857  1.00 13.15           C  
+ATOM   1725  CD2 TYR H 228      20.715  36.315  31.871  1.00 14.36           C  
+ATOM   1726  CE1 TYR H 228      20.619  36.488  29.102  1.00 11.52           C  
+ATOM   1727  CE2 TYR H 228      20.055  35.348  31.142  1.00 15.38           C  
+ATOM   1728  CZ  TYR H 228      20.002  35.431  29.766  1.00 16.84           C  
+ATOM   1729  OH  TYR H 228      19.301  34.463  29.078  1.00 13.97           O  
+ATOM   1730  N   THR H 229      21.636  40.599  34.476  1.00 12.77           N  
+ATOM   1731  CA  THR H 229      22.311  41.467  35.438  1.00 14.63           C  
+ATOM   1732  C   THR H 229      23.778  41.036  35.474  1.00 15.04           C  
+ATOM   1733  O   THR H 229      24.070  39.846  35.580  1.00 13.56           O  
+ATOM   1734  CB  THR H 229      21.700  41.315  36.846  1.00 13.87           C  
+ATOM   1735  OG1 THR H 229      20.283  41.510  36.767  1.00  9.76           O  
+ATOM   1736  CG2 THR H 229      22.294  42.348  37.808  1.00 13.91           C  
+ATOM   1737  N   ARG H 230      24.687  41.993  35.303  1.00 14.05           N  
+ATOM   1738  CA  ARG H 230      26.120  41.708  35.310  1.00 15.02           C  
+ATOM   1739  C   ARG H 230      26.574  41.577  36.764  1.00 13.87           C  
+ATOM   1740  O   ARG H 230      26.946  42.567  37.411  1.00 14.21           O  
+ATOM   1741  CB  ARG H 230      26.888  42.830  34.594  1.00 14.86           C  
+ATOM   1742  CG  ARG H 230      28.361  42.510  34.319  1.00 15.57           C  
+ATOM   1743  CD  ARG H 230      29.081  43.668  33.613  1.00 17.78           C  
+ATOM   1744  NE  ARG H 230      28.483  43.997  32.314  1.00 18.53           N  
+ATOM   1745  CZ  ARG H 230      29.093  43.877  31.135  1.00 32.69           C  
+ATOM   1746  NH1 ARG H 230      30.339  43.427  31.056  1.00 35.49           N  
+ATOM   1747  NH2 ARG H 230      28.457  44.226  30.022  1.00 30.75           N  
+ATOM   1748  N   VAL H 231      26.534  40.342  37.258  1.00 11.27           N  
+ATOM   1749  CA  VAL H 231      26.884  40.019  38.638  1.00  9.24           C  
+ATOM   1750  C   VAL H 231      28.247  40.515  39.134  1.00 12.60           C  
+ATOM   1751  O   VAL H 231      28.378  40.849  40.303  1.00 11.72           O  
+ATOM   1752  CB  VAL H 231      26.746  38.491  38.898  1.00 13.82           C  
+ATOM   1753  CG1 VAL H 231      27.241  38.118  40.313  1.00 12.46           C  
+ATOM   1754  CG2 VAL H 231      25.281  38.077  38.746  1.00 10.39           C  
+ATOM   1755  N   SER H 232      29.237  40.587  38.248  1.00 15.62           N  
+ATOM   1756  CA  SER H 232      30.581  41.037  38.632  1.00 16.33           C  
+ATOM   1757  C   SER H 232      30.603  42.428  39.267  1.00 16.91           C  
+ATOM   1758  O   SER H 232      31.476  42.734  40.080  1.00 16.63           O  
+ATOM   1759  CB  SER H 232      31.533  40.992  37.429  1.00 17.42           C  
+ATOM   1760  OG  SER H 232      31.080  41.829  36.375  1.00 16.06           O  
+ATOM   1761  N   GLN H 233      29.634  43.262  38.914  1.00 17.11           N  
+ATOM   1762  CA  GLN H 233      29.545  44.611  39.472  1.00 17.23           C  
+ATOM   1763  C   GLN H 233      29.125  44.605  40.939  1.00 17.52           C  
+ATOM   1764  O   GLN H 233      29.332  45.584  41.656  1.00 16.05           O  
+ATOM   1765  CB  GLN H 233      28.506  45.429  38.691  1.00 12.52           C  
+ATOM   1766  CG  GLN H 233      28.889  45.714  37.242  1.00 13.81           C  
+ATOM   1767  CD  GLN H 233      29.859  46.873  37.124  1.00 23.22           C  
+ATOM   1768  OE1 GLN H 233      30.646  47.129  38.032  1.00 26.33           O  
+ATOM   1769  NE2 GLN H 233      29.781  47.605  36.018  1.00 23.39           N  
+ATOM   1770  N   TYR H 234      28.534  43.499  41.380  1.00 14.87           N  
+ATOM   1771  CA  TYR H 234      28.017  43.401  42.742  1.00 17.08           C  
+ATOM   1772  C   TYR H 234      28.731  42.483  43.703  1.00 14.20           C  
+ATOM   1773  O   TYR H 234      28.259  42.300  44.824  1.00 14.71           O  
+ATOM   1774  CB  TYR H 234      26.541  42.987  42.694  1.00 14.80           C  
+ATOM   1775  CG  TYR H 234      25.704  43.901  41.844  1.00 14.22           C  
+ATOM   1776  CD1 TYR H 234      25.151  45.061  42.379  1.00 12.96           C  
+ATOM   1777  CD2 TYR H 234      25.514  43.639  40.488  1.00 12.00           C  
+ATOM   1778  CE1 TYR H 234      24.433  45.948  41.584  1.00 14.43           C  
+ATOM   1779  CE2 TYR H 234      24.796  44.525  39.678  1.00 16.00           C  
+ATOM   1780  CZ  TYR H 234      24.264  45.678  40.239  1.00 16.13           C  
+ATOM   1781  OH  TYR H 234      23.587  46.573  39.455  1.00 15.10           O  
+ATOM   1782  N   ILE H 235      29.848  41.895  43.285  1.00 12.32           N  
+ATOM   1783  CA  ILE H 235      30.574  40.977  44.163  1.00 15.50           C  
+ATOM   1784  C   ILE H 235      30.890  41.553  45.541  1.00 17.33           C  
+ATOM   1785  O   ILE H 235      30.593  40.926  46.557  1.00 16.13           O  
+ATOM   1786  CB  ILE H 235      31.891  40.473  43.525  1.00 15.33           C  
+ATOM   1787  CG1 ILE H 235      31.610  39.818  42.167  1.00 17.51           C  
+ATOM   1788  CG2 ILE H 235      32.590  39.489  44.479  1.00 12.43           C  
+ATOM   1789  CD1 ILE H 235      30.637  38.665  42.218  1.00 18.56           C  
+ATOM   1790  N   GLU H 236      31.492  42.738  45.581  1.00 17.03           N  
+ATOM   1791  CA  GLU H 236      31.849  43.364  46.849  1.00 16.22           C  
+ATOM   1792  C   GLU H 236      30.626  43.658  47.704  1.00 13.79           C  
+ATOM   1793  O   GLU H 236      30.641  43.436  48.912  1.00 15.49           O  
+ATOM   1794  CB  GLU H 236      32.625  44.672  46.621  1.00 22.16           C  
+ATOM   1795  CG  GLU H 236      34.088  44.499  46.236  1.00 39.63           C  
+ATOM   1796  CD  GLU H 236      34.311  44.199  44.762  1.00 48.86           C  
+ATOM   1797  OE1 GLU H 236      33.335  44.211  43.970  1.00 53.33           O  
+ATOM   1798  OE2 GLU H 236      35.484  43.960  44.396  1.00 53.68           O  
+ATOM   1799  N   TRP H 237      29.584  44.183  47.064  1.00 12.15           N  
+ATOM   1800  CA  TRP H 237      28.325  44.527  47.727  1.00 13.36           C  
+ATOM   1801  C   TRP H 237      27.724  43.275  48.395  1.00 14.08           C  
+ATOM   1802  O   TRP H 237      27.333  43.309  49.563  1.00 12.22           O  
+ATOM   1803  CB  TRP H 237      27.368  45.114  46.682  1.00 10.52           C  
+ATOM   1804  CG  TRP H 237      26.020  45.552  47.203  1.00 14.66           C  
+ATOM   1805  CD1 TRP H 237      25.727  46.722  47.848  1.00 12.27           C  
+ATOM   1806  CD2 TRP H 237      24.786  44.833  47.098  1.00 11.48           C  
+ATOM   1807  NE1 TRP H 237      24.386  46.776  48.148  1.00 14.87           N  
+ATOM   1808  CE2 TRP H 237      23.785  45.628  47.701  1.00 15.74           C  
+ATOM   1809  CE3 TRP H 237      24.428  43.591  46.554  1.00 13.06           C  
+ATOM   1810  CZ2 TRP H 237      22.442  45.217  47.778  1.00 12.00           C  
+ATOM   1811  CZ3 TRP H 237      23.094  43.183  46.631  1.00 16.67           C  
+ATOM   1812  CH2 TRP H 237      22.119  43.996  47.242  1.00 15.57           C  
+ATOM   1813  N   LEU H 238      27.691  42.167  47.658  1.00 13.67           N  
+ATOM   1814  CA  LEU H 238      27.171  40.895  48.172  1.00 13.13           C  
+ATOM   1815  C   LEU H 238      28.023  40.343  49.322  1.00 12.81           C  
+ATOM   1816  O   LEU H 238      27.497  39.938  50.359  1.00 10.23           O  
+ATOM   1817  CB  LEU H 238      27.124  39.857  47.049  1.00  9.18           C  
+ATOM   1818  CG  LEU H 238      26.192  40.146  45.864  1.00 13.48           C  
+ATOM   1819  CD1 LEU H 238      26.500  39.192  44.703  1.00 13.01           C  
+ATOM   1820  CD2 LEU H 238      24.741  40.005  46.309  1.00 10.36           C  
+ATOM   1821  N   GLN H 239      29.341  40.319  49.134  1.00 14.76           N  
+ATOM   1822  CA  GLN H 239      30.236  39.793  50.169  1.00 15.39           C  
+ATOM   1823  C   GLN H 239      30.113  40.558  51.481  1.00 14.68           C  
+ATOM   1824  O   GLN H 239      30.105  39.962  52.555  1.00 14.80           O  
+ATOM   1825  CB  GLN H 239      31.696  39.810  49.693  1.00 18.55           C  
+ATOM   1826  CG  GLN H 239      32.001  38.842  48.553  1.00 21.48           C  
+ATOM   1827  CD  GLN H 239      31.975  37.387  48.985  1.00 32.43           C  
+ATOM   1828  OE1 GLN H 239      31.956  37.076  50.180  1.00 36.32           O  
+ATOM   1829  NE2 GLN H 239      31.984  36.482  48.010  1.00 39.48           N  
+ATOM   1830  N   LYS H 240      30.013  41.880  51.398  1.00 14.43           N  
+ATOM   1831  CA  LYS H 240      29.880  42.680  52.614  1.00 15.86           C  
+ATOM   1832  C   LYS H 240      28.589  42.338  53.354  1.00 17.83           C  
+ATOM   1833  O   LYS H 240      28.589  42.158  54.573  1.00 16.72           O  
+ATOM   1834  CB  LYS H 240      29.907  44.175  52.289  1.00 17.82           C  
+ATOM   1835  CG  LYS H 240      29.870  45.054  53.548  1.00 27.19           C  
+ATOM   1836  CD  LYS H 240      29.986  46.528  53.207  1.00 36.76           C  
+ATOM   1837  CE  LYS H 240      29.877  47.387  54.459  1.00 40.70           C  
+ATOM   1838  NZ  LYS H 240      29.982  48.838  54.128  1.00 45.77           N  
+ATOM   1839  N   LEU H 241      27.489  42.229  52.613  1.00 16.39           N  
+ATOM   1840  CA  LEU H 241      26.202  41.900  53.220  1.00 14.66           C  
+ATOM   1841  C   LEU H 241      26.208  40.521  53.857  1.00 12.64           C  
+ATOM   1842  O   LEU H 241      25.684  40.327  54.955  1.00 14.81           O  
+ATOM   1843  CB  LEU H 241      25.081  41.998  52.177  1.00 15.39           C  
+ATOM   1844  CG  LEU H 241      24.725  43.438  51.798  1.00 17.38           C  
+ATOM   1845  CD1 LEU H 241      23.908  43.449  50.525  1.00 18.82           C  
+ATOM   1846  CD2 LEU H 241      23.980  44.127  52.947  1.00 15.96           C  
+ATOM   1847  N   MET H 242      26.834  39.556  53.199  1.00 14.14           N  
+ATOM   1848  CA  MET H 242      26.863  38.216  53.767  1.00 14.57           C  
+ATOM   1849  C   MET H 242      27.634  38.148  55.076  1.00 16.68           C  
+ATOM   1850  O   MET H 242      27.444  37.219  55.846  1.00 18.35           O  
+ATOM   1851  CB  MET H 242      27.388  37.197  52.758  1.00 17.74           C  
+ATOM   1852  CG  MET H 242      26.452  37.025  51.567  1.00 10.93           C  
+ATOM   1853  SD  MET H 242      26.887  35.621  50.535  1.00 16.03           S  
+ATOM   1854  CE  MET H 242      28.207  36.309  49.629  1.00 12.96           C  
+ATOM   1855  N   ARG H 243      28.504  39.127  55.322  1.00 14.66           N  
+ATOM   1856  CA  ARG H 243      29.275  39.173  56.572  1.00 20.56           C  
+ATOM   1857  C   ARG H 243      28.536  39.932  57.679  1.00 22.46           C  
+ATOM   1858  O   ARG H 243      29.008  39.991  58.812  1.00 24.69           O  
+ATOM   1859  CB  ARG H 243      30.640  39.835  56.346  1.00 23.49           C  
+ATOM   1860  CG  ARG H 243      31.615  39.017  55.521  1.00 26.04           C  
+ATOM   1861  CD  ARG H 243      33.008  39.646  55.525  1.00 32.93           C  
+ATOM   1862  NE  ARG H 243      33.006  41.029  55.044  1.00 37.60           N  
+ATOM   1863  CZ  ARG H 243      33.320  41.403  53.805  1.00 37.44           C  
+ATOM   1864  NH1 ARG H 243      33.668  40.501  52.894  1.00 41.10           N  
+ATOM   1865  NH2 ARG H 243      33.290  42.686  53.476  1.00 42.57           N  
+ATOM   1866  N   SER H 244      27.374  40.499  57.359  1.00 19.36           N  
+ATOM   1867  CA  SER H 244      26.609  41.267  58.343  1.00 20.90           C  
+ATOM   1868  C   SER H 244      25.552  40.466  59.097  1.00 20.02           C  
+ATOM   1869  O   SER H 244      25.081  39.434  58.631  1.00 17.46           O  
+ATOM   1870  CB  SER H 244      25.936  42.469  57.670  1.00 25.74           C  
+ATOM   1871  OG  SER H 244      24.832  42.058  56.875  1.00 31.60           O  
+ATOM   1872  N   GLU H 245      25.166  40.974  60.263  1.00 18.90           N  
+ATOM   1873  CA  GLU H 245      24.140  40.340  61.080  1.00 16.70           C  
+ATOM   1874  C   GLU H 245      22.765  40.655  60.499  1.00 21.58           C  
+ATOM   1875  O   GLU H 245      22.556  41.730  59.926  1.00 23.09           O  
+ATOM   1876  CB  GLU H 245      24.199  40.874  62.521  1.00 17.25           C  
+ATOM   1877  CG  GLU H 245      25.444  40.450  63.301  1.00 12.27           C  
+ATOM   1878  CD  GLU H 245      25.489  38.952  63.561  1.00 18.58           C  
+ATOM   1879  OE1 GLU H 245      24.438  38.299  63.480  1.00 17.42           O  
+ATOM   1880  OE2 GLU H 245      26.575  38.425  63.865  1.00 21.98           O  
+ATOM   1881  N   PRO H 246      21.821  39.706  60.603  1.00 20.05           N  
+ATOM   1882  CA  PRO H 246      20.462  39.899  60.095  1.00 23.51           C  
+ATOM   1883  C   PRO H 246      19.819  41.079  60.830  1.00 24.62           C  
+ATOM   1884  O   PRO H 246      20.132  41.341  61.992  1.00 23.13           O  
+ATOM   1885  CB  PRO H 246      19.764  38.597  60.494  1.00 20.77           C  
+ATOM   1886  CG  PRO H 246      20.858  37.604  60.498  1.00 24.93           C  
+ATOM   1887  CD  PRO H 246      21.986  38.349  61.151  1.00 20.85           C  
+ATOM   1888  N   ARG H 247      18.913  41.773  60.150  1.00 29.29           N  
+ATOM   1889  CA  ARG H 247      18.212  42.909  60.731  1.00 30.83           C  
+ATOM   1890  C   ARG H 247      16.719  42.632  60.702  1.00 32.59           C  
+ATOM   1891  O   ARG H 247      16.245  41.905  59.833  1.00 31.58           O  
+ATOM   1892  CB  ARG H 247      18.519  44.190  59.947  1.00 31.66           C  
+ATOM   1893  CG  ARG H 247      19.864  44.807  60.269  1.00 38.77           C  
+ATOM   1894  CD  ARG H 247      20.014  46.169  59.604  1.00 45.58           C  
+ATOM   1895  NE  ARG H 247      20.547  47.179  60.523  1.00 54.07           N  
+ATOM   1896  CZ  ARG H 247      19.806  48.071  61.182  1.00 54.54           C  
+ATOM   1897  NH1 ARG H 247      20.386  48.950  61.989  1.00 56.05           N  
+ATOM   1898  NH2 ARG H 247      18.488  48.097  61.033  1.00 58.38           N  
+ATOM   1899  N   PRO H 248      15.968  43.144  61.698  1.00 31.38           N  
+ATOM   1900  CA  PRO H 248      14.514  42.935  61.751  1.00 31.83           C  
+ATOM   1901  C   PRO H 248      13.840  43.545  60.521  1.00 31.24           C  
+ATOM   1902  O   PRO H 248      14.279  44.578  60.013  1.00 31.41           O  
+ATOM   1903  CB  PRO H 248      14.109  43.650  63.047  1.00 35.93           C  
+ATOM   1904  CG  PRO H 248      15.198  44.677  63.243  1.00 36.63           C  
+ATOM   1905  CD  PRO H 248      16.431  43.904  62.873  1.00 35.12           C  
+ATOM   1906  N   GLY H 249      12.785  42.894  60.039  1.00 29.33           N  
+ATOM   1907  CA  GLY H 249      12.091  43.374  58.852  1.00 27.22           C  
+ATOM   1908  C   GLY H 249      12.713  42.681  57.653  1.00 27.73           C  
+ATOM   1909  O   GLY H 249      13.922  42.799  57.425  1.00 30.26           O  
+ATOM   1910  N   VAL H 250      11.897  41.963  56.883  1.00 25.46           N  
+ATOM   1911  CA  VAL H 250      12.396  41.219  55.732  1.00 24.98           C  
+ATOM   1912  C   VAL H 250      13.110  42.049  54.670  1.00 24.43           C  
+ATOM   1913  O   VAL H 250      14.298  41.828  54.407  1.00 22.68           O  
+ATOM   1914  CB  VAL H 250      11.286  40.346  55.089  1.00 26.74           C  
+ATOM   1915  CG1 VAL H 250      11.832  39.615  53.856  1.00 25.54           C  
+ATOM   1916  CG2 VAL H 250      10.770  39.325  56.099  1.00 25.28           C  
+ATOM   1917  N   LEU H 251      12.420  43.034  54.099  1.00 20.16           N  
+ATOM   1918  CA  LEU H 251      13.031  43.852  53.058  1.00 18.86           C  
+ATOM   1919  C   LEU H 251      14.045  44.842  53.614  1.00 23.69           C  
+ATOM   1920  O   LEU H 251      13.776  45.547  54.586  1.00 19.94           O  
+ATOM   1921  CB  LEU H 251      11.958  44.579  52.237  1.00 23.39           C  
+ATOM   1922  CG  LEU H 251      12.417  45.296  50.958  1.00 27.51           C  
+ATOM   1923  CD1 LEU H 251      13.194  44.356  50.047  1.00 21.87           C  
+ATOM   1924  CD2 LEU H 251      11.214  45.806  50.215  1.00 38.47           C  
+ATOM   1925  N   LEU H 252      15.225  44.859  53.003  1.00 18.93           N  
+ATOM   1926  CA  LEU H 252      16.299  45.763  53.402  1.00 18.38           C  
+ATOM   1927  C   LEU H 252      16.903  46.419  52.169  1.00 17.31           C  
+ATOM   1928  O   LEU H 252      17.267  45.734  51.215  1.00 15.99           O  
+ATOM   1929  CB  LEU H 252      17.404  44.994  54.143  1.00 17.02           C  
+ATOM   1930  CG  LEU H 252      18.618  45.817  54.589  1.00 19.27           C  
+ATOM   1931  CD1 LEU H 252      18.182  46.819  55.662  1.00 20.80           C  
+ATOM   1932  CD2 LEU H 252      19.722  44.901  55.126  1.00 21.57           C  
+ATOM   1933  N   ARG H 253      16.932  47.747  52.149  1.00 14.58           N  
+ATOM   1934  CA  ARG H 253      17.544  48.454  51.043  1.00 14.62           C  
+ATOM   1935  C   ARG H 253      18.938  48.776  51.552  1.00 18.29           C  
+ATOM   1936  O   ARG H 253      19.094  49.361  52.623  1.00 14.93           O  
+ATOM   1937  CB  ARG H 253      16.759  49.720  50.681  1.00 15.38           C  
+ATOM   1938  CG  ARG H 253      15.430  49.415  49.974  1.00 17.06           C  
+ATOM   1939  CD  ARG H 253      14.655  50.680  49.577  1.00 15.05           C  
+ATOM   1940  NE  ARG H 253      15.348  51.478  48.562  1.00 16.03           N  
+ATOM   1941  CZ  ARG H 253      15.852  52.694  48.771  1.00 20.75           C  
+ATOM   1942  NH1 ARG H 253      15.759  53.275  49.963  1.00 19.21           N  
+ATOM   1943  NH2 ARG H 253      16.437  53.345  47.775  1.00 15.64           N  
+ATOM   1944  N   ALA H 254      19.950  48.295  50.839  1.00 17.72           N  
+ATOM   1945  CA  ALA H 254      21.326  48.511  51.250  1.00 15.46           C  
+ATOM   1946  C   ALA H 254      22.033  49.410  50.264  1.00 16.97           C  
+ATOM   1947  O   ALA H 254      21.846  49.293  49.048  1.00 17.06           O  
+ATOM   1948  CB  ALA H 254      22.062  47.163  51.373  1.00 18.04           C  
+ATOM   1949  N   PRO H 255      22.881  50.316  50.774  1.00 16.35           N  
+ATOM   1950  CA  PRO H 255      23.630  51.247  49.933  1.00 14.81           C  
+ATOM   1951  C   PRO H 255      24.459  50.546  48.873  1.00 16.26           C  
+ATOM   1952  O   PRO H 255      25.136  49.559  49.154  1.00 16.48           O  
+ATOM   1953  CB  PRO H 255      24.574  51.926  50.932  1.00 18.87           C  
+ATOM   1954  CG  PRO H 255      23.834  51.866  52.209  1.00 23.51           C  
+ATOM   1955  CD  PRO H 255      23.240  50.484  52.193  1.00 18.21           C  
+ATOM   1956  N   PHE H 256      24.379  51.059  47.655  1.00 12.23           N  
+ATOM   1957  CA  PHE H 256      25.177  50.569  46.559  1.00 16.01           C  
+ATOM   1958  C   PHE H 256      25.798  51.835  45.969  1.00 19.29           C  
+ATOM   1959  O   PHE H 256      25.087  52.805  45.707  1.00 21.32           O  
+ATOM   1960  CB  PHE H 256      24.358  49.858  45.476  1.00 11.77           C  
+ATOM   1961  CG  PHE H 256      25.215  49.348  44.358  1.00 16.51           C  
+ATOM   1962  CD1 PHE H 256      25.988  48.202  44.537  1.00 16.16           C  
+ATOM   1963  CD2 PHE H 256      25.378  50.090  43.191  1.00 21.17           C  
+ATOM   1964  CE1 PHE H 256      26.922  47.812  43.581  1.00 13.79           C  
+ATOM   1965  CE2 PHE H 256      26.311  49.707  42.228  1.00 20.37           C  
+ATOM   1966  CZ  PHE H 256      27.087  48.565  42.428  1.00 19.35           C  
+ATOM   1967  N   PRO H 257      27.118  51.830  45.715  1.00 22.31           N  
+ATOM   1968  CA  PRO H 257      28.115  50.765  45.913  1.00 22.42           C  
+ATOM   1969  C   PRO H 257      28.286  50.332  47.370  1.00 23.26           C  
+ATOM   1970  O   PRO H 257      28.722  49.184  47.593  1.00 27.50           O  
+ATOM   1971  CB  PRO H 257      29.407  51.406  45.395  1.00 24.95           C  
+ATOM   1972  CG  PRO H 257      28.922  52.430  44.414  1.00 31.47           C  
+ATOM   1973  CD  PRO H 257      27.752  53.025  45.132  1.00 24.81           C  
+TER    1974      PRO H 257                                                      
+ATOM   1975  N   ILE L  90      50.947  37.838  35.531  1.00 46.87           N  
+ATOM   1976  CA  ILE L  90      49.911  38.581  34.818  1.00 43.67           C  
+ATOM   1977  C   ILE L  90      48.544  37.884  34.844  1.00 35.90           C  
+ATOM   1978  O   ILE L  90      48.207  37.083  33.966  1.00 33.96           O  
+ATOM   1979  CB  ILE L  90      50.337  38.891  33.359  1.00 50.57           C  
+ATOM   1980  CG1 ILE L  90      51.021  37.669  32.724  1.00 54.94           C  
+ATOM   1981  CG2 ILE L  90      51.247  40.115  33.334  1.00 55.22           C  
+ATOM   1982  CD1 ILE L  90      51.558  37.905  31.305  1.00 52.96           C  
+ATOM   1983  N   CYS L  91      47.763  38.210  35.868  1.00 31.35           N  
+ATOM   1984  CA  CYS L  91      46.431  37.640  36.056  1.00 28.39           C  
+ATOM   1985  C   CYS L  91      45.479  37.929  34.901  1.00 31.40           C  
+ATOM   1986  O   CYS L  91      44.550  37.158  34.646  1.00 30.84           O  
+ATOM   1987  CB  CYS L  91      45.820  38.159  37.360  1.00 22.81           C  
+ATOM   1988  SG  CYS L  91      46.739  37.680  38.851  1.00 24.01           S  
+ATOM   1989  N   VAL L  92      45.707  39.038  34.204  1.00 32.96           N  
+ATOM   1990  CA  VAL L  92      44.851  39.407  33.082  1.00 34.43           C  
+ATOM   1991  C   VAL L  92      45.038  38.481  31.874  1.00 35.74           C  
+ATOM   1992  O   VAL L  92      44.126  38.325  31.060  1.00 35.35           O  
+ATOM   1993  CB  VAL L  92      45.069  40.883  32.671  1.00 36.67           C  
+ATOM   1994  CG1 VAL L  92      46.442  41.065  32.038  1.00 37.81           C  
+ATOM   1995  CG2 VAL L  92      43.959  41.340  31.736  1.00 42.31           C  
+ATOM   1996  N   ASN L  93      46.211  37.857  31.766  1.00 33.50           N  
+ATOM   1997  CA  ASN L  93      46.487  36.948  30.654  1.00 34.02           C  
+ATOM   1998  C   ASN L  93      46.395  35.479  31.069  1.00 32.09           C  
+ATOM   1999  O   ASN L  93      47.154  35.019  31.927  1.00 30.95           O  
+ATOM   2000  CB  ASN L  93      47.868  37.241  30.050  1.00 38.84           C  
+ATOM   2001  CG  ASN L  93      47.921  38.589  29.340  1.00 45.36           C  
+ATOM   2002  OD1 ASN L  93      47.059  38.905  28.513  1.00 47.69           O  
+ATOM   2003  ND2 ASN L  93      48.930  39.392  29.667  1.00 43.09           N  
+ATOM   2004  N   GLU L  94      45.467  34.753  30.447  1.00 29.96           N  
+ATOM   2005  CA  GLU L  94      45.243  33.335  30.731  1.00 31.35           C  
+ATOM   2006  C   GLU L  94      45.056  33.078  32.231  1.00 26.50           C  
+ATOM   2007  O   GLU L  94      45.539  32.074  32.759  1.00 22.85           O  
+ATOM   2008  CB  GLU L  94      46.408  32.484  30.205  1.00 37.62           C  
+ATOM   2009  CG  GLU L  94      46.798  32.757  28.756  1.00 47.99           C  
+ATOM   2010  CD  GLU L  94      45.668  32.502  27.784  1.00 55.29           C  
+ATOM   2011  OE1 GLU L  94      45.147  31.363  27.757  1.00 59.93           O  
+ATOM   2012  OE2 GLU L  94      45.306  33.439  27.037  1.00 62.03           O  
+ATOM   2013  N   ASN L  95      44.412  34.027  32.912  1.00 22.36           N  
+ATOM   2014  CA  ASN L  95      44.133  33.930  34.347  1.00 23.18           C  
+ATOM   2015  C   ASN L  95      45.402  33.753  35.193  1.00 23.09           C  
+ATOM   2016  O   ASN L  95      45.353  33.220  36.303  1.00 18.87           O  
+ATOM   2017  CB  ASN L  95      43.160  32.772  34.605  1.00 20.24           C  
+ATOM   2018  CG  ASN L  95      42.341  32.972  35.864  1.00 22.74           C  
+ATOM   2019  OD1 ASN L  95      41.859  34.075  36.136  1.00 21.51           O  
+ATOM   2020  ND2 ASN L  95      42.178  31.908  36.641  1.00 16.30           N  
+ATOM   2021  N   GLY L  96      46.536  34.205  34.660  1.00 22.77           N  
+ATOM   2022  CA  GLY L  96      47.807  34.081  35.361  1.00 21.18           C  
+ATOM   2023  C   GLY L  96      48.239  32.634  35.540  1.00 20.64           C  
+ATOM   2024  O   GLY L  96      49.152  32.338  36.319  1.00 22.34           O  
+ATOM   2025  N   GLY L  97      47.579  31.733  34.818  1.00 20.51           N  
+ATOM   2026  CA  GLY L  97      47.872  30.316  34.919  1.00 18.36           C  
+ATOM   2027  C   GLY L  97      47.103  29.655  36.057  1.00 17.67           C  
+ATOM   2028  O   GLY L  97      47.174  28.439  36.224  1.00 18.88           O  
+ATOM   2029  N   CYS L  98      46.342  30.446  36.815  1.00 18.11           N  
+ATOM   2030  CA  CYS L  98      45.563  29.938  37.954  1.00 17.00           C  
+ATOM   2031  C   CYS L  98      44.293  29.192  37.537  1.00 16.47           C  
+ATOM   2032  O   CYS L  98      43.641  29.550  36.559  1.00 18.92           O  
+ATOM   2033  CB  CYS L  98      45.157  31.093  38.885  1.00 17.91           C  
+ATOM   2034  SG  CYS L  98      46.506  32.166  39.502  1.00 18.28           S  
+ATOM   2035  N   GLU L  99      43.927  28.171  38.301  1.00 16.49           N  
+ATOM   2036  CA  GLU L  99      42.712  27.427  38.002  1.00 17.91           C  
+ATOM   2037  C   GLU L  99      41.515  28.276  38.438  1.00 17.83           C  
+ATOM   2038  O   GLU L  99      40.481  28.303  37.760  1.00 17.36           O  
+ATOM   2039  CB  GLU L  99      42.701  26.084  38.726  1.00 16.29           C  
+ATOM   2040  CG  GLU L  99      41.454  25.240  38.459  1.00 20.33           C  
+ATOM   2041  CD  GLU L  99      41.451  23.943  39.239  1.00 23.60           C  
+ATOM   2042  OE1 GLU L  99      42.539  23.380  39.457  1.00 16.35           O  
+ATOM   2043  OE2 GLU L  99      40.362  23.479  39.643  1.00 24.79           O  
+ATOM   2044  N   GLN L 100      41.681  29.003  39.544  1.00 14.23           N  
+ATOM   2045  CA  GLN L 100      40.610  29.845  40.064  1.00 14.76           C  
+ATOM   2046  C   GLN L 100      40.972  31.325  40.189  1.00 14.46           C  
+ATOM   2047  O   GLN L 100      41.064  32.021  39.179  1.00 17.57           O  
+ATOM   2048  CB  GLN L 100      40.048  29.287  41.389  1.00 14.16           C  
+ATOM   2049  CG  GLN L 100      39.391  27.893  41.247  1.00 11.72           C  
+ATOM   2050  CD  GLN L 100      38.723  27.397  42.523  1.00 14.05           C  
+ATOM   2051  OE1 GLN L 100      38.827  28.018  43.569  1.00 13.59           O  
+ATOM   2052  NE2 GLN L 100      38.028  26.266  42.431  1.00 14.12           N  
+ATOM   2053  N   TYR L 101      41.203  31.806  41.410  1.00 15.93           N  
+ATOM   2054  CA  TYR L 101      41.491  33.227  41.621  1.00 14.37           C  
+ATOM   2055  C   TYR L 101      42.962  33.601  41.498  1.00 17.69           C  
+ATOM   2056  O   TYR L 101      43.838  32.791  41.793  1.00 18.33           O  
+ATOM   2057  CB  TYR L 101      40.906  33.672  42.962  1.00 12.51           C  
+ATOM   2058  CG  TYR L 101      39.444  33.261  43.104  1.00 15.13           C  
+ATOM   2059  CD1 TYR L 101      38.562  33.392  42.031  1.00 13.78           C  
+ATOM   2060  CD2 TYR L 101      38.959  32.706  44.293  1.00 18.11           C  
+ATOM   2061  CE1 TYR L 101      37.227  32.979  42.130  1.00 17.54           C  
+ATOM   2062  CE2 TYR L 101      37.619  32.289  44.403  1.00 16.30           C  
+ATOM   2063  CZ  TYR L 101      36.767  32.431  43.312  1.00 16.04           C  
+ATOM   2064  OH  TYR L 101      35.462  31.996  43.392  1.00 15.49           O  
+ATOM   2065  N   CYS L 102      43.214  34.842  41.086  1.00 19.28           N  
+ATOM   2066  CA  CYS L 102      44.574  35.339  40.860  1.00 19.29           C  
+ATOM   2067  C   CYS L 102      44.787  36.766  41.348  1.00 21.95           C  
+ATOM   2068  O   CYS L 102      43.927  37.622  41.160  1.00 21.92           O  
+ATOM   2069  CB  CYS L 102      44.866  35.296  39.355  1.00 17.37           C  
+ATOM   2070  SG  CYS L 102      46.591  35.650  38.851  1.00 21.86           S  
+ATOM   2071  N   SER L 103      45.931  37.002  41.990  1.00 22.00           N  
+ATOM   2072  CA  SER L 103      46.326  38.329  42.471  1.00 25.60           C  
+ATOM   2073  C   SER L 103      47.749  38.644  42.007  1.00 27.14           C  
+ATOM   2074  O   SER L 103      48.648  37.806  42.146  1.00 20.92           O  
+ATOM   2075  CB  SER L 103      46.295  38.398  43.999  1.00 25.98           C  
+ATOM   2076  OG  SER L 103      44.973  38.560  44.475  1.00 32.09           O  
+ATOM   2077  N   ASP L 104      47.940  39.833  41.435  1.00 30.33           N  
+ATOM   2078  CA  ASP L 104      49.258  40.283  40.979  1.00 35.98           C  
+ATOM   2079  C   ASP L 104      49.937  41.004  42.150  1.00 38.41           C  
+ATOM   2080  O   ASP L 104      49.296  41.785  42.858  1.00 38.55           O  
+ATOM   2081  CB  ASP L 104      49.132  41.271  39.804  1.00 37.12           C  
+ATOM   2082  CG  ASP L 104      48.754  40.600  38.490  1.00 40.32           C  
+ATOM   2083  OD1 ASP L 104      49.414  39.618  38.088  1.00 39.03           O  
+ATOM   2084  OD2 ASP L 104      47.810  41.085  37.833  1.00 45.71           O  
+ATOM   2085  N   HIS L 105      51.223  40.741  42.363  1.00 42.28           N  
+ATOM   2086  CA  HIS L 105      51.966  41.389  43.449  1.00 46.25           C  
+ATOM   2087  C   HIS L 105      52.932  42.455  42.942  1.00 49.36           C  
+ATOM   2088  O   HIS L 105      53.088  43.506  43.566  1.00 51.62           O  
+ATOM   2089  CB  HIS L 105      52.687  40.351  44.302  1.00 50.26           C  
+ATOM   2090  CG  HIS L 105      51.758  39.473  45.077  1.00 49.55           C  
+ATOM   2091  ND1 HIS L 105      50.590  39.945  45.639  1.00 52.13           N  
+ATOM   2092  CD2 HIS L 105      51.816  38.155  45.380  1.00 51.80           C  
+ATOM   2093  CE1 HIS L 105      49.969  38.956  46.256  1.00 52.97           C  
+ATOM   2094  NE2 HIS L 105      50.692  37.859  46.114  1.00 55.15           N  
+ATOM   2095  N   THR L 106      53.612  42.157  41.838  1.00 48.95           N  
+ATOM   2096  CA  THR L 106      54.530  43.104  41.194  1.00 50.84           C  
+ATOM   2097  C   THR L 106      54.436  42.785  39.705  1.00 50.59           C  
+ATOM   2098  O   THR L 106      53.456  42.176  39.263  1.00 54.49           O  
+ATOM   2099  CB  THR L 106      56.014  42.950  41.652  1.00 50.23           C  
+ATOM   2100  OG1 THR L 106      56.539  41.697  41.189  1.00 49.04           O  
+ATOM   2101  CG2 THR L 106      56.143  43.048  43.175  1.00 45.65           C  
+ATOM   2102  N   GLY L 107      55.438  43.198  38.935  0.00 49.11           N  
+ATOM   2103  CA  GLY L 107      55.435  42.910  37.513  0.00 47.04           C  
+ATOM   2104  C   GLY L 107      55.955  41.513  37.224  0.00 46.01           C  
+ATOM   2105  O   GLY L 107      55.943  41.069  36.075  0.00 45.95           O  
+ATOM   2106  N   THR L 108      56.400  40.813  38.269  1.00 45.36           N  
+ATOM   2107  CA  THR L 108      56.940  39.459  38.122  1.00 43.91           C  
+ATOM   2108  C   THR L 108      56.441  38.453  39.174  1.00 42.15           C  
+ATOM   2109  O   THR L 108      56.824  37.282  39.145  1.00 43.32           O  
+ATOM   2110  CB  THR L 108      58.486  39.472  38.171  0.00 40.80           C  
+ATOM   2111  OG1 THR L 108      58.923  40.139  39.362  0.00 38.90           O  
+ATOM   2112  CG2 THR L 108      59.063  40.180  36.953  0.00 39.78           C  
+ATOM   2113  N   LYS L 109      55.591  38.901  40.094  1.00 39.02           N  
+ATOM   2114  CA  LYS L 109      55.085  38.014  41.138  1.00 36.32           C  
+ATOM   2115  C   LYS L 109      53.558  37.872  41.142  1.00 34.07           C  
+ATOM   2116  O   LYS L 109      52.841  38.836  40.870  1.00 29.06           O  
+ATOM   2117  CB  LYS L 109      55.573  38.516  42.496  1.00 37.11           C  
+ATOM   2118  CG  LYS L 109      55.233  37.629  43.669  1.00 42.39           C  
+ATOM   2119  CD  LYS L 109      55.866  38.144  44.959  1.00 46.32           C  
+ATOM   2120  CE  LYS L 109      57.382  38.138  44.879  1.00 47.27           C  
+ATOM   2121  NZ  LYS L 109      58.002  38.435  46.206  1.00 49.68           N  
+ATOM   2122  N   ARG L 110      53.070  36.658  41.398  1.00 28.34           N  
+ATOM   2123  CA  ARG L 110      51.625  36.420  41.466  1.00 26.16           C  
+ATOM   2124  C   ARG L 110      51.255  35.244  42.351  1.00 24.16           C  
+ATOM   2125  O   ARG L 110      52.007  34.276  42.479  1.00 18.72           O  
+ATOM   2126  CB  ARG L 110      50.989  36.258  40.079  1.00 27.75           C  
+ATOM   2127  CG  ARG L 110      51.275  34.962  39.354  1.00 33.13           C  
+ATOM   2128  CD  ARG L 110      50.255  33.842  39.659  1.00 34.68           C  
+ATOM   2129  NE  ARG L 110      50.511  32.689  38.794  1.00 29.83           N  
+ATOM   2130  CZ  ARG L 110      50.984  31.515  39.202  1.00 26.47           C  
+ATOM   2131  NH1 ARG L 110      51.245  31.291  40.486  1.00 22.80           N  
+ATOM   2132  NH2 ARG L 110      51.304  30.598  38.303  1.00 22.76           N  
+ATOM   2133  N   SER L 111      50.092  35.357  42.977  1.00 15.48           N  
+ATOM   2134  CA  SER L 111      49.579  34.320  43.850  1.00 19.15           C  
+ATOM   2135  C   SER L 111      48.197  33.864  43.391  1.00 20.68           C  
+ATOM   2136  O   SER L 111      47.341  34.690  43.069  1.00 17.24           O  
+ATOM   2137  CB  SER L 111      49.485  34.848  45.281  1.00 22.43           C  
+ATOM   2138  OG  SER L 111      50.775  35.096  45.809  1.00 32.26           O  
+ATOM   2139  N   CYS L 112      48.020  32.550  43.274  1.00 17.93           N  
+ATOM   2140  CA  CYS L 112      46.725  31.991  42.916  1.00 18.31           C  
+ATOM   2141  C   CYS L 112      46.046  31.657  44.232  1.00 17.58           C  
+ATOM   2142  O   CYS L 112      46.706  31.436  45.248  1.00 18.41           O  
+ATOM   2143  CB  CYS L 112      46.864  30.701  42.110  1.00 12.89           C  
+ATOM   2144  SG  CYS L 112      47.703  30.887  40.524  1.00 15.76           S  
+ATOM   2145  N   ARG L 113      44.725  31.633  44.215  1.00 17.97           N  
+ATOM   2146  CA  ARG L 113      43.960  31.303  45.403  1.00 16.53           C  
+ATOM   2147  C   ARG L 113      42.762  30.458  44.979  1.00 12.96           C  
+ATOM   2148  O   ARG L 113      42.464  30.333  43.779  1.00 14.10           O  
+ATOM   2149  CB  ARG L 113      43.540  32.588  46.144  1.00 22.29           C  
+ATOM   2150  CG  ARG L 113      44.732  33.272  46.847  1.00 26.85           C  
+ATOM   2151  CD  ARG L 113      44.483  34.714  47.271  1.00 36.29           C  
+ATOM   2152  NE  ARG L 113      44.207  35.590  46.131  1.00 38.32           N  
+ATOM   2153  CZ  ARG L 113      42.993  36.038  45.841  1.00 31.50           C  
+ATOM   2154  NH1 ARG L 113      41.985  35.683  46.618  1.00 26.55           N  
+ATOM   2155  NH2 ARG L 113      42.776  36.784  44.762  1.00 23.76           N  
+ATOM   2156  N   CYS L 114      42.139  29.804  45.952  1.00 12.75           N  
+ATOM   2157  CA  CYS L 114      40.987  28.952  45.693  1.00 14.21           C  
+ATOM   2158  C   CYS L 114      39.819  29.390  46.573  1.00 18.55           C  
+ATOM   2159  O   CYS L 114      40.024  29.918  47.668  1.00 16.71           O  
+ATOM   2160  CB  CYS L 114      41.336  27.499  46.016  1.00 15.79           C  
+ATOM   2161  SG  CYS L 114      42.791  26.863  45.119  1.00 15.91           S  
+ATOM   2162  N   HIS L 115      38.604  29.130  46.094  1.00 15.37           N  
+ATOM   2163  CA  HIS L 115      37.364  29.447  46.812  1.00 14.41           C  
+ATOM   2164  C   HIS L 115      37.308  28.594  48.076  1.00 17.23           C  
+ATOM   2165  O   HIS L 115      37.996  27.571  48.184  1.00 12.80           O  
+ATOM   2166  CB  HIS L 115      36.175  29.067  45.919  1.00 16.68           C  
+ATOM   2167  CG  HIS L 115      34.899  29.784  46.241  1.00 17.52           C  
+ATOM   2168  ND1 HIS L 115      34.001  29.331  47.186  1.00 21.40           N  
+ATOM   2169  CD2 HIS L 115      34.341  30.890  45.695  1.00 11.54           C  
+ATOM   2170  CE1 HIS L 115      32.943  30.126  47.204  1.00 10.48           C  
+ATOM   2171  NE2 HIS L 115      33.125  31.079  46.307  1.00 18.40           N  
+ATOM   2172  N   GLU L 116      36.472  29.007  49.027  1.00 13.35           N  
+ATOM   2173  CA  GLU L 116      36.275  28.250  50.259  1.00 15.16           C  
+ATOM   2174  C   GLU L 116      35.846  26.842  49.825  1.00 15.23           C  
+ATOM   2175  O   GLU L 116      35.142  26.697  48.825  1.00 15.81           O  
+ATOM   2176  CB  GLU L 116      35.148  28.897  51.085  1.00 17.63           C  
+ATOM   2177  CG  GLU L 116      34.817  28.141  52.349  1.00 29.39           C  
+ATOM   2178  CD  GLU L 116      33.708  28.793  53.153  1.00 38.64           C  
+ATOM   2179  OE1 GLU L 116      34.021  29.654  54.004  1.00 40.79           O  
+ATOM   2180  OE2 GLU L 116      32.529  28.438  52.936  1.00 44.89           O  
+ATOM   2181  N   GLY L 117      36.269  25.817  50.560  1.00 12.82           N  
+ATOM   2182  CA  GLY L 117      35.922  24.456  50.188  1.00 14.93           C  
+ATOM   2183  C   GLY L 117      36.922  23.818  49.226  1.00 15.59           C  
+ATOM   2184  O   GLY L 117      36.705  22.693  48.744  1.00 13.21           O  
+ATOM   2185  N   TYR L 118      38.016  24.537  48.959  1.00 13.92           N  
+ATOM   2186  CA  TYR L 118      39.095  24.085  48.073  1.00 15.89           C  
+ATOM   2187  C   TYR L 118      40.443  24.504  48.682  1.00 16.88           C  
+ATOM   2188  O   TYR L 118      40.509  25.469  49.433  1.00 14.86           O  
+ATOM   2189  CB  TYR L 118      39.007  24.771  46.703  1.00 11.83           C  
+ATOM   2190  CG  TYR L 118      37.847  24.392  45.814  1.00 12.65           C  
+ATOM   2191  CD1 TYR L 118      36.622  25.058  45.909  1.00 14.09           C  
+ATOM   2192  CD2 TYR L 118      37.984  23.401  44.845  1.00 11.55           C  
+ATOM   2193  CE1 TYR L 118      35.568  24.737  45.062  1.00 10.31           C  
+ATOM   2194  CE2 TYR L 118      36.932  23.081  43.988  1.00 14.98           C  
+ATOM   2195  CZ  TYR L 118      35.732  23.754  44.108  1.00 12.86           C  
+ATOM   2196  OH  TYR L 118      34.684  23.445  43.280  1.00 12.95           O  
+ATOM   2197  N   SER L 119      41.516  23.809  48.314  1.00 13.23           N  
+ATOM   2198  CA  SER L 119      42.865  24.145  48.778  1.00 17.87           C  
+ATOM   2199  C   SER L 119      43.792  24.167  47.560  1.00 14.32           C  
+ATOM   2200  O   SER L 119      43.610  23.390  46.633  1.00 13.57           O  
+ATOM   2201  CB  SER L 119      43.375  23.118  49.797  1.00 19.21           C  
+ATOM   2202  OG  SER L 119      42.853  23.405  51.083  1.00 28.38           O  
+ATOM   2203  N   LEU L 120      44.758  25.084  47.565  1.00 15.44           N  
+ATOM   2204  CA  LEU L 120      45.731  25.245  46.474  1.00 14.19           C  
+ATOM   2205  C   LEU L 120      46.760  24.115  46.566  1.00 14.67           C  
+ATOM   2206  O   LEU L 120      47.243  23.814  47.649  1.00 13.17           O  
+ATOM   2207  CB  LEU L 120      46.486  26.568  46.659  1.00 18.32           C  
+ATOM   2208  CG  LEU L 120      46.691  27.637  45.578  1.00 28.07           C  
+ATOM   2209  CD1 LEU L 120      48.079  28.223  45.741  1.00 16.92           C  
+ATOM   2210  CD2 LEU L 120      46.492  27.126  44.179  1.00 23.65           C  
+ATOM   2211  N   LEU L 121      47.089  23.498  45.438  1.00 12.47           N  
+ATOM   2212  CA  LEU L 121      48.081  22.424  45.396  1.00 14.56           C  
+ATOM   2213  C   LEU L 121      49.502  23.030  45.353  1.00 12.62           C  
+ATOM   2214  O   LEU L 121      49.662  24.237  45.140  1.00 12.03           O  
+ATOM   2215  CB  LEU L 121      47.844  21.546  44.158  1.00 12.39           C  
+ATOM   2216  CG  LEU L 121      46.856  20.380  44.252  1.00 23.62           C  
+ATOM   2217  CD1 LEU L 121      45.598  20.819  44.910  1.00 30.95           C  
+ATOM   2218  CD2 LEU L 121      46.572  19.793  42.875  1.00 19.08           C  
+ATOM   2219  N   ALA L 122      50.521  22.181  45.510  1.00 14.21           N  
+ATOM   2220  CA  ALA L 122      51.916  22.641  45.501  1.00 15.35           C  
+ATOM   2221  C   ALA L 122      52.376  23.238  44.172  1.00 15.56           C  
+ATOM   2222  O   ALA L 122      53.399  23.929  44.123  1.00 15.70           O  
+ATOM   2223  CB  ALA L 122      52.859  21.526  45.950  1.00 11.20           C  
+ATOM   2224  N   ASP L 123      51.632  22.984  43.095  1.00 14.70           N  
+ATOM   2225  CA  ASP L 123      51.987  23.582  41.811  1.00 14.16           C  
+ATOM   2226  C   ASP L 123      51.674  25.085  41.848  1.00 13.73           C  
+ATOM   2227  O   ASP L 123      52.070  25.833  40.965  1.00 12.36           O  
+ATOM   2228  CB  ASP L 123      51.292  22.880  40.622  1.00 15.14           C  
+ATOM   2229  CG  ASP L 123      49.754  22.956  40.665  1.00 15.07           C  
+ATOM   2230  OD1 ASP L 123      49.166  23.640  41.523  1.00 12.62           O  
+ATOM   2231  OD2 ASP L 123      49.123  22.309  39.804  1.00 11.13           O  
+ATOM   2232  N   GLY L 124      50.986  25.514  42.907  1.00 14.58           N  
+ATOM   2233  CA  GLY L 124      50.642  26.916  43.083  1.00 15.35           C  
+ATOM   2234  C   GLY L 124      49.531  27.467  42.199  1.00 18.24           C  
+ATOM   2235  O   GLY L 124      49.255  28.670  42.238  1.00 15.72           O  
+ATOM   2236  N   VAL L 125      48.898  26.604  41.406  1.00 15.83           N  
+ATOM   2237  CA  VAL L 125      47.818  27.033  40.507  1.00 12.64           C  
+ATOM   2238  C   VAL L 125      46.520  26.217  40.627  1.00 15.59           C  
+ATOM   2239  O   VAL L 125      45.425  26.759  40.464  1.00 15.39           O  
+ATOM   2240  CB  VAL L 125      48.258  27.002  39.008  1.00 14.21           C  
+ATOM   2241  CG1 VAL L 125      49.390  27.994  38.752  1.00 17.25           C  
+ATOM   2242  CG2 VAL L 125      48.675  25.594  38.586  1.00 13.21           C  
+ATOM   2243  N   SER L 126      46.647  24.924  40.916  1.00 15.26           N  
+ATOM   2244  CA  SER L 126      45.492  24.031  41.006  1.00 16.06           C  
+ATOM   2245  C   SER L 126      44.733  24.070  42.335  1.00 16.27           C  
+ATOM   2246  O   SER L 126      45.322  24.293  43.400  1.00 16.18           O  
+ATOM   2247  CB  SER L 126      45.915  22.586  40.716  1.00 15.79           C  
+ATOM   2248  OG  SER L 126      46.540  22.466  39.444  1.00 15.84           O  
+ATOM   2249  N   CYS L 127      43.425  23.828  42.255  1.00 13.59           N  
+ATOM   2250  CA  CYS L 127      42.555  23.806  43.432  1.00 16.59           C  
+ATOM   2251  C   CYS L 127      41.905  22.448  43.554  1.00 16.70           C  
+ATOM   2252  O   CYS L 127      41.381  21.914  42.576  1.00 19.96           O  
+ATOM   2253  CB  CYS L 127      41.454  24.857  43.314  1.00 15.38           C  
+ATOM   2254  SG  CYS L 127      42.097  26.549  43.243  1.00 15.06           S  
+ATOM   2255  N   THR L 128      41.901  21.906  44.766  1.00 13.71           N  
+ATOM   2256  CA  THR L 128      41.294  20.609  44.995  1.00 14.67           C  
+ATOM   2257  C   THR L 128      40.264  20.738  46.116  1.00 13.43           C  
+ATOM   2258  O   THR L 128      40.491  21.459  47.090  1.00 13.51           O  
+ATOM   2259  CB  THR L 128      42.358  19.548  45.389  1.00 18.66           C  
+ATOM   2260  OG1 THR L 128      41.766  18.244  45.357  1.00 21.80           O  
+ATOM   2261  CG2 THR L 128      42.888  19.811  46.796  1.00 22.79           C  
+ATOM   2262  N   PRO L 129      39.105  20.075  45.970  1.00 13.45           N  
+ATOM   2263  CA  PRO L 129      38.038  20.116  46.978  1.00 15.96           C  
+ATOM   2264  C   PRO L 129      38.499  19.593  48.335  1.00 17.24           C  
+ATOM   2265  O   PRO L 129      39.210  18.604  48.415  1.00 14.61           O  
+ATOM   2266  CB  PRO L 129      36.971  19.187  46.387  1.00 14.54           C  
+ATOM   2267  CG  PRO L 129      37.142  19.363  44.916  1.00 16.38           C  
+ATOM   2268  CD  PRO L 129      38.658  19.354  44.763  1.00 15.29           C  
+ATOM   2269  N   THR L 130      38.077  20.270  49.395  1.00 16.88           N  
+ATOM   2270  CA  THR L 130      38.417  19.875  50.756  1.00 16.25           C  
+ATOM   2271  C   THR L 130      37.142  19.438  51.491  1.00 16.20           C  
+ATOM   2272  O   THR L 130      37.187  19.056  52.664  1.00 14.11           O  
+ATOM   2273  CB  THR L 130      39.050  21.040  51.522  1.00 16.79           C  
+ATOM   2274  OG1 THR L 130      38.155  22.158  51.505  1.00 17.43           O  
+ATOM   2275  CG2 THR L 130      40.393  21.456  50.884  1.00 13.11           C  
+ATOM   2276  N   VAL L 131      36.008  19.542  50.805  1.00 14.99           N  
+ATOM   2277  CA  VAL L 131      34.712  19.156  51.375  1.00 16.10           C  
+ATOM   2278  C   VAL L 131      33.964  18.273  50.393  1.00 14.24           C  
+ATOM   2279  O   VAL L 131      34.349  18.148  49.221  1.00 15.42           O  
+ATOM   2280  CB  VAL L 131      33.824  20.381  51.713  1.00 14.76           C  
+ATOM   2281  CG1 VAL L 131      34.442  21.192  52.827  1.00 15.30           C  
+ATOM   2282  CG2 VAL L 131      33.608  21.240  50.474  1.00 16.25           C  
+ATOM   2283  N   GLU L 132      32.867  17.693  50.858  1.00 15.20           N  
+ATOM   2284  CA  GLU L 132      32.074  16.795  50.031  1.00 13.46           C  
+ATOM   2285  C   GLU L 132      31.323  17.507  48.915  1.00 17.02           C  
+ATOM   2286  O   GLU L 132      31.256  17.014  47.785  1.00 16.83           O  
+ATOM   2287  CB  GLU L 132      31.095  16.023  50.916  1.00 19.94           C  
+ATOM   2288  CG  GLU L 132      30.305  14.966  50.182  1.00 20.98           C  
+ATOM   2289  CD  GLU L 132      29.414  14.142  51.107  1.00 20.88           C  
+ATOM   2290  OE1 GLU L 132      29.215  14.510  52.283  1.00 25.56           O  
+ATOM   2291  OE2 GLU L 132      28.895  13.124  50.645  1.00 22.50           O  
+ATOM   2292  N   TYR L 133      30.782  18.681  49.220  1.00 13.72           N  
+ATOM   2293  CA  TYR L 133      30.019  19.435  48.230  1.00 12.99           C  
+ATOM   2294  C   TYR L 133      30.558  20.844  47.992  1.00 11.67           C  
+ATOM   2295  O   TYR L 133      29.980  21.830  48.454  1.00 12.16           O  
+ATOM   2296  CB  TYR L 133      28.535  19.483  48.630  1.00 13.01           C  
+ATOM   2297  CG  TYR L 133      27.872  18.116  48.692  1.00 11.01           C  
+ATOM   2298  CD1 TYR L 133      27.658  17.369  47.528  1.00 14.25           C  
+ATOM   2299  CD2 TYR L 133      27.469  17.565  49.913  1.00 14.38           C  
+ATOM   2300  CE1 TYR L 133      27.057  16.101  47.578  1.00 17.91           C  
+ATOM   2301  CE2 TYR L 133      26.864  16.295  49.979  1.00 15.76           C  
+ATOM   2302  CZ  TYR L 133      26.660  15.572  48.810  1.00 14.32           C  
+ATOM   2303  OH  TYR L 133      26.044  14.338  48.852  1.00 17.80           O  
+ATOM   2304  N   PRO L 134      31.709  20.949  47.305  1.00 14.74           N  
+ATOM   2305  CA  PRO L 134      32.320  22.248  47.005  1.00 12.37           C  
+ATOM   2306  C   PRO L 134      31.439  22.966  45.983  1.00 14.61           C  
+ATOM   2307  O   PRO L 134      30.742  22.325  45.184  1.00 13.57           O  
+ATOM   2308  CB  PRO L 134      33.672  21.850  46.407  1.00 14.40           C  
+ATOM   2309  CG  PRO L 134      33.369  20.574  45.719  1.00 14.75           C  
+ATOM   2310  CD  PRO L 134      32.514  19.850  46.738  1.00 10.45           C  
+ATOM   2311  N   CYS L 135      31.455  24.292  46.011  1.00 12.27           N  
+ATOM   2312  CA  CYS L 135      30.633  25.054  45.082  1.00 12.89           C  
+ATOM   2313  C   CYS L 135      31.057  24.831  43.634  1.00 14.12           C  
+ATOM   2314  O   CYS L 135      32.216  24.498  43.354  1.00 14.05           O  
+ATOM   2315  CB  CYS L 135      30.694  26.559  45.407  1.00 15.21           C  
+ATOM   2316  SG  CYS L 135      32.322  27.354  45.114  1.00 14.22           S  
+ATOM   2317  N   GLY L 136      30.096  24.960  42.721  1.00 12.72           N  
+ATOM   2318  CA  GLY L 136      30.390  24.840  41.303  1.00 10.68           C  
+ATOM   2319  C   GLY L 136      30.714  23.476  40.717  1.00 11.06           C  
+ATOM   2320  O   GLY L 136      31.160  23.407  39.575  1.00 11.90           O  
+ATOM   2321  N   LYS L 137      30.545  22.405  41.486  1.00 13.33           N  
+ATOM   2322  CA  LYS L 137      30.797  21.055  40.981  1.00 14.81           C  
+ATOM   2323  C   LYS L 137      29.458  20.339  41.040  1.00 13.67           C  
+ATOM   2324  O   LYS L 137      28.669  20.581  41.948  1.00 15.21           O  
+ATOM   2325  CB  LYS L 137      31.790  20.296  41.869  1.00 16.61           C  
+ATOM   2326  CG  LYS L 137      33.170  20.912  42.000  1.00 26.70           C  
+ATOM   2327  CD  LYS L 137      34.005  20.700  40.767  1.00 25.61           C  
+ATOM   2328  CE  LYS L 137      35.441  21.181  40.995  1.00 23.86           C  
+ATOM   2329  NZ  LYS L 137      36.250  21.056  39.768  1.00 28.31           N  
+ATOM   2330  N   ILE L 138      29.229  19.435  40.096  1.00 12.18           N  
+ATOM   2331  CA  ILE L 138      27.983  18.672  40.018  1.00 11.12           C  
+ATOM   2332  C   ILE L 138      28.248  17.231  40.438  1.00 15.50           C  
+ATOM   2333  O   ILE L 138      28.795  16.440  39.664  1.00 15.23           O  
+ATOM   2334  CB  ILE L 138      27.417  18.760  38.581  1.00 12.36           C  
+ATOM   2335  CG1 ILE L 138      27.218  20.243  38.223  1.00 13.82           C  
+ATOM   2336  CG2 ILE L 138      26.099  18.007  38.476  1.00 11.69           C  
+ATOM   2337  CD1 ILE L 138      27.002  20.529  36.753  1.00 14.17           C  
+ATOM   2338  N   PRO L 139      27.858  16.876  41.676  1.00 12.64           N  
+ATOM   2339  CA  PRO L 139      28.042  15.540  42.250  1.00 18.08           C  
+ATOM   2340  C   PRO L 139      27.743  14.338  41.352  1.00 21.93           C  
+ATOM   2341  O   PRO L 139      28.578  13.436  41.250  1.00 20.37           O  
+ATOM   2342  CB  PRO L 139      27.146  15.573  43.484  1.00 19.38           C  
+ATOM   2343  CG  PRO L 139      27.249  16.997  43.925  1.00 17.02           C  
+ATOM   2344  CD  PRO L 139      27.102  17.737  42.607  1.00 13.97           C  
+ATOM   2345  N   ILE L 140      26.587  14.309  40.696  1.00 19.13           N  
+ATOM   2346  CA  ILE L 140      26.280  13.150  39.860  1.00 26.22           C  
+ATOM   2347  C   ILE L 140      27.224  12.988  38.674  1.00 26.31           C  
+ATOM   2348  O   ILE L 140      27.468  11.870  38.217  1.00 28.56           O  
+ATOM   2349  CB  ILE L 140      24.811  13.106  39.399  1.00 28.12           C  
+ATOM   2350  CG1 ILE L 140      24.476  14.287  38.494  1.00 28.91           C  
+ATOM   2351  CG2 ILE L 140      23.882  13.050  40.610  1.00 33.94           C  
+ATOM   2352  CD1 ILE L 140      23.091  14.205  37.922  1.00 35.93           C  
+ATOM   2353  N   LEU L 141      27.795  14.096  38.218  1.00 26.65           N  
+ATOM   2354  CA  LEU L 141      28.732  14.056  37.103  1.00 25.89           C  
+ATOM   2355  C   LEU L 141      30.163  13.800  37.594  1.00 31.77           C  
+ATOM   2356  O   LEU L 141      30.979  13.253  36.855  1.00 32.36           O  
+ATOM   2357  CB  LEU L 141      28.663  15.352  36.295  1.00 26.68           C  
+ATOM   2358  CG  LEU L 141      27.322  15.670  35.634  1.00 26.91           C  
+ATOM   2359  CD1 LEU L 141      27.418  16.989  34.871  1.00 26.86           C  
+ATOM   2360  CD2 LEU L 141      26.922  14.529  34.699  1.00 33.20           C  
+ATOM   2361  N   GLU L 142      30.454  14.172  38.843  1.00 30.06           N  
+ATOM   2362  CA  GLU L 142      31.782  13.973  39.432  1.00 30.56           C  
+ATOM   2363  C   GLU L 142      32.024  12.515  39.824  1.00 33.50           C  
+ATOM   2364  O   GLU L 142      31.114  11.835  40.311  1.00 36.84           O  
+ATOM   2365  CB  GLU L 142      31.972  14.871  40.661  1.00 30.41           C  
+ATOM   2366  CG  GLU L 142      32.069  16.372  40.357  1.00 25.96           C  
+ATOM   2367  CD  GLU L 142      33.342  16.754  39.604  1.00 29.90           C  
+ATOM   2368  OE1 GLU L 142      34.404  16.159  39.878  1.00 29.38           O  
+ATOM   2369  OE2 GLU L 142      33.281  17.658  38.744  1.00 23.54           O  
+TER    2370      GLU L 142                                                      
+HETATM 2371 CA    CA H 300       9.418  17.844  42.779  1.00 19.21          CA  
+HETATM 2372 CA    CA H 538      22.160  22.160  58.164  0.50 22.54          CA  
+HETATM 2446  O   HOH H 402      16.504  17.178  42.210  1.00 16.14           O  
+HETATM 2447  O   HOH H 404      20.560  34.223  40.280  1.00 13.40           O  
+HETATM 2448  O   HOH H 405      36.159  40.485  44.646  1.00 23.76           O  
+HETATM 2449  O   HOH H 406      38.199  25.047  39.765  1.00 21.07           O  
+HETATM 2450  O   HOH H 407      21.013  45.482  36.114  1.00 15.72           O  
+HETATM 2451  O   HOH H 408      18.872  44.577  34.477  1.00 13.96           O  
+HETATM 2452  O   HOH H 409      12.379  29.683  37.138  1.00 13.25           O  
+HETATM 2453  O   HOH H 411       4.988  30.095  49.012  1.00 17.17           O  
+HETATM 2454  O   HOH H 412      30.398  35.170  30.914  1.00 14.78           O  
+HETATM 2455  O   HOH H 413      30.392  37.342  38.329  1.00 13.53           O  
+HETATM 2456  O   HOH H 415      29.318  38.738  35.973  1.00 12.28           O  
+HETATM 2457  O   HOH H 416      26.339  42.782  26.442  1.00 24.55           O  
+HETATM 2458  O   HOH H 417      42.227  31.557  30.357  1.00 37.47           O  
+HETATM 2459  O   HOH H 418      30.010  27.840  30.464  1.00 15.62           O  
+HETATM 2460  O   HOH H 420      11.557  26.639  31.352  1.00 11.23           O  
+HETATM 2461  O   HOH H 421       2.611  38.617  48.328  1.00 42.32           O  
+HETATM 2462  O   HOH H 422      16.395  50.480  38.632  1.00 14.18           O  
+HETATM 2463  O   HOH H 423       7.171  41.430  40.693  1.00 39.90           O  
+HETATM 2464  O   HOH H 424      15.231  24.082  43.363  1.00 11.72           O  
+HETATM 2465  O   HOH H 425      15.078  30.559  36.752  1.00  9.51           O  
+HETATM 2466  O   HOH H 426      24.464  16.395  41.137  1.00 18.65           O  
+HETATM 2467  O   HOH H 427      30.291  47.893  45.827  1.00 17.83           O  
+HETATM 2468  O   HOH H 428      18.318  17.319  48.796  1.00 12.42           O  
+HETATM 2469  O   HOH H 429      38.011  27.176  37.918  1.00 12.44           O  
+HETATM 2470  O   HOH H 430      20.035  13.051  36.314  1.00 20.23           O  
+HETATM 2471  O   HOH H 431      22.407  12.866  34.716  1.00 25.16           O  
+HETATM 2472  O   HOH H 432      13.434  16.855  43.136  1.00 12.50           O  
+HETATM 2473  O   HOH H 434      30.088  45.483  44.315  1.00 16.04           O  
+HETATM 2474  O   HOH H 435       8.644  31.733  21.492  1.00 17.93           O  
+HETATM 2475  O   HOH H 436      31.486  40.944  33.758  1.00 14.01           O  
+HETATM 2476  O   HOH H 437      29.890  31.152  46.580  1.00 12.02           O  
+HETATM 2477  O   HOH H 438      23.810  22.945  55.947  1.00 10.20           O  
+HETATM 2478  O   HOH H 440      13.177  24.993  26.682  1.00 16.04           O  
+HETATM 2479  O   HOH H 442      15.741  36.147  19.155  1.00 25.51           O  
+HETATM 2480  O   HOH H 443      18.207  34.933  23.248  1.00 13.87           O  
+HETATM 2481  O   HOH H 445      22.031  42.882  57.347  1.00 25.55           O  
+HETATM 2482  O   HOH H 448      42.294  35.774  31.873  1.00 28.64           O  
+HETATM 2483  O   HOH H 449       9.068  38.636  37.158  1.00 25.76           O  
+HETATM 2484  O   HOH H 450      22.389  35.484  17.145  1.00 25.26           O  
+HETATM 2485  O   HOH H 453      17.743  21.213  41.058  1.00 13.44           O  
+HETATM 2486  O   HOH H 454       7.961  19.331  44.073  1.00 15.06           O  
+HETATM 2487  O   HOH H 455      31.670  27.328  28.131  1.00 29.94           O  
+HETATM 2488  O   HOH H 458       9.174  33.491  54.297  1.00 30.55           O  
+HETATM 2489  O   HOH H 459      31.387  38.275  34.199  1.00 14.82           O  
+HETATM 2490  O   HOH H 460      18.920  18.842  41.986  1.00 14.10           O  
+HETATM 2491  O   HOH H 461      18.573  22.950  43.325  1.00 12.39           O  
+HETATM 2492  O   HOH H 462      25.325  21.087  54.487  1.00 11.97           O  
+HETATM 2493  O   HOH H 463      11.479  46.494  37.730  1.00 16.35           O  
+HETATM 2494  O   HOH H 464      33.000  42.914  32.652  1.00 18.97           O  
+HETATM 2495  O   HOH H 467      19.057  19.781  38.895  1.00 15.09           O  
+HETATM 2496  O   HOH H 469      10.674  25.819  23.814  1.00 20.51           O  
+HETATM 2497  O   HOH H 470       3.681  30.086  51.785  1.00 48.65           O  
+HETATM 2498  O   HOH H 471      19.049  34.727  26.421  1.00 15.89           O  
+HETATM 2499  O   HOH H 472      38.406  33.527  29.331  1.00 34.20           O  
+HETATM 2500  O   HOH H 474      17.374  37.454  30.651  1.00 15.17           O  
+HETATM 2501  O   HOH H 476      25.321  25.047  56.775  1.00 12.41           O  
+HETATM 2502  O   HOH H 477      27.917  24.626  55.912  1.00 22.25           O  
+HETATM 2503  O   HOH H 478      27.883  22.141  54.522  1.00 22.59           O  
+HETATM 2504  O   HOH H 484      40.553  39.468  44.437  1.00 31.17           O  
+HETATM 2505  O   HOH H 485      38.368  40.929  43.035  1.00 23.54           O  
+HETATM 2506  O   HOH H 489      11.498  44.861  44.367  1.00 11.59           O  
+HETATM 2507  O   HOH H 490      26.671  33.776  27.785  1.00 18.46           O  
+HETATM 2508  O   HOH H 494      22.983  20.461  30.732  1.00 47.67           O  
+HETATM 2509  O   HOH H 496      35.071  34.466  46.060  1.00 30.90           O  
+HETATM 2510  O   HOH H 497      33.678  36.813  45.868  1.00 58.92           O  
+HETATM 2511  O   HOH H 498       4.294  22.977  30.104  1.00 32.02           O  
+HETATM 2512  O   HOH H 500       8.825  42.527  57.535  1.00 37.34           O  
+HETATM 2513  O   HOH H 505       9.312  33.915  19.892  1.00 31.37           O  
+HETATM 2514  O   HOH H 506      24.084  34.664  19.119  1.00 19.93           O  
+HETATM 2515  O   HOH H 507      25.072  32.349  17.518  1.00 31.46           O  
+HETATM 2516  O   HOH H 510      18.990  33.234  58.605  1.00 27.90           O  
+HETATM 2517  O   HOH H 511      13.994  38.732  23.039  1.00 14.53           O  
+HETATM 2518  O   HOH H 512       6.623  40.496  43.278  1.00 17.00           O  
+HETATM 2519  O   HOH H 514      21.427  55.054  46.254  1.00 33.09           O  
+HETATM 2520  O   HOH H 517      24.254  23.034  35.038  1.00 30.39           O  
+HETATM 2521  O   HOH H 524      23.517  25.658  35.786  1.00 17.39           O  
+HETATM 2522  O   HOH H 525      11.662  46.312  56.205  1.00 39.82           O  
+HETATM 2523  O   HOH H 526       5.713  25.784  35.759  1.00 23.03           O  
+HETATM 2524  O   HOH H 529      31.013  20.128  34.792  1.00 35.93           O  
+HETATM 2525  O   HOH H 530      22.407  38.837  57.388  1.00 26.55           O  
+HETATM 2526  O   HOH H 532      30.472  33.159  48.754  1.00 39.44           O  
+HETATM 2527  O   HOH H 533      13.911  19.968  54.577  1.00 44.13           O  
+HETATM 2528  O   HOH H 534      21.363  24.665  24.754  1.00 19.60           O  
+HETATM 2529  O   HOH H 535      16.022  50.077  46.137  1.00 17.03           O  
+HETATM 2530  O   HOH H 536       9.023  42.679  27.255  1.00 22.49           O  
+HETATM 2531  O   HOH H 537      29.831  41.294  28.006  1.00 27.43           O  
+HETATM 2532  O   HOH H 540      29.257  47.537  49.722  1.00 24.11           O  
+HETATM 2533  O   HOH H 541      11.253  16.716  41.497  1.00 16.86           O  
+HETATM 2534  O   HOH H 542      25.917  52.322  32.663  1.00 45.36           O  
+HETATM 2535  O   HOH H 543      11.787  21.001  53.283  1.00 20.15           O  
+HETATM 2536  O   HOH H 544      42.350  38.266  38.716  1.00 25.40           O  
+HETATM 2537  O   HOH H 545      17.155  19.414  36.948  1.00 15.37           O  
+HETATM 2538  O   HOH H 546       2.158  26.806  25.630  1.00 18.82           O  
+HETATM 2539  O   HOH H 547      40.741  36.681  41.171  1.00 23.12           O  
+HETATM 2540  O   HOH H 549      29.103  33.569  28.896  1.00 15.20           O  
+HETATM 2541  O   HOH H 550      16.545  19.944  55.003  1.00 32.11           O  
+HETATM 2542  O   HOH H 551      15.925  13.998  34.834  1.00 20.41           O  
+HETATM 2543  O   HOH H 552       2.685  31.886  39.016  1.00 22.29           O  
+HETATM 2544  O   HOH H 553      22.988  19.545  58.137  1.00 15.24           O  
+HETATM 2545  O   HOH H 554      27.356  45.858  50.855  1.00 18.24           O  
+HETATM 2546  O   HOH H 555      25.800  48.142  51.240  1.00 18.86           O  
+HETATM 2547  O   HOH H 559      35.438  42.213  31.511  1.00 32.20           O  
+HETATM 2548  O   HOH H 560      29.822  28.241  48.642  1.00 27.65           O  
+HETATM 2549  O   HOH H 561      31.803  35.926  26.913  1.00 27.56           O  
+HETATM 2550  O   HOH H 562      23.410  44.334  60.380  1.00 34.57           O  
+HETATM 2551  O   HOH H 564      11.184  14.348  40.376  1.00 22.06           O  
+HETATM 2552  O   HOH H 567      37.855  26.128  30.937  1.00 20.74           O  
+HETATM 2553  O   HOH H 568      16.249  36.586  22.300  1.00 20.67           O  
+HETATM 2554  O   HOH H 569      14.366  18.040  26.867  1.00 30.31           O  
+HETATM 2555  O   HOH H 570      32.371  28.831  25.805  1.00 25.72           O  
+HETATM 2556  O   HOH H 574      34.690  30.246  25.409  1.00 31.87           O  
+HETATM 2557  O   HOH H 575       9.840  37.517  16.909  1.00 24.71           O  
+HETATM 2558  O   HOH H 581      18.351  25.636  62.400  1.00 21.27           O  
+HETATM 2559  O   HOH H 582      35.995  38.507  46.703  1.00 40.91           O  
+HETATM 2560  O   HOH H 583       6.487  21.072  30.753  1.00 35.23           O  
+HETATM 2561  O   HOH H 585      31.215  37.525  52.677  1.00 24.37           O  
+HETATM 2562  O   HOH H 586      31.962  44.252  36.563  1.00 17.55           O  
+HETATM 2563  O   HOH H 591       8.882  52.933  41.292  1.00 43.24           O  
+HETATM 2564  O   HOH H 595      16.652  47.428  59.120  1.00 48.91           O  
+HETATM 2565  O   HOH H 599      11.452  23.355  25.153  1.00 23.02           O  
+HETATM 2566  O   HOH H 601      28.149  27.696  53.418  1.00 47.99           O  
+HETATM 2567  O   HOH H 605      16.563  51.695  34.881  1.00 18.27           O  
+HETATM 2568  O   HOH H 606      31.704  30.225  49.955  1.00 30.31           O  
+HETATM 2569  O   HOH H 607      21.977  27.668  34.540  1.00 17.48           O  
+HETATM 2570  O   HOH H 609      11.445  47.161  46.591  1.00 35.71           O  
+HETATM 2571  O   HOH H 610       5.543  35.141  27.768  1.00 22.24           O  
+HETATM 2572  O   HOH H 611      29.765  43.447  56.603  1.00 29.98           O  
+HETATM 2573  O   HOH H 612      34.022  42.233  28.607  1.00 36.71           O  
+HETATM 2574  O   HOH H 613      20.634  17.435  58.408  1.00 33.23           O  
+HETATM 2575  O   HOH H 615      28.004  50.184  51.421  1.00 46.75           O  
+HETATM 2576  O   HOH H 616      34.317  26.739  29.550  1.00 47.92           O  
+HETATM 2577  O   HOH H 619       8.946  46.587  47.259  1.00 48.72           O  
+HETATM 2578  O   HOH H 620      23.843  52.764  35.108  1.00 23.41           O  
+HETATM 2579  O   HOH H 621      18.416  14.465  48.896  1.00 25.96           O  
+HETATM 2580  O   HOH H 622      24.210  15.217  52.457  1.00 16.65           O  
+HETATM 2581  O   HOH H 623      26.827  46.972  29.265  1.00 30.62           O  
+HETATM 2582  O   HOH H 624      13.292  49.128  46.477  1.00 42.32           O  
+HETATM 2583  O   HOH H 625      32.397  45.260  34.046  1.00 24.45           O  
+HETATM 2584  O   HOH H 627      32.739  40.054  27.200  1.00 42.44           O  
+HETATM 2585  O   HOH H 630      13.071  11.296  41.320  1.00 35.99           O  
+HETATM 2586  O   HOH H 631       9.373  20.758  31.050  1.00 25.99           O  
+HETATM 2587  O   HOH H 634      15.277  41.695  24.191  1.00 25.43           O  
+HETATM 2588  O   HOH H 635      14.775  53.134  44.980  1.00 20.73           O  
+HETATM 2589  O   HOH H 637      24.692  35.982  62.200  1.00 18.46           O  
+HETATM 2590  O   HOH H 638      15.208  45.469  57.247  1.00 52.29           O  
+HETATM 2591  O   HOH H 641      30.540  40.195  21.256  1.00 41.00           O  
+HETATM 2592  O   HOH H 642      16.724  10.881  44.401  1.00 27.40           O  
+HETATM 2593  O   HOH H 645      18.142  50.735  31.841  1.00 29.67           O  
+HETATM 2594  O   HOH H 651       0.045  25.025  25.839  1.00 28.64           O  
+HETATM 2595  O   HOH H 654      26.903  35.212  19.447  1.00 30.75           O  
+HETATM 2596  O   HOH H 658      33.134  43.405  50.307  1.00 26.15           O  
+HETATM 2597  O   HOH H 671      30.502  48.133  41.026  1.00 29.55           O  
+HETATM 2598  O   HOH H 672      27.490  36.643  60.629  1.00 55.42           O  
+HETATM 2599  O   HOH H 676      28.057  26.296  28.911  1.00 19.13           O  
+HETATM 2600  O   HOH H 684      28.993  41.187  61.702  1.00 31.28           O  
+HETATM 2601  O   HOH H 685      30.318  46.434  32.647  1.00 40.79           O  
+HETATM 2602  O   HOH H 687      21.433  51.010  25.349  1.00 51.18           O  
+HETATM 2603  O   HOH H 688       2.826  21.532  40.082  1.00 19.50           O  
+HETATM 2604  O   HOH H 689       4.616  25.929  26.574  1.00 31.64           O  
+HETATM 2605  O   HOH H 690      10.745  25.880  20.993  1.00 33.49           O  
+HETATM 2606  O   HOH H 693      18.055  12.106  34.501  1.00 29.95           O  
+HETATM 2607  O   HOH H 698      24.468  54.387  48.017  1.00 40.17           O  
+HETATM 2608  O   HOH H 701      26.019  36.989  58.289  1.00 49.94           O  
+HETATM 2609  O   HOH H 715      19.956  53.724  37.342  1.00 29.55           O  
+HETATM 2610  O   HOH H 716       3.535  35.149  40.868  1.00 37.66           O  
+HETATM 2611  O   HOH H 720      30.833  47.062  24.486  1.00 42.94           O  
+HETATM 2612  O   HOH H 722      31.634  36.761  24.329  1.00 39.87           O  
+HETATM 2613  O   HOH H 728      22.332  14.441  54.461  1.00 45.51           O  
+HETATM 2614  O   HOH H 743      16.084  33.568  20.303  1.00 31.24           O  
+HETATM 2615  O   HOH H 747      27.334  53.658  48.678  1.00 29.62           O  
+HETATM 2616  O   HOH H 748      27.417  54.186  51.508  1.00 38.66           O  
+HETATM 2617  O   HOH H 749       5.772  32.618  36.527  1.00 52.41           O  
+HETATM 2618  O   HOH H 750       3.527  31.058  36.365  1.00 31.86           O  
+HETATM 2619  O   HOH H 752      19.617  12.671  40.075  1.00 33.72           O  
+HETATM 2620  O   HOH H 757      11.680  51.093  47.507  1.00 37.70           O  
+HETATM 2621  O   HOH H 766      11.655  52.140  50.185  1.00 30.34           O  
+HETATM 2622  O   HOH H 779       7.193  47.935  44.058  1.00 32.53           O  
+HETATM 2623  O   HOH H 787       5.615  34.480  34.400  1.00 27.86           O  
+HETATM 2624  O   HOH H 788       4.021  22.946  27.234  1.00 38.51           O  
+HETATM 2625  O   HOH H 789      29.991  47.645  30.053  1.00 33.76           O  
+HETATM 2626  O   HOH H 796       4.283  38.924  43.117  1.00 40.77           O  
+HETATM 2627  O   HOH H 838      21.093  33.400  15.822  1.00 40.71           O  
+HETATM 2628  O   HOH H 839       8.526  44.086  24.896  1.00 42.92           O  
+HETATM 2629  O   HOH H 848      10.545  30.316  19.800  1.00 24.05           O  
+HETATM 2630  O   HOH H 862      17.874  52.753  38.850  1.00 28.04           O  
+HETATM 2631  O   HOH H 863       6.037  21.008  43.143  1.00 21.88           O  
+HETATM 2632  O   HOH H 864       9.382  17.955  30.561  1.00 38.45           O  
+HETATM 2633  O   HOH H 866       6.952  46.787  39.101  1.00 26.44           O  
+HETATM 2634  O   HOH H 867       6.427  41.508  31.362  1.00 27.20           O  
+HETATM 2635  O   HOH H 869       6.278  38.831  39.495  1.00 38.61           O  
+HETATM 2636  O   HOH H 870      20.914  25.671  37.305  1.00 34.05           O  
+HETATM 2637  O   HOH H 873       7.323  35.918  36.131  1.00 41.12           O  
+HETATM 2638  O   HOH H 874      27.300  20.564  32.843  1.00 37.93           O  
+HETATM 2639  O   HOH H 889      11.143  33.866  58.722  1.00 53.86           O  
+HETATM 2640  O   HOH H 896       8.378  31.659  37.531  1.00 25.27           O  
+HETATM 2641  O   HOH H 897      17.865  16.443  29.060  1.00 22.44           O  
+HETATM 2642  O   HOH H 927       9.999  44.206  55.280  1.00 33.94           O  
+HETATM 2643  O   HOH H 946      12.877  35.320  60.482  1.00 59.32           O  
+HETATM 2644  O   HOH H1013       9.134  39.399  27.795  1.00 21.77           O  
+HETATM 2645  O   HOH H1016      24.600  20.566  32.846  1.00 43.26           O  
+HETATM 2646  O   HOH H1052       6.447  46.750  36.291  1.00 37.79           O  
+HETATM 2647  O   HOH H1073       6.885  37.815  26.888  1.00 37.83           O  
+HETATM 2648  O   HOH H1093       9.013  37.116  21.378  1.00 26.55           O  
+HETATM 2649  O   HOH L 401      50.342  30.895  43.355  1.00 16.36           O  
+HETATM 2650  O   HOH L 403      32.588  25.693  48.338  1.00 19.68           O  
+HETATM 2651  O   HOH L 414      43.827  29.102  41.518  1.00 16.97           O  
+HETATM 2652  O   HOH L 433      40.525  28.060  49.988  1.00 22.08           O  
+HETATM 2653  O   HOH L 439      30.240  23.924  50.134  1.00 20.01           O  
+HETATM 2654  O   HOH L 441      43.528  29.616  48.582  1.00 29.62           O  
+HETATM 2655  O   HOH L 444      48.479  31.628  47.164  1.00 15.36           O  
+HETATM 2656  O   HOH L 447      42.713  39.729  42.281  1.00 23.73           O  
+HETATM 2657  O   HOH L 452      54.869  24.687  39.969  1.00 22.44           O  
+HETATM 2658  O   HOH L 456      28.908  26.398  50.669  1.00 23.69           O  
+HETATM 2659  O   HOH L 457      42.660  36.462  36.570  1.00 26.05           O  
+HETATM 2660  O   HOH L 465      56.505  26.609  38.960  1.00 28.71           O  
+HETATM 2661  O   HOH L 468      30.237  19.680  51.800  1.00 12.15           O  
+HETATM 2662  O   HOH L 475      55.672  24.342  42.597  1.00 12.12           O  
+HETATM 2663  O   HOH L 479      30.206  22.303  52.590  1.00 22.13           O  
+HETATM 2664  O   HOH L 480      34.500  16.551  46.927  1.00 23.29           O  
+HETATM 2665  O   HOH L 481      33.874  17.318  44.371  1.00 21.82           O  
+HETATM 2666  O   HOH L 482      31.109  17.470  43.924  1.00 20.48           O  
+HETATM 2667  O   HOH L 483      29.715  19.731  44.662  1.00 11.65           O  
+HETATM 2668  O   HOH L 487      38.734  21.556  41.276  1.00 19.76           O  
+HETATM 2669  O   HOH L 488      50.095  19.600  46.988  1.00 14.43           O  
+HETATM 2670  O   HOH L 491      54.757  22.912  37.816  1.00 25.66           O  
+HETATM 2671  O   HOH L 492      52.607  28.475  40.523  1.00 24.30           O  
+HETATM 2672  O   HOH L 495      35.601  31.853  49.295  1.00 24.14           O  
+HETATM 2673  O   HOH L 513      32.447  17.845  53.759  1.00 21.97           O  
+HETATM 2674  O   HOH L 516      44.018  25.533  52.245  1.00 34.69           O  
+HETATM 2675  O   HOH L 522      35.082  19.143  37.037  1.00 42.71           O  
+HETATM 2676  O   HOH L 523      32.410  25.444  50.901  1.00 35.10           O  
+HETATM 2677  O   HOH L 528      31.222  19.188  38.111  1.00 17.41           O  
+HETATM 2678  O   HOH L 548      38.554  21.609  38.410  1.00 28.84           O  
+HETATM 2679  O   HOH L 556      30.017  16.265  54.066  1.00 34.17           O  
+HETATM 2680  O   HOH L 557      26.659  14.034  53.325  1.00 35.80           O  
+HETATM 2681  O   HOH L 572      45.092  26.591  50.031  1.00 26.93           O  
+HETATM 2682  O   HOH L 579      55.464  28.736  40.433  1.00 22.43           O  
+HETATM 2683  O   HOH L 592      41.592  17.729  50.111  1.00 37.37           O  
+HETATM 2684  O   HOH L 594      50.189  21.341  37.448  1.00 22.39           O  
+HETATM 2685  O   HOH L 596      29.250  12.344  48.262  1.00 44.11           O  
+HETATM 2686  O   HOH L 597      48.124  17.609  47.695  1.00 38.85           O  
+HETATM 2687  O   HOH L 603      43.438  21.261  52.829  1.00 25.28           O  
+HETATM 2688  O   HOH L 608      28.367  18.388  53.484  1.00 23.97           O  
+HETATM 2689  O   HOH L 614      40.802  17.697  52.645  1.00 28.46           O  
+HETATM 2690  O   HOH L 617      52.887  20.567  37.795  1.00 31.61           O  
+HETATM 2691  O   HOH L 618      47.802  33.904  48.960  1.00 38.79           O  
+HETATM 2692  O   HOH L 626      30.284  15.367  45.950  1.00 31.79           O  
+HETATM 2693  O   HOH L 640      37.426  15.716  49.880  1.00 43.74           O  
+HETATM 2694  O   HOH L 644      29.434  19.999  55.538  1.00 25.15           O  
+HETATM 2695  O   HOH L 686      33.972  16.606  55.884  1.00 32.50           O  
+HETATM 2696  O   HOH L 691      32.158  20.282  55.481  1.00 35.95           O  
+HETATM 2697  O   HOH L 714      43.143  28.108  51.066  1.00 62.02           O  
+HETATM 2698  O   HOH L 721      50.785  20.792  49.329  1.00 35.29           O  
+HETATM 2699  O   HOH L 736      41.707  17.912  42.359  1.00 38.18           O  
+HETATM 2700  O   HOH L 820      50.237  23.579  48.959  1.00 33.44           O  
+HETATM 2701  O   HOH L 859      33.497  25.212  53.336  1.00 29.62           O  
+HETATM 2702  O   HOH L 871      39.320  18.798  41.199  1.00 29.51           O  
+HETATM 2703  O   HOH L 892      42.350  20.781  39.945  1.00 34.47           O  
+HETATM 2704  O   HOH L 912      51.171  34.461  48.828  1.00 34.54           O  
+HETATM 2705  O   HOH L1092      35.566  15.233  51.851  1.00 48.34           O  
+CONECT   45   80                                                                
+CONECT   80   45                                                                
+CONECT  188  302                                                                
+CONECT  302  188                                                                
+CONECT  436 2371                                                                
+CONECT  451 2371                                                                
+CONECT  473 2371                                                                
+CONECT  517 2371                                                                
+CONECT  844 2316                                                                
+CONECT 1224 1377                                                                
+CONECT 1377 1224                                                                
+CONECT 1451 1662                                                                
+CONECT 1662 1451                                                                
+CONECT 1988 2070                                                                
+CONECT 2034 2144                                                                
+CONECT 2070 1988                                                                
+CONECT 2144 2034                                                                
+CONECT 2161 2254                                                                
+CONECT 2254 2161                                                                
+CONECT 2316  844                                                                
+CONECT 2371  436  451  473  517                                                 
+CONECT 2371 2486 2533                                                           
+CONECT 2372 2477 2544                                                           
+CONECT 2373 2374 2375 2376 2377                                                 
+CONECT 2374 2373                                                                
+CONECT 2375 2373                                                                
+CONECT 2376 2373                                                                
+CONECT 2377 2373                                                                
+CONECT 2378 2379 2380 2381 2382                                                 
+CONECT 2379 2378                                                                
+CONECT 2380 2378                                                                
+CONECT 2381 2378                                                                
+CONECT 2382 2378                                                                
+CONECT 2383 2384 2385 2386 2387                                                 
+CONECT 2384 2383                                                                
+CONECT 2385 2383                                                                
+CONECT 2386 2383                                                                
+CONECT 2387 2383                                                                
+CONECT 2388 2389 2390 2391 2392                                                 
+CONECT 2389 2388                                                                
+CONECT 2390 2388                                                                
+CONECT 2391 2388                                                                
+CONECT 2392 2388                                                                
+CONECT 2393 2394 2395 2396 2397                                                 
+CONECT 2394 2393                                                                
+CONECT 2395 2393                                                                
+CONECT 2396 2393                                                                
+CONECT 2397 2393                                                                
+CONECT 2398 2399 2400 2401 2402                                                 
+CONECT 2399 2398                                                                
+CONECT 2400 2398                                                                
+CONECT 2401 2398                                                                
+CONECT 2402 2398                                                                
+CONECT 2403 2404                                                                
+CONECT 2404 2403 2405 2437                                                      
+CONECT 2405 2404 2406                                                           
+CONECT 2406 2405 2407 2435                                                      
+CONECT 2407 2406 2408                                                           
+CONECT 2408 2407 2409 2422                                                      
+CONECT 2409 2408 2410 2411                                                      
+CONECT 2410 2409                                                                
+CONECT 2411 2409 2412                                                           
+CONECT 2412 2411 2413 2414 2415                                                 
+CONECT 2413 2412                                                                
+CONECT 2414 2412                                                                
+CONECT 2415 2412 2416 2421                                                      
+CONECT 2416 2415 2417                                                           
+CONECT 2417 2416 2418                                                           
+CONECT 2418 2417 2419                                                           
+CONECT 2419 2418 2420 2421                                                      
+CONECT 2420 2419                                                                
+CONECT 2421 2415 2419                                                           
+CONECT 2422 2408 2423 2434                                                      
+CONECT 2423 2422 2424 2425                                                      
+CONECT 2424 2423                                                                
+CONECT 2425 2423 2426 2429                                                      
+CONECT 2426 2425 2427                                                           
+CONECT 2427 2426 2428                                                           
+CONECT 2428 2427                                                                
+CONECT 2429 2425 2430                                                           
+CONECT 2430 2429 2431 2434                                                      
+CONECT 2431 2430 2432                                                           
+CONECT 2432 2431 2433                                                           
+CONECT 2433 2432                                                                
+CONECT 2434 2422 2430                                                           
+CONECT 2435 2406 2436                                                           
+CONECT 2436 2435 2437                                                           
+CONECT 2437 2404 2436 2438                                                      
+CONECT 2438 2437 2439 2440                                                      
+CONECT 2439 2438                                                                
+CONECT 2440 2438                                                                
+CONECT 2441 2442 2443 2444 2445                                                 
+CONECT 2442 2441                                                                
+CONECT 2443 2441                                                                
+CONECT 2444 2441                                                                
+CONECT 2445 2441                                                                
+CONECT 2477 2372                                                                
+CONECT 2486 2371                                                                
+CONECT 2533 2371                                                                
+CONECT 2544 2372                                                                
+MASTER      423    0   10    8   20    0   19    6 2703    2  100   25          
+END                                                                             

--- a/ops/gates/configs/legacy_runtime_receptors/README.md
+++ b/ops/gates/configs/legacy_runtime_receptors/README.md
@@ -1,0 +1,19 @@
+# Legacy production-runtime receptor snapshots — NOT canonical
+
+These three `_apo.pdb` files are immutable snapshots of the **deprecated**
+historical second-prep receptor tree:
+
+    benchmarks/astex_diverse/data/astex_diverse/{PDB}/{PDB}_apo.pdb   (deprecated)
+
+which is byte-identical (hash-for-hash) to the runtime cache
+`~/.flexaidds/benchmarks/astex_diverse/{PDB}/{PDB}_apo.pdb` that the legacy
+campaign actually scored against. This prep **retains crystallographic waters**
+(and metals where present).
+
+They are NOT the repository-canonical Astex receptors. Per
+`benchmarks/datasets/CANONICAL.md` and `benchmarks/astex_diverse/README.md`, the
+canonical apo tree is `benchmarks/astex_diverse/astex_diverse/{PDB}/` (waters
+stripped) — which produces materially different CF (1YGC: +7.30 canonical vs
+-0.871 legacy). These snapshots exist only to pin the exact structures that
+produced the legacy production-runtime baseline recorded in
+`../SCORING_LOCKED_BASELINE_RECEIPT.{md,json}`. Use the canonical tree for new work.


### PR DESCRIPTION
## What

Tracks the three reconstructed scoring-locked dock configs, **legacy production-runtime receptor snapshots**, and a provenance receipt (Markdown + JSON).

## Protocol-tier correction (Codex re-reviews `87e757a8`, `5af6d5f8`)

The receptors that reproduce the legacy campaign numbers are the **deprecated** historical second-prep copies (`benchmarks/astex_diverse/data/astex_diverse/...`, byte-identical to the `~/.flexaidds` runtime cache), which **retain waters**. Per `benchmarks/datasets/CANONICAL.md` + `benchmarks/astex_diverse/README.md`, the repo-canonical tree is `benchmarks/astex_diverse/astex_diverse/` (waters stripped) — a different protocol, different CF (`1YGC: -0.871` legacy vs `+7.30` canonical).

So these numbers are the **legacy production-runtime surface**, not a canonical baseline — labelled as a separate protocol tier throughout. Snapshots committed under `ops/gates/configs/legacy_runtime_receptors/` with a README marking them deprecated-prep, not canonical.

## Receipt

`SCORING_LOCKED_BASELINE_RECEIPT.{md,json}`: protocol tier, tracked origin path, per-target config path, binary/config/receptor/pose SHA256s, exact command, expected CF (`-34.229803 / -73.413683 / -0.871396`), reps (3/3/2), tolerance 0.

## Regenerability (narrowed)

Inputs tracked; numeric baseline replayable only while a binary matching the recorded SHA is retained. `source_commit: null`, no committed binary → **not source-regenerable from tracked state (KNOWN GAP)**.

## CI

Inherits pre-#311 red stack; rebase on green `main` after #311, no waiver.
