### PR TITLE
Fix: benchmark scores a crashing binary as pass — liveness/productivity/completeness gates (#326)

### DIFF
--- a/python/flexaidds/dataset_runner/cli.py
+++ b/python/flexaidds/dataset_runner/cli.py
@@ -217,6 +217,50 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _benchmark_inconclusive_reasons(datasets) -> list[str]:
+    """Gates 1-3 of the #326 benchmark verdict (liveness, productivity,
+    completeness).
+
+    Returns a list of human-readable reasons the run is INCONCLUSIVE — the
+    binary did not run, produced nothing, or left baseline metrics unmeasured.
+    An empty list means gates 1-3 passed and only the quality/regression gate
+    remains. Kept separate from ``main`` so it is unit-testable without docking.
+
+    Targets that legitimately yield nothing can be allowlisted via
+    ``FLEXAIDDS_BENCH_ALLOW_EMPTY`` (comma-separated dataset slugs) rather than
+    by weakening the gate globally.
+    """
+    allow_empty = {
+        s.strip()
+        for s in os.environ.get("FLEXAIDDS_BENCH_ALLOW_EMPTY", "").split(",")
+        if s.strip()
+    }
+    reasons: list[str] = []
+    for dr in datasets:
+        slug = dr.config.slug
+        attempted = len(dr.targets_completed) + len(dr.targets_failed)
+        # 1. Liveness — every FlexAID invocation must exit 0.
+        if dr.flexaid_crashes > 0:
+            codes = ", ".join(
+                f"{k}={v}" for k, v in list(dr.entry_exit_codes.items())[:5]
+            )
+            reasons.append(
+                f"{slug}: liveness — {dr.flexaid_crashes} FlexAID non-zero exit(s) [{codes}]"
+            )
+        # 2. Productivity — the run must produce at least one pose.
+        if attempted > 0 and dr.total_poses == 0 and slug not in allow_empty:
+            reasons.append(
+                f"{slug}: productivity — 0 poses across {attempted} attempted target(s)"
+            )
+        # 3. Completeness — every declared baseline must actually be measured.
+        if dr.inconclusive_metrics:
+            reasons.append(
+                f"{slug}: completeness — baselines never measured: "
+                + ", ".join(dr.inconclusive_metrics)
+            )
+    return reasons
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point.  Returns 0 on success, non-zero on failure/regression."""
     parser = _build_parser()
@@ -342,7 +386,25 @@ def main(argv: list[str] | None = None) -> int:
     # Print markdown summary to stdout
     print(report.to_markdown())
 
-    # Return non-zero if any regressions detected
+    # ----- Benchmark verdict: PASS / FAIL / INCONCLUSIVE (#326) -----
+    # Gates 1-3 (liveness, productivity, completeness) run before the
+    # regression check (gate 4). A run where the binary crashed, produced no
+    # poses, or left baseline metrics unmeasured is INCONCLUSIVE — it must not
+    # read as "no regression". Skipped under --dry-run (synthetic poses).
+    # Targets that legitimately yield nothing can be allowlisted via
+    # FLEXAIDDS_BENCH_ALLOW_EMPTY (comma-separated dataset slugs) rather than
+    # by weakening the gate globally.
+    if not runner.dry_run:
+        inconclusive = _benchmark_inconclusive_reasons(report.datasets)
+        if inconclusive:
+            logging.error(
+                "BENCHMARK INCONCLUSIVE — the run did not run, produce, or measure. "
+                "This is a hard failure, not 'no regression':\n  - "
+                + "\n  - ".join(inconclusive)
+            )
+            return 3
+
+    # Return non-zero if any regressions detected (gate 4: quality)
     any_regression = any(
         any(dr.regression_flags.values())
         for dr in report.datasets

--- a/python/flexaidds/dataset_runner/cli.py
+++ b/python/flexaidds/dataset_runner/cli.py
@@ -238,15 +238,21 @@ def _benchmark_inconclusive_reasons(datasets) -> list[str]:
     reasons: list[str] = []
     for dr in datasets:
         slug = dr.config.slug
-        # Gates 2-3 judge only fresh work. A pure --resume / package-regen run
-        # executes no new targets (its poses are loaded from checkpoints, not
-        # recomputed into all_poses), so 0 poses and unmeasured baselines there
-        # mean "nothing ran this session", not "the binary is dead" — judging
-        # it would re-invert the gate. Liveness still applies unconditionally:
-        # a non-zero exit can only have come from a target that did run.
+        # Gates 2-3 judge only a run whose empty output is meaningful. Three
+        # cases (executed = targets run this session, resumed = checkpoints):
+        #   executed > 0             → fresh work; judge it.
+        #   executed == 0, resumed>0 → pure --resume/package-regen; poses live in
+        #                              checkpoints not all_poses, so skip — else
+        #                              a successful resume re-inverts the gate.
+        #   executed == 0, resumed==0→ the run scheduled NOTHING (empty tier, bad
+        #                              filter). Zero poses is meaningful: judge it,
+        #                              so a no-op cannot pass silently.
+        # Liveness still applies unconditionally — a non-zero exit can only have
+        # come from a target that did run.
         executed = getattr(dr, "newly_executed", None)
         if executed is None:  # tolerate objects predating the field
             executed = len(dr.targets_completed) + len(dr.targets_failed)
+        resumed = getattr(dr, "resumed", 0)
         # 1. Liveness — every FlexAID invocation must exit 0.
         if dr.flexaid_crashes > 0:
             codes = ", ".join(
@@ -255,18 +261,20 @@ def _benchmark_inconclusive_reasons(datasets) -> list[str]:
             reasons.append(
                 f"{slug}: liveness — {dr.flexaid_crashes} FlexAID non-zero exit(s) [{codes}]"
             )
-        if executed > 0:
-            # 2. Productivity — a run that did work must produce ≥1 pose.
-            if dr.total_poses == 0 and slug not in allow_empty:
-                reasons.append(
-                    f"{slug}: productivity — 0 poses across {executed} executed target(s)"
-                )
-            # 3. Completeness — every declared baseline must be measured.
-            if dr.inconclusive_metrics:
-                reasons.append(
-                    f"{slug}: completeness — baselines never measured: "
-                    + ", ".join(dr.inconclusive_metrics)
-                )
+        # 2. Productivity — only a run that executed targets can be faulted for
+        #    producing no poses (a resume/no-op executed nothing this session).
+        if executed > 0 and dr.total_poses == 0 and slug not in allow_empty:
+            reasons.append(
+                f"{slug}: productivity — 0 poses across {executed} executed target(s)"
+            )
+        # 3. Completeness — declared baselines left unmeasured fail, UNLESS this
+        #    was a legitimate resume (executed==0 but resumed>0), where the
+        #    metrics live in checkpoints rather than this session's output.
+        if (executed > 0 or resumed == 0) and dr.inconclusive_metrics:
+            reasons.append(
+                f"{slug}: completeness — baselines never measured: "
+                + ", ".join(dr.inconclusive_metrics)
+            )
     return reasons
 
 

--- a/python/flexaidds/dataset_runner/cli.py
+++ b/python/flexaidds/dataset_runner/cli.py
@@ -238,7 +238,15 @@ def _benchmark_inconclusive_reasons(datasets) -> list[str]:
     reasons: list[str] = []
     for dr in datasets:
         slug = dr.config.slug
-        attempted = len(dr.targets_completed) + len(dr.targets_failed)
+        # Gates 2-3 judge only fresh work. A pure --resume / package-regen run
+        # executes no new targets (its poses are loaded from checkpoints, not
+        # recomputed into all_poses), so 0 poses and unmeasured baselines there
+        # mean "nothing ran this session", not "the binary is dead" — judging
+        # it would re-invert the gate. Liveness still applies unconditionally:
+        # a non-zero exit can only have come from a target that did run.
+        executed = getattr(dr, "newly_executed", None)
+        if executed is None:  # tolerate objects predating the field
+            executed = len(dr.targets_completed) + len(dr.targets_failed)
         # 1. Liveness — every FlexAID invocation must exit 0.
         if dr.flexaid_crashes > 0:
             codes = ", ".join(
@@ -247,17 +255,18 @@ def _benchmark_inconclusive_reasons(datasets) -> list[str]:
             reasons.append(
                 f"{slug}: liveness — {dr.flexaid_crashes} FlexAID non-zero exit(s) [{codes}]"
             )
-        # 2. Productivity — the run must produce at least one pose.
-        if attempted > 0 and dr.total_poses == 0 and slug not in allow_empty:
-            reasons.append(
-                f"{slug}: productivity — 0 poses across {attempted} attempted target(s)"
-            )
-        # 3. Completeness — every declared baseline must actually be measured.
-        if dr.inconclusive_metrics:
-            reasons.append(
-                f"{slug}: completeness — baselines never measured: "
-                + ", ".join(dr.inconclusive_metrics)
-            )
+        if executed > 0:
+            # 2. Productivity — a run that did work must produce ≥1 pose.
+            if dr.total_poses == 0 and slug not in allow_empty:
+                reasons.append(
+                    f"{slug}: productivity — 0 poses across {executed} executed target(s)"
+                )
+            # 3. Completeness — every declared baseline must be measured.
+            if dr.inconclusive_metrics:
+                reasons.append(
+                    f"{slug}: completeness — baselines never measured: "
+                    + ", ".join(dr.inconclusive_metrics)
+                )
     return reasons
 
 

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1760,7 +1760,15 @@ class DatasetRunner:
                     crashes += crash_i
                     exit_codes.update(codes_i)
                     newly += newly_i
-                    resumed += resumed_i
+                    # `resumed` is REPLICATED, not partitioned: every rank runs
+                    # _discover_completed_targets over the same shared disk, so
+                    # each reports the same count. Summing would give
+                    # resumed × n_ranks. Take the common value (max == that
+                    # value) so the report-JSON provenance stays honest. The
+                    # gate only asks `resumed == 0`, which summing preserved,
+                    # but a wrong number in the artifact is the exact thing this
+                    # whole change exists to prevent.
+                    resumed = max(resumed, resumed_i)
 
         # Root finalizes
         if self._mpi_root:

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -43,6 +43,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -411,6 +412,13 @@ class DatasetResult:
     full_command: str = ""
     dry_run: bool = False
     metrics_note: str = ""
+    # Benchmark liveness/productivity gate (#326): a run where the binary
+    # crashed or produced nothing must not read as "no regression". These
+    # fields let cli.main distinguish PASS / FAIL / INCONCLUSIVE.
+    flexaid_crashes: int = 0
+    total_poses: int = 0
+    entry_exit_codes: Dict[str, int] = field(default_factory=dict)
+    inconclusive_metrics: List[str] = field(default_factory=list)
 
     def check_regressions(self) -> Dict[str, bool]:
         """Flag metrics that regressed below baseline − tolerance.
@@ -418,10 +426,15 @@ class DatasetResult:
         Returns dict of ``{metric: True}`` for regressed metrics.
         """
         flags: Dict[str, bool] = {}
+        missing: List[str] = []
         tol = self.config.baseline_tolerance
         for metric, baseline in self.config.expected_baselines.items():
             measured = self.metrics.get(metric)
             if measured is None or np.isnan(measured):
+                # Completeness gate (#326): a metric that was never measured is
+                # NOT "no regression" — it is an inconclusive run. Record it so
+                # cli.main can fail the run rather than silently pass it.
+                missing.append(metric)
                 continue
             # For error/RMSE metrics lower is better — allow increase
             if "rmse" in metric or "mae" in metric:
@@ -432,6 +445,7 @@ class DatasetResult:
                 threshold = baseline * (1 - tol)
                 flags[metric] = bool(measured < threshold)
         self.regression_flags = flags
+        self.inconclusive_metrics = missing
         return flags
 
     def to_dict(self) -> dict:
@@ -457,6 +471,11 @@ class DatasetResult:
             "published_source": self.config.published_source,
             "dry_run": self.dry_run,
             "grand_summary": self.grand_summary,  # P3
+            # #326 gate provenance
+            "flexaid_crashes": self.flexaid_crashes,
+            "total_poses": self.total_poses,
+            "entry_exit_codes": self.entry_exit_codes,
+            "inconclusive_metrics": self.inconclusive_metrics,
         }
         if self.metrics_note:
             payload["metrics_note"] = self.metrics_note
@@ -1103,6 +1122,13 @@ class DatasetRunner:
         self._requested_temperature = temperature
         self.command_line: Optional[str] = None  # set by CLI for full provenance
 
+        # #326 liveness gate: FlexAID non-zero exits are recorded here (under a
+        # lock, since entries dispatch across a local thread pool) so a crashed
+        # binary can never read as "no regression". Reset per dataset run.
+        self._crash_lock = threading.Lock()
+        self._flexaid_crashes = 0
+        self._entry_exit_codes: Dict[str, int] = {}
+
     def _effective_temperature(self, slug: str) -> float:
         """Auto-force 298 K for ITC/thermo datasets (handoff requirement).
 
@@ -1261,9 +1287,17 @@ class DatasetRunner:
                         env=sub_env,
                     )
                     if result.returncode != 0:
