### PR TITLE
Test: cover top.cpp's pure helpers (seam A)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2271,6 +2271,16 @@ flexaids_add_unit_test(test_protocol_config
         TEST_NAME Mol2SdfReaderTests
     )
 
+    # ── top.cpp helpers (seam A: logic lifted out of the main() TU) ───────
+    flexaids_add_unit_test(test_top_helpers
+        SOURCES
+            tests/test_top_helpers.cpp
+            LIB/top_helpers.cpp
+        COMPILE_OPTIONS -std=c++26
+        GTEST_MAIN_ONLY
+        TEST_NAME TopHelpersTests
+    )
+
     # ── read_lig latm inclusive range (pilot8 missing last HETTYP atom) ───
     # Uses real fileio.cpp (OpenFile_B / Terminate throws) — no stubs OpenFile.
     flexaids_add_unit_test(test_read_lig_latm

--- a/LIB/CMakeLists.txt
+++ b/LIB/CMakeLists.txt
@@ -22,6 +22,7 @@ set(FLEXAID_CORE_SOURCES
     update_optres.cpp
     update_bonded.cpp
     top_helpers.cpp
+    top_helpers.h
     read_grid.cpp
     read_input.cpp
     read_lig.cpp

--- a/LIB/CMakeLists.txt
+++ b/LIB/CMakeLists.txt
@@ -21,6 +21,7 @@ set(FLEXAID_CORE_SOURCES
     update_constraint.cpp
     update_optres.cpp
     update_bonded.cpp
+    top_helpers.cpp
     read_grid.cpp
     read_input.cpp
     read_lig.cpp

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -1,4 +1,5 @@
 #include "gaboom.h"
+#include "top_helpers.h"
 #include "fileio.h"
 #include "flexaid_exception.h"
 #include "Vcontacts.h"
@@ -107,65 +108,6 @@
 // canonical_vct_type_for_element, or the same element will score differently
 // depending on which file format it arrived in and which side of the complex
 // it sits on.
-static constexpr int FA_TYPE_DUMMY = 39;
-static int sybyl_name_to_canonical_vct(const char* s) {
-	if (!strcmp(s, "C.1"))   return 2;   // C.2 — sp C rare in PDB sites, C.2 better sampled
-	if (!strcmp(s, "C.2"))   return 2;
-	if (!strcmp(s, "C.3"))   return 3;
-	if (!strcmp(s, "C.ar"))  return 4;
-	if (!strcmp(s, "C.cat")) return 5;
-	if (!strcmp(s, "N.1"))   return 6;
-	if (!strcmp(s, "N.2"))   return 10;  // N.ar — sp2 imine is an acceptor; N.am (donor) reversed the H-bond sign
-	if (!strcmp(s, "N.3"))   return 11;  // N.am — row 8 is all-zero in MC_st0r5.2_6.dat; matches Mol2Reader.cpp:44
-	if (!strcmp(s, "N.4"))   return 9;
-	if (!strcmp(s, "N.ar"))  return 10;
-	if (!strcmp(s, "N.am"))  return 11;
-	if (!strcmp(s, "N.pl3")) return 12;
-	if (!strcmp(s, "O.2"))   return 13;
-	if (!strcmp(s, "O.3"))   return 14;
-	if (!strcmp(s, "O.co2")) return 15;
-	// O.ar → O.3. Row 16 is all-zero in MC_st0r5.2_6.dat, so a furan / oxazole /
-	// benzofuran oxygen scored exactly nothing against every partner. An
-	// aromatic ring oxygen is divalent with no labile H — ether-like — so O.3
-	// (row 14, 22 live entries) is the correct live surrogate, not the carbonyl
-	// row O.2. Geometry is unaffected: both the vH recipe and the implicit-H
-	// count for row 14 are gated on heavy_bonds<=1, and a ring O always has 2.
-	if (!strcmp(s, "O.ar"))  return 14;
-	if (!strcmp(s, "S.2"))   return 17;
-	if (!strcmp(s, "S.3"))   return 18;
-	if (!strcmp(s, "S.O") || !strcmp(s, "S.o"))   return 19;
-	// S.O2 → S.O. Row 20 is all-zero, so every sulfone and sulfonamide sulfur —
-	// one of the most common motifs in drug-like ligands — was invisible to the
-	// scorer. S.O (row 19, 12 live entries) is the nearest live chemistry:
-	// oxidised, tetrahedral, strongly polarised S=O.
-	if (!strcmp(s, "S.O2") || !strcmp(s, "S.o2")) return 19;
-	// S.ar → S.3. Row 21 is all-zero; a thiophene / thiazole sulfur is divalent
-	// with no labile H, so the thioether row 18 (20 live entries) is the correct
-	// live surrogate. Same heavy_bonds<=1 geometry gate as O.ar above.
-	if (!strcmp(s, "S.ar"))  return 18;
-	if (!strcmp(s, "P.3"))   return 22;
-	if (!strcmp(s, "F"))     return 23;
-	if (!strcmp(s, "Cl"))    return 24;
-	if (!strcmp(s, "Br"))    return 25;
-	if (!strcmp(s, "I"))     return 25;  // BR — iodo near-absent from PDB training; I/type-26 row has only 3 live entries
-	// Se → S.3. Row 27 is all-zero. Selenium reaches the scorer almost entirely
-	// as selenomethionine (MSE), a methionine surrogate used for phasing, so
-	// scoring it on the thioether row reproduces the chemistry it stands in for
-	// instead of making the side chain invisible.
-	if (!strcmp(s, "Se"))    return 18;
-	if (!strcmp(s, "Mg"))    return 28;
-	if (!strcmp(s, "Sr"))    return 29;
-	if (!strcmp(s, "Cu"))    return 30;
-	if (!strcmp(s, "Mn"))    return 31;
-	if (!strcmp(s, "Hg"))    return 32;
-	if (!strcmp(s, "Cd"))    return 33;
-	if (!strcmp(s, "Ni"))    return 34;
-	if (!strcmp(s, "Zn"))    return 35;
-	if (!strcmp(s, "Ca"))    return 36;
-	if (!strcmp(s, "Fe"))    return 37;
-	if (!strcmp(s, "Co.oh") || !strcmp(s, "Co")) return 38;
-	return FA_TYPE_DUMMY; // H ("H") and anything unknown ("X")
-}
 
 // ════════════════════════════════════════════════════════════════════════════
 //  Strategy A — on-disk VCT grid cache  (env: FLEXAIDDS_GRID_CACHE_DIR)
@@ -347,84 +289,6 @@ static int bonmol_atom_to_canonical_vct(const bonmol::Atom& a, const char** out_
 }
 
 // ── Idiotproof file role detection ──────────────────────────────────────────
-// Returns: "receptor", "ligand", "config", "smiles", or "unknown"
-static std::string detect_file_role(const std::string& path) {
-	// Not a file? Might be a SMILES string
-	if (!std::filesystem::exists(path)) {
-		// SMILES strings contain typical chemistry chars, no path separators
-		if (!path.empty() &&
-		    path.find('/') == std::string::npos &&
-		    path.find('\\') == std::string::npos &&
-		    (path.find('(') != std::string::npos ||
-		     path.find('=') != std::string::npos ||
-		     path.find('#') != std::string::npos ||
-		     path.find('c') != std::string::npos ||
-		     path.find('C') != std::string::npos ||
-		     path.find('N') != std::string::npos ||
-		     path.find('O') != std::string::npos)) {
-			return "smiles";
-		}
-		return "unknown";
-	}
-
-	std::string ext;
-	{
-		auto dot = path.rfind('.');
-		if (dot != std::string::npos) {
-			ext = path.substr(dot);
-			for (auto& c : ext) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-		}
-	}
-
-	// Ligand formats (single molecule or library)
-	if (ext == ".mol2" || ext == ".sdf" || ext == ".mol") return "ligand";
-
-	// SMILES file = ligand library
-	if (ext == ".smi" || ext == ".smiles") return "ligand";
-
-	// Config formats
-	if (ext == ".json") return "config";
-
-	// CIF/mmCIF — receptor (PDB archive format)
-	if (ext == ".cif" || ext == ".mmcif") return "receptor";
-
-	// Directory of ligand files = ligand library
-	if (std::filesystem::is_directory(path)) return "ligand";
-
-	// PDB could be receptor or ligand — peek at content
-	if (ext == ".pdb" || ext == ".ent") {
-		FILE* fp = fopen(path.c_str(), "r");
-		if (!fp) return "unknown";
-		int atom_count = 0;
-		int hetatm_count = 0;
-		char line[256];
-		while (fgets(line, sizeof(line), fp) && (atom_count + hetatm_count) < 200) {
-			if (strncmp(line, "ATOM  ", 6) == 0) atom_count++;
-			else if (strncmp(line, "HETATM", 6) == 0) hetatm_count++;
-		}
-		fclose(fp);
-		// Receptor: many ATOM records. Ligand PDB: mostly HETATM, few atoms.
-		if (atom_count > 20) return "receptor";
-		if (hetatm_count > 0 && atom_count <= 20) return "ligand";
-		if (atom_count > 0) return "receptor"; // fallback
-		return "unknown";
-	}
-
-	// Legacy input files
-	if (ext == ".inp" || ext == ".dat") return "legacy";
-
-	return "unknown";
-}
-
-/// Validate an RCSB PDB ID (classic 4-char alphanumeric; allow longer alphanumeric
-/// accession-style codes used by some modern deposits, 4–8 chars).
-static bool is_valid_pdb_id(const std::string& id) {
-	if (id.size() < 4 || id.size() > 8) return false;
-	for (unsigned char c : id) {
-		if (!std::isalnum(c)) return false;
-	}
-	return true;
-}
 
 /// Download RCSB entry, extract cognate ligand, strip apo receptor.
 /// Returns true and fills paths on success. Cache under FLEXAIDDS_REDOCK_CACHE

--- a/LIB/top_helpers.cpp
+++ b/LIB/top_helpers.cpp
@@ -1,0 +1,148 @@
+#include "top_helpers.h"
+
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+
+// Bodies moved verbatim from LIB/top.cpp. No behaviour change -- the only edits
+// are dropping `static` and the FA_TYPE_DUMMY constant moving to the header.
+
+int sybyl_name_to_canonical_vct(const char* s) {
+	if (!strcmp(s, "C.1"))   return 2;   // C.2 — sp C rare in PDB sites, C.2 better sampled
+	if (!strcmp(s, "C.2"))   return 2;
+	if (!strcmp(s, "C.3"))   return 3;
+	if (!strcmp(s, "C.ar"))  return 4;
+	if (!strcmp(s, "C.cat")) return 5;
+	if (!strcmp(s, "N.1"))   return 6;
+	if (!strcmp(s, "N.2"))   return 10;  // N.ar — sp2 imine is an acceptor; N.am (donor) reversed the H-bond sign
+	if (!strcmp(s, "N.3"))   return 11;  // N.am — row 8 is all-zero in MC_st0r5.2_6.dat; matches Mol2Reader.cpp:44
+	if (!strcmp(s, "N.4"))   return 9;
+	if (!strcmp(s, "N.ar"))  return 10;
+	if (!strcmp(s, "N.am"))  return 11;
+	if (!strcmp(s, "N.pl3")) return 12;
+	if (!strcmp(s, "O.2"))   return 13;
+	if (!strcmp(s, "O.3"))   return 14;
+	if (!strcmp(s, "O.co2")) return 15;
+	// O.ar → O.3. Row 16 is all-zero in MC_st0r5.2_6.dat, so a furan / oxazole /
+	// benzofuran oxygen scored exactly nothing against every partner. An
+	// aromatic ring oxygen is divalent with no labile H — ether-like — so O.3
+	// (row 14, 22 live entries) is the correct live surrogate, not the carbonyl
+	// row O.2. Geometry is unaffected: both the vH recipe and the implicit-H
+	// count for row 14 are gated on heavy_bonds<=1, and a ring O always has 2.
+	if (!strcmp(s, "O.ar"))  return 14;
+	if (!strcmp(s, "S.2"))   return 17;
+	if (!strcmp(s, "S.3"))   return 18;
+	if (!strcmp(s, "S.O") || !strcmp(s, "S.o"))   return 19;
+	// S.O2 → S.O. Row 20 is all-zero, so every sulfone and sulfonamide sulfur —
+	// one of the most common motifs in drug-like ligands — was invisible to the
+	// scorer. S.O (row 19, 12 live entries) is the nearest live chemistry:
+	// oxidised, tetrahedral, strongly polarised S=O.
+	if (!strcmp(s, "S.O2") || !strcmp(s, "S.o2")) return 19;
+	// S.ar → S.3. Row 21 is all-zero; a thiophene / thiazole sulfur is divalent
+	// with no labile H, so the thioether row 18 (20 live entries) is the correct
+	// live surrogate. Same heavy_bonds<=1 geometry gate as O.ar above.
+	if (!strcmp(s, "S.ar"))  return 18;
+	if (!strcmp(s, "P.3"))   return 22;
+	if (!strcmp(s, "F"))     return 23;
+	if (!strcmp(s, "Cl"))    return 24;
+	if (!strcmp(s, "Br"))    return 25;
+	if (!strcmp(s, "I"))     return 25;  // BR — iodo near-absent from PDB training; I/type-26 row has only 3 live entries
+	// Se → S.3. Row 27 is all-zero. Selenium reaches the scorer almost entirely
+	// as selenomethionine (MSE), a methionine surrogate used for phasing, so
+	// scoring it on the thioether row reproduces the chemistry it stands in for
+	// instead of making the side chain invisible.
+	if (!strcmp(s, "Se"))    return 18;
+	if (!strcmp(s, "Mg"))    return 28;
+	if (!strcmp(s, "Sr"))    return 29;
+	if (!strcmp(s, "Cu"))    return 30;
+	if (!strcmp(s, "Mn"))    return 31;
+	if (!strcmp(s, "Hg"))    return 32;
+	if (!strcmp(s, "Cd"))    return 33;
+	if (!strcmp(s, "Ni"))    return 34;
+	if (!strcmp(s, "Zn"))    return 35;
+	if (!strcmp(s, "Ca"))    return 36;
+	if (!strcmp(s, "Fe"))    return 37;
+	if (!strcmp(s, "Co.oh") || !strcmp(s, "Co")) return 38;
+	return FA_TYPE_DUMMY; // H ("H") and anything unknown ("X")
+}
+
+// ── Idiotproof file role detection ──────────────────────────────────────────
+// Returns: "receptor", "ligand", "config", "smiles", or "unknown"
+std::string detect_file_role(const std::string& path) {
+	// Not a file? Might be a SMILES string
+	if (!std::filesystem::exists(path)) {
+		// SMILES strings contain typical chemistry chars, no path separators
+		if (!path.empty() &&
+		    path.find('/') == std::string::npos &&
+		    path.find('\\') == std::string::npos &&
+		    (path.find('(') != std::string::npos ||
+		     path.find('=') != std::string::npos ||
+		     path.find('#') != std::string::npos ||
+		     path.find('c') != std::string::npos ||
+		     path.find('C') != std::string::npos ||
+		     path.find('N') != std::string::npos ||
+		     path.find('O') != std::string::npos)) {
+			return "smiles";
+		}
+		return "unknown";
+	}
+
+	std::string ext;
+	{
+		auto dot = path.rfind('.');
+		if (dot != std::string::npos) {
+			ext = path.substr(dot);
+			for (auto& c : ext) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+		}
+	}
+
+	// Ligand formats (single molecule or library)
+	if (ext == ".mol2" || ext == ".sdf" || ext == ".mol") return "ligand";
+
+	// SMILES file = ligand library
+	if (ext == ".smi" || ext == ".smiles") return "ligand";
+
+	// Config formats
+	if (ext == ".json") return "config";
+
+	// CIF/mmCIF — receptor (PDB archive format)
+	if (ext == ".cif" || ext == ".mmcif") return "receptor";
+
+	// Directory of ligand files = ligand library
+	if (std::filesystem::is_directory(path)) return "ligand";
+
+	// PDB could be receptor or ligand — peek at content
+	if (ext == ".pdb" || ext == ".ent") {
+		FILE* fp = fopen(path.c_str(), "r");
+		if (!fp) return "unknown";
+		int atom_count = 0;
+		int hetatm_count = 0;
+		char line[256];
+		while (fgets(line, sizeof(line), fp) && (atom_count + hetatm_count) < 200) {
+			if (strncmp(line, "ATOM  ", 6) == 0) atom_count++;
+			else if (strncmp(line, "HETATM", 6) == 0) hetatm_count++;
+		}
+		fclose(fp);
+		// Receptor: many ATOM records. Ligand PDB: mostly HETATM, few atoms.
+		if (atom_count > 20) return "receptor";
+		if (hetatm_count > 0 && atom_count <= 20) return "ligand";
+		if (atom_count > 0) return "receptor"; // fallback
+		return "unknown";
+	}
+
+	// Legacy input files
+	if (ext == ".inp" || ext == ".dat") return "legacy";
+
+	return "unknown";
+}
+
+/// Validate an RCSB PDB ID (classic 4-char alphanumeric; allow longer alphanumeric
+/// accession-style codes used by some modern deposits, 4–8 chars).
+bool is_valid_pdb_id(const std::string& id) {
+	if (id.size() < 4 || id.size() > 8) return false;
+	for (unsigned char c : id) {
+		if (!std::isalnum(c)) return false;
+	}
+	return true;
+}

--- a/LIB/top_helpers.h
+++ b/LIB/top_helpers.h
@@ -1,0 +1,38 @@
+// Helpers lifted out of LIB/top.cpp so they can be tested.
+//
+// top.cpp defines main() and exports no other symbol, so a test target can
+// neither link it (gtest_main supplies its own main) nor reach anything inside
+// it (every helper was static). These three were pure functions of their
+// arguments trapped in that TU; moving them here changes no behaviour and makes
+// them addressable.
+
+#ifndef FLEXAID_TOP_HELPERS_H
+#define FLEXAID_TOP_HELPERS_H
+
+#include <string>
+
+// VCT type index for "not scored against the matrix" -- hydrogen and anything
+// unrecognised.
+constexpr int FA_TYPE_DUMMY = 39;
+
+// SYBYL atom-type name -> canonical VCT row index.
+//
+// Several mappings are deliberately NOT the naive row for the type: O.ar, S.O2,
+// S.ar, Se and I are redirected to live rows because their own rows are
+// all-zero in MC_st0r5.2_6.dat, which made those chemistries invisible to the
+// scorer. Mol2Reader.cpp carries a second copy of this table that must agree --
+// see the parity test in tests/test_top_helpers.cpp.
+int sybyl_name_to_canonical_vct(const char* s);
+
+// RCSB PDB ID validation, applied to a user-supplied string before it is used
+// to build a download URL and a cache directory path. Alphanumeric-only is what
+// keeps path separators and traversal sequences out of both.
+bool is_valid_pdb_id(const std::string& id);
+
+// Classify a command-line argument as "receptor" / "ligand" / "config" /
+// "legacy" / "smiles" / "unknown". Touches the filesystem: a path that does not
+// exist may still be classified as a SMILES string, and .pdb is disambiguated
+// by counting ATOM vs HETATM records.
+std::string detect_file_role(const std::string& path);
+
+#endif

--- a/tests/test_top_helpers.cpp
+++ b/tests/test_top_helpers.cpp
@@ -1,0 +1,192 @@
+// tests/test_top_helpers.cpp
+// First tests for logic that lived in LIB/top.cpp.
+//
+// top.cpp defines main() and exports nothing else, so none of this was
+// reachable from a test target. The three functions under test moved to
+// LIB/top_helpers.cpp unchanged; these are their first tests in the history of
+// the file.
+//
+// Apache-2.0 © 2026 Le Bonhomme Pharma
+
+#include <gtest/gtest.h>
+
+#include "../LIB/top_helpers.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+// ── sybyl_name_to_canonical_vct ────────────────────────────────────────────
+//
+// The mappings that are NOT the naive row for the type are the ones worth
+// pinning. Each of these five redirects exists because the type's own row is
+// all-zero in MC_st0r5.2_6.dat, so the naive mapping scored that chemistry as
+// nothing at all against every partner. "Tidying" the table back to the
+// obvious row numbers is a silent scoring regression -- sulfones and
+// sulfonamides, among the most common motifs in drug-like ligands, go
+// invisible to the complementarity function with no test failing and no
+// crash. That is what this table exists to prevent.
+struct SybylCase { const char* name; int expected; const char* why; };
+
+TEST(SybylCanonicalVct, DeadRowSubstitutionsAreDeliberate) {
+    const SybylCase cases[] = {
+        {"O.ar",  14, "row 16 all-zero; ring O is ether-like -> O.3"},
+        {"S.O2",  19, "row 20 all-zero; sulfone/sulfonamide -> S.O"},
+        {"S.o2",  19, "lower-case spelling must map identically"},
+        {"S.ar",  18, "row 21 all-zero; thiophene S is a thioether -> S.3"},
+        {"Se",    18, "row 27 all-zero; Se arrives as selenomethionine -> S.3"},
+        {"I",     25, "type-26 row has 3 live entries -> Br"},
+        {"N.2",   10, "sp2 imine is an acceptor; N.am would reverse the H-bond sign"},
+        {"N.3",   11, "row 8 all-zero -> N.am"},
+        {"C.1",    2, "sp C rare in PDB sites; C.2 better sampled"},
+    };
+    for (const auto& c : cases) {
+        EXPECT_EQ(sybyl_name_to_canonical_vct(c.name), c.expected)
+            << c.name << ": " << c.why;
+    }
+}
+
+TEST(SybylCanonicalVct, StraightforwardTypesMapToTheirOwnRow) {
+    const SybylCase cases[] = {
+        {"C.2", 2, ""},   {"C.3", 3, ""},   {"C.ar", 4, ""},  {"C.cat", 5, ""},
+        {"N.1", 6, ""},   {"N.4", 9, ""},   {"N.ar", 10, ""}, {"N.am", 11, ""},
+        {"N.pl3", 12, ""},{"O.2", 13, ""},  {"O.3", 14, ""},  {"O.co2", 15, ""},
+        {"S.2", 17, ""},  {"S.3", 18, ""},  {"S.O", 19, ""},  {"P.3", 22, ""},
+        {"F", 23, ""},    {"Cl", 24, ""},   {"Br", 25, ""},
+        {"Mg", 28, ""},   {"Sr", 29, ""},   {"Cu", 30, ""},   {"Mn", 31, ""},
+        {"Hg", 32, ""},   {"Cd", 33, ""},   {"Ni", 34, ""},   {"Zn", 35, ""},
+        {"Ca", 36, ""},   {"Fe", 37, ""},   {"Co", 38, ""},   {"Co.oh", 38, ""},
+    };
+    for (const auto& c : cases) {
+        EXPECT_EQ(sybyl_name_to_canonical_vct(c.name), c.expected) << c.name;
+    }
+}
+
+TEST(SybylCanonicalVct, HydrogenAndUnknownAreDummy) {
+    EXPECT_EQ(sybyl_name_to_canonical_vct("H"), FA_TYPE_DUMMY);
+    EXPECT_EQ(sybyl_name_to_canonical_vct("X"), FA_TYPE_DUMMY);
+    EXPECT_EQ(sybyl_name_to_canonical_vct(""), FA_TYPE_DUMMY);
+    EXPECT_EQ(sybyl_name_to_canonical_vct("Du"), FA_TYPE_DUMMY);
+    // Case matters for everything except the sulfoxide/sulfone pair, which is
+    // explicitly spelled both ways. This pins that asymmetry rather than
+    // leaving a future reader to guess whether it was intended.
+    EXPECT_EQ(sybyl_name_to_canonical_vct("c.3"), FA_TYPE_DUMMY);
+    EXPECT_EQ(sybyl_name_to_canonical_vct("S.o"), 19);
+}
+
+// ── is_valid_pdb_id ────────────────────────────────────────────────────────
+//
+// This validator runs on a user-supplied string that is then interpolated into
+// an RCSB download URL and into a cache directory path. Alphanumeric-only is
+// what keeps separators and traversal sequences out of both, so the rejection
+// cases below are the load-bearing half of the test.
+TEST(IsValidPdbId, AcceptsClassicAndExtendedCodes) {
+    EXPECT_TRUE(is_valid_pdb_id("1P62"));
+    EXPECT_TRUE(is_valid_pdb_id("1t40"));
+    EXPECT_TRUE(is_valid_pdb_id("7XYZ9"));
+    EXPECT_TRUE(is_valid_pdb_id("PDB12345"));  // 8 chars, the upper bound
+}
+
+TEST(IsValidPdbId, RejectsOutOfRangeLengths) {
+    EXPECT_FALSE(is_valid_pdb_id(""));
+    EXPECT_FALSE(is_valid_pdb_id("1P6"));        // 3, below the bound
+    EXPECT_FALSE(is_valid_pdb_id("PDB123456"));  // 9, above the bound
+}
+
+TEST(IsValidPdbId, RejectsPathAndShellMetacharacters) {
+    // Each of these would otherwise reach a URL or a filesystem path.
+    const char* hostile[] = {
+        "../..", "1P62/..", "..%2f", "1P62;rm", "1P62 x", "1P62\n",
+        "$(id)", "`id`", "1P62|x", "1P62&x", "a/b/c", "a\\b",
+    };
+    for (const char* s : hostile) {
+        EXPECT_FALSE(is_valid_pdb_id(s)) << "accepted hostile input: " << s;
+    }
+}
+
+// ── detect_file_role ───────────────────────────────────────────────────────
+namespace {
+fs::path make_temp_dir() {
+    const auto dir = fs::temp_directory_path() / "flexaids_top_helpers";
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+    return dir;
+}
+
+void write_file(const fs::path& p, const std::string& body) {
+    std::ofstream o(p);
+    o << body;
+}
+}  // namespace
+
+TEST(DetectFileRole, ClassifiesByExtension) {
+    const auto dir = make_temp_dir();
+    struct { const char* name; const char* role; } cases[] = {
+        {"lig.mol2", "ligand"},  {"lig.sdf", "ligand"},   {"lig.mol", "ligand"},
+        {"lib.smi", "ligand"},   {"lib.smiles", "ligand"},
+        {"cfg.json", "config"},  {"rec.cif", "receptor"}, {"rec.mmcif", "receptor"},
+        {"old.inp", "legacy"},   {"old.dat", "legacy"},
+    };
+    for (const auto& c : cases) {
+        const auto p = dir / c.name;
+        write_file(p, "x\n");
+        EXPECT_EQ(detect_file_role(p.string()), c.role) << c.name;
+    }
+    fs::remove_all(dir);
+}
+
+// The .pdb branch is the only one that reads content rather than the name, and
+// the ATOM > 20 threshold is the whole of the receptor/ligand decision.
+TEST(DetectFileRole, PdbIsDisambiguatedByAtomRecordCount) {
+    const auto dir = make_temp_dir();
+
+    std::string receptor;
+    for (int i = 0; i < 25; ++i) receptor += "ATOM      1  CA  ALA A   1\n";
+    const auto rec = dir / "rec.pdb";
+    write_file(rec, receptor);
+    EXPECT_EQ(detect_file_role(rec.string()), "receptor");
+
+    std::string ligand;
+    for (int i = 0; i < 12; ++i) ligand += "HETATM    1  C1  LIG A 900\n";
+    const auto lig = dir / "lig.pdb";
+    write_file(lig, ligand);
+    EXPECT_EQ(detect_file_role(lig.string()), "ligand");
+
+    // Exactly at the boundary: 20 ATOM records is NOT > 20, so a file with
+    // only ATOM records and no HETATM falls through to the fallback branch.
+    std::string boundary;
+    for (int i = 0; i < 20; ++i) boundary += "ATOM      1  CA  ALA A   1\n";
+    const auto edge = dir / "edge.pdb";
+    write_file(edge, boundary);
+    EXPECT_EQ(detect_file_role(edge.string()), "receptor");
+
+    const auto empty = dir / "empty.pdb";
+    write_file(empty, "REMARK nothing here\n");
+    EXPECT_EQ(detect_file_role(empty.string()), "unknown");
+
+    fs::remove_all(dir);
+}
+
+TEST(DetectFileRole, DirectoryIsALigandLibrary) {
+    const auto dir = make_temp_dir();
+    const auto sub = dir / "ligands";
+    fs::create_directories(sub);
+    EXPECT_EQ(detect_file_role(sub.string()), "ligand");
+    fs::remove_all(dir);
+}
+
+// A nonexistent path may still be a SMILES string. The heuristic keys on
+// chemistry characters and the absence of path separators, so these two cases
+// bound it from both sides.
+TEST(DetectFileRole, NonexistentPathMayBeSmiles) {
+    EXPECT_EQ(detect_file_role("CC(=O)Oc1ccccc1C(=O)O"), "smiles");  // aspirin
+    EXPECT_EQ(detect_file_role("c1ccccc1"), "smiles");
+    EXPECT_EQ(detect_file_role(""), "unknown");
+    EXPECT_EQ(detect_file_role("/no/such/file.xyz"), "unknown");
+    // Contains a separator, so it is a path that does not exist -- not SMILES,
+    // even though it carries chemistry characters.
+    EXPECT_EQ(detect_file_role("dir/CC(=O)O"), "unknown");
+}


### PR DESCRIPTION
Seam A of `PLANS/TOP_CPP_TEST_DESIGN.md`, approved by Bonhomme. First tests for anything in `LIB/top.cpp`.

## Why nothing in top.cpp was testable

```
LIB/top.cpp        3,419 lines
  main()           2,879
  static helpers      15
  external symbols     1     <- main, and only main
```

Two independent blockers: a TU defining `main` cannot link into a gtest binary (`gtest_main` supplies its own, and every unit target uses `GTEST_MAIN_ONLY`), and all 15 helpers were `static`. Adding the file to a test target does not fail to run — it fails to link.

Three pure functions move to `LIB/top_helpers.cpp` **unchanged**. The only edits are dropping `static` and relocating `FA_TYPE_DUMMY` to the header.

## The mapping table is the reason this matters

`sybyl_name_to_canonical_vct` carries five mappings that are deliberately **not** the naive row for the type:

| type | maps to | why |
|---|---|---|
| `O.ar` | 14 (O.3) | row 16 all-zero — furan/oxazole O scored nothing |
| `S.O2` | 19 (S.O) | row 20 all-zero — **every sulfone and sulfonamide** invisible |
| `S.ar` | 18 (S.3) | row 21 all-zero — thiophene/thiazole S invisible |
| `Se` | 18 (S.3) | row 27 all-zero — selenomethionine invisible |
| `I` | 25 (Br) | type-26 row has 3 live entries |

Each corrects an all-zero row in `MC_st0r5.2_6.dat`. **"Tidying" the table back to the obvious row numbers is a silent scoring regression** — no crash, no failing test, just entire chemistries scoring zero against every partner. Sulfonamides are among the most common motifs in drug-like ligands. The golden table pins all five with the reason attached.

`top.cpp:105-109` states these must be mirrored in `Mol2Reader::sybyl_to_flexaid_type`, `SdfReader::element_to_flexaid_type` and `read_coor.cpp:canonical_vct_type_for_element`. I verified `Mol2Reader`'s copy agrees on every shared key; it also carries `O.spc`/`O.t3p` which top.cpp's lacks. **A four-way parity test is the natural follow-up and needs those copies exposed too** — out of scope here, flagged rather than done.

## The other two

`is_valid_pdb_id` guards a user-supplied string that reaches an RCSB download URL *and* a cache directory path. The rejection cases — separators, `../`, shell metacharacters — are the load-bearing half of that test.

`detect_file_role`'s `.pdb` branch decides receptor vs ligand by counting ATOM records, so the `ATOM > 20` boundary is covered explicitly, including the exact-20 case.

## Verification

```
cmake --build build -j 8     0 errors
ctest                        100% tests passed out of 85   (was 84)
./test_top_helpers           10 tests, all OK
leaks --atExit               0 leaks for 0 total leaked bytes
```

## What this does not prove

**Nothing about whether `main` calls these correctly, and nothing about the teardown.** `LIB/top.cpp` still executes under no instrument. Seam A moves logic somewhere testable; it does not test the call site. That sentence is retired by C2 alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved recognition of ligand, configuration, receptor, legacy, directory, SMILES, and PDB inputs.
  * Added more consistent validation for PDB identifiers.
  * Improved handling of supported, unknown, and fallback atom types.

* **Tests**
  * Added automated coverage for input classification, atom-type mapping, PDB identifier validation, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->