### PR TITLE
Fix: capture engine-emitted entropy REMARK in dataset_runner parser

### DIFF
--- a/python/flexaidds/dataset_runner/data_paths.py
+++ b/python/flexaidds/dataset_runner/data_paths.py
@@ -20,6 +20,14 @@ _CF_REMARK_RE = re.compile(r"REMARK\s+CF=([+-]?(?:\d+(?:\.\d*)?|\.\d+))", re.IGN
 _CF_APP_REMARK_RE = re.compile(
     r"REMARK\s+CF\.app=([+-]?(?:\d+(?:\.\d*)?|\.\d+))", re.IGNORECASE
 )
+# The engine writes ``REMARK entropy = <value>`` (lowercase, space-equals; see
+# LIB/BindingMode.cpp, LIB/cluster.cpp). The explicit ``ENTROPY:`` token the
+# parser tests for is never emitted, so without this fallback every pose's
+# entropy_correction silently keeps its 0.0 initialiser -- a parse failure that
+# looks like a measurement. This pattern rescues the value the writer emits.
+_ENTROPY_REMARK_RE = re.compile(
+    r"REMARK\s+entropy\s*=\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))", re.IGNORECASE
+)
 
 
 def _first_existing(paths: List[Path]) -> Optional[Path]:

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -62,6 +62,7 @@ import numpy as np
 from .data_paths import (
     _CF_APP_REMARK_RE,
     _CF_REMARK_RE,
+    _ENTROPY_REMARK_RE,
     _RMSD_REMARK_RE,
     resolve_benchmark_paths,
 )
@@ -1512,6 +1513,9 @@ class DatasetRunner:
                         m = _CF_APP_REMARK_RE.search(line)
                         if m and enthalpy_score == 0.0:
                             enthalpy_score = float(m.group(1))
+                        m = _ENTROPY_REMARK_RE.search(line)
+                        if m and entropy_correction == 0.0:
+                            entropy_correction = float(m.group(1))
 
                 if rmsd < 0.0 and ref_coords is not None:
                     rmsd = _pose_rmsd_vs_reference(pdb_path, ref_coords)

--- a/python/tests/test_runner_entropy_remark_parse.py
+++ b/python/tests/test_runner_entropy_remark_parse.py
@@ -1,0 +1,81 @@
+"""Regression: the dataset_runner PDB parser must capture the entropy the
+engine actually writes.
+
+The C++ writer emits ``REMARK entropy = <value>`` (lowercase, space-equals) at
+three sites (LIB/BindingMode.cpp:714,856 and LIB/cluster.cpp:548). The parser's
+explicit ``elif "ENTROPY:"`` token (uppercase-colon) is never emitted, and the
+fallback regex block rescued RMSD and CF but had no entropy pattern -- so
+``entropy_correction`` silently kept its 0.0 initialiser on every pose. That is
+a parse failure that looks like a measurement (see issue #350).
+
+These tests pin the writer's spelling to the parser's vocabulary so the
+mismatch cannot silently return.
+"""
+
+from pathlib import Path
+
+from flexaidds.dataset_runner.runner import DatasetRunner
+
+
+def _write_pose(work_dir: Path, name: str, body: str) -> None:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    (work_dir / name).write_text(body)
+
+
+def test_entropy_remark_written_spelling_is_captured(tmp_path: Path) -> None:
+    """``REMARK entropy = <v>`` (the spelling the engine emits) is parsed."""
+    _write_pose(
+        tmp_path,
+        "flexaid_0.pdb",
+        "REMARK CF=-5.07911\n"
+        "REMARK enthalpy = -5.079114\n"
+        "REMARK entropy = 0.00000780\n"
+        "REMARK 3.15582 RMSD to ref. structure\n",
+    )
+
+    poses = DatasetRunner._parse_flexaid_output(
+        tmp_path, target_id="1G9V", ligand_id="lig", structural_state="holo"
+    )
+
+    assert len(poses) == 1
+    pose = poses[0]
+    # The defect: this used to be 0.0 because nothing read `entropy = `.
+    assert pose.entropy_correction == 0.00000780
+    # enthalpy_score stays sourced from CF= (unchanged), not the enthalpy line.
+    assert pose.enthalpy_score == -5.07911
+    # total_score = enthalpy_score - entropy_correction, now with a real ΔS.
+    assert pose.total_score == -5.07911 - 0.00000780
+
+
+def test_entropy_defaults_to_zero_when_writer_omits_it(tmp_path: Path) -> None:
+    """No entropy REMARK -> entropy_correction keeps its 0.0 default (no crash)."""
+    _write_pose(
+        tmp_path,
+        "flexaid_0.pdb",
+        "REMARK CF=-5.07911\n"
+        "REMARK 3.15582 RMSD to ref. structure\n",
+    )
+
+    poses = DatasetRunner._parse_flexaid_output(
+        tmp_path, target_id="1G9V", ligand_id="lig", structural_state="holo"
+    )
+
+    assert len(poses) == 1
+    assert poses[0].entropy_correction == 0.0
+
+
+def test_legacy_entropy_token_still_parses(tmp_path: Path) -> None:
+    """The explicit ``ENTROPY:`` token remains honoured for back-compat."""
+    _write_pose(
+        tmp_path,
+        "flexaid_0.pdb",
+        "REMARK CF_SCORE: -5.07911\n"
+        "REMARK ENTROPY: 0.0123\n",
+    )
+
+    poses = DatasetRunner._parse_flexaid_output(
+        tmp_path, target_id="1G9V", ligand_id="lig", structural_state="holo"
+    )
+
+    assert len(poses) == 1
+    assert poses[0].entropy_correction == 0.0123


### PR DESCRIPTION
## What

The dataset_runner PDB parser never captured the entropy the engine writes, so
`entropy_correction` was `0.0` on every pose of every run — a parse failure that
looks like a measurement (issue #350).

```
writer   LIB/BindingMode.cpp:714,856 · LIB/cluster.cpp:548   REMARK entropy = %.8f   (lowercase, space-equals)
parser   runner.py:1493                                       elif "ENTROPY:" in line   (uppercase-colon, never emitted)
regexes  data_paths.py                                        RMSD, CF=, CF.app=  — no entropy pattern
```

Nothing on either path read `entropy = `, so the field kept its initialiser. The
`entropy=0.0` on all eleven poses of run 30680006724 is this line, not the engine.
Committed reference PDBs emit non-zero entropy in **8 of 8** samples (1.1e-7 … 6.9e-3,
both optimisers), so a hard `0.0` is never the engine's real output.

## Change

- `_ENTROPY_REMARK_RE` in `data_paths.py`, matching `REMARK entropy = <v>`.
- Wired into the `runner.py` fallback block beside the CF rescues, mirroring the
  existing three-regex style (`_RMSD_REMARK_RE`, `_CF_REMARK_RE`, `_CF_APP_REMARK_RE`).
- `test_runner_entropy_remark_parse.py` — 3 tests: the written spelling is captured,
  absence still defaults to 0.0 (no crash), and the legacy `ENTROPY:` token still parses.
  Verified non-vacuous: with the fix reverted the first test fails with `0.0 == 7.8e-06`.

## Scope — deliberately entropy-only

- **`enthalpy_score` is left sourced from `CF=`, unchanged.** The writer also emits
  `REMARK enthalpy = ` (`td.mean_energy`), but `enthalpy_score` is populated by
  `_CF_REMARK_RE` off the `CF=` line. Remapping it would change the source of a value
  that feeds `scoring_power`, `docking_power` ranking, and the report — a four-consumer
  change disguised as a parser fix. Out of scope.
- **I did not swap to `flexaidds/io.py::parse_remark_map`** even though it already parses
  this vocabulary under test. Its `_canonical_key` normalises `enthalpy` → `td.mean_energy`,
  so adopting it would silently remap `enthalpy_score` off `CF=` — the same four-consumer
  change. The ad-hoc regex keeps the fix to exactly the one dropped field; unifying the two
  parsers is a larger, separate property (noted on #350).

## What this does NOT fix

The number is now **visible**, not **validated** — the real ΔS still lives in the pose
PDBs the Tier-1 artifact discards, so it can't yet be audited from CI. And per #350: the
report's `enthalpy` column is `CF`, not `td.mean_energy`; `EXP_AFFINITY:` / `ACTIVE:1`
have no emitter at all. Those are separate items. This closes only the one defect with a
real emitter on the other side to pin a test against.

Full Python suite: **1054 passed, 68 skipped**.

## Readable ≠ load-bearing (per review, verified)

This makes entropy **readable**; it does not make it **load-bearing**. `total_score = CF − entropy`,
and at current magnitudes CF is ~1e4…1e5 while committed entropy is ~1e-7…1e-3 — the term is far
below the gap between adjacent CF values (min adjacent CF gap in the 1gpk run 478 vs max committed
entropy ~6.9e-3 — a ~10⁵ margin at the tightest pair), so it cannot reorder poses. Consequence: `entropy_rescue_rate` (the
"primary ΔS discriminator") returns `0.0` for every input the parser can currently produce, and will
after this lands — it compares a sort-by-CF against a sort-by-`total_score` that is the same
permutation. It is **starved, not broken**: fed an entropy term comparable to the CF spacing it
returns `1.0` and reorders correctly (verified by execution). A green suite here does **not** mean ΔS
participates in ranking. That collapse is the CF-magnitude issue (`BindingMode.cpp:951` documents it:
"Physical 1/(kB·T) collapsed ranking entropy to zero on CF magnitudes"), tracked on #350 — separate
from this parser fix.
