### PR TITLE
ci: run the shipping FlexAID binary (--help) in the Linux core matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,40 @@ jobs:
           cmake "${CMAKE_ARGS[@]}"
       - name: Build
         run: cmake --build build --parallel
+      # Smoke: execute the shipping binary. Until this step existed, no CI job
+      # ever ran FlexAID itself — only unit tests linked against LIB/. That gap
+      # let a startup abort live in main and still show a green matrix: the
+      # 255-byte realpath() destination at LIB/top.cpp tripped glibc
+      # _FORTIFY_SOURCE (__realpath_chk fails when the destination is smaller
+      # than PATH_MAX, before resolving anything), so every fortified gcc build
+      # died before parsing argv. --help is the cheapest invocation that proves
+      # the binary starts, so this is deliberately a liveness gate and not a
+      # behaviour test.
+      #
+      # detect_leaks=0 on purpose: this asserts the binary starts, not that it
+      # frees. Error-path leaks are a separate concern with its own probe, and
+      # letting LSan fail this step would conflate "dead on arrival" with
+      # "exits dirty".
+      - name: Smoke — shipping binary starts (--help)
+        if: matrix.name == 'linux-gcc' || matrix.name == 'linux-clang' || matrix.name == 'linux-gcc-mpi' || matrix.name == 'linux-gcc-asan'
+        env:
+          ASAN_OPTIONS: detect_leaks=0
+        run: |
+          set -euo pipefail
+          test -x build/FlexAID || { echo "::error::build/FlexAID missing or not executable"; exit 1; }
+          build/FlexAID --help > help.out 2> help.err || {
+            echo "::error::FlexAID --help exited $? — the shipping binary does not start"
+            echo "--- stdout ---"; cat help.out
+            echo "--- stderr ---"; cat help.err
+            exit 1
+          }
+          grep -q "Usage:" help.out || {
+            echo "::error::FlexAID --help exited 0 but printed no usage text"
+            echo "--- stdout ---"; cat help.out
+            echo "--- stderr ---"; cat help.err
+            exit 1
+          }
+          echo "FlexAID --help: exit 0, usage text present"
       - name: Test
         if: matrix.name == 'linux-gcc' || matrix.name == 'linux-clang' || matrix.name == 'linux-gcc-mpi' || matrix.name == 'linux-gcc-asan'
         run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,15 +129,25 @@ jobs:
           cmake "${CMAKE_ARGS[@]}"
       - name: Build
         run: cmake --build build --parallel
-      # Smoke: execute the shipping binary. Until this step existed, no CI job
-      # ever ran FlexAID itself — only unit tests linked against LIB/. That gap
-      # let a startup abort live in main and still show a green matrix: the
+      # Smoke: assert the shipping binary starts. Until this step existed, no
+      # job in this workflow ran FlexAID at all — only unit tests linked
+      # against LIB/. Tier-1 (benchmark-tier1.yml) did run it, but treated a
+      # non-zero exit as a logger.warning and reported a pass anyway, so a
+      # binary that aborted on all five entries and produced zero poses still
+      # went green in 0.4s. Nothing anywhere failed on "the binary did not
+      # run."
+      #
+      # That is how a startup abort lived in main under a green matrix: the
       # 255-byte realpath() destination at LIB/top.cpp tripped glibc
       # _FORTIFY_SOURCE (__realpath_chk fails when the destination is smaller
       # than PATH_MAX, before resolving anything), so every fortified gcc build
       # died before parsing argv. --help is the cheapest invocation that proves
       # the binary starts, so this is deliberately a liveness gate and not a
       # behaviour test.
