### PR TITLE
Fix: pypi-release.yml unparseable — embedded Python breaks the run block scalar

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -56,24 +56,24 @@ jobs:
           # Version must be non-empty and match the static PEP 621 field in pyproject.toml
           # (do not hardcode — that drifted when we shipped 2.0.1/2.0.2).
           python -c "
-import re
-from pathlib import Path
-import flexaidds as fd
-assert fd.__version__, fd.__version__
-text = Path('python/pyproject.toml').read_text(encoding='utf-8')
-in_project = False
-found = None
-for line in text.splitlines():
-    s = line.strip()
-    if s.startswith('[') and s.endswith(']'):
-        in_project = s == '[project]'
-        continue
-    if in_project and s.startswith('version') and '=' in s:
-        found = s.split('=', 1)[1].strip().strip('\"\'')
-        break
-assert found == fd.__version__, (found, fd.__version__)
-print('version_ok', fd.__version__)
-"
+          import re
+          from pathlib import Path
+          import flexaidds as fd
+          assert fd.__version__, fd.__version__
+          text = Path('python/pyproject.toml').read_text(encoding='utf-8')
+          in_project = False
+          found = None
+          for line in text.splitlines():
+              s = line.strip()
+              if s.startswith('[') and s.endswith(']'):
+                  in_project = s == '[project]'
+                  continue
+              if in_project and s.startswith('version') and '=' in s:
+                  found = s.split('=', 1)[1].strip().strip('\"\'')
+                  break
+          assert found == fd.__version__, (found, fd.__version__)
+          print('version_ok', fd.__version__)
+          "
 
       - name: Upload sdist artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
The workflow has failed at workflow level on every push since `283d9ee1` (2026-07-15) with 0 jobs, 0s, no logs.

**Cause:** L45 opens `run: |` at 10-space indent; the embedded Python at L59-76 sits at column 0, ending the block scalar. `yaml.safe_load` fails at line 59 col 1. GitHub cannot parse the file, so the run dies before scheduling anything — hence `total_count: 0` and the display name falling back to the literal path.

**Bisect:** `155ebbb7` parses; `283d9ee1` does not.

**Fix:** indent L59-76 to the block level. YAML strips the common indentation, so Python still receives the snippet at column 0 — verified by parsing the patched file and reading the `run:` value back.

Parseable is not the same as passing: nobody has exercised this release path in 16 days. A `workflow_dispatch` against testpypi after this lands is what would actually prove it.

Found by @Bumble via the API; root-caused here.