### PR TITLE
Fix: absolutise data roots at construction; wire the existing binary resolver

### DIFF
--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -262,7 +262,12 @@ class DatasetConfig:
             ligand_concs=DatasetConfig._parse_ligand_concs(raw),
         )
         if data_dir_raw:
-            config.data_dir = Path(data_dir_raw)
+            # Absolute at construction: the engine runs with cwd=<per-entry tmp
+            # dir> (DatasetRunner._run_flexaid), so a relative data_dir resolves
+            # against that tmp dir for the child and finds nothing. It is never
+            # correct to hand a subprocess a relative directory, regardless of
+            # where the runner itself was invoked from.
+            config.data_dir = Path(data_dir_raw).expanduser().resolve()
         return config
 
     def tier1_targets(self) -> List[str]:
@@ -1156,6 +1161,14 @@ class DatasetRunner:
         self.datasets_dir = Path(datasets_dir) if datasets_dir is not None else _default_datasets
         self.results_dir = Path(results_dir)
         self.binary = binary or os.environ.get("FLEXAIDDS_BINARY") or "FlexAID"
+        # _resolve_binary already existed and was correct -- but it was wired
+        # only into the *report* (provenance), while the actual invocation used
+        # the raw string. Resolve once here so the engine and the report agree.
+        # It deliberately does NOT blanket-absolutise: a bare name is left for
+        # PATH (subprocess ignores cwd for those), a name containing a separator
+        # is made absolute, and an unfindable name is left alone so subprocess
+        # raises and the liveness gate counts it.
+        self.binary = self._resolve_binary()
         self.temperature = temperature
         self.n_workers = max(1, int(n_workers))
         # OMP threads per worker: explicit > env > auto (aim for 2 on M3 Pro's 5 P-cores).
@@ -1164,9 +1177,12 @@ class DatasetRunner:
             omp_threads = int(env_val) if env_val else max(1, 2 if self.n_workers > 1 else 4)
         self.omp_threads = max(1, int(omp_threads))
         self.use_mpi = use_mpi
+        # Same reason as DatasetConfig.data_dir: this root is joined into paths
+        # handed to a subprocess running in a tmp dir. Note the fallback literal
+        # is relative, so the *default* is the trap, not just a bad override.
         self.cache_dir = Path(
             cache_dir or os.environ.get("FLEXAIDDS_BENCHMARK_DATA", "benchmark_data")
-        )
+        ).expanduser().resolve()
         self.do_bootstrap = bootstrap_ci
         self.n_bootstrap = n_bootstrap
         self.dry_run = dry_run

--- a/python/tests/test_runner_absolute_paths.py
+++ b/python/tests/test_runner_absolute_paths.py
@@ -1,0 +1,93 @@
+"""Paths handed to the engine must be absolute at construction -- except the
+binary, where "absolute" is the wrong rule.
+
+FlexAID is invoked with ``cwd=<per-entry temp dir>`` (``_run_flexaid``), so a
+relative directory means one thing to the runner and another to the child. The
+data roots therefore get ``.resolve()``.
+
+The binary is NOT a directory and NOT reliably a path: ``subprocess`` looks a
+bare name up on ``PATH`` and ignores ``cwd``, so ``.resolve()`` there would
+convert a working lookup into a nonexistent absolute path. The separator is what
+says which of the two you have. These tests pin both halves, because the obvious
+uniform fix passes the first three and breaks the fourth.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from flexaidds.dataset_runner.runner import DatasetConfig, DatasetRunner
+
+
+def _runner(tmp_path, **kw):
+    return DatasetRunner(results_dir=str(tmp_path / "results"), **kw)
+
+
+def test_cache_dir_default_is_absolute(tmp_path, monkeypatch):
+    """The fallback literal is relative -- the default is the trap."""
+    monkeypatch.delenv("FLEXAIDDS_BENCHMARK_DATA", raising=False)
+    monkeypatch.chdir(tmp_path)
+    assert _runner(tmp_path).cache_dir.is_absolute()
+
+
+def test_cache_dir_from_env_is_absolute(tmp_path, monkeypatch):
+    monkeypatch.setenv("FLEXAIDDS_BENCHMARK_DATA", "benchmark_data")
+    monkeypatch.chdir(tmp_path)
+    r = _runner(tmp_path)
+    assert r.cache_dir.is_absolute()
+    assert r.cache_dir == (tmp_path / "benchmark_data").resolve()
+
+
+def test_data_dir_from_yaml_is_absolute(tmp_path, monkeypatch):
+    """A relative data_dir: in a config is a claim about every caller."""
+    monkeypatch.chdir(tmp_path)
+    yaml_path = tmp_path / "toy.yaml"
+    yaml_path.write_text(
+        "slug: toy\nname: Toy\ndocking_mode: self_docking\n"
+        "data_dir: benchmarks/toy\ntargets: [t1]\n"
+    )
+    cfg = DatasetConfig.from_yaml(yaml_path)
+    assert cfg.data_dir is not None
+    assert cfg.data_dir.is_absolute()
+    assert cfg.data_dir == (tmp_path / "benchmarks" / "toy").resolve()
+
+
+def test_bare_binary_name_is_NOT_absolutised(tmp_path):
+    """The case the obvious fix destroys.
+
+    ``Path("FlexAID").resolve()`` yields ``<cwd>/FlexAID`` -- a path that does
+    not exist -- turning a working PATH lookup into a hard FileNotFoundError.
+    A bare name must survive untouched unless PATH can actually resolve it.
+    """
+    r = _runner(tmp_path, binary="definitely-not-on-path-xyzzy")
+    assert r.binary == "definitely-not-on-path-xyzzy"
+    assert not os.path.isabs(r.binary)
+
+
+def test_bare_name_on_PATH_still_resolves(tmp_path):
+    """A bare name that PATH *can* resolve becomes absolute, via PATH -- not cwd."""
+    import shutil
+
+    if shutil.which("sh") is None:  # pragma: no cover - POSIX runners have sh
+        pytest.skip("no 'sh' on PATH")
+    r = _runner(tmp_path, binary="sh")
+    assert os.path.isabs(r.binary)
+    assert Path(r.binary).exists()
+    assert Path(r.binary).name == "sh"
+
+
+def test_relative_binary_with_separator_is_absolutised(tmp_path, monkeypatch):
+    """Contains a separator -> subprocess would resolve it against the tmp dir."""
+    build = tmp_path / "build"
+    build.mkdir()
+    exe = build / "FlexAID"
+    exe.write_text("#!/bin/sh\nexit 0\n")
+    exe.chmod(0o755)
+    monkeypatch.chdir(tmp_path)
+
+    r = _runner(tmp_path, binary=os.path.join("build", "FlexAID"))
+    assert os.path.isabs(r.binary)
+    assert Path(r.binary) == exe.resolve()

--- a/python/tests/test_runner_absolute_paths.py
+++ b/python/tests/test_runner_absolute_paths.py
@@ -62,6 +62,11 @@ def test_bare_binary_name_is_NOT_absolutised(tmp_path):
     not exist -- turning a working PATH lookup into a hard FileNotFoundError.
     A bare name must survive untouched unless PATH can actually resolve it.
     """
