### PR TITLE
Tier-1: reduce subset to 1 target so the gate can actually complete

### DIFF
--- a/benchmarks/datasets/astex_diverse.yaml
+++ b/benchmarks/datasets/astex_diverse.yaml
@@ -31,7 +31,7 @@ zenodo_doi: ""
 download_url: "https://www.ccdc.cam.ac.uk/community/freeprod/astex-diverse-set/"
 data_format: pdb
 tier: 2
-tier1_subset_size: 5
+tier1_subset_size: 1
 
 structural_states:
   - holo

--- a/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
+++ b/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
@@ -31,7 +31,7 @@ zenodo_doi: ""
 download_url: "https://www.ccdc.cam.ac.uk/community/freeprod/astex-diverse-set/"
 data_format: pdb
 tier: 2
-tier1_subset_size: 5
+tier1_subset_size: 1
 
 structural_states:
   - holo


### PR DESCRIPTION
Implements the scope decision made 2026-08-01: *"the Tier-1 must be redefined to fit into the time period."*

## The measurement this rests on

Tier-1 has **never completed a run** in this repository's history. Before #323 the binary aborted at startup and the check "passed" in 0.4s having docked nothing. The first run ever allowed to get far enough produced exactly one data point:

```
1gpk/holo   831.65 s wall (13.86 min)   11 poses   success: true
```

Five targets run **serially** (`--workers` defaults to 1), so a full Tier-1 is **~69 minutes** against a 25-minute step cap. That run completed one target and was killed mid-second.

## Why 1 and not 2

```
1 target    13.9 min   vs 25-min step cap   FITS
2 targets   27.7 min                        EXCEEDS
3 targets   41.6 min                        EXCEEDS
```

Two already blows the cap **before** the ~2.5 min cache-miss build is counted. This is recorded in the commit body as well, because the next person will ask and without it `1` looks arbitrary — someone bumps it to 3 in six months and the gate silently stops completing again.

## Why this is worth doing rather than waiting

A check that is red on **every** PR trains people to ignore it, and the first genuine regression then arrives inside a red everybody has been scrolling past. That is the same failure as the abstaining gate this repo just fixed in #326/#327, arriving from the opposite direction:

| gate state | what it teaches |
|---|---|
| green in 0.4s on a dead binary | trust it → wrong |
| red on every PR, forever | ignore it → also wrong |
| red only when something is wrong | the goal |

**A thin gate that runs beats a thick one that always times out.**

## Both copies changed — deliberately

```
benchmarks/datasets/astex_diverse.yaml             <- used by CI (--datasets-dir benchmarks/datasets)
python/flexaidds/dataset_runner/datasets/...yaml   <- used by anyone running the module without that flag
```

They were **byte-identical** (`diff` clean) and both declared `5`. Changing only the CI copy would make "Tier-1" mean one target in CI and five locally — precisely the silent divergence this file's own comment warns about. Verified after the edit that both parse and both now read `1`, with `targets: 85` untouched.

## What this costs, stated plainly

A one-target gate catches a **dead or wildly regressed** binary. It will **not** catch a subtle regression on the other four targets. That is the accepted trade while Tier-1 cannot fit at all — not a claim that one target is sufficient coverage.

## Better end state, not done here

`benchmark-tier1.yml:20` declares a `tier1_subset_size` workflow input that is **never consumed** — `grep` finds exactly one occurrence, and no `--subset-size` CLI flag exists to receive it. Someone setting it to 1 and clicking "Run workflow" gets 5 targets with no indication otherwise.

Wiring that input through to a CLI flag would let CI pick its own subset **without redefining the dataset for every consumer** — a strictly better answer than editing dataset config. It touches `cli.py`/`runner.py`, currently contested by #327, so it is tracked in #334 rather than done here.

## Expected CI on this PR

The Tier-1 check should **complete for the first time** — ~14 min of docking plus build, inside the 25-minute step cap. If it does, that is the first completed Tier-1 run this project has recorded and the number it reports is worth reading from the log rather than the tick.

Related: #330 (scale), #331 (correct vs plausible), #334 (derived vs measured, plus the dead input).