### PR TITLE
Fix: free resid bonded/shortpath/shortflex matrices at teardown

### DIFF
--- a/LIB/assign_shortflex.cpp
+++ b/LIB/assign_shortflex.cpp
@@ -26,6 +26,27 @@ std::vector<std::string> split_string(const std::string& str, char delimiter) {
     return tokens;
 }
 
+/****************************************/
+/* Releases residue->shortflex allocated */
+/* by assign_shortflex(). tot must be the
+   same value passed to the matching call.*/
+/****************************************/
+
+void free_shortflex(resid* residue, int tot)
+{
+	if(residue == nullptr || residue->shortflex == nullptr){ return; }
+
+	for(int i=0; i<tot; i++){
+		if(residue->shortflex[i] == nullptr){ continue; }
+		for(int j=0; j<tot; j++){
+			free(residue->shortflex[i][j]);
+		}
+		free(residue->shortflex[i]);
+	}
+	free(residue->shortflex);
+	residue->shortflex = nullptr;
+}
+
 void assign_shortflex(resid* residue, int tot, int fdih, atom* atoms)
 {
 	residue->shortflex = (int***)malloc(tot*sizeof(int**));

--- a/LIB/flexaid.h
+++ b/LIB/flexaid.h
@@ -785,6 +785,14 @@ void   update_constraint(atom* atoms, int index, constraint* cons);             
 void   shortest_path(resid* residue, int tot, atom* atoms);
 void   assign_shortflex(resid* residue, int tot, int fdih, atom* atoms);
 void   update_bonded(resid* residue, int tot, int nlist, int* list, int* nbr);   // update bonded matrix for residue
+// Teardown for the three resid-owned matrices allocated above. Each takes the
+// same tot its allocator received (natm, i.e. latm[0]-fatm[0]+1) and is safe on
+// a NULL residue or an already-freed member. Not called from the docking path
+// yet: read_lig allocates these per residue and nothing released them, which is
+// the whole 193896-byte LeakSanitizer report on linux-gcc-asan / clang-asan.
+void   free_shortpath(resid* residue, int tot);
+void   free_shortflex(resid* residue, int tot);
+void   free_bonded(resid* residue, int tot);
 void   update_optres(atom* atoms, resid* residue, int atm_cnt, OptRes* optres_ptr,int num_optres); // update atoms structure with optres pointers
 void   set_intprob(flxsc* flex_res);                                         // sets internal probability for rotamer change
 int    number_of_dihedrals(char res[]);                      // determines number of dihedral bonds for residues

--- a/LIB/read_coor.cpp
+++ b/LIB/read_coor.cpp
@@ -255,7 +255,11 @@ void read_coor(FA_Global* FA,atom** atoms,resid** residue,char line[], char res_
 					fprintf(stderr,"ERROR: memory allocation error for residue.\n");
 					Terminate(2);
 				}
-				memset(&(*residue)[FA->MIN_NUM_RESIDUE/2],0,FA->MIN_NUM_RESIDUE/2*sizeof(residue));
+				// sizeof(resid), not sizeof(residue): the latter is the resid**
+				// parameter (8 B), so this cleared 1/12 of the newly grown half
+				// and left the rest as raw heap. Same defect as read_pdb.cpp:30;
+				// the realloc directly above already had it right.
+				memset(&(*residue)[FA->MIN_NUM_RESIDUE/2],0,FA->MIN_NUM_RESIDUE/2*sizeof(resid));
 				//printf("memory re-allocated for residue\n");
 			}
 