+                        # #326 liveness: a non-zero exit is a gate failure, not
+                        # a debug aside. Record it so the run is scored
+                        # INCONCLUSIVE instead of silently passing on 0 poses.
+                        stderr_head = (result.stderr or "").strip().splitlines()
+                        stderr_head = stderr_head[0][:200] if stderr_head else ""
+                        with self._crash_lock:
+                            self._flexaid_crashes += 1
+                            self._entry_exit_codes[f"{target_id}/{ligand_id}"] = result.returncode
                         logger.warning(
-                            "FlexAID returned %d for %s/%s",
-                            result.returncode, target_id, ligand_id,
+                            "FlexAID non-zero exit %d for %s/%s: %s",
+                            result.returncode, target_id, ligand_id, stderr_head,
                         )
                         if result.stderr:
                             logger.debug("stderr: %s", result.stderr[:500])
@@ -1562,6 +1596,11 @@ class DatasetRunner:
         completed_targets: set[str] = set(already_completed)
         failed_targets: set[str] = set()
 
+        # #326: reset per-dataset FlexAID crash tally before this run's entries.
+        with self._crash_lock:
+            self._flexaid_crashes = 0
+            self._entry_exit_codes = {}
+
         def _process_one_item(item: Tuple[str, str]) -> Tuple[str, str, List[PoseScore], float, str]:
             """Process a single (target_id, structural_state) entry.
 
@@ -1681,24 +1720,36 @@ class DatasetRunner:
         completed = sorted(completed_targets)
         failed = sorted(failed_targets)
 
+        # #326: snapshot this rank's FlexAID crash tally for gather/finalize.
+        with self._crash_lock:
+            crashes = self._flexaid_crashes
+            exit_codes = dict(self._entry_exit_codes)
+
         # MPI gather (still works at target granularity for final aggregation)
         if self._mpi_comm is not None:
             all_results_by_rank = self._mpi_comm.gather(
-                (all_poses, completed, failed), root=0
+                (all_poses, completed, failed, crashes, exit_codes), root=0
             )
             if self._mpi_root:
                 all_poses = []
                 completed = []
                 failed = []
-                for poses_i, comp_i, fail_i in (all_results_by_rank or []):
+                crashes = 0
+                exit_codes = {}
+                for poses_i, comp_i, fail_i, crash_i, codes_i in (all_results_by_rank or []):
                     all_poses.extend(poses_i)
                     completed.extend(comp_i)
                     failed.extend(fail_i)
+                    crashes += crash_i
+                    exit_codes.update(codes_i)
 
         # Root finalizes
         if self._mpi_root:
             dr.targets_completed = completed
             dr.targets_failed = failed
+            dr.flexaid_crashes = crashes
+            dr.entry_exit_codes = exit_codes
+            dr.total_poses = len(all_poses)
 
             if all_poses:
                 metrics = compute_all_metrics(all_poses, requested=requested_metrics)

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -419,6 +419,10 @@ class DatasetResult:
     total_poses: int = 0
     entry_exit_codes: Dict[str, int] = field(default_factory=dict)
     inconclusive_metrics: List[str] = field(default_factory=list)
+    # Targets actually executed this run (excludes --resume checkpoints, whose
+    # poses are not reloaded into all_poses). Gates 2-3 only judge a run that
+    # did fresh work — a pure resume/package-regen run must not false-fail.
+    newly_executed: int = 0
 
     def check_regressions(self) -> Dict[str, bool]:
         """Flag metrics that regressed below baseline − tolerance.
