### PR TITLE
Fix: point astex_diverse at its in-repo data; drop unmeasurable scoring_power baselines

### DIFF
--- a/benchmarks/datasets/astex_diverse.yaml
+++ b/benchmarks/datasets/astex_diverse.yaml
@@ -27,15 +27,6 @@ canonical_data_root: benchmarks/astex_diverse/astex_diverse
 checksum_manifest: benchmarks/datasets/astex_diverse_sha256.csv
 canonical_doc: benchmarks/datasets/CANONICAL.md
 
-# Resolved dataset root. WITHOUT this key the runner falls back to
-# <FLEXAIDDS_BENCHMARK_DATA>/<slug> (runner.py:1182,1195) -- which is
-# benchmark_data/astex_diverse for Tier-2, an empty directory, because the
-# Zenodo record map at benchmark-tier2.yml:181 is entirely commented out.
-# Tier-1 works only because its workflow sets the env var to the in-repo path.
-# This value is the same one canonical_data_root already declares above;
-# canonical_data_root is discarded by the parser (runner.py:233), data_dir is not.
-# Relative to the repo root, which is the CWD for both benchmark workflows.
-data_dir: benchmarks/astex_diverse/astex_diverse
 
 zenodo_doi: ""
 download_url: "https://www.ccdc.cam.ac.uk/community/freeprod/astex-diverse-set/"

--- a/benchmarks/datasets/astex_diverse.yaml
+++ b/benchmarks/datasets/astex_diverse.yaml
@@ -27,6 +27,16 @@ canonical_data_root: benchmarks/astex_diverse/astex_diverse
 checksum_manifest: benchmarks/datasets/astex_diverse_sha256.csv
 canonical_doc: benchmarks/datasets/CANONICAL.md
 
+# Resolved dataset root. WITHOUT this key the runner falls back to
+# <FLEXAIDDS_BENCHMARK_DATA>/<slug> (runner.py:1182,1195) -- which is
+# benchmark_data/astex_diverse for Tier-2, an empty directory, because the
+# Zenodo record map at benchmark-tier2.yml:181 is entirely commented out.
+# Tier-1 works only because its workflow sets the env var to the in-repo path.
+# This value is the same one canonical_data_root already declares above;
+# canonical_data_root is discarded by the parser (runner.py:233), data_dir is not.
+# Relative to the repo root, which is the CWD for both benchmark workflows.
+data_dir: benchmarks/astex_diverse/astex_diverse
+
 zenodo_doi: ""
 download_url: "https://www.ccdc.cam.ac.uk/community/freeprod/astex-diverse-set/"
 data_format: pdb
@@ -128,8 +138,6 @@ targets:
 metrics:
   - docking_power_top1
   - docking_power_top3
-  - scoring_power_pearson_r
-  - scoring_power_rmse
   - mean_rmsd
   - median_rmsd
   - entropy_rescue_rate
@@ -137,8 +145,11 @@ metrics:
 expected_baselines:
   docking_power_top1: 0.70
   docking_power_top3: 0.85
-  scoring_power_pearson_r: 0.65
-  scoring_power_rmse: 2.10
+  # scoring_power_* removed: metrics.py:524-526 needs >=2 poses carrying
+  # exp_affinity, and astex_diverse is a pose-reproduction set whose poses
+  # carry none (verified: all 11 poses in run 30680006724 have
+  # exp_affinity=null). The baseline was unmeasurable at ANY subset size,
+  # so the completeness gate failed the run for a config error. See #337.
   mean_rmsd: 2.30
   median_rmsd: 1.95
   entropy_rescue_rate: 0.30

--- a/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
+++ b/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
@@ -27,15 +27,6 @@ canonical_data_root: benchmarks/astex_diverse/astex_diverse
 checksum_manifest: benchmarks/datasets/astex_diverse_sha256.csv
 canonical_doc: benchmarks/datasets/CANONICAL.md
 
-# Resolved dataset root. WITHOUT this key the runner falls back to
-# <FLEXAIDDS_BENCHMARK_DATA>/<slug> (runner.py:1182,1195) -- which is
-# benchmark_data/astex_diverse for Tier-2, an empty directory, because the
-# Zenodo record map at benchmark-tier2.yml:181 is entirely commented out.
-# Tier-1 works only because its workflow sets the env var to the in-repo path.
-# This value is the same one canonical_data_root already declares above;
-# canonical_data_root is discarded by the parser (runner.py:233), data_dir is not.
-# Relative to the repo root, which is the CWD for both benchmark workflows.
-data_dir: benchmarks/astex_diverse/astex_diverse
 
 zenodo_doi: ""
 download_url: "https://www.ccdc.cam.ac.uk/community/freeprod/astex-diverse-set/"

--- a/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
+++ b/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
@@ -27,6 +27,16 @@ canonical_data_root: benchmarks/astex_diverse/astex_diverse
 checksum_manifest: benchmarks/datasets/astex_diverse_sha256.csv
 canonical_doc: benchmarks/datasets/CANONICAL.md
 
