### PR TITLE
Fix: baseline tolerance is additive slack, not a scaling of the baseline

### DIFF
--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -501,8 +501,26 @@ class DatasetResult:
             # Direction is looked up, never inferred from the name. See
             # _LOWER_IS_BETTER: substring-sniffing silently inverted
             # mean_rmsd/median_rmsd because "rmsd" is not "rmse".
+            # Tolerance is ADDITIVE slack around the baseline, not a scaling
+            # of it.  `baseline * (1 + tol)` happens to equal
+            # `baseline + abs(baseline) * tol` for every POSITIVE baseline, so
+            # the scaling form was correct until a negative one appeared:
+            # erds_specificity declares target_specificity_zscore: -2.50, and
+            # scaling moves a negative baseline AWAY from zero -- demanding
+            # -2.625, stricter than the target itself, so exactly-on-baseline
+            # flagged as a regression.  The additive form is sign-correct in
+            # both directions and byte-identical on all 143 positive baselines
+            # currently in the repo.
+            #
+            # Degenerate case, stated so the next person finds it rather than
+            # discovers it: at baseline == 0 the slack is abs(0) * tol == 0, so
+            # ANY non-zero measurement flags.  Arguably correct -- 5% of zero is
+            # zero -- but "additive slack" stops being slack there.  The scaling
+            # form has the identical hole; no dataset declares a zero baseline
+            # today (checked across both trees).
+            slack = abs(baseline) * tol
             if metric in _LOWER_IS_BETTER:
-                threshold = baseline * (1 + tol)
+                threshold = baseline + slack
                 flags[metric] = bool(measured > threshold)
             else:
                 if metric not in _HIGHER_IS_BETTER:
@@ -513,7 +531,7 @@ class DatasetResult:
                         "regression verdict.",
                         metric,
                     )
-                threshold = baseline * (1 - tol)
+                threshold = baseline - slack
                 flags[metric] = bool(measured < threshold)
         self.regression_flags = flags
         self.inconclusive_metrics = missing

--- a/python/tests/test_baseline_tolerance_sign.py
+++ b/python/tests/test_baseline_tolerance_sign.py
@@ -1,0 +1,97 @@
+"""Baseline tolerance must be additive slack, not a scaling of the baseline.
+
+`baseline * (1 ± tol)` is correct only while every baseline is positive.
+erds_specificity declares ``target_specificity_zscore: -2.50`` (more negative
+= better binding), and scaling a negative baseline moves the threshold AWAY
+from zero -- demanding -2.625, which is stricter than the target itself.  The
+metric could then only pass by beating its baseline by 5%, and sitting exactly
+on target flagged as a regression.
+"""
+import pytest
+
+from flexaidds.dataset_runner.runner import (
+    DatasetResult,
+    _HIGHER_IS_BETTER,
+    _LOWER_IS_BETTER,
+)
+
+
+class _Cfg:
+    def __init__(self, baselines, tol=0.05):
+        self.expected_baselines = baselines
+        self.baseline_tolerance = tol
+
+
+def _flags(metrics, baselines):
+    dr = DatasetResult.__new__(DatasetResult)
+    dr.metrics = metrics
+    dr.config = _Cfg(baselines)
+    dr.regression_flags = {}
+    dr.inconclusive_metrics = []
+    return dr.check_regressions()
+
+
+# `mean_rmsd` is lower-is-better; `docking_power_top1` is higher-is-better.
+# Both are produced and registered, so they exercise the real lookup.
+_LOWER = "mean_rmsd"
+_HIGHER = "docking_power_top1"
+
+
+def test_registry_membership_assumed_by_this_module_holds():
+    """Guard the fixtures themselves: a re-file would silently void the tests."""
+    assert _LOWER in _LOWER_IS_BETTER
+    assert _HIGHER in _HIGHER_IS_BETTER
+
+
+@pytest.mark.parametrize(
+    "measured,flagged",
+    [
+        (-3.00, False),  # better than target
+        (-2.50, False),  # EXACTLY on target -- scaling form flagged this
+        (-2.40, False),  # 4% worse, inside the 5% slack
+        (-2.30, True),   # 8% worse, genuinely outside
+        (0.00, True),    # no signal at all
+    ],
+)
+def test_negative_baseline_lower_is_better(measured, flagged):
+    """Slack runs toward zero for a negative lower-is-better baseline."""
+    assert _flags({_LOWER: measured}, {_LOWER: -2.50})[_LOWER] is flagged
+
+
+@pytest.mark.parametrize(
+    "measured,flagged",
+    [
+        (-2.00, False),  # above a negative baseline
+        (-2.50, False),  # exactly on target
+        (-3.00, True),   # below the slack floor
+    ],
+)
+def test_negative_baseline_higher_is_better(measured, flagged):
+    """The mirror branch: -5.0 must not read as a regression from -2.50."""
+    assert _flags({_HIGHER: measured}, {_HIGHER: -2.50})[_HIGHER] is flagged
+
+
+@pytest.mark.parametrize("baseline", [0.70, 2.10, 2.30, 0.85, 0.30])
+def test_positive_baselines_are_unchanged(baseline):
+    """The fix is a no-op wherever the baseline is positive.
+
+    Every baseline in the repo today is positive except one, so this pins the
+    property that made the change safe to land ahead of anything else.
+    """
+    tol = 0.05
+    for metric, scaled in (
+        (_LOWER, baseline * (1 + tol)),
+        (_HIGHER, baseline * (1 - tol)),
+    ):
+        # Just inside the old threshold must stay unflagged; just outside must
+        # flag -- identical behaviour to the scaling form.
+        inside = scaled - 0.001 if metric is _LOWER else scaled + 0.001
+        outside = scaled + 0.001 if metric is _LOWER else scaled - 0.001
+        assert _flags({metric: inside}, {metric: baseline})[metric] is False
+        assert _flags({metric: outside}, {metric: baseline})[metric] is True
+
+
+def test_zero_baseline_has_no_slack():
+    """abs(0) * tol == 0: a zero baseline permits nothing, which is honest."""
+    assert _flags({_LOWER: 0.001}, {_LOWER: 0.0})[_LOWER] is True
+    assert _flags({_LOWER: 0.0}, {_LOWER: 0.0})[_LOWER] is False


