### PR TITLE
Add: preserve engine pose PDBs under results_dir (opt-in)

### DIFF
--- a/.github/workflows/benchmark-tier1.yml
+++ b/.github/workflows/benchmark-tier1.yml
@@ -46,6 +46,14 @@ jobs:
     env:
       DATASET: ${{ inputs.dataset || 'astex_diverse' }}
       RESULTS_DIR: results/tier1
+      # Keep the engine's pose PDBs. Without this the runner deletes them with
+      # the per-ligand temp dir it docks in (runner.py _run_flexaid), so the
+      # upload step below has only ever collected JSON: every question that
+      # needs coordinates rather than scalars was unanswerable from CI, and no
+      # change to the `path:` list could have fixed it. The copy destination is
+      # under RESULTS_DIR by construction (DatasetRunner.pose_pdb_dir), which
+      # is what makes the existing upload reach them.
+      FLEXAIDDS_KEEP_POSES: "1"
       # NOTE: this MUST stay an absolute path. The "Verify binary exists" step
       # below now hard-fails when the binary is absent (no more dry-run
       # fallback), and it tests this exact string with `-x` from the repo root

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -39,6 +39,8 @@ import json
 import csv
 import logging
 import os
+import re
+import shutil
 import socket
 import subprocess
 import sys
@@ -1207,6 +1209,16 @@ class DatasetRunner:
         self.resume = bool(resume)
         self.command_line = command_line
         self.default_conc_M = float(default_conc_M)
+        # Pose PDBs are written by the engine into a per-ligand TemporaryDirectory
+        # and destroyed when that ligand's iteration ends -- before the target
+        # finishes, let alone the job.  Every question that needs coordinates
+        # rather than scalars (was the search collapsed, do these poses share a
+        # conformer, what ΔS did the engine actually compute) is unanswerable
+        # from a run's output for that reason alone, and no workflow change can
+        # fix it: the CI upload step names RESULTS_DIR, which never held a PDB.
+        # Opt-in, because keeping them costs disk on every entry and the default
+        # behaviour of every existing run must not change.
+        self.keep_poses = os.environ.get("FLEXAIDDS_KEEP_POSES", "").strip() not in ("", "0")
 
         self.results_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1450,6 +1462,13 @@ class DatasetRunner:
                     structural_state,
                     reference_ligand=ligand_path,
                 )
+                # Copy the coordinates out BEFORE the with-block closes and
+                # takes them.  Deliberately after the parse, so a preservation
+                # failure can never cost us the scalars we already have.
+                if self.keep_poses:
+                    self._preserve_pose_pdbs(
+                        tmp_path, target_id, ligand_id, structural_state
+                    )
                 # P3: capture grand log_Z from [GRAND] stdout (emitted by C++ cluster hook when --conc used)
                 grand_log_z = None
                 if result.stdout:
@@ -1465,6 +1484,52 @@ class DatasetRunner:
                 poses.extend(parsed)
 
         return poses
