### PR TITLE
Fix: free residue[0] fatm/latm; res_rmsd double-free; stub-teardown note

### DIFF
--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -3317,6 +3317,17 @@ int main(int argc, char **argv){
 			if(residue[i].bond != NULL) free(residue[i].bond);
 		}
 
+		// residue[0] is allocated by read_pdb.cpp:44-45 (and twice more in
+		// python_bindings.cpp) but the loop above starts at 1, so its fatm/latm
+		// were never released -- 16 bytes on every run since the code was written.
+		// Freed here rather than by widening the loop to i=0: slot 0's fatm[0]
+		// and latm[0] are never written, so the natm expression above would read
+		// uninitialised memory on that slot even though the free_* helpers would
+		// ignore the result. Every other pointer on slot 0 is explicitly NULL
+		// (read_pdb.cpp:42,51,52,55,56), so there is nothing else there to free.
+		if(residue[0].fatm != NULL) free(residue[0].fatm);
+		if(residue[0].latm != NULL) free(residue[0].latm);
+
 		free(residue);
 	}
 
@@ -3368,7 +3379,7 @@ int main(int argc, char **argv){
 	// RMSD
 	for(i=0;i<FA->num_het;i++){
 	if(FA->res_rmsd[i].fatm != NULL) free(FA->res_rmsd[i].fatm);
-	if(FA->res_rmsd[i].latm != NULL) free(FA->res_rmsd[i].fatm);
+	if(FA->res_rmsd[i].latm != NULL) free(FA->res_rmsd[i].latm);  // was .fatm: double-free + leaked .latm
 	}
 	//if(FA->atoms_rmsd != NULL) free(FA->atoms_rmsd);
 	*/

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -3320,11 +3320,14 @@ int main(int argc, char **argv){
 		// residue[0] is allocated by read_pdb.cpp:44-45 (and twice more in
 		// python_bindings.cpp) but the loop above starts at 1, so its fatm/latm
 		// were never released -- 16 bytes on every run since the code was written.
-		// Freed here rather than by widening the loop to i=0: slot 0's fatm[0]
-		// and latm[0] are never written, so the natm expression above would read
+		// Freed here rather than by widening the loop to i=0: slot 0's fatm[0] is
+		// never written by anything, so the natm expression above would read
 		// uninitialised memory on that slot even though the free_* helpers would
-		// ignore the result. Every other pointer on slot 0 is explicitly NULL
-		// (read_pdb.cpp:42,51,52,55,56), so there is nothing else there to free.
+		// ignore the result. latm[0] IS written -- read_coor.cpp:299 stores
+		// through residue[res_cnt-1] and res_cnt is 1 on the first residue, which
+		// is exactly why the read_pdb.cpp:44-45 allocation must stay. Every other
+		// pointer on slot 0 is explicitly NULL (read_pdb.cpp:42,51,52,55,56), so
+		// there is nothing else there to free.
 		if(residue[0].fatm != NULL) free(residue[0].fatm);
 		if(residue[0].latm != NULL) free(residue[0].latm);
 

--- a/tests/test_mol2_sdf_reader.cpp
+++ b/tests/test_mol2_sdf_reader.cpp
@@ -46,6 +46,14 @@ static void init_fa_for_reader(FA_Global* FA, atom** atoms, resid** residue) {
 }
 
 static void cleanup_fa(FA_Global* FA, atom* atoms, resid* residue) {
+    // NOTE: bonded / shortpath / shortflex are deliberately NOT freed here.
+    // This target links tests/stubs.cpp, whose update_bonded / shortest_path /
+    // assign_shortflex are empty bodies, so Mol2Reader and SdfReader call them
+    // and nothing is allocated. If those stubs are ever replaced by the real
+    // LIB/ allocators in this target's SOURCES, this function must also call
+    // free_bonded / free_shortpath / free_shortflex -- omitting them is what
+    // made test_read_lig_latm leak 2360 objects under LeakSanitizer.
+    //
     // Free residue sub-allocations created by the readers
     for (int r = 1; r <= FA->res_cnt; ++r) {
         free(residue[r].fatm);

--- a/tests/test_read_lig_latm.cpp
+++ b/tests/test_read_lig_latm.cpp
@@ -188,3 +188,44 @@ TEST(ReadLigLatm, OneT40Style28Atoms) {
     cleanup_fa(&FA, atoms, residue);
     fs::remove_all(tmp);
 }
+
+// The residue[0] shape read_pdb.cpp:42-56 builds: fatm/latm allocated, every
+// other pointer explicitly NULL. top.cpp frees that slot after its i=1 loop,
+// and top.cpp is compiled into no test target — so this pins the contract the
+// three helpers must honour there: no-op on NULL members, leaving the caller
+// free to release fatm/latm afterwards.
+//
+// cleanup_fa above does not cover it. Its r=0 iteration sees the calloc'd
+// residue[0] from init_fa, where fatm and latm are NULL and the guard skips
+// the whole body. This is the only place the allocated-slot-0 shape is built.
+//
+// natm is derived exactly as top.cpp:3308 derives it — latm[0]-fatm[0]+1 —
+// so a change to either copy of that expression shows up here.
+TEST(ResidTeardown, Slot0ShapeFreesCleanlyWithOnlyFatmLatmAllocated) {
+    resid r{};
+    r.fatm = static_cast<int*>(malloc(sizeof(int)));
+    r.latm = static_cast<int*>(malloc(sizeof(int)));
+    ASSERT_NE(r.fatm, nullptr);
+    ASSERT_NE(r.latm, nullptr);
+    r.fatm[0] = 0;
+    r.latm[0] = 0;
+    r.gpa = nullptr;
+    r.bond = nullptr;
+    r.bonded = nullptr;
+    r.shortpath = nullptr;
+    r.shortflex = nullptr;
+
+    const int natm = r.latm[0] - r.fatm[0] + 1;
+    EXPECT_EQ(natm, 1);
+
+    free_bonded(&r, natm);
+    free_shortpath(&r, natm);
+    free_shortflex(&r, natm);
+
+    EXPECT_EQ(r.bonded, nullptr);
+    EXPECT_EQ(r.shortpath, nullptr);
+    EXPECT_EQ(r.shortflex, nullptr);
+
+    free(r.fatm);
+    free(r.latm);
+}


### PR DESCRIPTION
Three small follow-ups from the #318 review. None is urgent; all are post-merge items the review surfaced and recorded.

## 1. `residue[0].fatm` / `.latm` leak — 16 bytes per process

`read_pdb.cpp:44-45` allocates both (and `python_bindings.cpp` does the same twice), but the teardown loop at `top.cpp:3298` starts at `i=1`, so slot 0 is never released. Sixteen bytes on every run since the code was written.

**Freed after the loop rather than by widening it to `i=0`.** Slot 0's `fatm[0]`/`latm[0]` are not written at allocation time, so the `natm = latm[0]-fatm[0]+1` expression inside the loop would read uninitialised memory on that slot — harmless, since the `free_*` helpers early-return on NULL fields, but not something worth relying on.

### The allocation must stay

A proposal to delete the `read_pdb` allocations instead was raised during review and **withdrawn**. It would be a null-pointer write on the main protein path:

```c
top.cpp:691         FA->res_cnt = 0;
read_coor.cpp:248   FA->res_cnt++;                              // first residue -> 1
read_coor.cpp:299   (*residue)[FA->res_cnt-1].latm[0] = ...;    // -> residue[0].latm[0]
```

`read_coor.cpp:299` closes out the previous residue's atom range, and for the first residue the "previous" one is slot 0. That write is what `read_pdb.cpp:44-45` exists to serve.

The contrast with `residue_conect.cpp:126-127` is the tell: same `[i-1]` idiom, but guarded by `if(i != 1)` because slot 0 would be wrong there. `read_coor:299` is unguarded because slot 0 is the intended target.

## 2. `top.cpp` `res_rmsd` cleanup — double-free

The `latm` branch freed `.fatm`, so it double-freed `fatm` and leaked `latm`. Inside a `/* */` block today, so dead until someone re-enables RMSD cleanup — at which point they would have inherited it.

## 3. `test_mol2_sdf_reader.cpp` — note on the stubbed trio

That target links `tests/stubs.cpp`, whose `update_bonded` / `shortest_path` / `assign_shortflex` are empty bodies, so `cleanup_fa` correctly frees nothing for them. Recorded in place, because if the real `LIB/` allocators are ever added to that target the frees must be added too — the same omission is what made `test_read_lig_latm` leak 2,360 objects.

## Verification

`cmake --build` 0 errors; `ctest` **84/84** at `83676149`, rebased onto `2264abc8`.

**Scope:** `top.cpp` is compiled into no unit test target, so item 1 is not covered by any test in this repo — that gap predates this PR and is unchanged by it.