### PR TITLE
Fix: docking RMSD is in-place (not Kabsch); preserve ligand atom file order

### DIFF
--- a/python/flexaidds/benchmark.py
+++ b/python/flexaidds/benchmark.py
@@ -93,8 +93,17 @@ def pic50_to_dg(pic50: float, temperature_K: float = 298.15) -> float:
 def extract_ligand_coords_from_pdb(pdb_path: Path) -> np.ndarray:
     """Extract ligand heavy-atom coordinates from a PDB file.
 
-    Selects HETATM records excluding HOH, returns (N, 3) array sorted
-    by atom name for deterministic ordering.
+    Selects HETATM records excluding HOH.  Returns an (N, 3) array in
+    **file order** — not sorted by atom name.
+
+    File order is load-bearing for docking RMSD.  FlexAID writes the
+    optimizable residue's HETATM block in the same topology order as the
+    input ligand (SDF/MOL2), and the benchmark reference is also read in
+    file order.  Sorting by atom name breaks that correspondence: FlexAID
+    names atoms ``C 0``, ``O 1``, … while the crystal PDB uses ``C1``,
+    ``O1``, …, and lexicographic sort reorders both differently.  On 1gpk
+    that alone turned a true ~1.6 Å pose into a ~4.7 Å number even after
+    the Kabsch bug was removed.
     """
     atoms = []
     with open(pdb_path) as fh:
@@ -107,18 +116,15 @@ def extract_ligand_coords_from_pdb(pdb_path: Path) -> np.ndarray:
             element = line[76:78].strip() if len(line) > 77 else ""
             if element == "H":
                 continue
-            atom_name = line[12:16].strip()
             x = float(line[30:38])
             y = float(line[38:46])
             z = float(line[46:54])
-            atoms.append((atom_name, x, y, z))
+            atoms.append((x, y, z))
 
     if not atoms:
         raise ValueError(f"No ligand heavy atoms found in {pdb_path}")
 
-    atoms.sort(key=lambda a: a[0])
-    coords = np.array([[a[1], a[2], a[3]] for a in atoms], dtype=np.float64)
-    return coords
+    return np.array(atoms, dtype=np.float64)
 
 
 def extract_ligand_coords_from_mmcif(mmcif_string: str, ligand_id: str = "") -> np.ndarray:
@@ -232,9 +238,46 @@ def _tokenize_mmcif_line(line: str) -> List[str]:
 
 
 def compute_rmsd(coords_pred: np.ndarray, coords_ref: np.ndarray) -> float:
-    """Compute RMSD after optimal Kabsch alignment.
+    """Docking RMSD: in-place, in the receptor frame, NO superposition.
 