+
+    def pose_pdb_dir(self, target_id: str, ligand_id: str, structural_state: str) -> Path:
+        """Destination for preserved pose PDBs, ALWAYS under ``results_dir``.
+
+        The destination root is not a detail.  ``benchmark-tier1.yml`` uploads
+        exactly ``${{ env.RESULTS_DIR }}/``, so files preserved anywhere else
+        survive the run, satisfy any local check, and still reach nobody --
+        the same empty-artifact outcome, relocated one step later and harder to
+        see.  Tests assert against this method rather than a literal path so
+        that "it persists" and "CI can reach it" cannot drift apart.
+        """
+        safe_target = re.sub(r"[^A-Za-z0-9_.-]", "_", target_id)
+        safe_ligand = re.sub(r"[^A-Za-z0-9_.-]", "_", ligand_id)
+        safe_state = re.sub(r"[^A-Za-z0-9_.-]", "_", structural_state)
+        return self.results_dir / "poses" / safe_target / f"{safe_ligand}_{safe_state}"
+
+    def _preserve_pose_pdbs(
+        self,
+        work_dir: Path,
+        target_id: str,
+        ligand_id: str,
+        structural_state: str,
+    ) -> List[Path]:
+        """Copy pose PDBs out of the engine's temp dir into ``results_dir``.
+
+        Returns the files written.  Never raises: preserving coordinates is a
+        diagnostic convenience, and it must not be able to fail a docking run
+        that has already produced its scores.
+        """
+        copied: List[Path] = []
+        try:
+            sources = sorted(work_dir.glob("*.pdb"))
+            if not sources:
+                return copied
+            dest_dir = self.pose_pdb_dir(target_id, ligand_id, structural_state)
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            for src in sources:
+                dest = dest_dir / src.name
+                shutil.copy2(src, dest)
+                copied.append(dest)
+        except OSError as exc:
+            logger.warning(
+                "Could not preserve pose PDBs for %s/%s: %s",
+                target_id, ligand_id, exc,
+            )
+        return copied
 
     @staticmethod
     def _parse_flexaid_output(

--- a/python/tests/test_pose_pdb_preservation.py
+++ b/python/tests/test_pose_pdb_preservation.py
@@ -1,0 +1,171 @@
+"""Pose PDBs must survive the docking loop, and land where CI can reach them.
+
+The engine writes ``flexaid_*.pdb`` into a ``tempfile.TemporaryDirectory``
+created per ligand (``runner.py`` ``_run_flexaid``).  That directory is removed
+when the ligand's iteration ends -- before the target finishes, let alone the
+job -- so every coordinate the engine produces is destroyed on the same pass
+that extracts its scalars.
+
+Two properties are pinned here, and the second is the one that is easy to lose:
+
+1. With ``FLEXAIDDS_KEEP_POSES`` set, the PDBs exist after the temp dir is gone.
+2. They are under ``results_dir`` -- the directory ``benchmark-tier1.yml``
+   actually uploads.  A copy that persists in a sibling directory passes any
+   "did the files survive" check and still uploads nothing.
+
+Pure Python: no compiled bindings and no FlexAID binary required.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from flexaidds.dataset_runner.runner import DatasetRunner
+
+
+PDB_BODY = (
+    "REMARK CF=-5.08119\n"
+    "REMARK enthalpy = -5.079114\n"
+    "REMARK entropy = 0.00000780\n"
+    "ATOM      1  C   LIG A   1       0.000   0.000   0.000  1.00  0.00\n"
+    "END\n"
+)
+
+
+def _runner(tmp_path: Path, keep: bool, monkeypatch) -> DatasetRunner:
+    if keep:
+        monkeypatch.setenv("FLEXAIDDS_KEEP_POSES", "1")
+    else:
+        monkeypatch.delenv("FLEXAIDDS_KEEP_POSES", raising=False)
+    return DatasetRunner(results_dir=tmp_path / "results", dry_run=True)
+
+
+def _engine_output(work_dir: Path, names=("flexaid_0.pdb", "flexaid_1.pdb")) -> None:
+    for name in names:
+        (work_dir / name).write_text(PDB_BODY)
+
+
+def test_poses_survive_the_temp_dir(tmp_path, monkeypatch):
+    """The whole point: coordinates outlive the directory they were written in."""
+    runner = _runner(tmp_path, keep=True, monkeypatch=monkeypatch)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        _engine_output(work)
+        runner._preserve_pose_pdbs(work, "1gpk", "1gpk_ligand", "holo")
+    # temp dir is now gone -- exactly the state the real loop leaves behind
+    assert not work.exists()
+
+    dest = runner.pose_pdb_dir("1gpk", "1gpk_ligand", "holo")
+    assert sorted(p.name for p in dest.glob("*.pdb")) == [
+        "flexaid_0.pdb", "flexaid_1.pdb"
+    ]
+    assert dest.joinpath("flexaid_0.pdb").read_text() == PDB_BODY
+
+
+def test_destination_is_inside_results_dir(tmp_path, monkeypatch):
+    """Reachability, not just persistence.
+
+    ``benchmark-tier1.yml`` uploads ``${{ env.RESULTS_DIR }}/`` and nothing
+    else.  If this relation breaks, the files still exist and CI still gets an
+    empty artifact -- which looks like the fix worked.
+    """
+    runner = _runner(tmp_path, keep=True, monkeypatch=monkeypatch)
+    dest = runner.pose_pdb_dir("1gpk", "1gpk_ligand", "holo")
+    assert runner.results_dir in dest.parents
+
+
+def test_disabled_by_default(tmp_path, monkeypatch):
+    """Default OFF: an existing run's behaviour and disk usage are unchanged."""
+    runner = _runner(tmp_path, keep=False, monkeypatch=monkeypatch)
+    assert runner.keep_poses is False
+
+
+def test_flag_is_read_from_the_environment(tmp_path, monkeypatch):
+    monkeypatch.setenv("FLEXAIDDS_KEEP_POSES", "1")
+    assert DatasetRunner(results_dir=tmp_path / "r", dry_run=True).keep_poses is True
+    # "0" is an explicit disable, not merely a set variable
+    monkeypatch.setenv("FLEXAIDDS_KEEP_POSES", "0")
+    assert DatasetRunner(results_dir=tmp_path / "r", dry_run=True).keep_poses is False
+
+
+def test_no_pdbs_is_not_an_error(tmp_path, monkeypatch):
+    """A crashed entry produces no output; that must not fail the run."""
+    runner = _runner(tmp_path, keep=True, monkeypatch=monkeypatch)
+    with tempfile.TemporaryDirectory() as tmp:
+        assert runner._preserve_pose_pdbs(Path(tmp), "t", "l", "holo") == []
+    assert not runner.pose_pdb_dir("t", "l", "holo").exists()
+
+
+def test_entries_do_not_collide(tmp_path, monkeypatch):
+    """Same ligand filename under two targets must not overwrite each other."""
+    runner = _runner(tmp_path, keep=True, monkeypatch=monkeypatch)
+    for target in ("1gpk", "1hnn"):
+        with tempfile.TemporaryDirectory() as tmp:
+            work = Path(tmp)
+            _engine_output(work, names=("flexaid_0.pdb",))
+            runner._preserve_pose_pdbs(work, target, "ligand", "holo")
+    assert runner.pose_pdb_dir("1gpk", "ligand", "holo").joinpath("flexaid_0.pdb").exists()
+    assert runner.pose_pdb_dir("1hnn", "ligand", "holo").joinpath("flexaid_0.pdb").exists()
+
+
+def test_structural_state_separates_destinations(tmp_path, monkeypatch):
+    """holo and apo runs of one target/ligand pair are different measurements."""
+    runner = _runner(tmp_path, keep=True, monkeypatch=monkeypatch)
+    holo = runner.pose_pdb_dir("1gpk", "ligand", "holo")
+    apo = runner.pose_pdb_dir("1gpk", "ligand", "apo")
+    assert holo != apo
+
+
+@pytest.mark.parametrize("hostile", ["../escape", "a/b", "with space"])
+def test_ids_cannot_escape_results_dir(tmp_path, monkeypatch, hostile):
+    """Target ids reach this from dataset YAML; a path separator must not escape."""
+    runner = _runner(tmp_path, keep=True, monkeypatch=monkeypatch)
+    dest = runner.pose_pdb_dir(hostile, hostile, "holo")
+    assert runner.results_dir in dest.parents
+
+
+def test_docking_loop_actually_preserves(tmp_path, monkeypatch):
+    """The wiring, not just the helper.
+
+    Every other test here calls ``_preserve_pose_pdbs`` directly, so deleting
+    the call site inside ``_run_flexaid`` leaves them all green -- a test you
+    know how to pass.  This one drives the real loop with a stubbed engine and
+    fails if the call site is removed, which is the only version of the check
+    that could have caught the defect in the first place.
+    """
+    from flexaidds.dataset_runner import runner as runner_mod
+
+    class _Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        # The engine writes into its cwd -- the per-ligand temp dir.
+        Path(kwargs["cwd"]).joinpath("flexaid_0.pdb").write_text(PDB_BODY)
+        return _Result()
+
+    monkeypatch.setattr(runner_mod.subprocess, "run", fake_run)
+    monkeypatch.setenv("FLEXAIDDS_KEEP_POSES", "1")
+
+    receptor = tmp_path / "rec.pdb"
+    receptor.write_text("ATOM      1  CA  ALA A   1       0.000   0.000   0.000\n")
+    ligand = tmp_path / "lig.mol2"
+    ligand.write_text(
+        "@<TRIPOS>MOLECULE\n"
+        "lig\n"
+        " 1 0 0 0 0\n"
+        "SMALL\nNO_CHARGES\n"
+        "@<TRIPOS>ATOM\n"
+        "      1 C1          0.0000    0.0000    0.0000 C.3     1  LIG     0.0000\n"
+    )
+
+    runner = DatasetRunner(results_dir=tmp_path / "results", dry_run=False)
+    runner._run_flexaid("1gpk", receptor, [ligand], "holo", True)
+
+    dest = runner.pose_pdb_dir("1gpk", "lig", "holo")
+    assert dest.joinpath("flexaid_0.pdb").exists(), (
+        "the docking loop did not preserve the pose PDB -- call site missing?"
+    )


### PR DESCRIPTION
## The problem is not the artifact upload

We spent hours filing three questions as "blocked on uploading the pose PDBs". They were blocked on a `with` statement.

```python
# runner.py  _run_flexaid
for ligand_path in ligand_paths:
    with tempfile.TemporaryDirectory(prefix=f"flexaid_{target_id}_") as tmp:
        subprocess.run([...], cwd=tmp_path, ...)      # engine writes flexaid_*.pdb HERE
        parsed = self._parse_flexaid_output(tmp_path, ...)
        poses.extend(parsed)
    # <- with-block exits. Tree deleted, coordinates gone.
```

The engine's pose PDBs (`*.pdb` in that directory) are destroyed at the end of the ligand that produced them — inside the docking loop, before the target finishes, let alone the job. The scalars are extracted and the geometry is dropped on the same pass. `grep -n "shutil\|copy2\|copyfile\|copytree" runner.py` returns two hits, both `shutil.which`.

Meanwhile `benchmark-tier1.yml:145` uploads `${{ env.RESULTS_DIR }}/` and nothing else — a directory that has never contained a PDB. **Adding a `path:` line would have uploaded an empty directory and looked like it worked.**

## What this unblocks

| question | previously filed as |
|---|---|
| collapsed search vs scoring nondeterminism | "undecidable — PDBs not uploaded" |
| do 11 poses share a conformer at 1.4e-4 Å RMSD spread | "PDB-only, cannot rule out" |
| what ΔS the engine actually computed (`REMARK entropy =`) | "lives in the discarded PDBs" |

None of them are answerable from scalars. All three become answerable from a CI run once the coordinates survive.

## The change

- `FLEXAIDDS_KEEP_POSES` — **library default OFF**, so nothing that imports `DatasetRunner` changes behaviour or disk usage. **The Tier-1 workflow sets it to `"1"` (`benchmark-tier1.yml:54`), so that job does change: it starts writing `RESULTS_DIR/poses/`.** That is the point of the PR, but "opt-in, default off" describes the code and not the deployment, and Tier-1 is the run people actually look at.
- `DatasetRunner.pose_pdb_dir()` — destination is **always under `results_dir`**. This is the constraint that matters and it is why the path is a method rather than a literal: a copy that persists in a sibling directory survives the loop, passes every local check, and still uploads nothing. Same empty-artifact outcome, relocated one step later and harder to see.
- Preservation runs **after** the parse and **never raises** — a diagnostic convenience must not be able to fail a run that already produced its scores.
- The tmpdir lifetime and the parser are untouched.
- One env line in `benchmark-tier1.yml` — which is what turns it on in CI. **No `path:` change** — the existing upload reaches `RESULTS_DIR/poses/` because the destination is under `RESULTS_DIR` by construction.

## Tests — 11, and the wiring is the one that counts

Ten of them call `_preserve_pose_pdbs` directly. Deleting the call site in `_run_flexaid` leaves all ten green — a test you know how to pass. `test_docking_loop_actually_preserves` drives the real loop with a stubbed engine and is the only one that fails when the wiring goes.

**Revert-check, run:** removed the call site → `1 failed, 10 passed`, failing on exactly that test. Restored → `11 passed`.

Full Python suite on this branch: **1077 passed, 68 skipped** (`main` at `44bad55e` is 1066; +11).

## What this does NOT do

It makes the coordinates available. It does not answer any of the three questions — that needs someone to look at a real run's PDBs. And it does not touch the 10⁴ CF magnitude gap (#350), which is the thing actually disabling the ΔS metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to preserve engine-generated pose PDB files after docking.
  * Preserved poses are saved under the results directory with isolated paths for targets, ligands, and structural states.
  * Enabled benchmark artifacts to include preserved pose files.

* **Bug Fixes**
  * Pose-preservation failures are logged without interrupting docking.
  * Added safeguards for missing outputs and unsafe file paths.

* **Tests**
  * Added coverage for configuration, persistence, isolation, path safety, and docking integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Two review notes from @Bumble worth keeping in the body

**The glob is `*.pdb`, not `flexaid*.pdb`** — deliberately the same glob `_parse_flexaid_output` uses, so *the preserved set is exactly the parsed set by construction*. A narrower pattern would let the two drift: the parser scores a file the preserver dropped, and a pose in the report has no coordinates behind it with nothing to indicate that. Same shape as the `RESULTS_DIR` constraint — pin the relation, not the literal.

**Receptor and ligand are passed to the engine by absolute path and never copied into the temp dir**, so `*.pdb` there is engine output only. The disk cost is what the poses cost.


## Known coverage gap: a timed-out entry preserves nothing

```python
except subprocess.TimeoutExpired:
    logger.error("Docking timed out: %s/%s", target_id, ligand_id)
    continue          # <- skips the parse AND the preservation
# with-block closes -> tmpdir deleted -> anything the engine had written is gone
```

| exit path | poses preserved |
|---|---|
| normal exit | yes |
| non-zero exit | yes (the parse runs, so does the copy) |
| **`TimeoutExpired`** | **no** |
| `OSError` (engine never ran) | nothing to preserve — correct |

The eleven tests here drive a stubbed engine that returns cleanly, so none of them exercises this path.

**It also cannot fire in Tier-1 CI**: `subprocess.run(timeout=3600)` against `timeout-minutes: 25` (1500s) on the step, so the step timeout always wins — and a step timeout kills the process tree, so no handler of any kind runs. Run #343 was a step timeout; a handler fix would have produced zero files there. The path is reachable outside CI (local, Tier-2), where there is no step timeout.

Not fixed here deliberately — it changes the timeout path's behaviour and needs its own test and revert-check, and this PR is already reviewed. **The gap is strictly less coverage, never wrong coverage.** Tracked in #353, which carries the ordering: the subprocess timeout has to drop below the step timeout *before* a handler fix is observable in CI.

