### PR TITLE
Fix: --help buffer overflow — realpath into undersized base_path buffer

### DIFF
--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -787,10 +787,13 @@ int main(int argc, char **argv){
 #ifndef _WIN32
 	{
 		// Resolve argv[0] with a glibc-allocated buffer (second arg NULL) rather
-		// than a fixed MAX_PATH__ stack buffer: a resolved path can be up to
-		// PATH_MAX (4096) bytes, and _FORTIFY_SOURCE aborts realpath() into an
-		// undersized buffer ("buffer overflow detected") whenever the deploy
-		// path exceeds MAX_PATH__ — e.g. CI runner paths. Falls back to argv[0].
+		// than a fixed MAX_PATH__ stack buffer. _FORTIFY_SOURCE rejects any
+		// realpath() destination smaller than PATH_MAX (4096): __realpath_chk
+		// calls __chk_fail() when resolvedlen < PATH_MAX, before resolving —
+		// so a MAX_PATH__ (255) buffer aborts ("buffer overflow detected")
+		// UNCONDITIONALLY on fortified glibc builds, every invocation, any
+		// path length. Passing NULL makes glibc size the buffer itself.
+		// Do not reintroduce a fixed-size destination here. Falls back to argv[0].
 		char* rp = realpath(argv[0], NULL);
 		const char* src = (rp != NULL) ? rp : argv[0];
 		// strrchr(const char*) returns const char* — keep a local const pointer

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -786,12 +786,13 @@ int main(int argc, char **argv){
 	// to Cellar/.../bin (where runtime data is installed), not /opt/homebrew/bin.
 #ifndef _WIN32
 	{
-		char resolved[MAX_PATH__];
-		const char* src = argv[0];
-		char* rp = realpath(src, resolved);
-		if (rp != NULL) {
-			src = resolved;
-		}
+		// Resolve argv[0] with a glibc-allocated buffer (second arg NULL) rather
+		// than a fixed MAX_PATH__ stack buffer: a resolved path can be up to
+		// PATH_MAX (4096) bytes, and _FORTIFY_SOURCE aborts realpath() into an
+		// undersized buffer ("buffer overflow detected") whenever the deploy
+		// path exceeds MAX_PATH__ — e.g. CI runner paths. Falls back to argv[0].
+		char* rp = realpath(argv[0], NULL);
+		const char* src = (rp != NULL) ? rp : argv[0];
 		// strrchr(const char*) returns const char* — keep a local const pointer
 		// instead of assigning into the legacy char* pch variable.
 		const char* slash = strrchr(src, '/');
@@ -804,6 +805,7 @@ int main(int argc, char **argv){
 			strncpy(FA->base_path, ".", MAX_PATH__ - 1);
 			FA->base_path[MAX_PATH__ - 1] = '\0';
 		}
+		free(rp);  // free(NULL) is a no-op
 	}
 #else
 	pch = strrchr(argv[0], '\\');


### PR DESCRIPTION
## What

`FlexAID --help` aborts with `*** buffer overflow detected ***: terminated`, printing no usage text, on every `_FORTIFY_SOURCE` build (`linux-gcc`, `linux-gcc-mpi`, `linux-gcc-asan`). `linux-clang` lacks the fortify check, so it passed — exactly the split #322 saw.

## Root cause

`main()` resolved `argv[0]` into a fixed 255-byte stack buffer:

```cpp
char resolved[MAX_PATH__];              // MAX_PATH__ == 255
char* rp = realpath(src, resolved);
```

POSIX `realpath` writes up to `PATH_MAX` (4096) bytes. glibc wraps it as `__realpath_chk` under `_FORTIFY_SOURCE`; when the resolved executable path exceeds 255 bytes — e.g. the CI runner path `/home/runner/work/FlexAIDdS/FlexAIDdS/build/.../FlexAID` — it calls `__chk_fail` and aborts **before** `print_usage` output flushes. Reachable by any user typing `--help` on a deep install path.

## Fix

Resolve with a glibc-allocated buffer instead:

```cpp
char* rp = realpath(argv[0], NULL);     // glibc mallocs correct size
const char* src = (rp != NULL) ? rp : argv[0];
...
free(rp);                               // free(NULL) is a no-op
```

Overflow-impossible and portable. `FA->base_path` stays bounded by the existing `MAX_PATH__` `memcpy` cap, so no truncation-overflow is introduced. One-region change, no include or API changes.

## Provenance & verification

Found by the **#322** C1 `--help` error-path leak probe during the three-way review (Bumble / Honey / Fizz consensus). The probe caught a **real shipping bug**, not a test defect. Verification is via the `linux-gcc-asan` CI job here — the exact environment that exhibits the overflow (macOS clang can't reproduce `_FORTIFY` realpath aborts).

Once this lands, **#322** should be re-derived on top as the green regression guard (its inverted-LSan arm assumed a clean unwind that never ran — re-derive, don't just rebase).

Originating channel: Benchmarking FlexAIDdS (#716e79b1-6a4f-4cde-8851-22836ba8738c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)