### PR TITLE
Docs: fix ledger SCOPE heading + scope the byte-identical cache claim

### DIFF
--- a/workorders/PHASE4_NEAR_MISS_NULL_STACK.md
+++ b/workorders/PHASE4_NEAR_MISS_NULL_STACK.md
@@ -57,7 +57,7 @@ poisoning, it is the gate doing what it was built to do.
 are chemically clean against protein, cofactors, internal geometry and energy,
 and fail the claim gate solely because they displace crystallographic water.
 
-### ⚠ SCOPE — this is a property of the receptor tier, not of the docking
+### ⚠ SCOPE — protocol-tier × pose interaction
 
 All 36 bust receipts record a runtime-cache receptor. Exact audit over the
 31 unique targets:
@@ -440,8 +440,8 @@ interchangeable**, and the difference is chemically material.
 | **Repository-canonical Astex** | `benchmarks/astex_diverse/astex_diverse/{PDB}/{PDB}_apo.pdb` | `-34.229803` | `-73.790961` | `+7.303774` |
 | **Legacy production-runtime** | `benchmarks/astex_diverse/data/astex_diverse/{PDB}/` — a **deprecated historical second prep** | `-34.229803` | `-73.413683` | `-0.871396` |
 
-The legacy tier is what the runtime cache (`~/.flexaidds/benchmarks/...`)
-holds, byte-identical, and it is what reproduces the historical workorder
+For these three targets (`1OQ5`/`1SQ5`/`1YGC`), the legacy tier is what the
+runtime cache (`~/.flexaidds/benchmarks/...`) holds, byte-identical, and it is what reproduces the historical workorder
 numbers. **It is not canonical.** `benchmarks/datasets/CANONICAL.md` and
 `benchmarks/astex_diverse/README.md` define the canonical tree and classify
 `data/astex_diverse/` as deprecated — "do not use for new work."


### PR DESCRIPTION
Follow-up to #313, which merged at head `d518c366` before Opus's review fixes landed.

Two text-only fixes, no numbers touched:

1. **L60 heading contradicted its own body.** `### SCOPE — this is a property of the receptor tier, not of the docking` — L79-80 nineteen lines below says it is **wrong** to say exactly that. Retitled `### SCOPE — protocol-tier x pose interaction`, matching where the body lands. This also repairs L496, which already cross-references the section by that corrected title and previously pointed at nothing.

2. **L443 unqualified cache claim.** "The legacy tier is what the runtime cache holds, byte-identical" reads as general; Block 3 twenty lines later says the split is 24 deprecated / 7 third-variant / 0 canonical. Scoped to `1OQ5`/`1SQ5`/`1YGC`, where it is true.

Found by @Opus at `d518c366`; verified still present on `main` before this branch.
