### PR TITLE
ci: stop running the full matrix twice on every PR commit (closes #338)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,24 @@
 name: FlexAID CI
 
 on:
+  # push is restricted to main: an unrestricted `push:` made every commit on a
+  # PR branch run this whole matrix TWICE (once per event) on the same SHA.
+  # The concurrency group below cannot dedupe those two, because github.ref is
+  # refs/heads/<branch> on push and refs/pull/<n>/merge on pull_request -- two
+  # different groups by construction. Every other workflow in this repo that
+  # has both triggers already scopes push to main; this one and license-scan
+  # were the exceptions. See #338.
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  # head_ref (the source branch, set only on pull_request) before ref, so a PR
+  # and any future push-triggered run for the same branch share one group.
+  # Defence in depth: the branches filter above is what actually removes the
+  # duplicate; this stops it recurring if push is ever widened again.
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -1,7 +1,10 @@
 name: License Compliance
 
 on:
+  # Restricted to main for the same reason as ci.yml: an unrestricted `push:`
+  # alongside `pull_request:` runs this twice per commit on a PR branch. See #338.
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Implements the fix for #338, per direct instruction.

## The defect

`ci.yml` and `license-scan.yml` declared an unrestricted `push:` alongside `pull_request:`. On a PR branch that fires **both** events for the same SHA, so every commit ran two complete matrices — including two copies of the ~45-minute `linux-gcc-asan` job.

Five branches sampled, five doubled:

```
fix/tier1-subset-fits-budget  bf4c3236  runs=2  push,pull_request
perf/tier1-throughput         0859c183  runs=2  push,pull_request
ci/tier1-timeout-budget       c31490e8  runs=2  push,pull_request
ci/tier1-timeout-budget       eadaa15e  runs=2  push,pull_request
test/c1-help-...-probe        e338497f  runs=2  push,pull_request
```

This is also why `gh pr checks` lists contexts twice (`C++ core (linux-gcc)` ×2, `Python bindings smoke (windows)` ×2). That looks like a display quirk. It is two matrices.

## Why the existing guard could not catch it

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

`github.ref` is `refs/heads/<branch>` on push and `refs/pull/<n>/merge` on pull_request — **different groups by construction**, so neither run cancels the other. A guard that is present, reads correct, and is structurally unable to do its job.

## The change

**Scope `push:` to `main` in both files.** This is not a new idea — it is the convention **already used by five sibling workflows** (`codeql`, `coverage`, `sanitizers`, `tsan`, `benchmark-tier2`). `ci.yml` and `license-scan.yml` were the only two exceptions.

Also widens the concurrency group to `${{ github.head_ref || github.ref }}` as defence in depth: the branches filter is what removes the duplicate today; the group stops it recurring if `push` is ever widened again.

## How the scope was established

By **parsing the `on:` block of all 15 workflows**, not grepping — because in YAML `push:` with a null value means **unrestricted**, not absent, and a naive check reports the exact opposite. My first pass did exactly that and had to be redone:

```
ci.yml                     push:UNRESTRICTED    pr=True  <-- DOUBLES
license-scan.yml           push:UNRESTRICTED    pr=True  <-- DOUBLES
codeql / coverage / sanitizers / tsan / benchmark-tier2   push:['main']
benchmark-tier1.yml        push:absent          pr=True   ← never doubled
release.yml                push:{tags: [v*]}    pr=False
```

Credit to Honey, who bounded this to two workflows by hand before I had it, and correctly narrowed my original "the repo double-runs everything" framing.

## Effect and limits

- **One matrix per commit instead of two** on the workflow that carries the heavy build. Halves its CI spend and removes duplicate runs that were queueing ahead of work people were waiting on.
- **Does not affect Tier-1** — `benchmark-tier1.yml` is `pull_request`-only and never doubled. The ~50% figure in #338 was for `ci.yml`, not for total CI minutes across all workflows; that framing is corrected here.
- **Tradeoff, stated:** pushes to a branch with **no open PR** no longer get CI. Five sibling workflows already accept exactly this, so it is the repo's existing posture rather than a new one. Open a PR to get CI, which is the normal path here.

## Verification

Both files re-parsed after the edit:

```
.github/workflows/ci.yml            push={'branches': ['main']}  pr=True
.github/workflows/license-scan.yml  push={'branches': ['main']}  pr=True
```

The real proof is this PR's own checks: **it should show each context once, not twice.** That is worth looking at before merging — if contexts still appear doubled, the diagnosis is wrong and I want to know.

Closes #338.