### PR TITLE
Refactor: single owner for the per-residue teardown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2285,6 +2285,7 @@ flexaids_add_unit_test(test_protocol_config
             LIB/update_bonded.cpp
             LIB/shortest_path.cpp
             LIB/assign_shortflex.cpp
+            LIB/free_resid.cpp
             LIB/buildcc.cpp
             LIB/geometry.cpp
         COMPILE_OPTIONS -std=c++26

--- a/LIB/CMakeLists.txt
+++ b/LIB/CMakeLists.txt
@@ -21,6 +21,7 @@ set(FLEXAID_CORE_SOURCES
     update_constraint.cpp
     update_optres.cpp
     update_bonded.cpp
+    free_resid.cpp
     read_grid.cpp
     read_input.cpp
     read_lig.cpp

--- a/LIB/flexaid.h
+++ b/LIB/flexaid.h
@@ -793,6 +793,10 @@ void   update_bonded(resid* residue, int tot, int nlist, int* list, int* nbr);  
 void   free_shortpath(resid* residue, int tot);
 void   free_shortflex(resid* residue, int tot);
 void   free_bonded(resid* residue, int tot);
+// Sole owner of the per-residue teardown order (LIB/free_resid.cpp). Safe on a
+// slot with only fatm/latm allocated, so callers loop from 0 with no special
+// case. Derives natm from fatm/latm, so it must run before those are freed.
+void   free_resid(resid* residue);
 void   update_optres(atom* atoms, resid* residue, int atm_cnt, OptRes* optres_ptr,int num_optres); // update atoms structure with optres pointers
 void   set_intprob(flxsc* flex_res);                                         // sets internal probability for rotamer change
 int    number_of_dihedrals(char res[]);                      // determines number of dihedral bonds for residues

--- a/LIB/free_resid.cpp
+++ b/LIB/free_resid.cpp
@@ -1,0 +1,45 @@
+#include "flexaid.h"
+
+// Sole owner of the per-residue teardown order.
+//
+// Before this file the sequence existed twice, byte-identical: the production
+// copy in top.cpp's cleanup loop and the test copy in tests/cleanup_fa. Nothing
+// tied them together, so a change to one silently diverged from the other --
+// and the production copy is the one no test target compiles, which is exactly
+// the pair that must not drift. Both now call this.
+//
+// Order is load-bearing. bonded / shortpath / shortflex are three sibling
+// matrices dimensioned by the same natm, and natm is recovered from the
+// residue's own fatm/latm -- so those two must still be readable when the trio
+// is released. Freeing fatm/latm first loses the dimension and the free walks
+// the wrong length.
+
+void free_resid(resid* residue)
+{
+	if(residue == nullptr){ return; }
+
+	// The natm derivation is guarded on the trio rather than run
+	// unconditionally: read_pdb.cpp:42,51,52,55,56 leaves slot 0 with all three
+	// NULL and its fatm[0] never written by anything, so computing natm there
+	// would read uninitialised memory for a result the free_* helpers ignore.
+	// latm[0] IS written -- read_coor.cpp:299 stores through residue[res_cnt-1]
+	// and res_cnt is 1 on the first residue, which is why the read_pdb.cpp:44-45
+	// allocation must stay. Guarding here is what lets callers loop from 0 with
+	// no special case for that slot.
+	if(residue->fatm != nullptr && residue->latm != nullptr &&
+	   (residue->bonded    != nullptr ||
+	    residue->shortpath != nullptr ||
+	    residue->shortflex != nullptr)){
+
+		const int natm = residue->latm[0]-residue->fatm[0]+1;
+
+		free_bonded(residue, natm);
+		free_shortpath(residue, natm);
+		free_shortflex(residue, natm);
+	}
+
+	if(residue->gpa  != nullptr){ free(residue->gpa);  residue->gpa  = nullptr; }
+	if(residue->fatm != nullptr){ free(residue->fatm); residue->fatm = nullptr; }
+	if(residue->latm != nullptr){ free(residue->latm); residue->latm = nullptr; }
+	if(residue->bond != nullptr){ free(residue->bond); residue->bond = nullptr; }
+}

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -542,7 +542,6 @@ int main(int argc, char **argv){
   try {
 	flexaids_rng::init_from_env();
 	int   i,j;
-	int   natm;
 
 	char remark[MAX_REMARK];
 	char tmpremark[MAX_REMARK];
@@ -3295,41 +3294,14 @@ int main(int argc, char **argv){
 
 	// Residues
 	if(residue != NULL) {
-		for(i=1;i<=FA->res_cnt;i++){
-			//printf("Residue[%d]\n",i);
-
-			// bonded / shortpath / shortflex are three sibling matrices sized by
-			// the same natm, recovered here from the residue's own atom bounds
-			// exactly as the bonded teardown already did. Only bonded was freed
-			// before; the other two were released nowhere in the tree, which is
-			// the 193896 B / 2360 allocations LeakSanitizer reports on
-			// linux-gcc-asan and linux-clang-asan.
-			if(residue[i].fatm != NULL && residue[i].latm != NULL){
-				natm = residue[i].latm[0]-residue[i].fatm[0]+1;
-				free_bonded(&residue[i], natm);
-				free_shortpath(&residue[i], natm);
-				free_shortflex(&residue[i], natm);
-			}
-
-			if(residue[i].gpa != NULL) free(residue[i].gpa);
-			if(residue[i].fatm != NULL) free(residue[i].fatm);
-			if(residue[i].latm != NULL) free(residue[i].latm);
-			if(residue[i].bond != NULL) free(residue[i].bond);
+		// From 0, not 1: slot 0 is allocated by read_pdb.cpp:44-45 and its
+		// fatm/latm went unreleased for as long as the loop started at 1.
+		// free_resid guards the natm derivation on the trio, so the slot that
+		// has only fatm/latm needs no special case here -- the reason that
+		// guard exists is documented at LIB/free_resid.cpp:22.
+		for(i=0;i<=FA->res_cnt;i++){
+			free_resid(&residue[i]);
 		}
-
-		// residue[0] is allocated by read_pdb.cpp:44-45 (and twice more in
-		// python_bindings.cpp) but the loop above starts at 1, so its fatm/latm
-		// were never released -- 16 bytes on every run since the code was written.
-		// Freed here rather than by widening the loop to i=0: slot 0's fatm[0] is
-		// never written by anything, so the natm expression above would read
-		// uninitialised memory on that slot even though the free_* helpers would
-		// ignore the result. latm[0] IS written -- read_coor.cpp:299 stores
-		// through residue[res_cnt-1] and res_cnt is 1 on the first residue, which
-		// is exactly why the read_pdb.cpp:44-45 allocation must stay. Every other
-		// pointer on slot 0 is explicitly NULL (read_pdb.cpp:42,51,52,55,56), so
-		// there is nothing else there to free.
-		if(residue[0].fatm != NULL) free(residue[0].fatm);
-		if(residue[0].latm != NULL) free(residue[0].latm);
 
 		free(residue);
 	}

--- a/tests/test_read_lig_latm.cpp
+++ b/tests/test_read_lig_latm.cpp
@@ -40,23 +40,12 @@ static void init_fa(FA_Global* FA, atom** atoms, resid** residue) {
 }
 
 static void cleanup_fa(FA_Global* FA, atom* atoms, resid* residue) {
+    // Same call the production teardown makes (top.cpp, inside the residue
+    // cleanup loop). This used to be a byte-identical copy of that sequence
+    // with nothing tying the two together; free_resid is now the sole owner,
+    // so this test exercises the real teardown rather than a replica of it.
     for (int r = 0; r <= FA->res_cnt; ++r) {
-        // read_lig allocates bonded / shortpath / shortflex per residue via
-        // update_bonded / shortest_path / assign_shortflex. Nothing in LIB
-        // released them, so the process exited dirty and LeakSanitizer
-        // reported 193896 B in 2360 allocations on linux-gcc-asan and
-        // linux-clang-asan. Freed before fatm/latm because the dimension the
-        // allocators used is read back out of them.
-        if (residue[r].fatm != nullptr && residue[r].latm != nullptr) {
-            const int natm = residue[r].latm[0] - residue[r].fatm[0] + 1;
-            free_bonded(&residue[r], natm);
-            free_shortpath(&residue[r], natm);
-            free_shortflex(&residue[r], natm);
-        }
-        free(residue[r].fatm);
-        free(residue[r].latm);
-        free(residue[r].bond);
-        free(residue[r].gpa);
+        free_resid(&residue[r]);
     }
     free(FA->optres);
     free(FA->num_atm);
@@ -190,17 +179,14 @@ TEST(ReadLigLatm, OneT40Style28Atoms) {
 }
 
 // The residue[0] shape read_pdb.cpp:42-56 builds: fatm/latm allocated, every
-// other pointer explicitly NULL. top.cpp frees that slot after its i=1 loop,
-// and top.cpp is compiled into no test target — so this pins the contract the
-// three helpers must honour there: no-op on NULL members, leaving the caller
-// free to release fatm/latm afterwards.
+// other pointer explicitly NULL. top.cpp is compiled into no test target, so
+// its call site still runs under no instrument — but the function it calls is
+// now the same one this test calls, which is what free_resid was extracted to
+// achieve. Before the extraction this test could only pin a replica.
 //
-// cleanup_fa above does not cover it. Its r=0 iteration sees the calloc'd
-// residue[0] from init_fa, where fatm and latm are NULL and the guard skips
-// the whole body. This is the only place the allocated-slot-0 shape is built.
-//
-// natm is derived exactly as top.cpp:3308 derives it — latm[0]-fatm[0]+1 —
-// so a change to either copy of that expression shows up here.
+// cleanup_fa above does not reach this shape. Its r=0 iteration sees the
+// calloc'd residue[0] from init_fa, where every pointer is NULL. This is the
+// only place the allocated-slot-0 shape is built.
 TEST(ResidTeardown, Slot0ShapeFreesCleanlyWithOnlyFatmLatmAllocated) {
     resid r{};
     r.fatm = static_cast<int*>(malloc(sizeof(int)));
@@ -215,17 +201,47 @@ TEST(ResidTeardown, Slot0ShapeFreesCleanlyWithOnlyFatmLatmAllocated) {
     r.shortpath = nullptr;
     r.shortflex = nullptr;
 
-    const int natm = r.latm[0] - r.fatm[0] + 1;
-    EXPECT_EQ(natm, 1);
+    free_resid(&r);
 
-    free_bonded(&r, natm);
-    free_shortpath(&r, natm);
-    free_shortflex(&r, natm);
-
+    EXPECT_EQ(r.fatm, nullptr);
+    EXPECT_EQ(r.latm, nullptr);
     EXPECT_EQ(r.bonded, nullptr);
     EXPECT_EQ(r.shortpath, nullptr);
     EXPECT_EQ(r.shortflex, nullptr);
+}
 
-    free(r.fatm);
-    free(r.latm);
+// The guard that lets both callers loop from 0. free_resid must not touch
+// fatm[0] when the trio is absent: on slot 0 that value is never written, so
+// deriving natm there reads uninitialised memory. Nothing observable
+// distinguishes the two paths at runtime -- no sanitizer flags a read of
+// uninitialised heap that is then discarded -- so this pins it structurally by
+// leaving fatm[0] deliberately unset and requiring a clean teardown anyway.
+TEST(ResidTeardown, NatmNotDerivedWhenTrioAbsent) {
+    resid r{};
+    r.fatm = static_cast<int*>(malloc(sizeof(int)));
+    r.latm = static_cast<int*>(malloc(sizeof(int)));
+    ASSERT_NE(r.fatm, nullptr);
+    ASSERT_NE(r.latm, nullptr);
+    // fatm[0] intentionally left unwritten -- the read_pdb slot-0 shape.
+    r.latm[0] = 0;
+    r.gpa = nullptr;
+    r.bond = nullptr;
+    r.bonded = nullptr;
+    r.shortpath = nullptr;
+    r.shortflex = nullptr;
+
+    free_resid(&r);
+
+    EXPECT_EQ(r.fatm, nullptr);
+    EXPECT_EQ(r.latm, nullptr);
+}
+
+// free_resid is the teardown every caller uses, so it must tolerate the empty
+// slot the calloc'd array is full of -- otherwise looping from 0 over
+// MIN_NUM_RESIDUE entries would fault on the first untouched one.
+TEST(ResidTeardown, AllNullSlotIsANoOp) {
+    resid r{};
+    free_resid(&r);
+    EXPECT_EQ(r.fatm, nullptr);
+    EXPECT_EQ(r.bonded, nullptr);
 }


### PR DESCRIPTION
Closes the residual named at the end of #319: two byte-identical teardown blocks with no shared owner.

## The problem

The per-residue teardown sequence existed twice:

- `LIB/top.cpp` — the production cleanup loop
- `tests/test_read_lig_latm.cpp` `cleanup_fa` — the test copy

Byte-identical, with nothing tying them together. **The production copy is the one compiled into no unit-test target**, so a change to either could silently diverge — and the untested side is the one that ships. The test could only ever pin a replica of the code that runs.

## The change

`LIB/free_resid.cpp` is the sole owner. Both call sites call it, so the test now exercises the real teardown.

Order is load-bearing and documented in the file: `bonded` / `shortpath` / `shortflex` are dimensioned by a `natm` recovered from the residue's own `fatm`/`latm`, so those must still be readable when the trio is released.

## The slot-0 special case is gone, not relocated

`#319` freed `residue[0]` in a separate block after the `i=1` loop, because widening the loop would have derived `natm` on a slot whose `fatm[0]` is never written — an uninitialised read for a result the helpers discard.

`free_resid` guards the derivation on the trio instead, so the shape with only `fatm`/`latm` needs no special handling. **Both callers now loop from 0 with one statement in the body.**

## Tests

`ResidTeardown.Slot0Shape…` now drives `free_resid` rather than the three helpers directly, plus two new cases:

- `NatmNotDerivedWhenTrioAbsent` — leaves `fatm[0]` deliberately unwritten and requires a clean teardown. Nothing observable distinguishes the two paths at runtime (no sanitizer flags a discarded read of uninitialised heap), so this pins the guard structurally.
- `AllNullSlotIsANoOp` — the empty slot a calloc'd array is full of, which looping from 0 now walks.

## Verification

```
cmake --build build -j 8        0 errors
ctest --output-on-failure       100% tests passed out of 84
./test_read_lig_latm            5 tests, all OK, both new cases named
leaks --atExit                  0 leaks for 0 total leaked bytes
```

## What this does not change

**`LIB/top.cpp` is still in no unit-test target.** Its call site still executes under no instrument. What this PR changes is that the function it calls is now the one the suite covers — the drift risk is closed, the coverage gap is not. Suite-linking `top.cpp` is a separate and larger question.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of residue-related resources during application shutdown.
  * Added safer handling for empty, partially initialized, or null residue data.
  * Ensured all residue slots, including the initial slot, are consistently cleaned up.

* **Tests**
  * Expanded cleanup test coverage for residues with different initialization states.
  * Updated tests to verify shared cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->