### PR TITLE
Fix: exclude flexaid_INI.pdb (input structure) from the pose list

### DIFF
--- a/python/flexaidds/benchmark.py
+++ b/python/flexaidds/benchmark.py
@@ -93,8 +93,17 @@ def pic50_to_dg(pic50: float, temperature_K: float = 298.15) -> float:
 def extract_ligand_coords_from_pdb(pdb_path: Path) -> np.ndarray:
     """Extract ligand heavy-atom coordinates from a PDB file.
 
-    Selects HETATM records excluding HOH, returns (N, 3) array sorted
-    by atom name for deterministic ordering.
+    Selects HETATM records excluding HOH.  Returns an (N, 3) array in
+    **file order** — not sorted by atom name.
+
+    File order is load-bearing for docking RMSD.  FlexAID writes the
+    optimizable residue's HETATM block in the same topology order as the
+    input ligand (SDF/MOL2), and the benchmark reference is also read in
+    file order.  Sorting by atom name breaks that correspondence: FlexAID
+    names atoms ``C 0``, ``O 1``, … while the crystal PDB uses ``C1``,
+    ``O1``, …, and lexicographic sort reorders both differently.  On 1gpk
+    that alone turned a true ~1.6 Å pose into a ~4.7 Å number even after
+    the Kabsch bug was removed.
     """
     atoms = []
     with open(pdb_path) as fh:
@@ -107,18 +116,15 @@ def extract_ligand_coords_from_pdb(pdb_path: Path) -> np.ndarray:
             element = line[76:78].strip() if len(line) > 77 else ""
             if element == "H":
                 continue
-            atom_name = line[12:16].strip()
             x = float(line[30:38])
             y = float(line[38:46])
             z = float(line[46:54])
-            atoms.append((atom_name, x, y, z))
+            atoms.append((x, y, z))
 
     if not atoms:
         raise ValueError(f"No ligand heavy atoms found in {pdb_path}")
 
-    atoms.sort(key=lambda a: a[0])
-    coords = np.array([[a[1], a[2], a[3]] for a in atoms], dtype=np.float64)
-    return coords
+    return np.array(atoms, dtype=np.float64)
 
 
 def extract_ligand_coords_from_mmcif(mmcif_string: str, ligand_id: str = "") -> np.ndarray:
@@ -232,9 +238,46 @@ def _tokenize_mmcif_line(line: str) -> List[str]:
 
 
 def compute_rmsd(coords_pred: np.ndarray, coords_ref: np.ndarray) -> float:
-    """Compute RMSD after optimal Kabsch alignment.
+    """Docking RMSD: in-place, in the receptor frame, NO superposition.
 