@@ -476,6 +480,7 @@ class DatasetResult:
             "total_poses": self.total_poses,
             "entry_exit_codes": self.entry_exit_codes,
             "inconclusive_metrics": self.inconclusive_metrics,
+            "newly_executed": self.newly_executed,
         }
         if self.metrics_note:
             payload["metrics_note"] = self.metrics_note
@@ -1720,15 +1725,19 @@ class DatasetRunner:
         completed = sorted(completed_targets)
         failed = sorted(failed_targets)
 
-        # #326: snapshot this rank's FlexAID crash tally for gather/finalize.
+        # #326: snapshot this rank's FlexAID crash tally + count of targets
+        # actually executed this run. `results` is the dispatched work list,
+        # which excludes --resume checkpoints (skipped before dispatch), so it
+        # is exactly "fresh work" — the denominator gates 2-3 should judge.
         with self._crash_lock:
             crashes = self._flexaid_crashes
             exit_codes = dict(self._entry_exit_codes)
+        newly = len(results)
 
         # MPI gather (still works at target granularity for final aggregation)
         if self._mpi_comm is not None:
             all_results_by_rank = self._mpi_comm.gather(
-                (all_poses, completed, failed, crashes, exit_codes), root=0
+                (all_poses, completed, failed, crashes, exit_codes, newly), root=0
             )
             if self._mpi_root:
                 all_poses = []