-    Both arrays must be (N, 3).  Returns RMSD in Angstrom.
+    This is the quantity the 2.0 A redocking criterion is defined on.  Both
+    poses are already expressed in the same (receptor) coordinate frame, so
+    the displacement between them *is* the error and must not be removed.
+
+    Do NOT superpose here.  Superposing before measuring discards exactly the
+    translation and rotation that docking is being scored on: a ligand placed
+    5 A outside the pocket and one placed on the crystal position differ only
+    by a rigid motion, so an aligned RMSD reports them as equally good.  That
+    bug shipped in this function and reported ~3.156 A for every pose of every
+    sweep cell on 1gpk -- for a 6.5 A miss and a ~1.3 A hit alike -- because
+    the ligand's internal conformation barely changes while its placement
+    changes by Angstroms.  See :func:`compute_rmsd_superposed` for the
+    conformer-shape comparison, which is a different question.
+
+    Both arrays must be (N, 3) with row i of each referring to the same atom.
+    Returns RMSD in Angstrom.
+    """
+    if coords_pred.shape != coords_ref.shape:
+        raise ValueError(
+            f"Shape mismatch: predicted {coords_pred.shape} vs "
+            f"reference {coords_ref.shape}."
+        )
+    n = coords_pred.shape[0]
+    if n == 0:
+        return 0.0
+
+    diff = coords_pred - coords_ref
+    return float(np.sqrt((diff * diff).sum() / n))
+
+
+def compute_rmsd_superposed(coords_pred: np.ndarray, coords_ref: np.ndarray) -> float:
+    """Shape-only RMSD after optimal Kabsch superposition.
+
+    Measures how well two conformers match *once placement is discarded*.
+    This answers "is it the same shape?", never "is it docked correctly?" --
+    use :func:`compute_rmsd` for the latter.  Note the result is not a metric
+    (it can violate the triangle inequality), so it must not be compared
+    against geometric bounds such as centre-of-mass separation.
     """
     if coords_pred.shape != coords_ref.shape:
         raise ValueError(

--- a/python/tests/test_benchmark.py
+++ b/python/tests/test_benchmark.py
@@ -17,6 +17,7 @@ from flexaidds.benchmark import (
     MethodResult,
     SystemBenchmarkResult,
     compute_rmsd,
+    compute_rmsd_superposed,
     enrichment_factor,
     extract_ligand_coords_from_mmcif,
     extract_ligand_coords_from_pdb,
@@ -171,10 +172,25 @@ class TestExtractPDB:
     def test_basic(self, sample_system):
         coords = extract_ligand_coords_from_pdb(sample_system.reference_pose_pdb_path)
         assert coords.shape == (3, 3)
-        # Sorted by atom name: C1, N1, O1
+        # File order (not name-sorted): C1, N1, O1 as written
         np.testing.assert_allclose(coords[0], [1.0, 2.0, 3.0])
         np.testing.assert_allclose(coords[1], [4.0, 5.0, 6.0])
         np.testing.assert_allclose(coords[2], [7.0, 8.0, 9.0])
+
+    def test_preserves_file_order_not_lexicographic_atom_names(self, tmp_path):
+        """FlexAID-style names must stay in write order, not C/O/N lex sort."""
+        # File order: O then C then N. Lex sort by name would be C, N, O.
+        pdb = tmp_path / "flexaid_style.pdb"
+        pdb.write_text(
+            "HETATM90001 O  1 HUP     1       1.000   0.000   0.000  1.00  0.00           O\n"
+            "HETATM90002 C  0 HUP     1       2.000   0.000   0.000  1.00  0.00           C\n"
+            "HETATM90003 N  2 HUP     1       3.000   0.000   0.000  1.00  0.00           N\n"
+            "END\n"
+        )
+        coords = extract_ligand_coords_from_pdb(pdb)
+        np.testing.assert_allclose(coords[0], [1.0, 0.0, 0.0])
+        np.testing.assert_allclose(coords[1], [2.0, 0.0, 0.0])
+        np.testing.assert_allclose(coords[2], [3.0, 0.0, 0.0])
 
     def test_empty_raises(self, tmp_path):
         empty = tmp_path / "empty.pdb"
@@ -219,37 +235,63 @@ class TestExtractMmcif:
 
 
 class TestComputeRmsd:
+    """Docking RMSD is in-place (no superposition). Placement is the signal."""
+
     def test_identity(self):
         coords = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         assert compute_rmsd(coords, coords) == pytest.approx(0.0, abs=1e-10)
 
-    def test_translation(self):
+    def test_translation_is_the_error(self):
         ref = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
-        # Pure translation → Kabsch should align → RMSD = 0
-        pred = ref + np.array([10.0, 20.0, 30.0])
-        assert compute_rmsd(pred, ref) == pytest.approx(0.0, abs=1e-8)
+        # Pure +5 Å translation: docking error is 5 Å, not 0.
+        pred = ref + np.array([5.0, 0.0, 0.0])
+        assert compute_rmsd(pred, ref) == pytest.approx(5.0, abs=1e-8)
+        # Superposed form still reports ~0 (shape match) — different question.
+        assert compute_rmsd_superposed(pred, ref) == pytest.approx(0.0, abs=1e-8)
 
-    def test_rotation(self):
+    def test_rotation_is_the_error(self):
         ref = np.array([[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
-        # 90-degree rotation about Z
         R = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-        pred = (ref @ R.T)
-        assert compute_rmsd(pred, ref) == pytest.approx(0.0, abs=1e-8)
+        pred = ref @ R.T
+        # In-place: non-zero. Superposed: ~0.
+        assert compute_rmsd(pred, ref) > 0.5
+        assert compute_rmsd_superposed(pred, ref) == pytest.approx(0.0, abs=1e-8)
 
-    def test_known_rmsd(self):
+    def test_known_single_atom(self):
         ref = np.array([[0.0, 0.0, 0.0]])
         pred = np.array([[1.0, 0.0, 0.0]])
-        # Single point: no rotation effect, RMSD = 1.0
-        # But with centering both are at origin → RMSD = 0
-        # (both single-point arrays center to origin)
-        assert compute_rmsd(pred, ref) == pytest.approx(0.0, abs=1e-10)
+        assert compute_rmsd(pred, ref) == pytest.approx(1.0, abs=1e-10)
 
     def test_two_points_known(self):
         ref = np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
         pred = np.array([[0.0, 0.0, 0.0], [2.0, 1.0, 0.0]])  # 1Å offset on one atom
-        rmsd = compute_rmsd(pred, ref)
-        # After Kabsch alignment this should be < 1.0
-        assert rmsd < 1.0
+        # In-place: sqrt((0 + 1)/2) = sqrt(0.5)
+        assert compute_rmsd(pred, ref) == pytest.approx(math.sqrt(0.5), abs=1e-10)
+
+    def test_kabsch_would_hide_pocket_miss(self):
+        """Regression: superposed RMSD collapsed every 1gpk pose to ~3.156 Å.
+
+        A rigid translation of a multi-atom ligand must stay visible to
+        ``compute_rmsd`` and invisible to ``compute_rmsd_superposed``.
+        """
+        ref = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        miss = ref + np.array([6.5, 0.0, 0.0])  # ligand left the pocket
+        hit = ref + np.array([0.1, 0.0, 0.0])  # near-native
+        assert compute_rmsd(miss, ref) == pytest.approx(6.5, abs=1e-8)
+        assert compute_rmsd(hit, ref) == pytest.approx(0.1, abs=1e-8)
+        # Superposed: both look like "same shape" → both ~0 (the old bug).
+        assert compute_rmsd_superposed(miss, ref) == pytest.approx(0.0, abs=1e-8)
+        assert compute_rmsd_superposed(hit, ref) == pytest.approx(0.0, abs=1e-8)
+        # The discriminator the gate needs: miss >> hit.
+        assert compute_rmsd(miss, ref) > 10 * compute_rmsd(hit, ref)
 
     def test_shape_mismatch(self):
         a = np.array([[1.0, 2.0, 3.0]])


### PR DESCRIPTION
## Summary

The Tier-1 `mean_rmsd` of ~3.156 Å was independent of pose. Two bugs made the metric useless for docking power / entropy rescue / the Tier-1 gate.

1. **`compute_rmsd` used Kabsch superposition.** A ligand 6.5 Å outside the pocket and one near the crystal differ by a rigid motion, so aligned RMSD reported them as equally good (~3.156 Å on every 1gpk pose in the com-floor sweep). Docking success is defined on **placement in the receptor frame**. Kabsch remains available as `compute_rmsd_superposed` for shape-only questions.

2. **`extract_ligand_coords_from_pdb` sorted HETATM by atom name.** FlexAID writes `C 0` / `O 1` / … in input topology order; the SDF reference is also file-order. Lex sort broke correspondence (true ~1.6 Å became ~4.7 Å on F=130 rank-0 after the Kabsch fix alone).

## Offline validation (same pose PDBs that reported 3.1557 for both)

| Pose | Old reported | Fixed in-place |
|------|-------------|----------------|
| baseline `flexaid_0` | 3.1557 Å | **7.76 Å** |
| F=130 `flexaid_0` | 3.1557 Å | **1.60 Å** |
| `flexaid_INI` | — | **0.03 Å** |

## Test plan

- [x] `PYTHONPATH=python pytest python/tests/` → **1082 passed, 68 skipped**
- [x] Regression test: pure translation is non-zero for `compute_rmsd`, zero for `compute_rmsd_superposed`
- [x] File-order atom extraction guard for FlexAID-style names
- [ ] After merge: Fizz clean redo (≥2 targets) re-reads meaningful RMSDs

Refs: Bonhomme assignment in Benchmarking FlexAIDdS channel; Fizz Finding “RMSD number is BROKEN”.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a superposed RMSD calculation for comparing conformer shapes independently of translation and rotation.

* **Bug Fixes**
  * Preserved ligand atom coordinates in their original HETATM file order.
  * Updated direct RMSD calculations to report receptor-frame displacement, including translation and rotation errors.
  * Improved validation for shape mismatches and empty coordinate arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->