### PR TITLE
Implement mean_rmsd / median_rmsd aggregates (#341 item 1)

### DIFF
--- a/python/flexaidds/dataset_runner/metrics.py
+++ b/python/flexaidds/dataset_runner/metrics.py
@@ -509,10 +509,17 @@ def compute_all_metrics(
 
     # Pose-accuracy aggregates: per-target best-pose RMSD, then mean/median
     # across targets — mirrors benchmark.BenchmarkSummary's median-of-best-pose
-    # definition.  Sentinel RMSDs (< 0, e.g. -1 = not computed) are excluded.
-    # When no target yields a valid best-pose RMSD the metric is left ABSENT so
-    # the #326 completeness gate reports it unmeasured, rather than emitting a
-    # misleading 0.0 the way an un-guarded aggregate would.
+    # definition.  Sentinel RMSDs (< 0 = not computed, 999 = no pose) are
+    # excluded, so a target that produced no usable pose contributes NOTHING to
+    # the aggregate.  This is a deliberate asymmetry with docking_power(), whose
+    # denominator counts an empty target as a FAILURE: a success *rate* is
+    # defined over attempts, but you cannot average a distance that does not
+    # exist.  The risk of that asymmetry is that a mostly-failed multi-target
+    # run reports a clean mean over its few survivors — so the coverage count is
+    # emitted alongside (``mean_rmsd_n_targets``) to put the denominator in the
+    # report rather than leave it inferred.  When no target yields a valid
+    # best-pose RMSD the metric is left ABSENT so the #326 completeness gate
+    # reports it unmeasured rather than emitting a misleading 0.0.
     if "mean_rmsd" in to_compute or "median_rmsd" in to_compute:
         from collections import defaultdict as _defaultdict
         _rmsd_by_target: dict[str, list[float]] = _defaultdict(list)
@@ -525,6 +532,11 @@ def compute_all_metrics(
         best_rmsds = sorted(min(v) for v in _rmsd_by_target.values() if v)
         if best_rmsds:
             n = len(best_rmsds)
+            # Coverage: number of targets the aggregate is actually over, so a
+            # reader sees "3.16 over 5 targets" rather than a clean-looking mean.
+            # Informational only — not a declared baseline, so it is neither
+            # gated by completeness nor direction-checked by check_regressions.
+            results["mean_rmsd_n_targets"] = float(n)
             if "mean_rmsd" in to_compute:
                 results["mean_rmsd"] = sum(best_rmsds) / n
             if "median_rmsd" in to_compute:

--- a/python/flexaidds/dataset_runner/metrics.py
+++ b/python/flexaidds/dataset_runner/metrics.py
@@ -482,6 +482,8 @@ def compute_all_metrics(
         "entropy_rescue_rate",
         "docking_power_top1",
         "docking_power_top3",
+        "mean_rmsd",
+        "median_rmsd",
         "ef_1pct",
         "ef_5pct",
         "log_auc",
@@ -504,6 +506,33 @@ def compute_all_metrics(
     if "docking_power_top3" in to_compute:
         results["docking_power_top3"] = docking_power(
             poses, top_n=3, n_targets=n_targets)
+
+    # Pose-accuracy aggregates: per-target best-pose RMSD, then mean/median
+    # across targets — mirrors benchmark.BenchmarkSummary's median-of-best-pose
+    # definition.  Sentinel RMSDs (< 0, e.g. -1 = not computed) are excluded.
+    # When no target yields a valid best-pose RMSD the metric is left ABSENT so
+    # the #326 completeness gate reports it unmeasured, rather than emitting a
+    # misleading 0.0 the way an un-guarded aggregate would.
+    if "mean_rmsd" in to_compute or "median_rmsd" in to_compute:
+        from collections import defaultdict as _defaultdict
+        _rmsd_by_target: dict[str, list[float]] = _defaultdict(list)
+        for p in poses:
+            # Exclude both sentinels: -1 (not computed) and 999 (no pose
+            # emitted).  Averaging 999 would silently poison the aggregate,
+            # unlike docking_power where the rmsd < 2.0 threshold neutralises it.
+            if 0.0 <= p.rmsd < 999.0:
+                _rmsd_by_target[p.target_id].append(p.rmsd)
+        best_rmsds = sorted(min(v) for v in _rmsd_by_target.values() if v)
+        if best_rmsds:
+            n = len(best_rmsds)
+            if "mean_rmsd" in to_compute:
+                results["mean_rmsd"] = sum(best_rmsds) / n
+            if "median_rmsd" in to_compute:
+                mid = n // 2
+                results["median_rmsd"] = (
+                    best_rmsds[mid] if n % 2 == 1
+                    else (best_rmsds[mid - 1] + best_rmsds[mid]) / 2.0
+                )
 
     # Virtual-screening metrics require active/decoy labels and scores
     all_scores = [p.total_score for p in poses]

--- a/python/tests/test_metrics_rmsd_aggregate.py
+++ b/python/tests/test_metrics_rmsd_aggregate.py
@@ -1,0 +1,86 @@
+"""Pose-accuracy aggregates: mean_rmsd / median_rmsd.
+
+These metrics are declared as baselines by pose-reproduction datasets
+(astex_diverse, hap2, ...) but had no implementation in ``compute_all_metrics``
+until #341 — so a run that produced real per-pose RMSDs still reported them as
+"never measured" and the #326 completeness gate failed on a metric the code
+simply never computed.
+
+Definition (mirrors ``benchmark.BenchmarkSummary``): per target take the
+best (minimum) valid pose RMSD, then mean / median across targets.  A target
+with no valid RMSD contributes nothing, and when *no* target yields a valid
+best-pose RMSD the metric is left ABSENT so the gate reports it unmeasured
+rather than emitting a misleading 0.0.
+"""
+
+from flexaidds.dataset_runner.metrics import PoseScore, compute_all_metrics
+
+_RMSD_KEYS = ["mean_rmsd", "median_rmsd"]
+
+
+def _pose(target, rmsd, rank=1):
+    return PoseScore(
+        target_id=target,
+        ligand_id=f"{target}_lig",
+        pose_rank=rank,
+        rmsd=rmsd,
+        enthalpy_score=-10.0,
+        entropy_correction=0.0,
+        total_score=-10.0,
+        is_active=True,
+    )
+
+
+def test_best_pose_per_target_then_mean_and_median():
+    poses = [
+        _pose("A", 1.0, rank=1), _pose("A", 2.5, rank=2),  # best = 1.0
+        _pose("B", 3.0, rank=1), _pose("B", 2.0, rank=2),  # best = 2.0
+        _pose("C", 3.0, rank=1),                            # best = 3.0
+    ]
+    r = compute_all_metrics(poses, requested=_RMSD_KEYS)
+    assert r["mean_rmsd"] == (1.0 + 2.0 + 3.0) / 3.0
+    assert r["median_rmsd"] == 2.0
+
+
+def test_even_target_count_median_is_mean_of_two_middle():
+    poses = [_pose("A", 1.0), _pose("B", 2.0), _pose("C", 3.0), _pose("D", 6.0)]
+    r = compute_all_metrics(poses, requested=_RMSD_KEYS)
+    assert r["median_rmsd"] == (2.0 + 3.0) / 2.0
+    assert r["mean_rmsd"] == (1.0 + 2.0 + 3.0 + 6.0) / 4.0
+
+
+def test_sentinel_rmsds_are_excluded_from_the_aggregate():
+    # -1 (not computed) and 999 (no pose) must not enter the best-pose set.
+    poses = [
+        _pose("A", -1.0, rank=1), _pose("A", 1.5, rank=2),  # best = 1.5, not -1
+        _pose("B", 999.0),                                   # no valid RMSD -> dropped
+    ]
+    r = compute_all_metrics(poses, requested=_RMSD_KEYS)
+    assert r["mean_rmsd"] == 1.5
+    assert r["median_rmsd"] == 1.5
+
+
+def test_no_valid_rmsd_leaves_metrics_absent_for_the_gate():
+    # Every pose has a sentinel RMSD -> the completeness gate must see the
+    # metric as unmeasured (absent), NOT as 0.0.
+    poses = [_pose("A", -1.0), _pose("B", 999.0)]
+    r = compute_all_metrics(poses, requested=_RMSD_KEYS)
+    assert "mean_rmsd" not in r
+    assert "median_rmsd" not in r
+
+
+def test_single_target_reproduces_the_1gpk_run():
+    # The first real Tier-1 run: one target (1gpk), 11 near-identical poses at
+    # ~3.156 A.  best = min; mean == median == that best for a single target.
+    rmsds = [
+        3.155735, 3.155741, 3.155754, 3.155757, 3.155762, 3.155792,
+        3.155814, 3.155819, 3.155820, 3.155822, 3.155878,
+    ]
+    poses = [_pose("1gpk", v, rank=i + 1) for i, v in enumerate(rmsds)]
+    r = compute_all_metrics(poses, requested=_RMSD_KEYS)
+    best = min(rmsds)
+    assert r["mean_rmsd"] == best
+    assert r["median_rmsd"] == best
+    # And it is now PRESENT — the exact metric the gate reported "never
+    # measured" on run 30680006724.
+    assert set(_RMSD_KEYS) <= r.keys()

--- a/python/tests/test_metrics_rmsd_aggregate.py
+++ b/python/tests/test_metrics_rmsd_aggregate.py
@@ -62,11 +62,35 @@ def test_sentinel_rmsds_are_excluded_from_the_aggregate():
 
 def test_no_valid_rmsd_leaves_metrics_absent_for_the_gate():
     # Every pose has a sentinel RMSD -> the completeness gate must see the
-    # metric as unmeasured (absent), NOT as 0.0.
+    # metric as unmeasured (absent), NOT as 0.0.  The coverage count is absent
+    # too — there is no denominator to report.
     poses = [_pose("A", -1.0), _pose("B", 999.0)]
     r = compute_all_metrics(poses, requested=_RMSD_KEYS)
     assert "mean_rmsd" not in r
     assert "median_rmsd" not in r
+    assert "mean_rmsd_n_targets" not in r
+
+
+def test_coverage_count_reports_contributing_target_total():
+    poses = [_pose("A", 1.0), _pose("B", 2.0), _pose("C", 3.0)]
+    r = compute_all_metrics(poses, requested=_RMSD_KEYS)
+    assert r["mean_rmsd_n_targets"] == 3.0
+
+
+def test_partial_valid_targets_average_over_valid_and_expose_the_denominator():
+    # Honey's failure mode: some targets produce a valid pose, others are
+    # all-sentinel.  The aggregate is over the valid targets only (you cannot
+    # average a distance that does not exist — the deliberate asymmetry with
+    # docking_power, whose denominator counts empty targets as failures), and
+    # the coverage count makes the shrunken denominator visible rather than
+    # letting a clean-looking mean hide it.
+    poses = [
+        _pose("valid1", 1.0), _pose("valid2", 3.0),
+        _pose("empty1", -1.0), _pose("empty2", 999.0),
+    ]
+    r = compute_all_metrics(poses, requested=_RMSD_KEYS)
+    assert r["mean_rmsd"] == 2.0            # over valid1, valid2 only
+    assert r["mean_rmsd_n_targets"] == 2.0  # not 4 — the two empties dropped out
 
 
 def test_single_target_reproduces_the_1gpk_run():


### PR DESCRIPTION
Closes **item 1 of #341**: `mean_rmsd` / `median_rmsd` were declared as baselines by `astex_diverse` (and other pose-reproduction datasets) but had **no implementation** in `compute_all_metrics`. The first real Tier-1 run (`30680006724`) produced 11 genuine per-pose RMSDs, yet the #326 completeness gate correctly reported both as *never measured* — because the aggregator that turns per-pose RMSD into a dataset-level number did not exist.

### What this does
Per target, take the best (minimum) valid pose RMSD; then mean / median across targets — mirroring `benchmark.BenchmarkSummary`. Both sentinels excluded: `-1` (not computed) and `999` (no pose emitted). When **no** target yields a valid best-pose RMSD the metric is left **absent** (not `0.0`), so a genuinely empty run still trips the completeness gate rather than reporting a misleading zero.

### Honest downstream consequence (not a regression in this PR)
On `1gpk` the best pose is **3.156 Å**, so `mean_rmsd`/`median_rmsd` now **compute** (completeness passes for these two) and then **legitimately fail the quality/regression gate** against the `2.30` baseline. That is the engine missing at 3.16 Å surfacing one layer down — the correct behaviour, not a defect here.

### Scope
Only #341 item 1. Does **not** touch `scoring_power` (#337 config drop), the `entropy = ` vs `ENTROPY:` parser gap, pose-PDB retention, or the other ledger items.

### Tests
`python/tests/test_metrics_rmsd_aggregate.py` — best-pose-per-target mean/median, even-count median, sentinel exclusion, absent-on-empty (gate stays honest), and a reproduction of the exact 1gpk single-target run. **Full `dataset_runner` + `tests` suite green: 1041 passed, 68 skipped.**

The Tier-1 check on this PR is **expected red** — the 3.16 Å regression above plus the still-open entropy-transmission gap (#341). Reviewers: verify the aggregator logic and the absent-on-empty gate behaviour; the red is documented, not a surprise.

Reviewed in the Buzz channel (GitHub self-review is structurally impossible — all three agents push as LeBonhommePharma; approvals recorded as PR comments).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mean and median RMSD metrics to default results.
  * Aggregates now use the best valid RMSD for each target.
  * Invalid or sentinel RMSD values are excluded from calculations.
  * Aggregate metrics are omitted when no valid RMSD data is available.

* **Tests**
  * Added coverage for target selection, median calculations, invalid values, and single-target results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->