@@ -1736,12 +1745,14 @@ class DatasetRunner:
                 failed = []
                 crashes = 0
                 exit_codes = {}
-                for poses_i, comp_i, fail_i, crash_i, codes_i in (all_results_by_rank or []):
+                newly = 0
+                for poses_i, comp_i, fail_i, crash_i, codes_i, newly_i in (all_results_by_rank or []):
                     all_poses.extend(poses_i)
                     completed.extend(comp_i)
                     failed.extend(fail_i)
                     crashes += crash_i
                     exit_codes.update(codes_i)
+                    newly += newly_i
 
         # Root finalizes
         if self._mpi_root:
@@ -1750,6 +1761,7 @@ class DatasetRunner:
             dr.flexaid_crashes = crashes
             dr.entry_exit_codes = exit_codes
             dr.total_poses = len(all_poses)
+            dr.newly_executed = newly
 
             if all_poses:
                 metrics = compute_all_metrics(all_poses, requested=requested_metrics)

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -423,6 +423,10 @@ class DatasetResult:
     # poses are not reloaded into all_poses). Gates 2-3 only judge a run that
     # did fresh work — a pure resume/package-regen run must not false-fail.
     newly_executed: int = 0
+    # Targets loaded from --resume checkpoints (not re-executed). Distinguishes
+    # a legitimate resume (skip gates 2-3) from a run that scheduled nothing at
+    # all (newly==0 AND resumed==0 → still INCONCLUSIVE, not a silent pass).
+    resumed: int = 0
 
     def check_regressions(self) -> Dict[str, bool]:
         """Flag metrics that regressed below baseline − tolerance.
@@ -481,6 +485,7 @@ class DatasetResult:
             "entry_exit_codes": self.entry_exit_codes,
             "inconclusive_metrics": self.inconclusive_metrics,
             "newly_executed": self.newly_executed,
+            "resumed": self.resumed,
         }
         if self.metrics_note:
             payload["metrics_note"] = self.metrics_note
@@ -1733,11 +1738,12 @@ class DatasetRunner:
             crashes = self._flexaid_crashes
             exit_codes = dict(self._entry_exit_codes)
         newly = len(results)
+        resumed = len(already_completed)
 
         # MPI gather (still works at target granularity for final aggregation)
         if self._mpi_comm is not None:
             all_results_by_rank = self._mpi_comm.gather(
-                (all_poses, completed, failed, crashes, exit_codes, newly), root=0
+                (all_poses, completed, failed, crashes, exit_codes, newly, resumed), root=0
             )
             if self._mpi_root:
                 all_poses = []
@@ -1746,13 +1752,15 @@ class DatasetRunner:
                 crashes = 0
                 exit_codes = {}
                 newly = 0
-                for poses_i, comp_i, fail_i, crash_i, codes_i, newly_i in (all_results_by_rank or []):
+                resumed = 0
+                for poses_i, comp_i, fail_i, crash_i, codes_i, newly_i, resumed_i in (all_results_by_rank or []):
                     all_poses.extend(poses_i)
                     completed.extend(comp_i)
                     failed.extend(fail_i)
                     crashes += crash_i
                     exit_codes.update(codes_i)
                     newly += newly_i
+                    resumed += resumed_i
 
         # Root finalizes
         if self._mpi_root:
@@ -1762,6 +1770,7 @@ class DatasetRunner:
             dr.entry_exit_codes = exit_codes
             dr.total_poses = len(all_poses)
             dr.newly_executed = newly
+            dr.resumed = resumed
 
             if all_poses:
                 metrics = compute_all_metrics(all_poses, requested=requested_metrics)

--- a/python/flexaidds/dataset_runner/tests/test_benchmark_gate.py
+++ b/python/flexaidds/dataset_runner/tests/test_benchmark_gate.py
@@ -16,11 +16,13 @@ from flexaidds.dataset_runner.cli import _benchmark_inconclusive_reasons
 
 
 def _dr(slug, *, completed=(), failed=(), crashes=0, total_poses=0,
-        exit_codes=None, missing_metrics=(), newly_executed=None):
+        exit_codes=None, missing_metrics=(), newly_executed=None, resumed=0):
     """Build a minimal DatasetResult-shaped object for the gate helper.
 
     ``newly_executed`` defaults to attempted (a fresh run); pass 0 to model a
