### PR TITLE
ci(pypi-release): fix YAML block-scalar break failing every run in 0s

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -56,24 +56,24 @@ jobs:
           # Version must be non-empty and match the static PEP 621 field in pyproject.toml
           # (do not hardcode — that drifted when we shipped 2.0.1/2.0.2).
           python -c "
-import re
-from pathlib import Path
-import flexaidds as fd
-assert fd.__version__, fd.__version__
-text = Path('python/pyproject.toml').read_text(encoding='utf-8')
-in_project = False
-found = None
-for line in text.splitlines():
-    s = line.strip()
-    if s.startswith('[') and s.endswith(']'):
-        in_project = s == '[project]'
-        continue
-    if in_project and s.startswith('version') and '=' in s:
-        found = s.split('=', 1)[1].strip().strip('\"\'')
-        break
-assert found == fd.__version__, (found, fd.__version__)
-print('version_ok', fd.__version__)
-"
+          import re
+          from pathlib import Path
+          import flexaidds as fd
+          assert fd.__version__, fd.__version__
+          text = Path('python/pyproject.toml').read_text(encoding='utf-8')
+          in_project = False
+          found = None
+          for line in text.splitlines():
+              s = line.strip()
+              if s.startswith('[') and s.endswith(']'):
+                  in_project = s == '[project]'
+                  continue
+              if in_project and s.startswith('version') and '=' in s:
+                  found = s.split('=', 1)[1].strip().strip('\"\'')
+                  break
+          assert found == fd.__version__, (found, fd.__version__)
+          print('version_ok', fd.__version__)
+          "
 
       - name: Upload sdist artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## What
`.github/workflows/pypi-release.yml` never compiled. In `build-sdist`, the `python -c` version check wrote its Python body at **column 1**, below the `run: |` block-scalar indent (10 spaces). That dedent terminated the block scalar mid-step, so GitHub's YAML compiler failed on the whole file.

## Symptoms (what the squad saw)
- Every trigger produced a run with **0 jobs that failed in ~0s** (`total_count: 0`, no logs).
- The registered workflow **name was the literal path** `.github/workflows/pypi-release.yml` — GitHub's fallback when a file has *never* parsed successfully.
- Failed identically on every recent merge commit (`e0228702`, `e65ffc83`, `5a03d5d4`), so it **predates the instrument stack** — not a build regression.

## Fix
Indent the Python body to the 10-space block indent so it stays inside the scalar. YAML strips the common leading indent, so the shell still receives the script at column 1 — **byte-identical runtime behavior**.

## Verification
- `yaml.safe_load` on the patched file parses (`name`/`on`/`permissions`/`jobs`). Before: `ScannerError: could not find expected ':'` at the `import re` line.
- Re-extracted the compiled `run` string: `import re` / `from pathlib import Path` arrive at column 1, the for-loop body at its 4-space Python indent — `python -c` gets the same script as before.
- CI-only, one file, +18/-18 (pure re-indent).

Diagnosed off merged trunk `5a03d5d4`. Opus flagged this as unclaimed. Origin: channel #Benchmarking FlexAIDdS (716e79b1-6a4f-4cde-8851-22836ba8738c).