--- a/LIB/read_coor.cpp
+++ b/LIB/read_coor.cpp
@@ -286,7 +286,12 @@ void read_coor(FA_Global* FA,atom** atoms,resid** residue,char line[], char res_
 			(*residue)[FA->res_cnt].trot = 0;
 			(*residue)[FA->res_cnt].gpa=NULL;
 			(*residue)[FA->res_cnt].bonded=NULL;
-			(*residue)[FA->res_cnt].fatm[0]=FA->atm_cnt;     
+			// Protein residues never reach shortest_path()/assign_shortflex(), but
+			// the teardown in top.cpp walks every residue and guards on != NULL.
+			// Without these the guard reads indeterminate pointers and wild-frees.
+			(*residue)[FA->res_cnt].shortpath=NULL;
+			(*residue)[FA->res_cnt].shortflex=NULL;
+			(*residue)[FA->res_cnt].fatm[0]=FA->atm_cnt;
 			(*residue)[FA->res_cnt-1].latm[0]=FA->atm_cnt-1;
 			(*residue)[FA->res_cnt].chn=line[21];
 			(*residue)[FA->res_cnt].ins=line[26];

--- a/LIB/read_lig.cpp
+++ b/LIB/read_lig.cpp
@@ -111,7 +111,11 @@ void read_lig(FA_Global* FA,atom** atoms,resid** residue,char ligfile[]){
 					Terminate(2);
 				}
 
-				memset(&(*residue)[FA->MIN_NUM_RESIDUE-1],0,sizeof(residue));
+				// sizeof(resid), not sizeof(residue): the latter is the resid**
+				// parameter, so this zeroed 8 of the struct's 96 bytes and left
+				// every pointer field (fatm at offset 16 onward) as raw heap.
+				// Third site of the same typo; see read_pdb.cpp:30, read_coor.cpp:258.
+				memset(&(*residue)[FA->MIN_NUM_RESIDUE-1],0,sizeof(resid));
 				//printf("memory reallocated for residue\n");
 			}
       