+      #
+      # Scope: this catches a binary that cannot start. It does NOT catch a
+      # binary that starts and then silently produces nothing — that is the
+      # benchmark's own gate to fix, not this one's.
       #
       # detect_leaks=0 on purpose: this asserts the binary starts, not that it
       # frees. Error-path leaks are a separate concern with its own probe, and

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -787,10 +787,13 @@ int main(int argc, char **argv){
 #ifndef _WIN32
 	{
 		// Resolve argv[0] with a glibc-allocated buffer (second arg NULL) rather
-		// than a fixed MAX_PATH__ stack buffer: a resolved path can be up to
-		// PATH_MAX (4096) bytes, and _FORTIFY_SOURCE aborts realpath() into an
-		// undersized buffer ("buffer overflow detected") whenever the deploy
-		// path exceeds MAX_PATH__ — e.g. CI runner paths. Falls back to argv[0].
+		// than a fixed MAX_PATH__ stack buffer. _FORTIFY_SOURCE rejects any
+		// realpath() destination smaller than PATH_MAX (4096): __realpath_chk
+		// calls __chk_fail() when resolvedlen < PATH_MAX, before resolving —
+		// so a MAX_PATH__ (255) buffer aborts ("buffer overflow detected")
+		// UNCONDITIONALLY on fortified glibc builds, every invocation, any
+		// path length. Passing NULL makes glibc size the buffer itself.
+		// Do not reintroduce a fixed-size destination here. Falls back to argv[0].
 		char* rp = realpath(argv[0], NULL);
 		const char* src = (rp != NULL) ? rp : argv[0];
 		// strrchr(const char*) returns const char* — keep a local const pointer

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -786,12 +786,13 @@ int main(int argc, char **argv){
 	// to Cellar/.../bin (where runtime data is installed), not /opt/homebrew/bin.
 #ifndef _WIN32
 	{
-		char resolved[MAX_PATH__];
-		const char* src = argv[0];
-		char* rp = realpath(src, resolved);
-		if (rp != NULL) {
-			src = resolved;
-		}
+		// Resolve argv[0] with a glibc-allocated buffer (second arg NULL) rather
+		// than a fixed MAX_PATH__ stack buffer: a resolved path can be up to
+		// PATH_MAX (4096) bytes, and _FORTIFY_SOURCE aborts realpath() into an
+		// undersized buffer ("buffer overflow detected") whenever the deploy
+		// path exceeds MAX_PATH__ — e.g. CI runner paths. Falls back to argv[0].
+		char* rp = realpath(argv[0], NULL);
+		const char* src = (rp != NULL) ? rp : argv[0];
 		// strrchr(const char*) returns const char* — keep a local const pointer
 		// instead of assigning into the legacy char* pch variable.
 		const char* slash = strrchr(src, '/');
@@ -804,6 +805,7 @@ int main(int argc, char **argv){
 			strncpy(FA->base_path, ".", MAX_PATH__ - 1);
 			FA->base_path[MAX_PATH__ - 1] = '\0';
 		}
+		free(rp);  // free(NULL) is a no-op
 	}
 #else
 	pch = strrchr(argv[0], '\\');


### PR DESCRIPTION
## The gap

> **Corrected after review.** The first version of this description claimed *no CI job has ever executed the FlexAID binary.* That is false, and Honey's log pull is what falsified it. The real gap is narrower and worse — see below.

`cxx_core_build` builds FlexAID and then runs unit tests linked against `LIB/` — never the shipping executable. **Tier-1 did run it**, and reported a pass anyway:

```
[WARNING] FlexAID returned -6 for 1t9b/1T9B_ligand
[DEBUG] stderr: *** buffer overflow detected ***: terminated
Entry 1gpk/holo: 0 poses in 0.1s      (…all five entries identical)
*Tier 1 · 5/5 targets · 0.4s*          ← green
```

`benchmarks/runner.py:1263-1268` logs a non-zero FlexAID exit as a `logger.warning` and continues; nothing downstream fails on "zero poses across 100% of entries."

So the gap was never *nothing runs the binary*. It is **nothing fails when the binary does not run.** A gate that goes green in 0.4s *because* the binary is dead is inverted, not merely weak.

## Root cause it hid

The 255-byte `realpath()` destination at `LIB/top.cpp:786` tripped glibc `_FORTIFY_SOURCE`:

```c
char *__realpath_chk (const char *buf, char *resolved, size_t resolvedlen)
{
#ifdef PATH_MAX
  if (resolvedlen < PATH_MAX)
    __chk_fail ();          /* aborts before __realpath is ever called */
  return __realpath (buf, resolved);
```
[glibc `debug/realpath_chk.c`](https://codebrowser.dev/glibc/glibc/debug/realpath_chk.c.html)

`MAX_PATH__` is 255, `PATH_MAX` is 4096 — the check fails unconditionally, so every fortified gcc build died before parsing `argv`. Confirmed at runtime by the log above: five different inputs, same abort, every time. #323 fixed it.

The bug is fixed. **The blind spot that let it report green is not.**

## The change

One step in the `cxx_core_build` matrix: `build/FlexAID --help` must exit 0 and print usage text. Gated to the same four Linux configs that already run `ctest` (`linux-gcc`, `linux-clang`, `linux-gcc-mpi`, `linux-gcc-asan`). `linux-gcc-avx512` is excluded for the same reason it has no `ctest` step — the runner CPU may not support the ISA.

A **liveness gate, not a behaviour test**. `--help` is the cheapest invocation that proves the binary starts. Failure output prints captured stdout, stderr and the exit code, so a regression names itself.

## Scope — what this does not fix

This catches a binary that **cannot start**. It does not catch a binary that starts and then silently produces nothing. Tier-1 swallowing a non-zero exit is a separate defect in the benchmark's own pass criterion, and it is not addressed here.

## Two decisions worth reviewing

- **`detect_leaks=0` on the ASan config.** Asserts the binary *starts*, not that it *frees*. Error-path leaks are #322's job; letting LSan fail this step would conflate "dead on arrival" with "exits dirty."
- **Branched off #323, not `main`.** The step fails on any commit predating the `realpath` fix — which is the point, and makes this branch's own green run the proof the gate works. **Merge after #323.**

## Verification status

CI on this branch is the verification; it is based on #323's head, so a green `linux-gcc-asan` here is the gate passing against the fixed binary. I have **not** built locally — macOS/clang has no `_FORTIFY_SOURCE` and cannot reproduce the condition this guards. YAML parse and step ordering (Configure → Build → Smoke → Test) checked locally.