### PR TITLE
Regression gate: look up metric direction instead of guessing it from the name

### DIFF
--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -374,6 +374,53 @@ class TargetResult:
         return not self.error and bool(self.poses)
 
 
+# ---------------------------------------------------------------------------
+# Regression direction registry
+# ---------------------------------------------------------------------------
+# check_regressions used to infer "lower is better" from the substring "rmse"
+# or "mae". That silently inverted every distance metric whose name is spelled
+# differently -- mean_rmsd, median_rmsd, crossdock_*_rmsd, selectivity_log_error
+# -- so a 37% WORSE RMSD scored as "no regression". Direction is a property of
+# the metric, not of its spelling: declare it here, beside nothing else.
+#
+# Every metric named in any benchmarks/datasets/*.yaml expected_baselines block
+# must appear in exactly one of these sets. An unlisted metric logs a warning
+# and falls back to higher-is-better rather than failing the run.
+_LOWER_IS_BETTER = frozenset({
+    "crossdock_mean_rmsd",
+    "crossdock_median_rmsd",
+    "delta_delta_g_rmse_kcal",
+    "mean_rmsd",
+    "median_rmsd",
+    "p_bind_agreement_rmse",
+    "scoring_power_mae",
+    "scoring_power_rmse",
+    "selectivity_log_error",
+})
+
+_HIGHER_IS_BETTER = frozenset({
+    "crossdock_success_rate_2A",
+    "crossdock_success_rate_3A",
+    "docking_power_top1",
+    "docking_power_top3",
+    "ef_1pct",
+    "ef_5pct",
+    "entropy_rescue_rate",
+    "hit_rate_top10",
+    "log_auc",
+    "occupancy_agreement",
+    "posebusters_pass_rate",
+    "scoring_power_pearson_r",
+    "scoring_power_spearman_r",
+    "target_specificity_zscore",
+})
+
+# Deliberately in NEITHER set: shannon_energy_collapse. Its preferred direction
+# is not determinable from the name or from any docstring in this repo, so it
+# warns rather than silently taking a side. Declare it once someone who knows
+# the physics says which way is better.
+
+
 @dataclass
 class DatasetResult:
     """Aggregated results for one complete dataset run.
@@ -444,12 +491,21 @@ class DatasetResult:
                 # cli.main can fail the run rather than silently pass it.
                 missing.append(metric)
                 continue
-            # For error/RMSE metrics lower is better — allow increase
-            if "rmse" in metric or "mae" in metric:
+            # Direction is looked up, never inferred from the name. See
+            # _LOWER_IS_BETTER: substring-sniffing silently inverted
+            # mean_rmsd/median_rmsd because "rmsd" is not "rmse".
+            if metric in _LOWER_IS_BETTER:
                 threshold = baseline * (1 + tol)
                 flags[metric] = bool(measured > threshold)
             else:
-                # For all other metrics higher is better
+                if metric not in _HIGHER_IS_BETTER:
+                    logger.warning(
+                        "Metric %r has no declared direction in "
+                        "_LOWER_IS_BETTER/_HIGHER_IS_BETTER; assuming "
+                        "higher-is-better. Declare it before trusting this "
+                        "regression verdict.",
+                        metric,
+                    )
                 threshold = baseline * (1 - tol)
                 flags[metric] = bool(measured < threshold)
         self.regression_flags = flags

--- a/python/tests/test_regression_direction.py
+++ b/python/tests/test_regression_direction.py
@@ -1,0 +1,79 @@
+"""Regression-direction registry: distance metrics must flag when they WORSEN.
+
+Guards the bug where check_regressions inferred direction from the substrings
+"rmse"/"mae", so mean_rmsd (spelled rmsD) took the higher-is-better branch and
+a 37% worse RMSD scored as no-regression.
+"""
+import yaml
+from pathlib import Path
+
+from flexaidds.dataset_runner.runner import (
+    DatasetResult,
+    _HIGHER_IS_BETTER,
+    _LOWER_IS_BETTER,
+)
+
+
+class _Cfg:
+    def __init__(self, baselines, tol=0.05):
+        self.expected_baselines = baselines
+        self.baseline_tolerance = tol
+
+
+def _result(metrics, baselines):
+    dr = DatasetResult.__new__(DatasetResult)
+    dr.metrics = metrics
+    dr.config = _Cfg(baselines)
+    dr.regression_flags = {}
+    dr.inconclusive_metrics = []
+    return dr
+
+
+def test_mean_rmsd_worse_than_baseline_is_flagged():
+    """The exact 1gpk case: 3.1557 measured against a 2.30 baseline."""
+    dr = _result({"mean_rmsd": 3.1557}, {"mean_rmsd": 2.30})
+    assert dr.check_regressions()["mean_rmsd"] is True
+
+
+def test_mean_rmsd_better_than_baseline_is_not_flagged():
+    dr = _result({"mean_rmsd": 1.80}, {"mean_rmsd": 2.30})
+    assert dr.check_regressions()["mean_rmsd"] is False
+
+
+def test_median_rmsd_and_crossdock_variants_flag_on_increase():
+    for name, base in (
+        ("median_rmsd", 1.95),
+        ("crossdock_mean_rmsd", 2.0),
+        ("crossdock_median_rmsd", 2.0),
+        ("selectivity_log_error", 0.5),
+    ):
+        dr = _result({name: base * 2}, {name: base})
+        assert dr.check_regressions()[name] is True, name
+
+
+def test_higher_is_better_metric_flags_on_decrease():
+    dr = _result({"docking_power_top1": 0.0}, {"docking_power_top1": 0.70})
+    assert dr.check_regressions()["docking_power_top1"] is True
+
+
+def test_registries_are_disjoint():
+    assert not (_LOWER_IS_BETTER & _HIGHER_IS_BETTER)
+
+
+def test_every_declared_baseline_has_a_direction():
+    """Any metric a dataset declares must be in exactly one registry.
+
+    shannon_energy_collapse is the known exception: direction undetermined,
+    warns at runtime rather than silently assuming.
+    """
+    known_gap = {"shannon_energy_collapse"}
+    root = Path(__file__).resolve().parents[2] / "benchmarks" / "datasets"
+    if not root.is_dir():
+        return  # package-only checkout
+    undeclared = set()
+    for f in sorted(root.glob("*.yaml")):
+        raw = yaml.safe_load(f.read_text()) or {}
+        for metric in (raw.get("expected_baselines") or {}):
+            if metric not in _LOWER_IS_BETTER and metric not in _HIGHER_IS_BETTER:
+                undeclared.add(metric)
+    assert undeclared <= known_gap, f"metrics with no declared direction: {sorted(undeclared)}"

--- a/python/tests/test_regression_direction.py
+++ b/python/tests/test_regression_direction.py
@@ -67,13 +67,24 @@ def test_every_declared_baseline_has_a_direction():
     warns at runtime rather than silently assuming.
     """
     known_gap = {"shannon_energy_collapse"}
