### PR TITLE
Test: C1 --help error-path leak probe for shipping FlexAID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2806,7 +2806,40 @@ flexaids_add_unit_test(test_protocol_config
     flexaids_configure_msvc_test(test_coarse_screen)
     add_test(NAME CoarseScreenTests COMMAND test_coarse_screen)
 
-    message(STATUS "Unit tests enabled — build targets: test_statmech, test_hardware_dispatch, test_tencom_diff, test_target_validation, test_grand_partition, test_target_server, test_ga_context, test_nascent_chain_scheduler, test_process_ligand, test_cmaes_search, test_coarse_screen")
+    # ─── C1: FlexAID --help error-path leak probe ─────────────────────────
+    # Shipping binary only. --help takes Terminate(0) and skips the entire
+    # teardown (throw from fileio.cpp, catch after free block in top.cpp).
+    # Process path is always checked. On Linux ASan builds the criterion is
+    # inverted: an LSan report is PASS (the finding). Does NOT cover teardown.
+    # See tests/cmake/c1_help_error_path_probe.cmake and board C1 design.
+    if(TARGET FlexAID)
+        string(CONCAT _c1_san_flags
+            "${CMAKE_CXX_FLAGS}" "${CMAKE_C_FLAGS}" "${CMAKE_EXE_LINKER_FLAGS}")
+        set(_c1_expect_leak OFF)
+        if(UNIX AND NOT APPLE AND _c1_san_flags MATCHES "fsanitize")
+            set(_c1_expect_leak ON)
+        endif()
+        add_test(
+            NAME FlexAID_C1_HelpErrorPathProbe
+            COMMAND ${CMAKE_COMMAND}
+                -DFlexAID_BINARY=$<TARGET_FILE:FlexAID>
+                -DEXPECT_LEAK=${_c1_expect_leak}
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/c1_help_error_path_probe.cmake
+        )
+        set_tests_properties(FlexAID_C1_HelpErrorPathProbe PROPERTIES
+            TIMEOUT 60
+            LABELS "c1;lsan_probe;top_cpp"
+        )
+        if(_c1_expect_leak)
+            set_property(TEST FlexAID_C1_HelpErrorPathProbe APPEND PROPERTY
+                ENVIRONMENT "ASAN_OPTIONS=detect_leaks=1:halt_on_error=0:strict_string_checks=1")
+            message(STATUS "C1 --help probe: Linux sanitizer build — inverted LSan criterion ON")
+        else()
+            message(STATUS "C1 --help probe: process path only (not Linux+fsanitize)")
+        endif()
+    endif()
+
+    message(STATUS "Unit tests enabled — build targets: test_statmech, test_hardware_dispatch, test_tencom_diff, test_target_validation, test_grand_partition, test_target_server, test_ga_context, test_nascent_chain_scheduler, test_process_ligand, test_cmaes_search, test_coarse_screen, FlexAID_C1_HelpErrorPathProbe")
 endif()
 
 # ─── Swift Bridge (macOS only) ────────────────────────────────────────────

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2854,7 +2854,10 @@ flexaids_add_unit_test(test_protocol_config
                 PASS_REGULAR_EXPRESSION "C1_RESULT=PASS ARM=lsan_inverted")
             message(STATUS
                 "C1 --help probe ARM=lsan_inverted "
-                "(Linux + -fsanitize=*address* — 3/6/9 LSan criterion ON)")
+                "(Linux + -fsanitize=*address* — an LSan report is required; "
+                "the direct/indirect split is asserted only when "
+                "C1_EXPECT_DIRECT/C1_EXPECT_INDIRECT are set, otherwise "
+                "measured and reported)")
         else()
             set_property(TEST FlexAID_C1_HelpErrorPathProbe APPEND PROPERTY
                 PASS_REGULAR_EXPRESSION "C1_RESULT=PASS ARM=process_path_only")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2809,16 +2809,24 @@ flexaids_add_unit_test(test_protocol_config
     # ─── C1: FlexAID --help error-path leak probe ─────────────────────────
     # Shipping binary only. --help takes Terminate(0) and skips the entire
     # teardown (throw from fileio.cpp, catch after free block in top.cpp).
-    # Process path is always checked. On Linux ASan builds the criterion is
-    # inverted: an LSan report is PASS (the finding). Structural prediction:
-    # 9 objects = 3 DIRECT (FA/GB/VC) + 6 INDIRECT (contacts + 5 VC arrays).
-    # Bytes are NOT asserted (macOS size classes ≠ glibc). Does NOT cover
-    # teardown — only C2 can. See tests/cmake/c1_help_error_path_probe.cmake.
+    # Process path is always checked. On Linux *Address*Sanitizer builds the
+    # criterion is inverted: an LSan report is PASS (the finding). Structural
+    # prediction: 9 objects = 3 DIRECT (FA/GB/VC) + 6 INDIRECT (contacts + 5
+    # VC arrays). Bytes are NOT asserted (macOS size classes ≠ glibc).
+    # Does NOT cover teardown — only C2 can.
+    # Gate MUST match the sanitizer, not the flag family: -fsanitize=thread
+    # contains "fsanitize" but ships no LSan; a bare "fsanitize" match arms
+    # EXPECT_LEAK under TSan and the inverted criterion fails a clean TSan
+    # run (Honey, 2026-07-31). Match address specifically so ASan+UBSan still
+    # arms and TSan demotes to process-path-only.
+    # See tests/cmake/c1_help_error_path_probe.cmake.
     if(TARGET FlexAID)
         string(CONCAT _c1_san_flags
             "${CMAKE_CXX_FLAGS}" "${CMAKE_C_FLAGS}" "${CMAKE_EXE_LINKER_FLAGS}")
         set(_c1_expect_leak OFF)
-        if(UNIX AND NOT APPLE AND _c1_san_flags MATCHES "fsanitize")
+        # Match -fsanitize=address and -fsanitize=undefined,address etc.
+        # Do NOT match -fsanitize=thread (TSan has no LSan).
+        if(UNIX AND NOT APPLE AND _c1_san_flags MATCHES "fsanitize=[a-z,]*address")
             set(_c1_expect_leak ON)
         endif()
         add_test(
@@ -2835,11 +2843,27 @@ flexaids_add_unit_test(test_protocol_config
         if(_c1_expect_leak)
             set_property(TEST FlexAID_C1_HelpErrorPathProbe APPEND PROPERTY
                 ENVIRONMENT "ASAN_OPTIONS=detect_leaks=1:halt_on_error=0:strict_string_checks=1")
-            message(STATUS "C1 --help probe: Linux sanitizer build — inverted LSan 3/6 criterion ON")
+            # PASS_REGULAR_EXPRESSION: green is not enough — output must prove
+            # which arm ran. If the gate silently demotes, this string is
+            # absent and ctest fails (Honey: check that disarms itself).
+            # Note: when PASS_REGULAR_EXPRESSION is set, CMake ignores the
+            # process exit code; FAIL lines must not match the PASS pattern
+            # (they use C1_RESULT=FAIL).
+            set_property(TEST FlexAID_C1_HelpErrorPathProbe APPEND PROPERTY
+                PASS_REGULAR_EXPRESSION "C1_RESULT=PASS ARM=lsan_inverted")
+            message(STATUS
+                "C1 --help probe ARM=lsan_inverted "
+                "(Linux + -fsanitize=*address* — 3/6/9 LSan criterion ON)")
         else()
-            message(STATUS "C1 --help probe: process path only (not Linux+fsanitize)")
+            set_property(TEST FlexAID_C1_HelpErrorPathProbe APPEND PROPERTY
+                PASS_REGULAR_EXPRESSION "C1_RESULT=PASS ARM=process_path_only")
+            message(STATUS
+                "C1 --help probe ARM=process_path_only "
+                "(not Linux+address; TSan/macOS/Release demote here — "
+                "ctest green on this arm does NOT mean LSan ran)")
         endif()
     endif()
+
 
     message(STATUS "Unit tests enabled — build targets: test_statmech, test_hardware_dispatch, test_tencom_diff, test_target_validation, test_grand_partition, test_target_server, test_ga_context, test_nascent_chain_scheduler, test_process_ligand, test_cmaes_search, test_coarse_screen, FlexAID_C1_HelpErrorPathProbe")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2810,8 +2810,10 @@ flexaids_add_unit_test(test_protocol_config
     # Shipping binary only. --help takes Terminate(0) and skips the entire
     # teardown (throw from fileio.cpp, catch after free block in top.cpp).
     # Process path is always checked. On Linux ASan builds the criterion is
-    # inverted: an LSan report is PASS (the finding). Does NOT cover teardown.
-    # See tests/cmake/c1_help_error_path_probe.cmake and board C1 design.
+    # inverted: an LSan report is PASS (the finding). Structural prediction:
+    # 9 objects = 3 DIRECT (FA/GB/VC) + 6 INDIRECT (contacts + 5 VC arrays).
+    # Bytes are NOT asserted (macOS size classes ≠ glibc). Does NOT cover
+    # teardown — only C2 can. See tests/cmake/c1_help_error_path_probe.cmake.
     if(TARGET FlexAID)
         string(CONCAT _c1_san_flags
             "${CMAKE_CXX_FLAGS}" "${CMAKE_C_FLAGS}" "${CMAKE_EXE_LINKER_FLAGS}")
@@ -2833,7 +2835,7 @@ flexaids_add_unit_test(test_protocol_config
         if(_c1_expect_leak)
             set_property(TEST FlexAID_C1_HelpErrorPathProbe APPEND PROPERTY
                 ENVIRONMENT "ASAN_OPTIONS=detect_leaks=1:halt_on_error=0:strict_string_checks=1")
-            message(STATUS "C1 --help probe: Linux sanitizer build — inverted LSan criterion ON")
+            message(STATUS "C1 --help probe: Linux sanitizer build — inverted LSan 3/6 criterion ON")
         else()
             message(STATUS "C1 --help probe: process path only (not Linux+fsanitize)")
         endif()

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -787,10 +787,13 @@ int main(int argc, char **argv){
 #ifndef _WIN32
 	{
 		// Resolve argv[0] with a glibc-allocated buffer (second arg NULL) rather
-		// than a fixed MAX_PATH__ stack buffer: a resolved path can be up to
-		// PATH_MAX (4096) bytes, and _FORTIFY_SOURCE aborts realpath() into an
-		// undersized buffer ("buffer overflow detected") whenever the deploy
-		// path exceeds MAX_PATH__ — e.g. CI runner paths. Falls back to argv[0].
+		// than a fixed MAX_PATH__ stack buffer. _FORTIFY_SOURCE rejects any
+		// realpath() destination smaller than PATH_MAX (4096): __realpath_chk
+		// calls __chk_fail() when resolvedlen < PATH_MAX, before resolving —
+		// so a MAX_PATH__ (255) buffer aborts ("buffer overflow detected")
+		// UNCONDITIONALLY on fortified glibc builds, every invocation, any
+		// path length. Passing NULL makes glibc size the buffer itself.
+		// Do not reintroduce a fixed-size destination here. Falls back to argv[0].
 		char* rp = realpath(argv[0], NULL);
 		const char* src = (rp != NULL) ? rp : argv[0];
 		// strrchr(const char*) returns const char* — keep a local const pointer

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -786,12 +786,13 @@ int main(int argc, char **argv){
 	// to Cellar/.../bin (where runtime data is installed), not /opt/homebrew/bin.
 #ifndef _WIN32
 	{
-		char resolved[MAX_PATH__];
-		const char* src = argv[0];
-		char* rp = realpath(src, resolved);
-		if (rp != NULL) {
-			src = resolved;
-		}
+		// Resolve argv[0] with a glibc-allocated buffer (second arg NULL) rather
+		// than a fixed MAX_PATH__ stack buffer: a resolved path can be up to
+		// PATH_MAX (4096) bytes, and _FORTIFY_SOURCE aborts realpath() into an
+		// undersized buffer ("buffer overflow detected") whenever the deploy
+		// path exceeds MAX_PATH__ — e.g. CI runner paths. Falls back to argv[0].
+		char* rp = realpath(argv[0], NULL);
+		const char* src = (rp != NULL) ? rp : argv[0];
 		// strrchr(const char*) returns const char* — keep a local const pointer
 		// instead of assigning into the legacy char* pch variable.
 		const char* slash = strrchr(src, '/');
@@ -804,6 +805,7 @@ int main(int argc, char **argv){
 			strncpy(FA->base_path, ".", MAX_PATH__ - 1);
 			FA->base_path[MAX_PATH__ - 1] = '\0';
 		}
+		free(rp);  // free(NULL) is a no-op
 	}
 #else
 	pch = strrchr(argv[0], '\\');

--- a/tests/cmake/c1_help_error_path_probe.cmake
+++ b/tests/cmake/c1_help_error_path_probe.cmake
@@ -224,9 +224,20 @@ else()
   # finding this probe exists to pin. The split is recorded, not judged.
   set(_split_ok TRUE)
   set(_total_ok TRUE)
-  message(STATUS
-    "C1_MEASURED direct=${_n_direct} indirect=${_n_indirect} total=${_n_sum} "
-    "summary_allocs=${_summary_n}")
+  set(_measured
+    "C1_MEASURED direct=${_n_direct} indirect=${_n_indirect} total=${_n_sum} summary_allocs=${_summary_n}")
+  message(STATUS "${_measured}")
+  # ctest swallows message(STATUS) on a PASSING test, so the measurement this
+  # arm exists to produce was invisible in CI: the probe measured the number
+  # and then discarded it. Persist it where a human can actually read it —
+  # a file beside the captured output, and the GitHub step summary when we are
+  # running under Actions. A measurement nobody can read is ceremony, which is
+  # the same criticism that got the 3/6/9 assertion removed.
+  file(WRITE "${_out_dir}/c1_measured.txt" "${_measured}\n")
+  if(DEFINED ENV{GITHUB_STEP_SUMMARY})
+    file(APPEND "$ENV{GITHUB_STEP_SUMMARY}"
+      "### C1 --help LSan probe\n\n```\n${_measured}\n```\n")
+  endif()
   message(STATUS
     "C1 probe: no expected split configured — reporting measured counts "
     "instead of asserting an unmeasured prediction. Bumble predicted 3/6/9 "

--- a/tests/cmake/c1_help_error_path_probe.cmake
+++ b/tests/cmake/c1_help_error_path_probe.cmake
@@ -86,19 +86,29 @@ if(NOT _out_txt MATCHES "Usage:" AND NOT _out_txt MATCHES "--help")
 endif()
 
 if(NOT EXPECT_LEAK)
-  # Non-instrumented / non-Linux: process path only — must be clean exit 0.
+  # Non-instrumented / non-Linux / TSan: process path only — must be clean exit 0.
+  # Machine line C1_RESULT=… is what PASS_REGULAR_EXPRESSION keys on so a
+  # silent demotion cannot share the green signature of the LSan arm
+  # (Honey: "the check that disarms itself").
   if(NOT _rc EQUAL 0)
     message(FATAL_ERROR
+      "C1_RESULT=FAIL ARM=process_path_only\n"
       "C1 probe: --help expected exit 0, got ${_rc}\n"
       "stdout:\n${_out_txt}\nstderr:\n${_err_txt}")
   endif()
-  message(STATUS "C1 probe: process path OK (exit 0, usage present); leak assertion not required on this config")
+  # Single-line machine receipt first (ctest PASS_REGULAR_EXPRESSION).
+  message(STATUS "C1_RESULT=PASS ARM=process_path_only")
+  message(STATUS
+    "C1 probe ARM=process_path_only: PASS (exit 0, usage present). "
+    "LSan inverted arm NOT armed on this config — do not read this green "
+    "as 'leaks measured' (TSan / macOS / non-ASan demote here).")
   return()
 endif()
 
 # ─── Inverted LSan arm ─────────────────────────────────────────────────────
 # Leak report is the expected finding today. LSan typically exits non-zero when
 # it reports; that is still a probe PASS if the structure matches prediction.
+message(STATUS "C1 probe ARM=lsan_inverted: requiring LeakSanitizer 3 direct / 6 indirect / 9 total")
 
 set(_saw_leak FALSE)
 if(_err_txt MATCHES "LeakSanitizer" OR _err_txt MATCHES "detected memory leaks")
@@ -106,42 +116,93 @@ if(_err_txt MATCHES "LeakSanitizer" OR _err_txt MATCHES "detected memory leaks")
 endif()
 
 if(NOT _saw_leak)
+  # Two clean causes (Bumble, 2026-07-31) — not equally informative:
+  #   (1) teardown actually ran / prologue freed  -> falsifies unwind read
+  #   (2) stale-root false negative (conservative stack scan keeps FA/GB/VC
+  #       "still reachable") -> instrument artefact, not ownership model
+  # Only total-9 with wrong split falsifies Bumble's ownership graph.
+  # Read the log: nine "still reachable" = stale-root signature; nine absent
+  # entirely is not. Do not collapse those into one narrative.
   message(FATAL_ERROR
-    "C1 probe UNEXPECTED: Linux ASan+LSan run of --help reported no leaks.\n"
-    "Either the Terminate-unwind source model is wrong, prologue allocs are freed "
-    "before throw, or LSan did not run. Investigate before claiming C1 green "
-    "as anything other than this surprising clean result.\n"
+    "C1_RESULT=FAIL ARM=lsan_inverted\n"
+    "C1 probe: Linux ASan+LSan --help reported no definitely-lost leaks.\n"
+    "Disambiguate before blaming the ownership model:\n"
+    "  - still-reachable count ~9 under LSAN_OPTIONS=report_objects=1 "
+    "    -> stale-root false negative (measurability, not wrong model)\n"
+    "  - nothing still-reachable and no leaks "
+    "    -> Terminate-unwind / free-before-throw / LSan-not-running "
+    "    (interesting finding about top.cpp)\n"
+    "  - total 9 with split != 3/6 "
+    "    -> ownership graph wrong (Bumble's read fails)\n"
     "exit=${_rc}\nstderr:\n${_err_txt}")
 endif()
 
-# Count Direct / Indirect report headers (one per leaked object at distinct sites).
-# macOS leaks reports a single total of 9; LSan splits reachability — the board
-# prediction is 3 direct roots (FA/GB/VC) + 6 indirect (contacts + 5 VC arrays).
-string(REGEX MATCHALL "Direct leak of" _direct_hits "${_err_txt}")
-string(REGEX MATCHALL "Indirect leak of" _indirect_hits "${_err_txt}")
-list(LENGTH _direct_hits _n_direct)
-list(LENGTH _indirect_hits _n_indirect)
+# Sum object counts from Direct/Indirect lines — not header counts alone.
+# Real LSan (board samples): "Direct leak of N byte(s) in M object(s)"
+# Coalesced stacks produce one header with M>1; counting headers only would
+# report 1/1 on a correct 3/6 ownership graph and fail a healthy binary.
+# That is the inverted vacuous shape Bumble/Honey called out for "expected 9"
+# against the Direct block alone.
+#
+# Prediction (Bumble, source + LSan reachability — unmeasured until Linux CI):
+#   3 direct roots (FA/GB/VC) + 6 indirect (contacts + 5 VC arrays) = 9.
+set(_n_direct 0)
+string(REGEX MATCHALL
+  "Direct leak of [0-9]+ byte\\(s\\) in [0-9]+ object\\(s\\)?"
+  _direct_lines "${_err_txt}")
+foreach(_line IN LISTS _direct_lines)
+  if(_line MATCHES "in ([0-9]+) object")
+    math(EXPR _n_direct "${_n_direct} + ${CMAKE_MATCH_1}")
+  endif()
+endforeach()
+
+set(_n_indirect 0)
+string(REGEX MATCHALL
+  "Indirect leak of [0-9]+ byte\\(s\\) in [0-9]+ object\\(s\\)?"
+  _indirect_lines "${_err_txt}")
+foreach(_line IN LISTS _indirect_lines)
+  if(_line MATCHES "in ([0-9]+) object")
+    math(EXPR _n_indirect "${_n_indirect} + ${CMAKE_MATCH_1}")
+  endif()
+endforeach()
+
 math(EXPR _n_sum "${_n_direct} + ${_n_indirect}")
 
-# Prefer SUMMARY allocation count when present (allocator-independent object total).
+# SUMMARY allocation count when present (must reconcile with Direct+Indirect).
 set(_summary_n "")
 if(_err_txt MATCHES "leaked in ([0-9]+) allocation")
   set(_summary_n "${CMAKE_MATCH_1}")
 endif()
 
-set(_total_ok FALSE)
-if(_summary_n STREQUAL "9")
-  set(_total_ok TRUE)
-elseif(_n_sum EQUAL 9)
-  set(_total_ok TRUE)
-endif()
-
+# Require a parsed split. SUMMARY-only is not enough — it can pass for the
+# wrong ownership graph (9/0, 4/5) and fails the handoff Honey just fixed.
 set(_split_ok FALSE)
 if(_n_direct EQUAL 3 AND _n_indirect EQUAL 6)
   set(_split_ok TRUE)
 endif()
 
-if(_total_ok AND _split_ok)
+set(_total_ok FALSE)
+if(_n_sum EQUAL 9)
+  set(_total_ok TRUE)
+endif()
+if(NOT _summary_n STREQUAL "" AND _summary_n STREQUAL "9")
+  set(_total_ok TRUE)
+endif()
+
+if(_split_ok AND _total_ok)
+  # Cross-check SUMMARY against the split when both are present.
+  if(NOT _summary_n STREQUAL "" AND NOT _summary_n STREQUAL "${_n_sum}")
+    message(FATAL_ERROR
+      "C1_RESULT=FAIL ARM=lsan_inverted\n"
+      "C1 probe: SUMMARY allocation count (${_summary_n}) != "
+      "Direct+Indirect (${_n_sum}=${_n_direct}+${_n_indirect}).\n"
+      "Parser or LSan format disagreement — fix before trusting either number.\n"
+      "exit=${_rc}\nstderr:\n${_err_txt}")
+  endif()
+  # Machine receipt first — ctest PASS_REGULAR_EXPRESSION requires this line.
+  message(STATUS
+    "C1_RESULT=PASS ARM=lsan_inverted direct=${_n_direct} indirect=${_n_indirect} "
+    "summary_allocs=${_summary_n}")
   message(STATUS
     "C1 probe FINDING (expected under current source model): "
     "--help under LSan: ${_n_direct} direct / ${_n_indirect} indirect "
@@ -154,18 +215,34 @@ endif()
 # Total 9 but wrong split: ownership graph is not what the source says.
 if(_total_ok AND NOT _split_ok)
   message(FATAL_ERROR
+    "C1_RESULT=FAIL ARM=lsan_inverted\n"
     "C1 probe: LSan object total is 9 but Direct/Indirect split is "
     "${_n_direct}/${_n_indirect} (expected 3/6).\n"
     "Reachability/ownership graph differs from FA/GB/VC roots + 6 children. "
-    "Do not silence this — it is a real finding about the source model.\n"
+    "Do not silence this — it is a real finding about the source model "
+    "(9/0 or 4/5 falsifies who owns what).\n"
     "summary_allocs=${_summary_n} exit=${_rc}\nstderr:\n${_err_txt}")
 endif()
 
-# Anything else: wrong total or unparseable.
+# Unparseable split (0/0) with only SUMMARY: refuse — that hands off a test
+# that cannot distinguish Direct-only from Direct+Indirect.
+if(_n_direct EQUAL 0 AND _n_indirect EQUAL 0)
+  message(FATAL_ERROR
+    "C1_RESULT=FAIL ARM=lsan_inverted\n"
+    "C1 probe: LSan reported leaks but Direct/Indirect object counts could "
+    "not be parsed (summary_allocs=${_summary_n}).\n"
+    "Refusing SUMMARY-only pass — that is the shape that fails on correct "
+    "behaviour if the assertion ever reads the Direct line alone.\n"
+    "Fix the parser against real LSan output; do not drop the 3/6 assertion.\n"
+    "exit=${_rc}\nstderr:\n${_err_txt}")
+endif()
+
+# Anything else: wrong total or wrong split.
 message(FATAL_ERROR
+  "C1_RESULT=FAIL ARM=lsan_inverted\n"
   "C1 probe: LSan reported leaks but not the predicted 9 objects (3 direct / 6 indirect).\n"
   "parsed: direct=${_n_direct} indirect=${_n_indirect} sum=${_n_sum} "
   "summary_allocs=${_summary_n} (expected total 9, split 3/6).\n"
-  "If summary is empty, LSan output format may have changed — fix the parser, "
-  "do not drop the structural assertion.\n"
+  "Frozen in PLANS/C2_ACCEPTANCE_CRITERION.md: MUST report LSan block; "
+  "MUST sum Direct+Indirect to 9; MUST split 3/6; bytes DO NOT compare.\n"
   "exit=${_rc}\nstderr:\n${_err_txt}")

--- a/tests/cmake/c1_help_error_path_probe.cmake
+++ b/tests/cmake/c1_help_error_path_probe.cmake
@@ -6,16 +6,28 @@
 #   Under Linux ASan+LSan that should report the prologue allocations.
 #
 # Criterion is INVERTED from a normal leak test:
-#   - process path always checked (--help -> exit 0, usage text)
+#   - process path always checked (--help -> usage text; exit 0 when not LSan-aborting)
 #   - when EXPECT_LEAK=1 (Linux instrumented builds only): a LeakSanitizer
 #     report is a PASS (the finding). Clean under LSan is FAIL — source model
 #     wrong, or someone fixed error-path free without updating this probe.
 #
+# Structural LSan prediction (Bumble, source + reachability — unmeasured until
+# Linux CI runs this):
+#   Direct:   FA, GB, VC                          (3 roots in main)
+#   Indirect: FA->contacts + 5 VC-> arrays        (6, reachable from roots)
+#   Total:    9 objects  (Direct + Indirect)
+#   Bytes:    DO NOT assert — macOS size classes ≠ glibc; 1,274,880 is mac-only.
+#
+# A clean LSan run, a total other than 9, or a split other than 3/6 is a finding
+# about the source model / ownership graph, not a silent pass.
+#
 # FORBIDDEN claim: "this test covers top.cpp teardown." It never reaches it.
+# Floor-not-ceiling: these nine are the early-exit floor; late Terminate mid-dock
+# is unmeasured and is C2's problem (or a future late-error probe).
 #
 # Inputs ( -D from add_test ):
 #   FlexAID_BINARY  absolute path to FlexAID
-#   EXPECT_LEAK     ON/OFF — require LSan report
+#   EXPECT_LEAK     ON/OFF — require LSan report with 3/6/9 structure
 
 if(NOT DEFINED FlexAID_BINARY)
   message(FATAL_ERROR "c1_help_error_path_probe: FlexAID_BINARY not set")
@@ -84,24 +96,76 @@ if(NOT EXPECT_LEAK)
   return()
 endif()
 
-# Inverted LSan arm — leak report is the expected finding today.
-# LSan typically exits non-zero when it reports; that is still a probe PASS.
+# ─── Inverted LSan arm ─────────────────────────────────────────────────────
+# Leak report is the expected finding today. LSan typically exits non-zero when
+# it reports; that is still a probe PASS if the structure matches prediction.
+
 set(_saw_leak FALSE)
-if(_err_txt MATCHES "LeakSanitizer" OR _err_txt MATCHES "detected memory leaks" OR _err_txt MATCHES "Direct leak")
+if(_err_txt MATCHES "LeakSanitizer" OR _err_txt MATCHES "detected memory leaks")
   set(_saw_leak TRUE)
 endif()
 
-if(_saw_leak)
+if(NOT _saw_leak)
+  message(FATAL_ERROR
+    "C1 probe UNEXPECTED: Linux ASan+LSan run of --help reported no leaks.\n"
+    "Either the Terminate-unwind source model is wrong, prologue allocs are freed "
+    "before throw, or LSan did not run. Investigate before claiming C1 green "
+    "as anything other than this surprising clean result.\n"
+    "exit=${_rc}\nstderr:\n${_err_txt}")
+endif()
+
+# Count Direct / Indirect report headers (one per leaked object at distinct sites).
+# macOS leaks reports a single total of 9; LSan splits reachability — the board
+# prediction is 3 direct roots (FA/GB/VC) + 6 indirect (contacts + 5 VC arrays).
+string(REGEX MATCHALL "Direct leak of" _direct_hits "${_err_txt}")
+string(REGEX MATCHALL "Indirect leak of" _indirect_hits "${_err_txt}")
+list(LENGTH _direct_hits _n_direct)
+list(LENGTH _indirect_hits _n_indirect)
+math(EXPR _n_sum "${_n_direct} + ${_n_indirect}")
+
+# Prefer SUMMARY allocation count when present (allocator-independent object total).
+set(_summary_n "")
+if(_err_txt MATCHES "leaked in ([0-9]+) allocation")
+  set(_summary_n "${CMAKE_MATCH_1}")
+endif()
+
+set(_total_ok FALSE)
+if(_summary_n STREQUAL "9")
+  set(_total_ok TRUE)
+elseif(_n_sum EQUAL 9)
+  set(_total_ok TRUE)
+endif()
+
+set(_split_ok FALSE)
+if(_n_direct EQUAL 3 AND _n_indirect EQUAL 6)
+  set(_split_ok TRUE)
+endif()
+
+if(_total_ok AND _split_ok)
   message(STATUS
     "C1 probe FINDING (expected under current source model): "
-    "--help path reports leaks under LSan (teardown skipped via Terminate). "
-    "exit=${_rc}. This is NOT production-teardown coverage.")
+    "--help under LSan: ${_n_direct} direct / ${_n_indirect} indirect "
+    "(summary_allocs=${_summary_n}, exit=${_rc}). "
+    "Teardown skipped via Terminate. NOT production-teardown coverage. "
+    "Bytes intentionally not asserted (cross-allocator).")
   return()
 endif()
 
+# Total 9 but wrong split: ownership graph is not what the source says.
+if(_total_ok AND NOT _split_ok)
+  message(FATAL_ERROR
+    "C1 probe: LSan object total is 9 but Direct/Indirect split is "
+    "${_n_direct}/${_n_indirect} (expected 3/6).\n"
+    "Reachability/ownership graph differs from FA/GB/VC roots + 6 children. "
+    "Do not silence this — it is a real finding about the source model.\n"
+    "summary_allocs=${_summary_n} exit=${_rc}\nstderr:\n${_err_txt}")
+endif()
+
+# Anything else: wrong total or unparseable.
 message(FATAL_ERROR
-  "C1 probe UNEXPECTED: Linux ASan+LSan run of --help reported no leaks.\n"
-  "Either the Terminate-unwind source model is wrong, prologue allocs are freed "
-  "before throw, or LSan did not run. Investigate before claiming C1 green "
-  "as anything other than this surprising clean result.\n"
+  "C1 probe: LSan reported leaks but not the predicted 9 objects (3 direct / 6 indirect).\n"
+  "parsed: direct=${_n_direct} indirect=${_n_indirect} sum=${_n_sum} "
+  "summary_allocs=${_summary_n} (expected total 9, split 3/6).\n"
+  "If summary is empty, LSan output format may have changed — fix the parser, "
+  "do not drop the structural assertion.\n"
   "exit=${_rc}\nstderr:\n${_err_txt}")

--- a/tests/cmake/c1_help_error_path_probe.cmake
+++ b/tests/cmake/c1_help_error_path_probe.cmake
@@ -5,21 +5,31 @@
 #   (LIB/top.cpp). --help takes Terminate(0) and exits 0 having freed nothing.
 #   Under Linux ASan+LSan that should report the prologue allocations.
 #
+#   This model was UNTESTABLE before #323: the shipping binary aborted in
+#   __realpath_chk at LIB/top.cpp:786 on every fortified-glibc invocation,
+#   before print_usage. Re-derived on top of that fix rather than rebased,
+#   because the original probe asserted a shape nothing had ever reached.
+#
 # Criterion is INVERTED from a normal leak test:
 #   - process path always checked (--help -> usage text; exit 0 when not LSan-aborting)
 #   - when EXPECT_LEAK=1 (Linux instrumented builds only): a LeakSanitizer
 #     report is a PASS (the finding). Clean under LSan is FAIL — source model
 #     wrong, or someone fixed error-path free without updating this probe.
 #
-# Structural LSan prediction (Bumble, source + reachability — unmeasured until
-# Linux CI runs this):
+# Structural LSan prediction (Bumble, from reading ownership in source):
 #   Direct:   FA, GB, VC                          (3 roots in main)
 #   Indirect: FA->contacts + 5 VC-> arrays        (6, reachable from roots)
 #   Total:    9 objects  (Direct + Indirect)
-#   Bytes:    DO NOT assert — macOS size classes ≠ glibc; 1,274,880 is mac-only.
+#   Bytes:    DO NOT assert — macOS size classes != glibc; 1,274,880 is mac-only.
 #
-# A clean LSan run, a total other than 9, or a split other than 3/6 is a finding
-# about the source model / ownership graph, not a silent pass.
+# THAT PREDICTION IS UNMEASURED and this probe no longer asserts it. Until
+# #323 landed, --help aborted in the glibc _FORTIFY_SOURCE realpath wrapper
+# before reaching print_usage, so the Terminate-unwind path this probe models
+# never executed and no LSan number was ever produced. See C1_EXPECT_DIRECT /
+# C1_EXPECT_INDIRECT below: empty means measure and report, set means assert.
+#
+# A clean LSan run is still a hard failure — that falsifies the unwind model.
+# Only the specific arithmetic waits for evidence.
 #
 # FORBIDDEN claim: "this test covers top.cpp teardown." It never reaches it.
 # Floor-not-ceiling: these nine are the early-exit floor; late Terminate mid-dock
@@ -27,7 +37,8 @@
 #
 # Inputs ( -D from add_test ):
 #   FlexAID_BINARY  absolute path to FlexAID
-#   EXPECT_LEAK     ON/OFF — require LSan report with 3/6/9 structure
+#   EXPECT_LEAK     ON/OFF — require an LSan report (split asserted only when
+#                   C1_EXPECT_DIRECT / C1_EXPECT_INDIRECT are both set)
 
 if(NOT DEFINED FlexAID_BINARY)
   message(FATAL_ERROR "c1_help_error_path_probe: FlexAID_BINARY not set")
@@ -108,7 +119,7 @@ endif()
 # ─── Inverted LSan arm ─────────────────────────────────────────────────────
 # Leak report is the expected finding today. LSan typically exits non-zero when
 # it reports; that is still a probe PASS if the structure matches prediction.
-message(STATUS "C1 probe ARM=lsan_inverted: requiring LeakSanitizer 3 direct / 6 indirect / 9 total")
+message(STATUS "C1 probe ARM=lsan_inverted: requiring a LeakSanitizer report; split asserted only if C1_EXPECT_DIRECT/INDIRECT are set")
 
 set(_saw_leak FALSE)
 if(_err_txt MATCHES "LeakSanitizer" OR _err_txt MATCHES "detected memory leaks")
@@ -132,8 +143,8 @@ if(NOT _saw_leak)
     "  - nothing still-reachable and no leaks "
     "    -> Terminate-unwind / free-before-throw / LSan-not-running "
     "    (interesting finding about top.cpp)\n"
-    "  - total 9 with split != 3/6 "
-    "    -> ownership graph wrong (Bumble's read fails)\n"
+    "  - leaks present but split != configured expectation "
+    "    -> ownership graph differs from the pinned numbers\n"
     "exit=${_rc}\nstderr:\n${_err_txt}")
 endif()
 
@@ -174,19 +185,52 @@ if(_err_txt MATCHES "leaked in ([0-9]+) allocation")
   set(_summary_n "${CMAKE_MATCH_1}")
 endif()
 
-# Require a parsed split. SUMMARY-only is not enough — it can pass for the
-# wrong ownership graph (9/0, 4/5) and fails the handoff Honey just fixed.
-set(_split_ok FALSE)
-if(_n_direct EQUAL 3 AND _n_indirect EQUAL 6)
-  set(_split_ok TRUE)
+# ── Expected split: configured, not hardcoded ──────────────────────────────
+#
+# 3/6/9 was MY PREDICTION (Bumble), derived from reading ownership in source.
+# It has never been measured. Asserting it turns an unverified guess into a
+# gate: the first honest LSan run that disagrees fails the build and reads as
+# "ownership graph wrong" when the likelier answer is "the prediction was".
+# That is a claim wearing a test's clothing, and this thread has already
+# corrected four of those.
+#
+# So the number is now a *setting*, empty by default. Empty means measure and
+# report; set means assert. Everything structural still fails hard — no leaks
+# at all, unparseable counts, SUMMARY disagreeing with the split. Only the
+# specific arithmetic is withheld until a real run supplies it.
+#
+# To pin it: read C1_MEASURED from a green Linux ASan run, set the two values
+# below, and cite the run in the commit. Do not fill them in from this comment.
+set(C1_EXPECT_DIRECT   "" CACHE STRING "Expected LSan direct object count (empty = measure only)")
+set(C1_EXPECT_INDIRECT "" CACHE STRING "Expected LSan indirect object count (empty = measure only)")
+
+set(_assert_split FALSE)
+if(NOT C1_EXPECT_DIRECT STREQUAL "" AND NOT C1_EXPECT_INDIRECT STREQUAL "")
+  set(_assert_split TRUE)
 endif()
 
+set(_split_ok FALSE)
 set(_total_ok FALSE)
-if(_n_sum EQUAL 9)
+if(_assert_split)
+  if(_n_direct EQUAL ${C1_EXPECT_DIRECT} AND _n_indirect EQUAL ${C1_EXPECT_INDIRECT})
+    set(_split_ok TRUE)
+  endif()
+  math(EXPR _expect_sum "${C1_EXPECT_DIRECT} + ${C1_EXPECT_INDIRECT}")
+  if(_n_sum EQUAL ${_expect_sum})
+    set(_total_ok TRUE)
+  endif()
+else()
+  # Measurement mode. A leak was reported and the counts parsed — that is the
+  # finding this probe exists to pin. The split is recorded, not judged.
+  set(_split_ok TRUE)
   set(_total_ok TRUE)
-endif()
-if(NOT _summary_n STREQUAL "" AND _summary_n STREQUAL "9")
-  set(_total_ok TRUE)
+  message(STATUS
+    "C1_MEASURED direct=${_n_direct} indirect=${_n_indirect} total=${_n_sum} "
+    "summary_allocs=${_summary_n}")
+  message(STATUS
+    "C1 probe: no expected split configured — reporting measured counts "
+    "instead of asserting an unmeasured prediction. Bumble predicted 3/6/9 "
+    "from source; compare against the line above before pinning it.")
 endif()
 
 # Unparseable first — even when SUMMARY says 9. Must not land in wrong-split
@@ -226,25 +270,29 @@ if(_split_ok AND _total_ok)
   return()
 endif()
 
-# Total 9 but wrong split: ownership graph is not what the source says.
-# Only this arm falsifies Bumble's FA/GB/VC root model (9/0 or 4/5).
+# Right total, wrong split: reachability/ownership differs from the pinned
+# expectation. Only reachable when a split has been configured.
 if(_total_ok AND NOT _split_ok)
   message(FATAL_ERROR
     "C1_RESULT=FAIL ARM=lsan_inverted\n"
-    "C1 probe: LSan object total is 9 but Direct/Indirect split is "
-    "${_n_direct}/${_n_indirect} (expected 3/6).\n"
+    "C1 probe: LSan object total matches but Direct/Indirect split is "
+    "${_n_direct}/${_n_indirect} (expected "
+    "${C1_EXPECT_DIRECT}/${C1_EXPECT_INDIRECT}).\n"
     "Reachability/ownership graph differs from FA/GB/VC roots + 6 children. "
     "Do not silence this — it is a real finding about the source model "
     "(9/0 or 4/5 falsifies who owns what).\n"
     "summary_allocs=${_summary_n} exit=${_rc}\nstderr:\n${_err_txt}")
 endif()
 
-# Anything else: wrong total or wrong split.
+# Anything else: wrong total or wrong split against a CONFIGURED expectation.
+# Unreachable in measurement mode — there, both flags are set true above.
 message(FATAL_ERROR
   "C1_RESULT=FAIL ARM=lsan_inverted\n"
-  "C1 probe: LSan reported leaks but not the predicted 9 objects (3 direct / 6 indirect).\n"
-  "parsed: direct=${_n_direct} indirect=${_n_indirect} sum=${_n_sum} "
-  "summary_allocs=${_summary_n} (expected total 9, split 3/6).\n"
-  "Frozen in PLANS/C2_ACCEPTANCE_CRITERION.md: MUST report LSan block; "
-  "MUST sum Direct+Indirect to 9; MUST split 3/6; bytes DO NOT compare.\n"
+  "C1 probe: LSan reported leaks but not the configured object counts.\n"
+  "parsed:   direct=${_n_direct} indirect=${_n_indirect} sum=${_n_sum} "
+  "summary_allocs=${_summary_n}\n"
+  "expected: direct=${C1_EXPECT_DIRECT} indirect=${C1_EXPECT_INDIRECT}\n"
+  "Before treating this as an ownership finding, check whether the expected "
+  "values were ever measured or merely predicted. If predicted, the "
+  "measurement is the evidence and the expectation is the guess.\n"
   "exit=${_rc}\nstderr:\n${_err_txt}")

--- a/tests/cmake/c1_help_error_path_probe.cmake
+++ b/tests/cmake/c1_help_error_path_probe.cmake
@@ -189,6 +189,20 @@ if(NOT _summary_n STREQUAL "" AND _summary_n STREQUAL "9")
   set(_total_ok TRUE)
 endif()
 
+# Unparseable first — even when SUMMARY says 9. Must not land in wrong-split
+# (that would look like an ownership finding when the defect is the parser).
+if(_n_direct EQUAL 0 AND _n_indirect EQUAL 0)
+  message(FATAL_ERROR
+    "C1_RESULT=FAIL ARM=lsan_inverted\n"
+    "C1 probe: LSan reported leaks but Direct/Indirect object counts could "
+    "not be parsed (summary_allocs=${_summary_n}).\n"
+    "Refusing SUMMARY-only pass — that is the shape that fails on correct "
+    "behaviour if the assertion ever reads the Direct line alone, and the "
+    "shape that cannot distinguish 3/6 from 9/0.\n"
+    "Fix the parser against real LSan output; do not drop the 3/6 assertion.\n"
+    "exit=${_rc}\nstderr:\n${_err_txt}")
+endif()
+
 if(_split_ok AND _total_ok)
   # Cross-check SUMMARY against the split when both are present.
   if(NOT _summary_n STREQUAL "" AND NOT _summary_n STREQUAL "${_n_sum}")
@@ -204,7 +218,7 @@ if(_split_ok AND _total_ok)
     "C1_RESULT=PASS ARM=lsan_inverted direct=${_n_direct} indirect=${_n_indirect} "
     "summary_allocs=${_summary_n}")
   message(STATUS
-    "C1 probe FINDING (expected under current source model): "
+    "C1 probe ARM=lsan_inverted FINDING (expected under current source model): "
     "--help under LSan: ${_n_direct} direct / ${_n_indirect} indirect "
     "(summary_allocs=${_summary_n}, exit=${_rc}). "
     "Teardown skipped via Terminate. NOT production-teardown coverage. "
@@ -213,6 +227,7 @@ if(_split_ok AND _total_ok)
 endif()
 
 # Total 9 but wrong split: ownership graph is not what the source says.
+# Only this arm falsifies Bumble's FA/GB/VC root model (9/0 or 4/5).
 if(_total_ok AND NOT _split_ok)
   message(FATAL_ERROR
     "C1_RESULT=FAIL ARM=lsan_inverted\n"
@@ -222,19 +237,6 @@ if(_total_ok AND NOT _split_ok)
     "Do not silence this — it is a real finding about the source model "
     "(9/0 or 4/5 falsifies who owns what).\n"
     "summary_allocs=${_summary_n} exit=${_rc}\nstderr:\n${_err_txt}")
-endif()
-
-# Unparseable split (0/0) with only SUMMARY: refuse — that hands off a test
-# that cannot distinguish Direct-only from Direct+Indirect.
-if(_n_direct EQUAL 0 AND _n_indirect EQUAL 0)
-  message(FATAL_ERROR
-    "C1_RESULT=FAIL ARM=lsan_inverted\n"
-    "C1 probe: LSan reported leaks but Direct/Indirect object counts could "
-    "not be parsed (summary_allocs=${_summary_n}).\n"
-    "Refusing SUMMARY-only pass — that is the shape that fails on correct "
-    "behaviour if the assertion ever reads the Direct line alone.\n"
-    "Fix the parser against real LSan output; do not drop the 3/6 assertion.\n"
-    "exit=${_rc}\nstderr:\n${_err_txt}")
 endif()
 
 # Anything else: wrong total or wrong split.

--- a/tests/cmake/c1_help_error_path_probe.cmake
+++ b/tests/cmake/c1_help_error_path_probe.cmake
@@ -1,0 +1,107 @@
+# C1: error-path leak probe for the shipping FlexAID binary.
+#
+# Design (board, 2026-07-31):
+#   Terminate() throws (LIB/fileio.cpp); main catches after the teardown
+#   (LIB/top.cpp). --help takes Terminate(0) and exits 0 having freed nothing.
+#   Under Linux ASan+LSan that should report the prologue allocations.
+#
+# Criterion is INVERTED from a normal leak test:
+#   - process path always checked (--help -> exit 0, usage text)
+#   - when EXPECT_LEAK=1 (Linux instrumented builds only): a LeakSanitizer
+#     report is a PASS (the finding). Clean under LSan is FAIL — source model
+#     wrong, or someone fixed error-path free without updating this probe.
+#
+# FORBIDDEN claim: "this test covers top.cpp teardown." It never reaches it.
+#
+# Inputs ( -D from add_test ):
+#   FlexAID_BINARY  absolute path to FlexAID
+#   EXPECT_LEAK     ON/OFF — require LSan report
+
+if(NOT DEFINED FlexAID_BINARY)
+  message(FATAL_ERROR "c1_help_error_path_probe: FlexAID_BINARY not set")
+endif()
+if(NOT EXISTS "${FlexAID_BINARY}")
+  message(FATAL_ERROR "c1_help_error_path_probe: binary missing: ${FlexAID_BINARY}")
+endif()
+
+if(NOT DEFINED EXPECT_LEAK)
+  set(EXPECT_LEAK OFF)
+endif()
+
+set(_out_dir "${CMAKE_CURRENT_BINARY_DIR}/c1_help_probe")
+file(MAKE_DIRECTORY "${_out_dir}")
+set(_stdout "${_out_dir}/help.stdout")
+set(_stderr "${_out_dir}/help.stderr")
+
+# Prefer explicit ASAN_OPTIONS from the environment (CI sets detect_leaks=1).
+# When EXPECT_LEAK, force detect_leaks so a bare ctest run still probes.
+if(EXPECT_LEAK)
+  set(ENV{ASAN_OPTIONS} "detect_leaks=1:halt_on_error=0:strict_string_checks=1")
+endif()
+
+execute_process(
+  COMMAND "${FlexAID_BINARY}" --help
+  OUTPUT_FILE "${_stdout}"
+  ERROR_FILE  "${_stderr}"
+  RESULT_VARIABLE _rc
+)
+
+file(READ "${_stdout}" _out_txt)
+file(READ "${_stderr}" _err_txt)
+
+# macOS AppleClang: detect_leaks is unsupported and aborts. Re-run without it
+# and only enforce the process path.
+if(_err_txt MATCHES "detect_leaks is not supported")
+  message(STATUS "C1 probe: LSan unsupported on this platform — process path only")
+  set(ENV{ASAN_OPTIONS} "detect_leaks=0:halt_on_error=0")
+  execute_process(
+    COMMAND "${FlexAID_BINARY}" --help
+    OUTPUT_FILE "${_stdout}"
+    ERROR_FILE  "${_stderr}"
+    RESULT_VARIABLE _rc
+  )
+  file(READ "${_stdout}" _out_txt)
+  file(READ "${_stderr}" _err_txt)
+  set(EXPECT_LEAK OFF)
+endif()
+
+# Usage text must appear on the --help path (stdout). LSan may force a
+# non-zero process exit when EXPECT_LEAK — do not require exit 0 first.
+if(NOT _out_txt MATCHES "Usage:" AND NOT _out_txt MATCHES "--help")
+  message(FATAL_ERROR
+    "C1 probe: --help did not print usage text (exit=${_rc})\n"
+    "stdout:\n${_out_txt}\nstderr:\n${_err_txt}")
+endif()
+
+if(NOT EXPECT_LEAK)
+  # Non-instrumented / non-Linux: process path only — must be clean exit 0.
+  if(NOT _rc EQUAL 0)
+    message(FATAL_ERROR
+      "C1 probe: --help expected exit 0, got ${_rc}\n"
+      "stdout:\n${_out_txt}\nstderr:\n${_err_txt}")
+  endif()
+  message(STATUS "C1 probe: process path OK (exit 0, usage present); leak assertion not required on this config")
+  return()
+endif()
+
+# Inverted LSan arm — leak report is the expected finding today.
+# LSan typically exits non-zero when it reports; that is still a probe PASS.
+set(_saw_leak FALSE)
+if(_err_txt MATCHES "LeakSanitizer" OR _err_txt MATCHES "detected memory leaks" OR _err_txt MATCHES "Direct leak")
+  set(_saw_leak TRUE)
+endif()
+
+if(_saw_leak)
+  message(STATUS
+    "C1 probe FINDING (expected under current source model): "
+    "--help path reports leaks under LSan (teardown skipped via Terminate). "
+    "exit=${_rc}. This is NOT production-teardown coverage.")
+  return()
+endif()
+
+message(FATAL_ERROR
+  "C1 probe UNEXPECTED: Linux ASan+LSan run of --help reported no leaks.\n"
+  "Either the Terminate-unwind source model is wrong, prologue allocs are freed "
+  "before throw, or LSan did not run. Investigate before claiming C1 green "
+  "as anything other than this surprising clean result.\n"
+  "exit=${_rc}\nstderr:\n${_err_txt}")


### PR DESCRIPTION
## Summary

C1 probe for the shipping `FlexAID` binary: `./FlexAID --help` under ctest.

- **Process path (all configs):** usage text + exit 0. Confirms `Terminate(0)` → throw → catch after teardown, freeing nothing.
- **Linux ASan/LSan only (inverted criterion):** LSan report is PASS. Structural prediction from source (`top.cpp:581-613`) + LSan reachability (Bumble):
  - **3 direct** — `FA` / `GB` / `VC` roots in `main`
  - **6 indirect** — `FA->contacts` + five `VC->` arrays
  - **9 total** — Direct + Indirect (macOS `leaks` already measured 9; bytes host-dependent and **not** asserted)
- Clean under LSan, wrong total, or wrong 3/6 split → FAIL (source-model finding, not a quiet green).

### What this does **not** claim

- Not production-teardown coverage (only C2).
- Not a successful dock under instrument.
- Not late-`Terminate` mid-dock (floor, not ceiling).
- Does not retire the open sentence about `LIB/top.cpp` under instrument on the success path.

Board: Bumble named the nine + 3/6 split; core-dev measured macOS `leaks` 9 / 1,274,880; Honey clause 6 FAIL arm + instrument-parity.

Tip: `2e402ae8` (3/6/9 structural assert). Prior tip `8542edc7` had inverted LSan without the split.

## Test plan

- [x] Local process path: `cmake -DFlexAID_BINARY=…/build/FlexAID -DEXPECT_LEAK=OFF -P tests/cmake/c1_help_error_path_probe.cmake` → exit 0
- [ ] Linux clang ASan+UBSan job runs `FlexAID_C1_HelpErrorPathProbe` with `EXPECT_LEAK=ON`
- [ ] Probe reports 3 direct / 6 indirect / 9 total (or fails loudly if not)
- [ ] macOS / non-sanitizer configs still process-path only