### PR TITLE
Fix: register a direction only for metrics something can produce

### DIFF
--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -389,23 +389,25 @@ class TargetResult:
 # the metric, not of its spelling: declare it here, beside nothing else.
 #
 # Every metric named in any benchmarks/datasets/*.yaml expected_baselines block
-# must appear in exactly one of these sets. An unlisted metric logs a warning
-# and falls back to higher-is-better rather than failing the run.
+# AND produced by compute_all_metrics must appear in exactly one of these sets.
+# An unlisted metric logs a warning and falls back to higher-is-better rather
+# than failing the run.
+#
+# A direction is only registered for a metric something can PRODUCE. A metric
+# that nothing computes has no behaviour to contradict its entry, so an entry
+# for it is not a record -- it is an instruction: the next person to implement
+# the metric reads the registry and writes code to match, and the guess becomes
+# true by recruiting the person who could have falsified it. Eleven such names
+# were removed here (they remain declared in dataset YAMLs and will be
+# re-registered by whoever dispatches them, in the same diff as the producer,
+# where the sign convention and the assignment are visible together).
 _LOWER_IS_BETTER = frozenset({
-    "crossdock_mean_rmsd",
-    "crossdock_median_rmsd",
-    "delta_delta_g_rmse_kcal",
     "mean_rmsd",
     "median_rmsd",
-    "p_bind_agreement_rmse",
-    "scoring_power_mae",
     "scoring_power_rmse",
-    "selectivity_log_error",
 })
 
 _HIGHER_IS_BETTER = frozenset({
-    "crossdock_success_rate_2A",
-    "crossdock_success_rate_3A",
     "docking_power_top1",
     "docking_power_top3",
     "ef_1pct",
@@ -413,11 +415,8 @@ _HIGHER_IS_BETTER = frozenset({
     "entropy_rescue_rate",
     "hit_rate_top10",
     "log_auc",
-    "occupancy_agreement",
-    "posebusters_pass_rate",
     "scoring_power_pearson_r",
     "scoring_power_spearman_r",
-    "target_specificity_zscore",
 })
 
 # Deliberately in NEITHER set: shannon_energy_collapse. Its preferred direction

--- a/python/tests/test_regression_direction.py
+++ b/python/tests/test_regression_direction.py
@@ -4,9 +4,12 @@ Guards the bug where check_regressions inferred direction from the substrings
 "rmse"/"mae", so mean_rmsd (spelled rmsD) took the higher-is-better branch and
 a 37% worse RMSD scored as no-regression.
 """
+import re
+
 import yaml
 from pathlib import Path
 
+from flexaidds.dataset_runner import metrics
 from flexaidds.dataset_runner.runner import (
     DatasetResult,
     _HIGHER_IS_BETTER,
@@ -40,15 +43,17 @@ def test_mean_rmsd_better_than_baseline_is_not_flagged():
     assert dr.check_regressions()["mean_rmsd"] is False
 
 
-def test_median_rmsd_and_crossdock_variants_flag_on_increase():
-    for name, base in (
-        ("median_rmsd", 1.95),
-        ("crossdock_mean_rmsd", 2.0),
-        ("crossdock_median_rmsd", 2.0),
-        ("selectivity_log_error", 0.5),
-    ):
-        dr = _result({name: base * 2}, {name: base})
-        assert dr.check_regressions()[name] is True, name
+def test_median_rmsd_flags_on_increase():
+    """Only produced distance metrics are asserted here.
+
+    This test used to cover crossdock_mean_rmsd, crossdock_median_rmsd and
+    selectivity_log_error as well. Nothing computes any of those -- the
+    assertions were exercising a registry entry that had never met a value, so
+    what they pinned was a guess, not a behaviour. They are removed with their
+    entries and come back with their producers.
+    """
+    dr = _result({"median_rmsd": 3.90}, {"median_rmsd": 1.95})
+    assert dr.check_regressions()["median_rmsd"] is True
 
 
 def test_higher_is_better_metric_flags_on_decrease():
@@ -60,13 +65,50 @@ def test_registries_are_disjoint():
     assert not (_LOWER_IS_BETTER & _HIGHER_IS_BETTER)
 
 
-def test_every_declared_baseline_has_a_direction():
-    """Any metric a dataset declares must be in exactly one registry.
+def _produced_metric_names() -> set[str]:
+    """Metric names `compute_all_metrics` can actually write into its results.
 
-    shannon_energy_collapse is the known exception: direction undetermined,
-    warns at runtime rather than silently assuming.
+    Derived by reading the source rather than kept as a hand-maintained list.
+    A list would be another table with no upstream -- exactly the object this
+    module exists to shrink -- and it would go stale silently the moment someone
+    dispatched a metric without editing it. This cannot go stale: the commit
+    that adds a producer is the same commit that creates the obligation below.
+
+    Crude on purpose: a regex over source text, not an import-and-introspect.
+    `results["x"] = ...` assignments are not visible without executing the
+    function, and executing it needs poses. Crude-and-derived beats
+    clean-and-hand-maintained here; the failure mode of the regex (missing a
+    producer written some other way) is a metric exempted that should not be,
+    which is the same state as today rather than a new one.
+    """
+    src = (
+        Path(metrics.__file__).read_text()
+        if hasattr(metrics, "__file__")
+        else ""
+    )
+    return set(re.findall(r'results\["([a-z0-9_]+)"\]', src))
+
+
+def test_every_declared_baseline_has_a_direction():
+    """A metric a dataset declares AND something produces must have a direction.
+
+    Declaration alone is not enough. Eleven names are declared in dataset YAMLs
+    with nothing computing them -- requiring a direction for those would red
+    `main` for whoever next touches a Python file, and the thing they would be
+    asked to resolve is the direction of a metric they are not implementing:
+    a red with nobody present who can answer it.
+
+    So the obligation is keyed on the producer, not the declaration. The moment
+    a producer appears the exemption evaporates and this test demands an entry
+    -- in the same edit, from the person writing the assignment, who is the only
+    one who knows what the stored value means.
+
+    shannon_energy_collapse stays a named exception: it IS produced, and its
+    direction is genuinely undetermined pending someone who knows the physics.
     """
     known_gap = {"shannon_energy_collapse"}
+    produced = _produced_metric_names()
+    assert produced, "producer scan found nothing -- the regex or the file moved"
     repo = Path(__file__).resolve().parents[2]
     # BOTH dataset trees. benchmarks/datasets is canonical (CANONICAL.md), but
     # the package copy is a declared mirror that has drifted in 10 of 12 shared
@@ -83,8 +125,26 @@ def test_every_declared_baseline_has_a_direction():
         for f in sorted(root.glob("*.yaml")):
             raw = yaml.safe_load(f.read_text()) or {}
             for metric in (raw.get("expected_baselines") or {}):
+                if metric not in produced:
+                    continue  # nothing can contradict a direction for it yet
                 if metric not in _LOWER_IS_BETTER and metric not in _HIGHER_IS_BETTER:
                     undeclared.add(f"{metric} ({root.name} tree)")
     assert not (
         {u.split(" (")[0] for u in undeclared} - known_gap
     ), f"metrics with no declared direction: {sorted(undeclared)}"
+
+
+def test_registry_holds_only_metrics_something_can_produce():
+    """The registry must not describe a metric nothing computes.
+
+    An entry with no producer cannot be contradicted by any behaviour, so it is
+    not a claim that can be wrong -- it is one that instructs. This is the guard
+    that keeps the registry to what is falsifiable; it is the same criterion as
+    the exemption above, applied from the other side.
+    """
+    produced = _produced_metric_names()
+    registered = set(_LOWER_IS_BETTER) | set(_HIGHER_IS_BETTER)
+    assert not (registered - produced), (
+        "registry entries with no producer (a direction nothing can contradict): "
+        f"{sorted(registered - produced)}"
+    )


### PR DESCRIPTION
#344 replaced substring-inference with a table. **Eleven of the table's twenty-three entries describe metrics no code computes** — so nothing can contradict them, and an entry nothing can contradict is not a record. It is an instruction: the next person to implement the metric reads the registry and writes code to match, and the guess becomes true by recruiting the person who could have falsified it.

That is exactly how `target_specificity_zscore` came to be filed `HIGHER_IS_BETTER` from its name while its docstring — *and its dataset baseline* — say the opposite.

## What changes

```
_LOWER_IS_BETTER    9 entries -> 3    (mean_rmsd, median_rmsd, scoring_power_rmse)
_HIGHER_IS_BETTER  14 entries -> 9
removed            11 names with no producer in compute_all_metrics
```

The eleven stay declared in dataset YAMLs. They come back **with their producers**, registered by whoever writes the assignment — the only person who knows what the stored value means.

## The test now keys on the producer, not the declaration

All eleven are declared baselines today, so simply pulling them would fail `test_every_declared_baseline_has_a_direction` **on `main`, for whoever next touches a Python file** — a red with nobody present who can answer it. (Same trap as putting Tier-1 in a required check set.)

So the obligation moved:

```python
if metric not in produced:
    continue                    # nothing can contradict a direction for it yet
if metric not in _LOWER_IS_BETTER and metric not in _HIGHER_IS_BETTER:
    FAIL
```

**The exemption is derived, not listed.** A hand-maintained exempt-list would be another table with no upstream — the exact object this PR shrinks — and it would go stale the moment someone dispatched a metric without editing it. This cannot go stale: **the commit that adds a producer is the commit that creates the obligation.**

Crude on purpose, and stated rather than hidden: it is a regex over `metrics.py` source, not import-and-introspect (`results["x"] = ...` isn't visible without executing the function, which needs poses). The regex's failure mode is exempting a metric that shouldn't be — the same state as today, not a new one.

## Verified the transition instead of asserting it

```
$ # add a simulated results["target_specificity_zscore"] producer
$ pytest python/tests/test_regression_direction.py
E  AssertionError: metrics with no declared direction:
   ['target_specificity_zscore (datasets tree)']
$ # reverted -> 7 passed
```

The exemption evaporates and the test names the metric. This PR's mechanism gets its first real execution in Honey's #341 dispatch, which is why that lands after this one.

## Also

- New `test_registry_holds_only_metrics_something_can_produce` — the same criterion from the other side, so the registry cannot re-acquire an unfalsifiable row.
- `test_median_rmsd_and_crossdock_variants_flag_on_increase` narrowed to `median_rmsd`. Its other three assertions pinned entries that had never met a value — they were testing a guess, not a behaviour, and they return with their producers.

**Full suite: 1060 passed, 68 skipped.** Branched from `ca67452d`.

## Review notes

- Gate on **Pure Python results tests**. Tier-1 dies at the 25-min cap before `check_regressions` runs; `Coverage Analysis` is a C++-only job; `Python bindings smoke (windows)` is the known `main` red.
- Not merged by me.

Credit: Honey's audit found the eleven and her constraint (all eleven are *declared*, so pulling alone reds `main`) is what forced the derived exemption rather than a naive removal. Fizz's negate-or-not sharpening is why `target_specificity_zscore` is removed here rather than corrected here — its direction and its dispatch are one decision.