-    root = Path(__file__).resolve().parents[2] / "benchmarks" / "datasets"
-    if not root.is_dir():
-        return  # package-only checkout
+    repo = Path(__file__).resolve().parents[2]
+    # BOTH dataset trees. benchmarks/datasets is canonical (CANONICAL.md), but
+    # the package copy is a declared mirror that has drifted in 10 of 12 shared
+    # pairs (#337) -- reading only one tree would pass by luck of the drift not
+    # currently being in metric names.
+    roots = [
+        repo / "benchmarks" / "datasets",
+        repo / "python" / "flexaidds" / "dataset_runner" / "datasets",
+    ]
+    roots = [r for r in roots if r.is_dir()]
+    assert roots, "no dataset directory found in either tree"
     undeclared = set()
-    for f in sorted(root.glob("*.yaml")):
-        raw = yaml.safe_load(f.read_text()) or {}
-        for metric in (raw.get("expected_baselines") or {}):
-            if metric not in _LOWER_IS_BETTER and metric not in _HIGHER_IS_BETTER:
-                undeclared.add(metric)
-    assert undeclared <= known_gap, f"metrics with no declared direction: {sorted(undeclared)}"
+    for root in roots:
+        for f in sorted(root.glob("*.yaml")):
+            raw = yaml.safe_load(f.read_text()) or {}
+            for metric in (raw.get("expected_baselines") or {}):
+                if metric not in _LOWER_IS_BETTER and metric not in _HIGHER_IS_BETTER:
+                    undeclared.add(f"{metric} ({root.name} tree)")
+    assert not (
+        {u.split(" (")[0] for u in undeclared} - known_gap
+    ), f"metrics with no declared direction: {sorted(undeclared)}"