-    Both arrays must be (N, 3).  Returns RMSD in Angstrom.
+    This is the quantity the 2.0 A redocking criterion is defined on.  Both
+    poses are already expressed in the same (receptor) coordinate frame, so
+    the displacement between them *is* the error and must not be removed.
+
+    Do NOT superpose here.  Superposing before measuring discards exactly the
+    translation and rotation that docking is being scored on: a ligand placed
+    5 A outside the pocket and one placed on the crystal position differ only
+    by a rigid motion, so an aligned RMSD reports them as equally good.  That
+    bug shipped in this function and reported ~3.156 A for every pose of every
+    sweep cell on 1gpk -- for a 6.5 A miss and a ~1.3 A hit alike -- because
+    the ligand's internal conformation barely changes while its placement
+    changes by Angstroms.  See :func:`compute_rmsd_superposed` for the
+    conformer-shape comparison, which is a different question.
+
+    Both arrays must be (N, 3) with row i of each referring to the same atom.
+    Returns RMSD in Angstrom.
+    """
+    if coords_pred.shape != coords_ref.shape:
+        raise ValueError(
+            f"Shape mismatch: predicted {coords_pred.shape} vs "
+            f"reference {coords_ref.shape}."
+        )
+    n = coords_pred.shape[0]
+    if n == 0:
+        return 0.0
+
+    diff = coords_pred - coords_ref
+    return float(np.sqrt((diff * diff).sum() / n))
+
+
+def compute_rmsd_superposed(coords_pred: np.ndarray, coords_ref: np.ndarray) -> float:
+    """Shape-only RMSD after optimal Kabsch superposition.
+
+    Measures how well two conformers match *once placement is discarded*.
+    This answers "is it the same shape?", never "is it docked correctly?" --
+    use :func:`compute_rmsd` for the latter.  Note the result is not a metric
+    (it can violate the triangle inequality), so it must not be compared
+    against geometric bounds such as centre-of-mass separation.
     """
     if coords_pred.shape != coords_ref.shape:
         raise ValueError(

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1549,10 +1549,13 @@ class DatasetRunner:
         poses: List[PoseScore] = []
         pdb_files = sorted(
             p for p in work_dir.glob("*.pdb")
-            if p.name.startswith("flexaid") or p.name.startswith("FlexAID")
+            if (p.name.startswith("flexaid") or p.name.startswith("FlexAID"))
+            and not _is_initial_pose_file(p)
         )
         if not pdb_files:
-            pdb_files = sorted(work_dir.glob("*.pdb"))
+            pdb_files = sorted(
+                p for p in work_dir.glob("*.pdb") if not _is_initial_pose_file(p)
+            )
 
         ref_coords = _reference_ligand_coords(reference_ligand) if reference_ligand else None
 
@@ -2366,6 +2369,30 @@ def _parse_remark_float(line: str, key: str) -> float:
         return float(line[idx:].split()[0])
     except (ValueError, IndexError):
         return 0.0
+
+
+def _is_initial_pose_file(pdb_path: Path) -> bool:
+    """True for FlexAID's ``flexaid_INI.pdb`` starting structure.
+
+    FlexAID writes the *input* ligand placement alongside the docked results as
+    ``flexaid_INI.pdb`` (``REMARK initial structure``).  It is not a docking
+    result and must never enter the pose list.
+
+    On a self-docking benchmark the input IS the crystal pose, so this file
+    scores ~0 A RMSD against the reference — measured at 0.0320 A on 1gpk, and
+    identical in every sweep cell because it never depends on the search.  Two
+    consequences if it is globbed in:
+
+    * it silently drags ``mean_rmsd``/``median_rmsd`` down (1gpk F=130:
+      3.841 A over the ten real poses vs 3.495 A once the 0.032 A input is
+      counted as an eleventh), and the pollution is constant across cells, so
+      the aggregate looks frozen while ``docking_power`` moves;
+    * more seriously it is a latent FALSE POSITIVE for ``docking_power`` — a
+      near-0 A entry that counts as a success whenever its score ranks inside
+      top-N.  It stayed out of top-N in the runs measured so far only because
+      its CF was worse than the docked poses, which is luck, not a guarantee.
+    """
+    return pdb_path.stem.upper().endswith("_INI")
 
 
 def _reference_ligand_coords(ligand_path: Path):

--- a/python/tests/test_benchmark.py
+++ b/python/tests/test_benchmark.py
@@ -17,6 +17,7 @@ from flexaidds.benchmark import (
     MethodResult,
     SystemBenchmarkResult,
     compute_rmsd,
+    compute_rmsd_superposed,
     enrichment_factor,
     extract_ligand_coords_from_mmcif,
     extract_ligand_coords_from_pdb,
@@ -171,10 +172,25 @@ class TestExtractPDB:
     def test_basic(self, sample_system):
         coords = extract_ligand_coords_from_pdb(sample_system.reference_pose_pdb_path)
         assert coords.shape == (3, 3)
-        # Sorted by atom name: C1, N1, O1
+        # File order (not name-sorted): C1, N1, O1 as written
         np.testing.assert_allclose(coords[0], [1.0, 2.0, 3.0])
         np.testing.assert_allclose(coords[1], [4.0, 5.0, 6.0])
         np.testing.assert_allclose(coords[2], [7.0, 8.0, 9.0])
+
+    def test_preserves_file_order_not_lexicographic_atom_names(self, tmp_path):
+        """FlexAID-style names must stay in write order, not C/O/N lex sort."""
+        # File order: O then C then N. Lex sort by name would be C, N, O.
+        pdb = tmp_path / "flexaid_style.pdb"
+        pdb.write_text(
+            "HETATM90001 O  1 HUP     1       1.000   0.000   0.000  1.00  0.00           O\n"
+            "HETATM90002 C  0 HUP     1       2.000   0.000   0.000  1.00  0.00           C\n"
+            "HETATM90003 N  2 HUP     1       3.000   0.000   0.000  1.00  0.00           N\n"
+            "END\n"
+        )
+        coords = extract_ligand_coords_from_pdb(pdb)
+        np.testing.assert_allclose(coords[0], [1.0, 0.0, 0.0])
+        np.testing.assert_allclose(coords[1], [2.0, 0.0, 0.0])
+        np.testing.assert_allclose(coords[2], [3.0, 0.0, 0.0])
 
     def test_empty_raises(self, tmp_path):
         empty = tmp_path / "empty.pdb"
@@ -219,37 +235,63 @@ class TestExtractMmcif:
 
 
 class TestComputeRmsd:
+    """Docking RMSD is in-place (no superposition). Placement is the signal."""
+
     def test_identity(self):
         coords = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         assert compute_rmsd(coords, coords) == pytest.approx(0.0, abs=1e-10)
 
-    def test_translation(self):
+    def test_translation_is_the_error(self):
         ref = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
-        # Pure translation → Kabsch should align → RMSD = 0
-        pred = ref + np.array([10.0, 20.0, 30.0])
-        assert compute_rmsd(pred, ref) == pytest.approx(0.0, abs=1e-8)
+        # Pure +5 Å translation: docking error is 5 Å, not 0.
+        pred = ref + np.array([5.0, 0.0, 0.0])
+        assert compute_rmsd(pred, ref) == pytest.approx(5.0, abs=1e-8)
+        # Superposed form still reports ~0 (shape match) — different question.
+        assert compute_rmsd_superposed(pred, ref) == pytest.approx(0.0, abs=1e-8)
 
-    def test_rotation(self):
+    def test_rotation_is_the_error(self):
         ref = np.array([[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
-        # 90-degree rotation about Z
         R = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-        pred = (ref @ R.T)
-        assert compute_rmsd(pred, ref) == pytest.approx(0.0, abs=1e-8)
+        pred = ref @ R.T
+        # In-place: non-zero. Superposed: ~0.
+        assert compute_rmsd(pred, ref) > 0.5
+        assert compute_rmsd_superposed(pred, ref) == pytest.approx(0.0, abs=1e-8)
 
-    def test_known_rmsd(self):
+    def test_known_single_atom(self):
         ref = np.array([[0.0, 0.0, 0.0]])
         pred = np.array([[1.0, 0.0, 0.0]])
-        # Single point: no rotation effect, RMSD = 1.0
-        # But with centering both are at origin → RMSD = 0
-        # (both single-point arrays center to origin)
-        assert compute_rmsd(pred, ref) == pytest.approx(0.0, abs=1e-10)
+        assert compute_rmsd(pred, ref) == pytest.approx(1.0, abs=1e-10)
 
     def test_two_points_known(self):
         ref = np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
         pred = np.array([[0.0, 0.0, 0.0], [2.0, 1.0, 0.0]])  # 1Å offset on one atom
-        rmsd = compute_rmsd(pred, ref)
-        # After Kabsch alignment this should be < 1.0
-        assert rmsd < 1.0
+        # In-place: sqrt((0 + 1)/2) = sqrt(0.5)
+        assert compute_rmsd(pred, ref) == pytest.approx(math.sqrt(0.5), abs=1e-10)
+
+    def test_kabsch_would_hide_pocket_miss(self):
+        """Regression: superposed RMSD collapsed every 1gpk pose to ~3.156 Å.
+
+        A rigid translation of a multi-atom ligand must stay visible to
+        ``compute_rmsd`` and invisible to ``compute_rmsd_superposed``.
+        """
+        ref = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        miss = ref + np.array([6.5, 0.0, 0.0])  # ligand left the pocket
+        hit = ref + np.array([0.1, 0.0, 0.0])  # near-native
+        assert compute_rmsd(miss, ref) == pytest.approx(6.5, abs=1e-8)
+        assert compute_rmsd(hit, ref) == pytest.approx(0.1, abs=1e-8)
+        # Superposed: both look like "same shape" → both ~0 (the old bug).
+        assert compute_rmsd_superposed(miss, ref) == pytest.approx(0.0, abs=1e-8)
+        assert compute_rmsd_superposed(hit, ref) == pytest.approx(0.0, abs=1e-8)
+        # The discriminator the gate needs: miss >> hit.
+        assert compute_rmsd(miss, ref) > 10 * compute_rmsd(hit, ref)
 
     def test_shape_mismatch(self):
         a = np.array([[1.0, 2.0, 3.0]])

--- a/python/tests/test_runner_excludes_initial_pose.py
+++ b/python/tests/test_runner_excludes_initial_pose.py
@@ -1,0 +1,33 @@
+"""FlexAID's ``flexaid_INI.pdb`` starting structure must never be a pose.
+
+On a self-docking benchmark the input placement IS the crystal pose, so this
+file scores ~0 A against the reference (measured 0.0320 A on 1gpk).  Globbing it
+into the pose list both depresses ``mean_rmsd`` by a constant amount in every
+cell and creates a latent false positive for ``docking_power``.
+"""
+
+from pathlib import Path
+
+from flexaidds.dataset_runner.runner import _is_initial_pose_file
+
+
+class TestIsInitialPoseFile:
+    def test_flags_the_initial_structure(self):
+        assert _is_initial_pose_file(Path("flexaid_INI.pdb"))
+
+    def test_flags_case_and_prefix_variants(self):
+        # FlexAID has shipped both capitalisations of the binary's output prefix.
+        assert _is_initial_pose_file(Path("FlexAID_INI.pdb"))
+        assert _is_initial_pose_file(Path("flexaid_ini.pdb"))
+
+    def test_does_not_flag_real_poses(self):
+        for name in ("flexaid_0.pdb", "flexaid_9.pdb", "flexaid_10.pdb"):
+            assert not _is_initial_pose_file(Path(name)), name
+
+    def test_does_not_flag_names_merely_starting_with_ini(self):
+        # Guard the suffix match: only a trailing ``_INI`` is the start structure.
+        assert not _is_initial_pose_file(Path("flexaid_INIT.pdb"))
+
+    def test_matches_on_full_path(self):
+        assert _is_initial_pose_file(Path("/tmp/poses/1gpk/flexaid_INI.pdb"))
+        assert not _is_initial_pose_file(Path("/tmp/poses/1gpk/flexaid_3.pdb"))


### PR DESCRIPTION
Fixes the `mean_rmsd` INI-pollution bug Fizz identified (`mean_rmsd` frozen at 2.278 across every sweep cell while `docking_power` moved 0 → 0.5).

## Cause

`_parse_flexaid_poses` globbed `*.pdb` and kept anything starting with `flexaid`. That matches `flexaid_INI.pdb`, which FlexAID writes as the **input** ligand placement, not a docking result:

```
$ grep REMARK flexaid_INI.pdb
REMARK coordinate file generated by FlexAID
REMARK initial structure          <- not a pose
```

On a self-docking benchmark the input IS the crystal pose, so it scores ~0 Å against the reference:

```
cell        INI RMSD   mean(10 real poses)   mean(11 with INI)
baseline     0.0320          7.466                6.790
F=130        0.0320          3.841                3.495
F=1e5        0.0320          7.962                7.241
```

Measured on the 1gpk sweep artifacts at `a395ee97`. `INI` is byte-identical across cells because it never depends on the search — which is exactly why the aggregate looked frozen while `docking_power` moved.

## Two consequences

**Cosmetic:** `mean_rmsd` / `median_rmsd` are pulled down by a constant offset in every cell.

**Not cosmetic:** `docking_power` gains a latent **false positive**. `docking_power()` counts a target as a success if any of its top-N poses (by `total_score`) is under 2.0 Å. A 0.032 Å entry qualifies the instant its score ranks inside top-N. It stayed out in the runs measured so far only because its CF was worse than the docked poses — luck, not a guarantee. A cell whose docked poses all scored worse than the input would have reported a spurious pass.

## Fix

Adds `_is_initial_pose_file()`, applied to both the prefixed glob and the bare `*.pdb` fallback. Suffix match on `_INI`, case-insensitive, so `flexaid_INIT.pdb` is not caught.

## Verification

- `1087 passed, 68 skipped` (full `python/tests/` suite)
- New `test_runner_excludes_initial_pose.py` covers the case variants, real poses, the `_INIT` guard, and full paths

Does not touch `docking_power_top1` for any cell reported tonight — those rank-1 picks were all genuine docked poses. It removes the path by which a future cell could report one that is not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ligand atom coordinates now retain their original file order for more reliable comparisons.
  * Docking metrics no longer include initial input structures when standard result files are available.
  * RMSD calculations now reflect direct placement differences, including translations and rotations.

* **New Features**
  * Added an optional superposed RMSD comparison for evaluating shape similarity independently of rigid placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->