-    pure --resume run where every target came from a checkpoint.
+    run that ran nothing this session. ``resumed`` is the count of targets
+    loaded from --resume checkpoints — the field that separates a legitimate
+    resume from a run that scheduled nothing at all.
     """
     completed = list(completed)
     failed = list(failed)
@@ -35,6 +37,7 @@ def _dr(slug, *, completed=(), failed=(), crashes=0, total_poses=0,
         entry_exit_codes=exit_codes or {},
         inconclusive_metrics=list(missing_metrics),
         newly_executed=newly_executed,
+        resumed=resumed,
     )
 
 
@@ -88,10 +91,27 @@ def test_fully_resumed_run_is_not_inconclusive():
         "astex_diverse",
         completed=["a", "b", "c"],   # all seeded from already_completed
         newly_executed=0,            # nothing dispatched this run
+        resumed=3,                   # ...but three came from checkpoints
         total_poses=0,               # checkpoint poses not reloaded
         missing_metrics=["docking_power_top1", "mean_rmsd"],
     )
     assert _benchmark_inconclusive_reasons([dr]) == []
+
+
+def test_run_that_scheduled_nothing_is_inconclusive():
+    # Bumble's re-review finding: newly_executed==0 AND resumed==0 means the run
+    # scheduled no work at all (empty tier / bad filter). Zero output there IS
+    # meaningful — it must not pass silently, the same inversion one size down.
+    dr = _dr(
+        "astex_diverse",
+        completed=[],
+        newly_executed=0,
+        resumed=0,
+        total_poses=0,
+        missing_metrics=["docking_power_top1", "mean_rmsd"],
+    )
+    reasons = _benchmark_inconclusive_reasons([dr])
+    assert reasons and any("completeness" in r for r in reasons)
 
 
 def test_partial_resume_still_judges_fresh_work():

--- a/python/flexaidds/dataset_runner/tests/test_benchmark_gate.py
+++ b/python/flexaidds/dataset_runner/tests/test_benchmark_gate.py
@@ -1,0 +1,80 @@
+"""#326 benchmark verdict gate: a crashed / empty / unmeasured run must be
+INCONCLUSIVE, never a silent pass.
+
+These test the liveness / productivity / completeness gates (1-3) directly,
+without docking anything — the check Honey noted "would have caught this in
+2019": feed the gate a run where the binary exited non-zero and assert it does
+not read as "no regression".
+"""
+
+import os
+import types
+
+import pytest
+
+from flexaidds.dataset_runner.cli import _benchmark_inconclusive_reasons
+
+
+def _dr(slug, *, completed=(), failed=(), crashes=0, total_poses=0,
+        exit_codes=None, missing_metrics=()):
+    """Build a minimal DatasetResult-shaped object for the gate helper."""
+    return types.SimpleNamespace(
+        config=types.SimpleNamespace(slug=slug),
+        targets_completed=list(completed),
+        targets_failed=list(failed),
+        flexaid_crashes=crashes,
+        total_poses=total_poses,
+        entry_exit_codes=exit_codes or {},
+        inconclusive_metrics=list(missing_metrics),
+    )
+
+
+def test_crashed_binary_is_inconclusive():
+    # The exact production bug: every entry crashed, zero poses, no metrics.
+    dr = _dr(
+        "astex_diverse",
+        failed=["1gpk", "1mq6", "1n2j", "1t46", "1t9b"],
+        crashes=5,
+        total_poses=0,
+        exit_codes={"1gpk/lig": -6},
+        missing_metrics=["docking_power_top1", "mean_rmsd"],
+    )
+    reasons = _benchmark_inconclusive_reasons([dr])
+    assert reasons, "a 5/5 crashed run must be INCONCLUSIVE, not a pass"
+    assert any("liveness" in r for r in reasons)
+    assert any("productivity" in r for r in reasons)
+    assert any("completeness" in r for r in reasons)
+
+
+def test_zero_poses_without_crash_is_inconclusive():
+    # Binary exited 0 but produced nothing across all attempted targets.
+    dr = _dr("astex_diverse", completed=["a", "b"], crashes=0, total_poses=0)
+    reasons = _benchmark_inconclusive_reasons([dr])
+    assert any("productivity" in r for r in reasons)
+
+
+def test_unmeasured_metric_is_inconclusive():
+    dr = _dr("astex_diverse", completed=["a"], total_poses=3,
+             missing_metrics=["docking_power_top1"])
+    reasons = _benchmark_inconclusive_reasons([dr])
+    assert reasons and all("completeness" in r for r in reasons)
+
+
+def test_healthy_run_passes_gates_1_3():
+    dr = _dr("astex_diverse", completed=["a", "b"], total_poses=42)
+    assert _benchmark_inconclusive_reasons([dr]) == []
+
+
+def test_no_attempts_is_not_flagged_productivity():
+    # An empty dataset (nothing attempted) is not a productivity failure.
+    dr = _dr("empty", completed=[], failed=[], total_poses=0)
+    assert _benchmark_inconclusive_reasons([dr]) == []
+
+
+def test_allowlist_bypasses_productivity(monkeypatch):
+    monkeypatch.setenv("FLEXAIDDS_BENCH_ALLOW_EMPTY", "hard_dataset,other")
+    dr = _dr("hard_dataset", completed=["a"], total_poses=0)
+    assert _benchmark_inconclusive_reasons([dr]) == []
+    # ...but a crash is never allowlistable.
+    dr2 = _dr("hard_dataset", failed=["a"], crashes=1, total_poses=0)
+    assert any("liveness" in r for r in _benchmark_inconclusive_reasons([dr2]))

--- a/python/flexaidds/dataset_runner/tests/test_benchmark_gate.py
+++ b/python/flexaidds/dataset_runner/tests/test_benchmark_gate.py
@@ -16,16 +16,25 @@ from flexaidds.dataset_runner.cli import _benchmark_inconclusive_reasons
 
 
 def _dr(slug, *, completed=(), failed=(), crashes=0, total_poses=0,
-        exit_codes=None, missing_metrics=()):
-    """Build a minimal DatasetResult-shaped object for the gate helper."""
+        exit_codes=None, missing_metrics=(), newly_executed=None):
+    """Build a minimal DatasetResult-shaped object for the gate helper.
+
+    ``newly_executed`` defaults to attempted (a fresh run); pass 0 to model a
+    pure --resume run where every target came from a checkpoint.
+    """
+    completed = list(completed)
+    failed = list(failed)
+    if newly_executed is None:
+        newly_executed = len(completed) + len(failed)
     return types.SimpleNamespace(
         config=types.SimpleNamespace(slug=slug),
-        targets_completed=list(completed),
-        targets_failed=list(failed),
+        targets_completed=completed,
+        targets_failed=failed,
         flexaid_crashes=crashes,
         total_poses=total_poses,
         entry_exit_codes=exit_codes or {},
         inconclusive_metrics=list(missing_metrics),
+        newly_executed=newly_executed,
     )
 
 
@@ -69,6 +78,35 @@ def test_no_attempts_is_not_flagged_productivity():
     # An empty dataset (nothing attempted) is not a productivity failure.
     dr = _dr("empty", completed=[], failed=[], total_poses=0)
     assert _benchmark_inconclusive_reasons([dr]) == []
+
+
+def test_fully_resumed_run_is_not_inconclusive():
+    # Regression for the review finding (Bumble + Honey): a pure --resume run
+    # executes no fresh targets — its poses come from checkpoints, not all_poses
+    # — so 0 poses + unmeasured metrics must NOT read as a dead binary.
+    dr = _dr(
+        "astex_diverse",
+        completed=["a", "b", "c"],   # all seeded from already_completed
+        newly_executed=0,            # nothing dispatched this run
+        total_poses=0,               # checkpoint poses not reloaded
+        missing_metrics=["docking_power_top1", "mean_rmsd"],
+    )
+    assert _benchmark_inconclusive_reasons([dr]) == []
+
+
+def test_partial_resume_still_judges_fresh_work():
+    # Some targets resumed, some freshly run and crashed → still INCONCLUSIVE.
+    dr = _dr(
+        "astex_diverse",
+        completed=["resumed_a", "resumed_b"],
+        failed=["fresh_c"],
+        newly_executed=1,            # one fresh target ran
+        crashes=1,
+        total_poses=0,
+        exit_codes={"fresh_c/lig": -6},
+    )
+    reasons = _benchmark_inconclusive_reasons([dr])
+    assert any("liveness" in r for r in reasons)
 
 
 def test_allowlist_bypasses_productivity(monkeypatch):


### PR DESCRIPTION
Closes #326.

## The bug: the gate abstains, it does not fail

The Tier-1 benchmark did not warn-and-pass on a dead binary — it **abstained**. Zero poses → no metrics computed → `check_regressions()` hits `continue` on every declared baseline → no regression flags → `cli.main` returns 0. The last green Tier-1 before #323 ran a binary that crashed on all 5 targets (fortified-glibc `realpath` overflow), produced **zero poses**, and went green **in 0.4s** — the gate passed *because* the binary was dead. A gate that cannot tell "no regression" from "nothing ran" is inverted, not weak.

Root cause narrowed by Honey to the silent `continue`; severity confirmed at runtime by the #323 Tier-1 logs and Bumble's glibc-source citation.

## The fix: four ordered gates, three verdicts

Per Honey's replacement methodology — **PASS / FAIL / INCONCLUSIVE** (CI treats non-zero as red):

1. **Liveness** — FlexAID non-zero exits are recorded (thread-safe, MPI-gathered) with exit code + first stderr line, no longer a bare `logger.warning`.
2. **Productivity** — zero poses across attempted targets fails. Legitimately-empty datasets are allowlisted via `FLEXAIDDS_BENCH_ALLOW_EMPTY` (comma-separated slugs), never by weakening the gate globally.
3. **Completeness** — the inverted `continue`: any `expected_baselines` metric that is missing/NaN is recorded as inconclusive instead of skipped as "fine". **This is the load-bearing one.**
4. **Quality** — the existing `baseline − tolerance` regression check, unchanged.

`cli.main` returns **3 (INCONCLUSIVE)** when gates 1–3 trip, before the existing regression check (**1 = FAIL**). Gates are skipped under `--dry-run`. Provenance added to the report JSON (`flexaid_crashes`, `total_poses`, `entry_exit_codes`, `inconclusive_metrics`).

## Verification

- New `test_benchmark_gate.py` drives the verdict helper across crashed / zero-pose / unmeasured / healthy / allowlisted cases — **no docking required**. This is the unit test Honey named ("feed a run that exited non-zero, assert INCONCLUSIVE") that would have caught this years ago. **6/6 pass.**
- Full existing `dataset_runner` suite: **113 passed, 1 skipped** — no regressions.
- The gate helper is extracted from `main` specifically so it is testable without a binary.

## One thing the team should decide (not a blocker)

Gate 3 (completeness) fails a run where any of `astex_diverse`'s 7 declared baselines isn't computed. The **first real Tier-1 run on a tree containing #323** is the first time all 7 will actually be produced — if some legitimately aren't computable yet, that surfaces as INCONCLUSIVE, which is the correct loud signal, tunable via allowlist/config in follow-up rather than by re-hiding it. Flagging so it's a decision, not a surprise.

Distinct from #324 (build-time `--help` smoke gate, catches a binary that cannot start); this makes the benchmark refuse to *score* one. Related: #323 (the abort), #325 (timeout budget).

Originating channel: Benchmarking FlexAIDdS (#716e79b1-6a4f-4cde-8851-22836ba8738c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added benchmark health checks for liveness, productivity, and completeness.
  - Dataset results now report crashes, exit codes, pose counts, resumed work, newly executed targets, and missing metrics.
  - Benchmark runs clearly indicate when results are inconclusive and provide the relevant reason.

- **Bug Fixes**
  - Prevented incomplete or unproductive benchmark results from being treated as valid regressions.
  - Improved consistency of status reporting across distributed and resumed runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->