### PR DESCRIPTION
`check_regressions` decided "lower is better" by testing for the substrings `"rmse"` or `"mae"`. **`mean_rmsd` is spelled `rmsD`**, so it took the higher-is-better branch.

On the first completed Tier-1 run in this repo's history (`30680006724`):

```
mean_rmsd     baseline 2.30   threshold 2.185   measured 3.1557   flagged: False
median_rmsd   baseline 1.95   threshold 1.852   measured 3.1557   flagged: False
```

**An RMSD 37% worse than baseline scored as no-regression, because the gate believed bigger RMSD is better.**

## Five metrics were inverted, not one

Audited every metric named in any `benchmarks/datasets/*.yaml` `expected_baselines` block:

| metric | old rule said | should be |
|---|---|---|
| `crossdock_mean_rmsd` | higher-better | **lower-better** |
| `crossdock_median_rmsd` | higher-better | **lower-better** |
| `mean_rmsd` | higher-better | **lower-better** |
| `median_rmsd` | higher-better | **lower-better** |
| `selectivity_log_error` | higher-better | **lower-better** |

`selectivity_log_error` is the one nobody had noticed: an error metric whose name contains neither `rmse` nor `mae`.

## Why this blocks #342 rather than waiting behind it

Today `mean_rmsd` is never computed, so the **completeness** gate fires and the run is honestly INCONCLUSIVE.

**#342 makes it computable.** At that moment completeness is satisfied, the regression check is consulted, and it returns `False` — converting an honest red into a green on the one axis that measures whether the engine *samples* a near-native pose. #342 is correct and well-tested; it is simply what makes this reachable.

## The fix is not a fourth substring

```python
# tempting, and wrong for the same reason the bug exists:
if "rmse" in metric or "mae" in metric or "rmsd" in metric:
```

That line has already failed once by inferring direction from spelling. Direction is a property of the metric, not of its name, so it is now declared:

- `_LOWER_IS_BETTER` — 9 distance/error metrics
- `_HIGHER_IS_BETTER` — 14 rate/correlation metrics
- a metric in **neither** logs a warning and falls back to higher-is-better, so it degrades loudly rather than silently

**`shannon_energy_collapse` is deliberately in neither set.** Its preferred direction is not determinable from the name or from any docstring in this repo. It warns rather than silently taking a side — someone who knows the physics should declare it.

## The test that caught my own gap

`test_every_declared_baseline_has_a_direction` walks every dataset YAML and fails when a declared baseline has no direction. **It immediately failed on `crossdock_success_rate_2A` and `_3A`** — two metrics my manual enumeration had missed. The guard works because it does not trust the author's list.

```
6 new tests, incl. the exact 1gpk case (3.1557 vs 2.30 -> flagged True)
full python suite: 1033 passed, 68 skipped
```

## Scope

Touches `runner.py` and one new test file only. **No collision with #342** (`metrics.py`) or **#343** (dataset YAMLs).

## Review record

Found by Bumble while reviewing #342; independently confirmed by Honey (`runner.py:445-452`, same arithmetic). Per the shared-identity constraint GitHub approvals are impossible here — approvals recorded as comments.

Review requested from Fizz specifically, as owner of the #327 gate whose semantics this changes.