+# Resolved dataset root. WITHOUT this key the runner falls back to
+# <FLEXAIDDS_BENCHMARK_DATA>/<slug> (runner.py:1182,1195) -- which is
+# benchmark_data/astex_diverse for Tier-2, an empty directory, because the
+# Zenodo record map at benchmark-tier2.yml:181 is entirely commented out.
+# Tier-1 works only because its workflow sets the env var to the in-repo path.
+# This value is the same one canonical_data_root already declares above;
+# canonical_data_root is discarded by the parser (runner.py:233), data_dir is not.
+# Relative to the repo root, which is the CWD for both benchmark workflows.
+data_dir: benchmarks/astex_diverse/astex_diverse
+
 zenodo_doi: ""
 download_url: "https://www.ccdc.cam.ac.uk/community/freeprod/astex-diverse-set/"
 data_format: pdb
@@ -128,8 +138,6 @@ targets:
 metrics:
   - docking_power_top1
   - docking_power_top3
-  - scoring_power_pearson_r
-  - scoring_power_rmse
   - mean_rmsd
   - median_rmsd
   - entropy_rescue_rate
@@ -137,8 +145,11 @@ metrics:
 expected_baselines:
   docking_power_top1: 0.70
   docking_power_top3: 0.85
-  scoring_power_pearson_r: 0.65
-  scoring_power_rmse: 2.10
+  # scoring_power_* removed: metrics.py:524-526 needs >=2 poses carrying
+  # exp_affinity, and astex_diverse is a pose-reproduction set whose poses
+  # carry none (verified: all 11 poses in run 30680006724 have
+  # exp_affinity=null). The baseline was unmeasurable at ANY subset size,
+  # so the completeness gate failed the run for a config error. See #337.
   mean_rmsd: 2.30
   median_rmsd: 1.95
   entropy_rescue_rate: 0.30


### PR DESCRIPTION
Closes the "no receptor found" failure from Tier-2 run [30680646422](https://github.com/LeBonhommePharma/FlexAIDdS/actions/runs/30680646422), and removes a baseline the dataset structurally cannot produce.

## 1. `data_dir` — the data was on disk; the runner looked elsewhere

That run logged `No receptor found` **3,580 times**, every one against `benchmark_data/<slug>`:

```
[WARNING] No receptor found for 1gpk (holo) in
    /home/runner/work/FlexAIDdS/FlexAIDdS/benchmark_data/astex_diverse
```

`1gpk` is the target Tier-1 docked successfully **ninety seconds earlier** in run 30680006724. It is in the repo at `benchmarks/astex_diverse/astex_diverse/1GPK/`.

Two things kept the runner from finding it:

- **`data_dir` was unset**, so `runner.py:1182,1195` fell back to `<FLEXAIDDS_BENCHMARK_DATA>/<slug>`. Tier-1 works only because `benchmark-tier1.yml:53` sets that env var to the in-repo path; `benchmark-tier2.yml:225` points at `benchmark_data/`, populated by a Zenodo step whose record map (`benchmark-tier2.yml:181`) is entirely commented out.
- **`canonical_data_root` already declares the correct value** — and `runner.py:233` pops and discards it. Two keys, one meaning, one honoured and one ignored.

**Why per-dataset rather than repointing the env var:** the env var is a *parent* and the slug is appended, so no single root satisfies all fourteen datasets (`casf2016` → `casf2016_tier1`, `posex_cd` absent, …). A repoint would fix one dataset while looking like it fixed the tier. `data_dir` is honest by construction: it makes a claim about exactly one dataset because it lives in exactly one dataset's file. The other thirteen keep warning and the gate keeps failing them correctly.

## 2. `scoring_power_*` — a baseline that could never be measured

`metrics.py:524-526` requires >=2 poses carrying `exp_affinity`. `astex_diverse` is a pose-reproduction (RMSD) set; **all 11 poses in run 30680006724 have `exp_affinity: null`.** So `scoring_power_pearson_r: 0.65` was unmeasurable at *any* subset size — 1 or 85 — and the completeness gate was failing the run for a config over-declaration rather than a benchmark result.

This is the **#337 pattern** (dataset declares a baseline it cannot feed), not the #336 subset conflict. Found by Fizz.

## Verification

```
DatasetConfig.from_yaml(...)
  data_dir     benchmarks/astex_diverse/astex_diverse    exists: True
  1GPK         present: True
  metrics      docking_power_top1/top3, mean_rmsd, median_rmsd, entropy_rescue_rate
  baselines    same five — scoring_power_* gone from both lists

both YAML copies byte-identical (benchmarks/datasets/CANONICAL.md)
python suite: 1027 passed, 68 skipped
```

## What this does **not** fix

- Thirteen datasets still have no in-repo data and still need the Zenodo IDs registered — **#340**
- The eight-field thermodynamic ledger is still unparsed — **#341**
- `mean_rmsd`/`median_rmsd` have no aggregator until **#342** lands
- **`check_regressions` treats `mean_rmsd` as higher-is-better** (`runner.py:445`, `"rmse" in metric` does not match `rmsd`). Once #342 makes the metric computable, 3.16 A against a 2.30 A baseline will **pass**. Found by Bumble; not fixed here and it should not land behind #342.

A Tier-2 run on this branch will still exit 3 — thirteen datasets have no data, and the ledger and ranking questions are open. The change it makes is that `astex_diverse` will, for the first time, be *found*.

Refs #340, #337, #341