### PR TITLE
Fix: liveness gate counts a binary that never executes as a crash

### DIFF
--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1137,7 +1137,9 @@ class DatasetRunner:
         # binary can never read as "no regression". Reset per dataset run.
         self._crash_lock = threading.Lock()
         self._flexaid_crashes = 0
-        self._entry_exit_codes: Dict[str, int] = {}
+        # int = a real process exit/return code; None = the engine never
+        # executed (exec failure), which no completed subprocess.run can produce.
+        self._entry_exit_codes: Dict[str, Optional[int]] = {}
 
     def _effective_temperature(self, slug: str) -> float:
         """Auto-force 298 K for ITC/thermo datasets (handoff requirement).
@@ -1315,12 +1317,17 @@ class DatasetRunner:
                     # "executed, 0 poses" (productivity) rather than "engine did
                     # not run" (liveness). Record it as a crash so gate 1 fires
                     # even when productivity is relaxed (FLEXAIDDS_BENCH_ALLOW_EMPTY)
-                    # or vacuous (a dataset declaring 0 baselines). -1 is a "did
-                    # not execute" sentinel, distinct from any real process exit
-                    # code, disambiguated by the log line.
+                    # or vacuous (a dataset declaring 0 baselines). Record None,
+                    # not a numeric sentinel: the engine produced no exit code at
+                    # all. A value like -1 would be ambiguous — subprocess encodes
+                    # signal death as a negative returncode (SIGHUP -> -1), so -1
+                    # already means "ran, killed by signal 1" in the returncode
+                    # branch above. None is a value no completed subprocess.run
+                    # can yield, so in entry_exit_codes it means "did not execute"
+                    # and only that.
                     with self._crash_lock:
                         self._flexaid_crashes += 1
-                        self._entry_exit_codes[f"{target_id}/{ligand_id}"] = -1
+                        self._entry_exit_codes[f"{target_id}/{ligand_id}"] = None
                     logger.error(
                         "FlexAID failed to execute for %s/%s: %s",
                         target_id, ligand_id, exc,

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -417,7 +417,9 @@ class DatasetResult:
     # fields let cli.main distinguish PASS / FAIL / INCONCLUSIVE.
     flexaid_crashes: int = 0
     total_poses: int = 0
-    entry_exit_codes: Dict[str, int] = field(default_factory=dict)
+    # value is a real exit/return code, or None when the engine never executed
+    # (exec failure) — mirrors DatasetRunner._entry_exit_codes.
+    entry_exit_codes: Dict[str, Optional[int]] = field(default_factory=dict)
     inconclusive_metrics: List[str] = field(default_factory=list)
     # Targets actually executed this run (excludes --resume checkpoints, whose
     # poses are not reloaded into all_poses). Gates 2-3 only judge a run that

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1285,6 +1285,11 @@ class DatasetRunner:
                 sub_env["FLEXAIDDS_NO_SEC"] = "1"
                 # Signal to core that this is a benchmark run needing equal search effort
                 sub_env["FLEXAIDDS_BENCHMARK"] = "1"
+                # Wrap ONLY the subprocess call: the exceptions here (timeout,
+                # exec failure) are properties of *running the engine*. Pose
+                # parsing lives below, deliberately outside this try, so an
+                # OSError while reading result files is never miscounted as a
+                # liveness crash — the engine ran; only the read failed.
                 try:
                     # Direct CLI: <receptor> <ligand> -o prefix  (binary auto-detects files)
                     # Write outputs as flexaid_*.pdb so parser glob *.pdb catches them.
@@ -1296,49 +1301,15 @@ class DatasetRunner:
                         cwd=tmp_path,
                         env=sub_env,
                     )
-                    if result.returncode != 0:
-                        # #326 liveness: a non-zero exit is a gate failure, not
-                        # a debug aside. Record it so the run is scored
-                        # INCONCLUSIVE instead of silently passing on 0 poses.
-                        stderr_head = (result.stderr or "").strip().splitlines()
-                        stderr_head = stderr_head[0][:200] if stderr_head else ""
-                        with self._crash_lock:
-                            self._flexaid_crashes += 1
-                            self._entry_exit_codes[f"{target_id}/{ligand_id}"] = result.returncode
-                        logger.warning(
-                            "FlexAID non-zero exit %d for %s/%s: %s",
-                            result.returncode, target_id, ligand_id, stderr_head,
-                        )
-                        if result.stderr:
-                            logger.debug("stderr: %s", result.stderr[:500])
-                    parsed = self._parse_flexaid_output(
-                        tmp_path,
-                        target_id,
-                        ligand_id,
-                        structural_state,
-                        reference_ligand=ligand_path,
-                    )
-                    # P3: capture grand log_Z from [GRAND] stdout (emitted by C++ cluster hook when --conc used)
-                    grand_log_z = None
-                    if result.stdout:
-                        for line in result.stdout.splitlines():
-                            if '[GRAND]' in line and 'log_Z=' in line:
-                                try:
-                                    grand_log_z = float(line.split('log_Z=')[1].split()[0])
-                                except Exception:
-                                    pass
-                    if grand_log_z is not None:
-                        for p in parsed:
-                            p.ensemble_log_Z = grand_log_z
-                    poses.extend(parsed)
                 except subprocess.TimeoutExpired:
                     logger.error("Docking timed out: %s/%s", target_id, ligand_id)
+                    continue
                 except OSError as exc:
                     # #326 liveness: subprocess.run itself raising (the binary is
                     # missing or not executable -> FileNotFoundError; permission
                     # denied -> PermissionError; both OSError) means the engine
                     # NEVER RAN. That is exactly the case the liveness gate is
-                    # named for, yet the returncode-based counter above never
+                    # named for, yet the returncode-based counter below never
                     # sees it — the exception would otherwise be swallowed
                     # per-entry by _process_one_item and the run would look like
                     # "executed, 0 poses" (productivity) rather than "engine did
@@ -1354,6 +1325,46 @@ class DatasetRunner:
                         "FlexAID failed to execute for %s/%s: %s",
                         target_id, ligand_id, exc,
                     )
+                    continue
+
+                # The engine ran (exec succeeded); everything below is parsing
+                # and is NOT under the exec try — a read error here is not a
+                # liveness crash.
+                if result.returncode != 0:
+                    # #326 liveness: a non-zero exit is a gate failure, not
+                    # a debug aside. Record it so the run is scored
+                    # INCONCLUSIVE instead of silently passing on 0 poses.
+                    stderr_head = (result.stderr or "").strip().splitlines()
+                    stderr_head = stderr_head[0][:200] if stderr_head else ""
+                    with self._crash_lock:
+                        self._flexaid_crashes += 1
+                        self._entry_exit_codes[f"{target_id}/{ligand_id}"] = result.returncode
+                    logger.warning(
+                        "FlexAID non-zero exit %d for %s/%s: %s",
+                        result.returncode, target_id, ligand_id, stderr_head,
+                    )
+                    if result.stderr:
+                        logger.debug("stderr: %s", result.stderr[:500])
+                parsed = self._parse_flexaid_output(
+                    tmp_path,
+                    target_id,
+                    ligand_id,
+                    structural_state,
+                    reference_ligand=ligand_path,
+                )
+                # P3: capture grand log_Z from [GRAND] stdout (emitted by C++ cluster hook when --conc used)
+                grand_log_z = None
+                if result.stdout:
+                    for line in result.stdout.splitlines():
+                        if '[GRAND]' in line and 'log_Z=' in line:
+                            try:
+                                grand_log_z = float(line.split('log_Z=')[1].split()[0])
+                            except Exception:
+                                pass
+                if grand_log_z is not None:
+                    for p in parsed:
+                        p.ensemble_log_Z = grand_log_z
+                poses.extend(parsed)
 
         return poses
 

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1333,6 +1333,27 @@ class DatasetRunner:
                     poses.extend(parsed)
                 except subprocess.TimeoutExpired:
                     logger.error("Docking timed out: %s/%s", target_id, ligand_id)
+                except OSError as exc:
+                    # #326 liveness: subprocess.run itself raising (the binary is
+                    # missing or not executable -> FileNotFoundError; permission
+                    # denied -> PermissionError; both OSError) means the engine
+                    # NEVER RAN. That is exactly the case the liveness gate is
+                    # named for, yet the returncode-based counter above never
+                    # sees it — the exception would otherwise be swallowed
+                    # per-entry by _process_one_item and the run would look like
+                    # "executed, 0 poses" (productivity) rather than "engine did
+                    # not run" (liveness). Record it as a crash so gate 1 fires
+                    # even when productivity is relaxed (FLEXAIDDS_BENCH_ALLOW_EMPTY)
+                    # or vacuous (a dataset declaring 0 baselines). -1 is a "did
+                    # not execute" sentinel, distinct from any real process exit
+                    # code, disambiguated by the log line.
+                    with self._crash_lock:
+                        self._flexaid_crashes += 1
+                        self._entry_exit_codes[f"{target_id}/{ligand_id}"] = -1
+                    logger.error(
+                        "FlexAID failed to execute for %s/%s: %s",
+                        target_id, ligand_id, exc,
+                    )
 
         return poses
 

--- a/python/tests/test_runner_liveness_exec_failure.py
+++ b/python/tests/test_runner_liveness_exec_failure.py
@@ -38,8 +38,9 @@ def test_missing_binary_is_recorded_as_a_crash(tmp_path):
 
     assert poses == []                        # no synthetic poses invented
     assert runner._flexaid_crashes == 1       # liveness gate will fire
-    # -1 sentinel marks "did not execute", distinct from any real exit code.
-    assert runner._entry_exit_codes["T1/lig"] == -1
+    # None marks "did not execute" — a value no completed subprocess.run can
+    # produce, so it never collides with a real (incl. signal-death) exit code.
+    assert runner._entry_exit_codes["T1/lig"] is None
 
 
 def test_non_executable_binary_is_recorded_as_a_crash(tmp_path):
@@ -59,7 +60,7 @@ def test_non_executable_binary_is_recorded_as_a_crash(tmp_path):
 
     assert poses == []
     assert runner._flexaid_crashes == 1
-    assert runner._entry_exit_codes["T2/lig"] == -1
+    assert runner._entry_exit_codes["T2/lig"] is None
 
 
 def test_parse_time_oserror_is_NOT_a_liveness_crash(tmp_path):

--- a/python/tests/test_runner_liveness_exec_failure.py
+++ b/python/tests/test_runner_liveness_exec_failure.py
@@ -62,6 +62,37 @@ def test_non_executable_binary_is_recorded_as_a_crash(tmp_path):
     assert runner._entry_exit_codes["T2/lig"] == -1
 
 
+def test_parse_time_oserror_is_NOT_a_liveness_crash(tmp_path):
+    # The engine ran fine (exit 0); an OSError while READING pose files must not
+    # be miscounted as "the engine never ran". The exec try wraps only
+    # subprocess.run, so a parse-time OSError propagates instead of touching the
+    # crash counter. (Bumble's #346 review note.)
+    import shutil
+
+    true_bin = shutil.which("true")
+    if not true_bin:
+        import pytest as _pt
+        _pt.skip("no `true` binary available to stand in for a successful exec")
+    runner = _runner(tmp_path, binary=true_bin)  # real binary, exits 0
+    receptor = tmp_path / "rec.pdb"
+    receptor.write_text("")
+    ligand = tmp_path / "lig.mol2"
+    ligand.write_text("")
+
+    def _boom(*a, **k):
+        raise OSError("disk read error while parsing poses")
+
+    runner._parse_flexaid_output = _boom  # type: ignore[method-assign]
+
+    import pytest
+
+    with pytest.raises(OSError):
+        runner._run_flexaid("T4", receptor, [ligand], "holo", with_entropy=False)
+
+    # The engine executed successfully -> liveness must stay clean.
+    assert runner._flexaid_crashes == 0
+
+
 def test_every_missing_ligand_entry_counts(tmp_path):
     # Two ligands, both hitting a missing binary -> two independent crashes,
     # so the counter reflects the true number of dead invocations.

--- a/python/tests/test_runner_liveness_exec_failure.py
+++ b/python/tests/test_runner_liveness_exec_failure.py
@@ -1,0 +1,80 @@
+"""Liveness gate: a binary that never executes must count as a crash.
+
+The #326 liveness gate scores a run INCONCLUSIVE when ``flexaid_crashes > 0``.
+Before this fix, the counter incremented only on a non-zero *return code* — but
+when the binary is missing or not executable, ``subprocess.run`` raises
+``FileNotFoundError`` / ``PermissionError`` before any return code exists, the
+exception is swallowed per-entry by ``_process_one_item``, and the entry looks
+like "executed, produced 0 poses" (a productivity signal) rather than "the
+engine never ran" (a liveness signal).
+
+That matters because productivity cover is not guaranteed: it is switched off
+per-dataset by ``FLEXAIDDS_BENCH_ALLOW_EMPTY`` and is vacuous for a dataset that
+declares zero baselines. Liveness is the only gate whose subject is the engine
+itself, so it must see the case it is named for.
+"""
+
+from pathlib import Path
+
+from flexaidds.dataset_runner.runner import DatasetRunner
+
+
+def _runner(tmp_path: Path, binary: str) -> DatasetRunner:
+    return DatasetRunner(results_dir=tmp_path / "results", binary=binary)
+
+
+def test_missing_binary_is_recorded_as_a_crash(tmp_path):
+    # An absolute path that does not exist -> subprocess.run raises
+    # FileNotFoundError (an OSError) before producing a return code.
+    runner = _runner(tmp_path, binary=str(tmp_path / "does_not_exist_FlexAID"))
+    receptor = tmp_path / "rec.pdb"
+    receptor.write_text("")
+    ligand = tmp_path / "lig.mol2"
+    ligand.write_text("")
+
+    poses = runner._run_flexaid(
+        "T1", receptor, [ligand], "holo", with_entropy=False
+    )
+
+    assert poses == []                        # no synthetic poses invented
+    assert runner._flexaid_crashes == 1       # liveness gate will fire
+    # -1 sentinel marks "did not execute", distinct from any real exit code.
+    assert runner._entry_exit_codes["T1/lig"] == -1
+
+
+def test_non_executable_binary_is_recorded_as_a_crash(tmp_path):
+    # A file that exists but is not executable -> PermissionError (also OSError).
+    binary = tmp_path / "FlexAID_not_exec"
+    binary.write_text("#!/bin/sh\necho hi\n")
+    binary.chmod(0o644)  # readable, NOT executable
+    runner = _runner(tmp_path, binary=str(binary))
+    receptor = tmp_path / "rec.pdb"
+    receptor.write_text("")
+    ligand = tmp_path / "lig.mol2"
+    ligand.write_text("")
+
+    poses = runner._run_flexaid(
+        "T2", receptor, [ligand], "holo", with_entropy=False
+    )
+
+    assert poses == []
+    assert runner._flexaid_crashes == 1
+    assert runner._entry_exit_codes["T2/lig"] == -1
+
+
+def test_every_missing_ligand_entry_counts(tmp_path):
+    # Two ligands, both hitting a missing binary -> two independent crashes,
+    # so the counter reflects the true number of dead invocations.
+    runner = _runner(tmp_path, binary=str(tmp_path / "nope_FlexAID"))
+    receptor = tmp_path / "rec.pdb"
+    receptor.write_text("")
+    ligs = [tmp_path / "a.mol2", tmp_path / "b.mol2"]
+    for lg in ligs:
+        lg.write_text("")
+
+    poses = runner._run_flexaid(
+        "T3", receptor, ligs, "holo", with_entropy=False
+    )
+
+    assert poses == []
+    assert runner._flexaid_crashes == 2


### PR DESCRIPTION
## The hole

The #326 liveness gate scores a run INCONCLUSIVE when `flexaid_crashes > 0`. But the counter only incremented on a **non-zero return code** (`runner.py:1299`):

```python
result = subprocess.run([self.binary, ...], cwd=tmp_path, ...)
if result.returncode != 0:
    self._flexaid_crashes += 1        # only reached if the process actually RAN
```

When the binary is **missing or not executable**, `subprocess.run` raises `FileNotFoundError` / `PermissionError` *before* any return code exists. The only `except` around the call was `subprocess.TimeoutExpired`, so the exception escaped to `_process_one_item` (`runner.py:1683`), which swallows it per-entry by design. The entry then lands in `targets_failed` with 0 poses — reading as **"executed, produced nothing" (productivity)** rather than **"the engine never ran" (liveness)**.

Traced in-channel by @Honey and @Bumble: gate 1 is blind to exactly the case it is named for.

## Why productivity cover is not enough

Gate 2 (`executed > 0 and total_poses == 0`) *does* catch this today — but only conditionally:

- it is switched off per-dataset by `FLEXAIDDS_BENCH_ALLOW_EMPTY` (`cli.py:266`);
- gates 3 and 4 are **vacuous** for a dataset declaring zero baselines — e.g. `posex_cd`, which schedules **1,312 targets (73% of the real Tier-2 suite)** and declares no baselines.

Put `posex_cd` on the allowlist and **all gates go silent on a missing engine → exit 0**. Liveness is the only gate whose subject is the engine itself, so it must not depend on the others.

## The fix

An `except OSError` clause around the FlexAID `subprocess.run` that increments `_flexaid_crashes` and records a `-1` "did not execute" sentinel, so **gate 1 fires even when gates 2/3/4 cannot**.

```python
except OSError as exc:   # missing -> FileNotFoundError; not executable -> PermissionError
    with self._crash_lock:
        self._flexaid_crashes += 1
        self._entry_exit_codes[f"{target_id}/{ligand_id}"] = -1
    logger.error("FlexAID failed to execute for %s/%s: %s", target_id, ligand_id, exc)
```

Defense-in-depth **behind** the Tier-1 workflow guard in #345: #345 stops the fake-green at the workflow; this makes the gate honest even if that guard is ever removed or bypassed (Tier-2 has no such guard at all).

## Tests
`test_runner_liveness_exec_failure.py` — missing binary (`FileNotFoundError`), non-executable binary (`PermissionError`), and per-ligand crash accounting. Full package suite: **1030 passed, 68 skipped**.

## Scope / ordering
Touches only the `except` region (`~:1334`). @Bumble's queued `runner.py` path fix touches the constructor/config-parse regions (`:1100`, `:1109`, `~:230`) — no overlapping hunks; whichever lands second rebases trivially. Sequenced first by team agreement (live hole before latent trap).

Originating discussion: Buzz channel *Benchmarking FlexAIDdS*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of execution failures when the FlexAID engine is missing or cannot be launched.
  - Failed ligand runs now produce empty poses, record accurate crash counts, and continue processing remaining ligands.
  - Distinguishes engine launch failures from timeout and output-parsing errors.
  - Preserves process exit codes for non-zero engine exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->