### PR TITLE
Fix: Tier-1 fails loudly on missing binary instead of silent dry-run

### DIFF
--- a/.github/workflows/benchmark-tier1.yml
+++ b/.github/workflows/benchmark-tier1.yml
@@ -98,9 +98,18 @@ jobs:
 
       - name: Verify binary exists
         run: |
+          # A Tier-1 benchmark exists to exercise the real engine. If the build
+          # did not produce a binary, FAIL loudly — do NOT fall back to
+          # --dry-run. The old fallback composed into an inverted gate: a
+          # missing binary set --dry-run, and the #327 completeness/liveness
+          # gate skips on dry-run (cli.py: `if not runner.dry_run`), so a run
+          # with no engine exited 0 GREEN — the exact fake-green that gate
+          # exists to prevent, and the shape that produced the 0.5s greens
+          # before #323. Tier-2 has never had this fallback and is honest by
+          # its absence; this makes Tier-1 match it.
           if [ ! -f "$FLEXAIDDS_BINARY" ]; then
-            echo "::warning::FlexAID binary not found at $FLEXAIDDS_BINARY — running in dry-run mode"
-            echo "DRY_RUN=--dry-run" >> "$GITHUB_ENV"
+            echo "::error::FlexAID binary not found at $FLEXAIDDS_BINARY — the build did not produce it. Failing rather than silently dry-running (a dry-run would skip the #327 gate and report a missing engine as a pass)."
+            exit 1
           fi
 
       # No dataset download step needed: Astex Diverse data lives in the repo
@@ -117,8 +126,7 @@ jobs:
             --tier 1 \
             --results-dir "$RESULTS_DIR" \
             --datasets-dir benchmarks/datasets \
-            --verbose \
-            ${{ env.DRY_RUN }}
+            --verbose
 
       - name: Upload benchmark results
         if: always()

--- a/.github/workflows/benchmark-tier1.yml
+++ b/.github/workflows/benchmark-tier1.yml
@@ -46,6 +46,13 @@ jobs:
     env:
       DATASET: ${{ inputs.dataset || 'astex_diverse' }}
       RESULTS_DIR: results/tier1
+      # NOTE: this MUST stay an absolute path. The "Verify binary exists" step
+      # below now hard-fails when the binary is absent (no more dry-run
+      # fallback), and it tests this exact string with `-x` from the repo root
+      # while FlexAID runs from a per-entry tmp dir. An absolute path means the
+      # guard and the subprocess resolve to the same file; making this
+      # overridable with a relative/bare value would reintroduce the CWD-mismatch
+      # class and could turn a PATH-resolvable binary into a hard failure.
       FLEXAIDDS_BINARY: ${{ github.workspace }}/build/FlexAID
       # Astex Diverse data lives in the repo under benchmarks/astex_diverse/.
       # Setting FLEXAIDDS_BENCHMARK_DATA makes the runner look at
@@ -107,8 +114,10 @@ jobs:
           # exists to prevent, and the shape that produced the 0.5s greens
           # before #323. Tier-2 has never had this fallback and is honest by
           # its absence; this makes Tier-1 match it.
-          if [ ! -f "$FLEXAIDDS_BINARY" ]; then
-            echo "::error::FlexAID binary not found at $FLEXAIDDS_BINARY — the build did not produce it. Failing rather than silently dry-running (a dry-run would skip the #327 gate and report a missing engine as a pass)."
+          # -x, not -f: a present-but-non-executable binary must also fail here,
+          # with this clear message, rather than at the opaque exec later.
+          if [ ! -x "$FLEXAIDDS_BINARY" ]; then
+            echo "::error::FlexAID binary not found or not executable at $FLEXAIDDS_BINARY — the build did not produce a runnable binary. Failing rather than silently dry-running (a dry-run would skip the #327 gate and report a missing engine as a pass)."
             exit 1
           fi
 


### PR DESCRIPTION
## The inverted gate

`benchmark-tier1.yml`'s **Verify binary exists** step fell back to `--dry-run` when the build produced no FlexAID binary:

```yaml
if [ ! -f "$FLEXAIDDS_BINARY" ]; then
    echo "::warning::...running in dry-run mode"
    echo "DRY_RUN=--dry-run" >> "$GITHUB_ENV"
fi
```

That composed into a fake-green:

```
missing binary → guard fires → --dry-run → #327 gate skips (cli.py: `if not runner.dry_run`) → exit 0 GREEN
```

A run with **no engine** exited **0 / green** — the exact fake-green the #327 gate exists to prevent, and the shape that produced the sub-second greens before #323. Neither component is wrong on its own: a graceful fallback is sensible, and the gate *must* skip dry-run (synthetic poses must not be judged). They are wrong *together*.

## The fix: delete, don't design

Tier-2 has **never had this fallback** and is honest by its absence — a missing binary there is caught per-entry (`runner.py:1683`) and trips the **productivity gate** (`executed > 0 & total_poses == 0`) → exit 3. This deletes the Tier-1 fallback so Tier-1 matches: a missing binary is now a **hard failure**, not a pass.

- `Verify binary exists` → `exit 1` with an `::error::` when the binary is absent.
- Removes the now-dead `${{ env.DRY_RUN }}` interpolation from the run step — nothing sets `DRY_RUN` anymore (Tier-1 has no `dry_run` input; the fallback was its only setter), so leaving it would falsely imply Tier-1 can dry-run.

## Scope

This is the **workflow-level** guard only. The adjacent runner-level hole Honey/Bumble surfaced — gate 1 (liveness) never increments `_flexaid_crashes` on `FileNotFoundError`, and `allow_empty` can switch gate 2 off — is a separate property in `runner.py`/`cli.py` and is tracked for that lane, not bundled here.

Originating discussion: Buzz channel *Benchmarking FlexAIDdS*.