### PR TITLE
Fix: zero-initialise shortpath cells to stop heap-buffer-overflow in assign_shortflex

### DIFF
--- a/LIB/shortest_path.cpp
+++ b/LIB/shortest_path.cpp
@@ -28,7 +28,11 @@ void shortest_path(resid* residue, int tot, atom* atoms)
 		}else{
 			for(int j=0; j<tot; j++){
 				// 90001-90002
-				residue->shortpath[i][j] = (char*)malloc(MAX_SHORTEST_PATH*6*sizeof(char));
+				// calloc, not malloc: cells left unwritten by the BFS below (any
+				// atom pair unreachable in residue->bonded, e.g. FA->bloops == 0)
+				// are later read as C strings by assign_shortflex(); an
+				// uninitialised buffer has no NUL and strlen walks past it.
+				residue->shortpath[i][j] = (char*)calloc(MAX_SHORTEST_PATH*6, sizeof(char));
 				if(!residue->shortpath[i][j]){
 					fprintf(stderr,
 						"ERROR: Could not allocate memory for residue->shortpath[%d][%d]\n", i,j);


### PR DESCRIPTION
## What

`shortest_path()` allocates every `residue->shortpath[i][j]` cell with `malloc` and only writes the cells its BFS can reach. Any unreachable atom pair leaves the cell holding uninitialised heap bytes.

`assign_shortflex()` then reads that cell as a C string (`split_string` → `strlen`). With no NUL in the buffer, `strlen` walks past the allocation:

```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 151
0 bytes after 150-byte region
#N assign_shortflex(...)  LIB/assign_shortflex.cpp:61
```

`MAX_SHORTEST_PATH*6 == 150`, so byte 151 is the first redzone byte.

`calloc` guarantees each cell is NUL-terminated at allocation, so an unwritten cell reads as the empty string instead of running off the end.

## Trigger

The bonded matrix is left entirely unpopulated when `FA->bloops == 0` — `bondedlist()` returns only the seed atom, `residue->bonded` stays at its `-1` init, the BFS never steps, and every off-diagonal cell goes unwritten. `config_parser.cpp:168` defaults `bonded_loops` to 2 but does not validate it, so a config setting `0` reproduces this outside the test fixture.

## Scope

All three ligand readers run the identical pair one line apart, and the allocation lives in the shared `shortest_path()`, so this one site covers every ligand format:

| Reader | Call |
|---|---|
| `LIB/read_lig.cpp` | `:485 shortest_path()` → `:486 assign_shortflex()` |
| `LIB/Mol2Reader.cpp` | `:424 shortest_path()` → `:425 assign_shortflex()` |
| `LIB/SdfReader.cpp` | `:754 shortest_path()` → `:755 assign_shortflex()` |

Independently confirmed by a reviewer who wrote neither the fix nor the original claim; `RingPerception.cpp`'s `bfs_shortest_path` is a different function and not on this path.

## Verification

Built with `-fsanitize=address` on macOS arm64. `ReadLigLatmTests`: **exit 0, 0 ASan errors, 2/2 passing** — with `FA->bloops` still `0`, so the fault input is unchanged and the regression witness is preserved rather than hidden.

The same fault reproduces on CI Linux x86 with identical sizes and frame, so this is not platform-specific.

## Not addressed here

Latent, deliberately left for a separate change:

- `shortpath[i]` (L24) and `shortpath[i][j]` (L31) are allocated **outside** the `residue->shortpath == NULL` guard, so a second call on the same residue leaks the previous rows.
- `shortpath` is never `free`d anywhere in the tree.

The leak checks need a Linux runner — LeakSanitizer is unsupported on macOS arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shortest-path handling by ensuring unreachable atom-pair results contain valid empty values instead of uninitialized data.
  * Prevented potential invalid reads when processing shortest-path results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->