+    # NB: deliberately not "FlexAID". A developer machine with FlexAID installed
+    # has it on PATH (`shutil.which("FlexAID") -> /opt/homebrew/bin/FlexAID`), so
+    # that spelling would pass in CI and fail locally -- a test whose correctness
+    # depends on what the reader happens to have installed. The name below cannot
+    # be on anyone's PATH.
     r = _runner(tmp_path, binary="definitely-not-on-path-xyzzy")
     assert r.binary == "definitely-not-on-path-xyzzy"
     assert not os.path.isabs(r.binary)


### PR DESCRIPTION
FlexAID is invoked with `cwd=<per-entry temp dir>` (`_run_flexaid`), so **any relative path handed to it resolves against that temp dir, never the repo root.** Three call sites relied on the caller's cwd being right.

CI only survives today because `benchmark-tier1.yml` interpolates `${{ github.workspace }}` into both `FLEXAIDDS_BENCHMARK_DATA` and `FLEXAIDDS_BINARY`. That is an accident of one workflow file, not a property of the code — a local run, or `FLEXAIDDS_BENCHMARK_DATA=benchmark_data`, or simply the default, hits the bug and it presents as *missing data* rather than as a path error. #343 reached it first through a relative `data_dir:` in a config and the whole Tier-1 run failed with `File not found and not valid SMILES`.

## Two treatments, because the members are not the same shape

```
DatasetConfig.data_dir   (yaml)  ->  .expanduser().resolve()
DatasetRunner.cache_dir  (env)   ->  .expanduser().resolve()
DatasetRunner.binary             ->  self._resolve_binary()      <- NOT a blanket resolve
```

`cache_dir`'s fallback literal is `"benchmark_data"` — relative — so **the default is the trap**, not just a bad override.

The binary is deliberately different. `subprocess` treats a **bare name** as a `PATH` lookup and ignores `cwd`; anything containing a **separator** it resolves against `cwd`. So:

```python
>>> Path("FlexAID").resolve()
PosixPath('/private/tmp/FlexAID')   # does not exist -- a working default, destroyed
```

"Make every path absolute" is the right rule for the two directories and the wrong rule for this argument, and **the separator is the only thing that tells you which you have.**

## `_resolve_binary` already existed and was correct

It implements exactly that discrimination (`shutil.which` for bare names, absolute for the rest, unchanged when unfindable) — and it was wired **only into the report's provenance field** (`:1667`, `:2052`, `:2287`), while the actual `subprocess.run` call used the raw `self.binary`. So the engine and the report could disagree about which binary ran. This resolves once in `__init__` so they cannot.

Leaving an unfindable bare name untouched is intentional: `subprocess` then raises, and #346's liveness gate counts it as "the engine never ran."

## Tests

`python/tests/test_runner_absolute_paths.py` — six cases pinning both halves, including **the one the obvious uniform fix destroys**:

- `test_bare_binary_name_is_NOT_absolutised` — a bare name not on PATH stays bare
- `test_bare_name_on_PATH_still_resolves` — resolves via PATH, not cwd
- `test_relative_binary_with_separator_is_absolutised`
- default / env `cache_dir`, and a relative `data_dir:` in a YAML config

**Full suite: 1059 passed, 68 skipped.**

## Review notes

- Branched from `main` at `02180999` (after #342/#344/#345/#346), no rebase needed.
- The check that exercises this is **Pure Python results tests**. `Tier-1 (astex_diverse)` cannot: it dies at the 25-minute cap before this code path matters. `Coverage Analysis` is a C++-only job (its own log reports the `*/python/*` exclude pattern as unused) and `Python bindings smoke (windows)` is the known `main` red.
- Not merged by me.

Credit: Honey enumerated `self.binary` as the third site and caught that my original two-line fix was incomplete; testing her suggested uniform treatment is what surfaced that it needed splitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of dataset, cache, and executable paths by resolving configured relative paths consistently.
  * Preserved bare executable names when they cannot be found on the system path.

* **Tests**
  * Added coverage for absolute path resolution across configuration, environment variables, cache locations, and executable discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->