### PR DESCRIPTION
`threshold = baseline * (1 ± tol)` is correct only while every baseline is positive. Scaling a **negative** baseline moves the threshold *away* from zero, so the slack lands on the wrong side.

`erds_specificity` declares `target_specificity_zscore: -2.50` (more negative = better binding):

| branch | current thr | behaviour |
|---|---|---|
| lower-is-better | `-2.625` | **exactly-on-target flags as a regression**; can only pass by beating the target by 5% |
| higher-is-better | `-2.375` | `-5.00` (twice as good) **flags**; `0.00` (no signal) **passes** |

**Both branches are wrong for a negative baseline** — the defect is attached to the sign, not to which set the metric sits in.

```diff
-                threshold = baseline * (1 + tol)
+            slack = abs(baseline) * tol
+                threshold = baseline + slack
```

## Provably inert on everything in the repo today

For `b > 0`, `b*(1±tol)` and `b ± abs(b)*tol` are the same expression — the scaling form is the additive form with the sign assumption baked in. Verified across both dataset trees:

```
baselines scanned:        147
thresholds that change:     4   (target_specificity_zscore, 2 branches x 2 trees)
```

143 of 147 produce a byte-identical threshold, so this **cannot change a verdict that is currently correct**.

## Why it lands before #341

`target_specificity_zscore` has no producer, so the bug is real but unreachable. **The #341 dispatch is what arms it.** Corrective change first, arming change second — so #341 becomes the first execution of corrected arithmetic rather than opening a window where the metric is live and the gate is wrong.

## Degenerate case, stated rather than left to be discovered

At `baseline == 0` the slack is `abs(0)*tol == 0`, so any non-zero measurement flags. Arguably correct — 5% of zero is zero — but "additive slack" stops being slack there. The scaling form has the identical hole, and no dataset declares a zero baseline today (checked). Flagged by Bumble; pinned by `test_zero_baseline_has_no_slack`.

## Tests

15 new, incl. both branches against `-2.50`, a positive-baseline no-op parametrisation, and a guard that the registry membership the fixtures rely on still holds (a re-file would otherwise silently void them). **Full suite 1065 passed, 68 skipped.**

**Gate on `Pure Python results tests`** — Tier-1 cannot reach this diff, Coverage is C++-only, windows-bindings is the known `main` red. Not merged by me.

Credit: Bumble found the sign break and verified the additive form independently; Fizz's negate-or-not sharpening is why the sign convention is decided in #341 rather than dodged here.