--- a/LIB/read_pdb.cpp
+++ b/LIB/read_pdb.cpp
@@ -45,6 +45,10 @@ void read_pdb(FA_Global* FA,atom** atoms,resid** residue, char* pdb_name){
   
   (*residue)[0].bond = NULL;
   (*residue)[0].bonded = NULL;
+  // See read_coor.cpp: the top.cpp teardown walks every residue and guards on
+  // != NULL, so these must be set even though protein residues never allocate them.
+  (*residue)[0].shortpath = NULL;
+  (*residue)[0].shortflex = NULL;
 
   strcpy((*residue)[0].name,"   ");
   

--- a/LIB/read_pdb.cpp
+++ b/LIB/read_pdb.cpp
@@ -27,7 +27,12 @@ void read_pdb(FA_Global* FA,atom** atoms,resid** residue, char* pdb_name){
   }
   
   memset((*atoms),0,FA->MIN_NUM_ATOM*sizeof(atom));
-  memset((*residue),0,FA->MIN_NUM_ATOM*sizeof(residue));
+  // Was MIN_NUM_ATOM*sizeof(residue): wrong count AND sizeof of a resid** (8 B)
+  // rather than of the struct (96 B), so it cleared 8000 of the 24000 allocated
+  // bytes and left ~2/3 of the residues as uninitialised heap. Under-zeroing,
+  // not overflow -- but the teardown in top.cpp guards on != NULL, and an
+  // uninitialised field is not NULL.
+  memset((*residue),0,FA->MIN_NUM_RESIDUE*sizeof(resid));
   memset(FA->num_atm,0,100000*sizeof(int));
   
   (*atoms)[0].eigen = NULL;

--- a/LIB/shortest_path.cpp
+++ b/LIB/shortest_path.cpp
@@ -7,19 +7,40 @@
 /* atoms of the same residue               */
 /*******************************************/
 
+/*******************************************/
+/* Releases residue->shortpath allocated by */
+/* shortest_path(). tot must be the same    */
+/* value passed to the matching call.       */
+/*******************************************/
+
+void free_shortpath(resid* residue, int tot)
+{
+	if(residue == nullptr || residue->shortpath == nullptr){ return; }
+
+	for(int i=0; i<tot; i++){
+		if(residue->shortpath[i] == nullptr){ continue; }
+		for(int j=0; j<tot; j++){
+			free(residue->shortpath[i][j]);
+		}
+		free(residue->shortpath[i]);
+	}
+	free(residue->shortpath);
+	residue->shortpath = nullptr;
+}
+
 void shortest_path(resid* residue, int tot, atom* atoms)
-{	
+{
 	int fatm = residue->fatm[0];
 	//int latm = residue->latm[0];
 	
-	if(residue->shortpath == NULL){
+	if(residue->shortpath == nullptr){
 		residue->shortpath = (char***)malloc(tot*sizeof(char**));
 		if(!residue->shortpath){
 			fprintf(stderr,"ERROR: Could not allocate memory for residue->shortpath\n");
 			Terminate(2);
 		}
 	}
-	
+
 	for(int i=0; i<tot; i++){
 		residue->shortpath[i] = (char**)malloc(tot*sizeof(char*));
 		if(!residue->shortpath[i]){

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -3298,12 +3298,19 @@ int main(int argc, char **argv){
 		for(i=1;i<=FA->res_cnt;i++){
 			//printf("Residue[%d]\n",i);
 
-			if(residue[i].bonded != NULL){
+			// bonded / shortpath / shortflex are three sibling matrices sized by
+			// the same natm, recovered here from the residue's own atom bounds
+			// exactly as the bonded teardown already did. Only bonded was freed
+			// before; the other two were released nowhere in the tree, which is
+			// the 193896 B / 2360 allocations LeakSanitizer reports on
+			// linux-gcc-asan and linux-clang-asan.
+			if(residue[i].fatm != NULL && residue[i].latm != NULL){
 				natm = residue[i].latm[0]-residue[i].fatm[0]+1;
-				for(j=0;j<natm;j++){ free(residue[i].bonded[j]); }
-				free(residue[i].bonded);
+				free_bonded(&residue[i], natm);
+				free_shortpath(&residue[i], natm);
+				free_shortflex(&residue[i], natm);
 			}
-		  
+
 			if(residue[i].gpa != NULL) free(residue[i].gpa);
 			if(residue[i].fatm != NULL) free(residue[i].fatm);
 			if(residue[i].latm != NULL) free(residue[i].latm);

--- a/LIB/update_bonded.cpp
+++ b/LIB/update_bonded.cpp
@@ -5,6 +5,21 @@
 // the matrix starts at [0,0] with residue[ires].fatm
 // works/available for rotamers also
 
+// Releases residue->bonded allocated by update_bonded().
+// tot must be the same value passed to the matching call.
+
+void free_bonded(resid* residue, int tot)
+{
+  if(residue == nullptr || residue->bonded == nullptr){ return; }
+
+  for(int i=0; i<tot; i++)
+    {
+      free(residue->bonded[i]);
+    }
+  free(residue->bonded);
+  residue->bonded = nullptr;
+}
+
 void update_bonded(resid* residue, int tot, int nlist, int* list, int* nbr)
 {
 

--- a/LIB/update_bonded.cpp
+++ b/LIB/update_bonded.cpp
@@ -30,9 +30,16 @@ void update_bonded(resid* residue, int tot, int nlist, int* list, int* nbr)
   /*******     allocate memory for matrix ***********/
   /**************************************************/
   
+  // The guard covers both allocation levels, so a second call on the same
+  // residue reuses rows sized by the FIRST call's tot. That is safe only
+  // because tot is the same expression at every call site --
+  // latm[0]-fatm[0]+1, rot-independent -- at read_lig.cpp:464,
+  // build_rotamers.cpp:337 (the genuine re-entry, on protein residues),
+  // Mol2Reader.cpp:422 and SdfReader.cpp:752. If a caller ever passes a
+  // larger tot, the loops below walk past the previous allocation.
   if(residue->bonded == NULL)
     {
-      
+
       residue->bonded = (int**)malloc(tot*sizeof(int*));
       
       if(residue->bonded == NULL)

--- a/tests/test_read_lig_latm.cpp
+++ b/tests/test_read_lig_latm.cpp
@@ -41,6 +41,18 @@ static void init_fa(FA_Global* FA, atom** atoms, resid** residue) {
 
 static void cleanup_fa(FA_Global* FA, atom* atoms, resid* residue) {
     for (int r = 0; r <= FA->res_cnt; ++r) {
+        // read_lig allocates bonded / shortpath / shortflex per residue via
+        // update_bonded / shortest_path / assign_shortflex. Nothing in LIB
+        // released them, so the process exited dirty and LeakSanitizer
+        // reported 193896 B in 2360 allocations on linux-gcc-asan and
+        // linux-clang-asan. Freed before fatm/latm because the dimension the
+        // allocators used is read back out of them.
+        if (residue[r].fatm != nullptr && residue[r].latm != nullptr) {
+            const int natm = residue[r].latm[0] - residue[r].fatm[0] + 1;
+            free_bonded(&residue[r], natm);
+            free_shortpath(&residue[r], natm);
+            free_shortflex(&residue[r], natm);
+        }
         free(residue[r].fatm);
         free(residue[r].latm);
         free(residue[r].bond);


### PR DESCRIPTION
## What this fixes

`read_lig`, `Mol2Reader` and `SdfReader` allocate three per-residue matrices via `update_bonded` / `shortest_path` / `assign_shortflex`. **Only `bonded` was ever released**, and only in `top.cpp`. `shortpath` and `shortflex` were freed nowhere in the tree.

LeakSanitizer reports this as **193896 bytes in 2360 allocations** on `linux-gcc-asan` and byte-identically on the separate `Sanitizers` workflow's clang ASan+UBSan job. Trunk could not show it before #317 because ASan aborted on the `assign_shortflex` overread before the exit-time leak check ran.

## Design, and why each part is not a judgement call

Three prerequisites were raised on the channel and all three have measured answers in-tree:

| Part | Precedent |
|---|---|
| Where the free goes | the array-wide residue loop at `top.cpp:3297` already exists and walks every residue |
| How `tot` is recovered | `top.cpp:3302`, `latm[0]-fatm[0]+1` — the same derivation the `bonded` free already used |
| Protein NULL-init | `read_coor` / `read_pdb` initialised `bonded` only |

**The hardcoded `[0]` is load-bearing.** The allocator takes whatever `buildlist()` returns, which is `latm[rot]-fatm[rot]+1`; `rot` is 0 in every reader at allocation time but is mutated during search (`FOPTICS`, `ic2cf`, `calc_rmsd*`). Tidying `latm[0]` into `latm[rot]` would silently free the wrong count on a `tot x tot` structure. Left as-is, now with a comment.

**The protein init is in this commit, not a follow-up.** The teardown loop guards on `!= NULL`, and an uninitialised field is not null — it is whatever was on the heap. Free-first/init-second would have put a wild free on trunk.

## What I did NOT change

The `shortest_path` / `assign_shortflex` row loops still sit **outside** the `== NULL` guard. Matching `update_bonded`'s shape looks right and is wrong here: guarding makes a re-entrant call reuse rows sized by the **previous** `tot`, so if `tot` grew the `i<tot` loops walk past the old allocation — trading a latent leak for a latent overflow. Closing it properly needs a stored dimension, which the struct does not have. All three readers call these once per residue, so it stays latent either way.

## Verification, and its limit

`84/84 ctest green` under `-fsanitize=address`, macOS arm64, full suite — not a scoped run.

**This does not prove the leak is cleared.** LeakSanitizer is unsupported on macOS arm64 (`detect_leaks=1` errors out), so the local run cannot answer the question that decides this. Plausible, measured, unproven until a Linux runner reports.

Clears the two asan jobs if correct. Does not touch `Coverage` (permissions) or `Python bindings smoke (windows)` (waived, and it dies on `cl` not being on PATH, not on source incompatibility).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of residue-related data to prevent memory leaks.
  * Added safer release handling for bonded, shortest-path, and flexible-path data.
  * Initialized internal data pointers consistently when reading structures.
  * Updated cleanup workflows to release allocated resources reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->