### PR TITLE
Promote validated COM-floor reference config + Tier-1 sweep harness

### DIFF
--- a/.github/workflows/benchmark-tier1.yml
+++ b/.github/workflows/benchmark-tier1.yml
@@ -61,8 +61,9 @@ jobs:
   tier1-benchmark:
     name: Tier-1 Benchmark (${{ inputs.dataset || 'astex_diverse' }})
     runs-on: ubuntu-latest
-    # Clean build (~20 min, no cache) + 2 targets x ~17 min docking + overhead.
-    timeout-minutes: 70
+    # Clean build (~20 min, no cache) + 2 targets docking + overhead. Switch-on cells
+    # (COM floor / P1) run ~2-3x slower; 1mq6 (flexible, 10 rotatable bonds) is the long pole.
+    timeout-minutes: 130
     permissions:
       contents: read
       pull-requests: write   # required by marocchino/sticky-pull-request-comment
@@ -154,8 +155,9 @@ jobs:
       # FLEXAIDDS_BENCHMARK_DATA env var above points the runner there.
 
       - name: Run tier-1 benchmark
-        # 2 targets x ~17 min each; give headroom over the ~34 min floor.
-        timeout-minutes: 45
+        # Measured: switches-off 2 targets ~44 min; switch-on cells time out at 45.
+        # 1mq6 (flexible) is the long pole under COM floor / P1. Give generous headroom.
+        timeout-minutes: 105
         env:
           PYTHONPATH: ${{ github.workspace }}/python
           # Scoring switches forwarded from workflow_dispatch inputs. All read at

--- a/.github/workflows/benchmark-tier1.yml
+++ b/.github/workflows/benchmark-tier1.yml
@@ -45,12 +45,16 @@ on:
         description: "FLEXAID_SEED (single-D; fixed GA seed for determinism). Empty = time(0)."
         required: false
         default: ""
+      tag:
+        description: "Free label to distinguish otherwise-identical cells (e.g. the G3' determinism repeat). Does not reach the engine."
+        required: false
+        default: ""
 
 concurrency:
-  # Include the sweep inputs so distinct (F, pocket, clash) points run in
-  # parallel instead of cancelling each other; a re-dispatch of the SAME point
-  # still supersedes its stale run.
-  group: bench-tier1-${{ github.workflow }}-${{ github.ref }}-${{ inputs.com_floor }}-${{ inputs.pb_pocket_w }}-${{ inputs.pb_clash_w }}
+  # Include the sweep inputs + tag so distinct cells run in parallel instead of
+  # cancelling each other; a re-dispatch of the SAME cell still supersedes its
+  # stale run. `tag` lets two identical-env cells (the G3' repeat) coexist.
+  group: bench-tier1-${{ github.workflow }}-${{ github.ref }}-${{ inputs.com_floor }}-${{ inputs.pb_pocket_w }}-${{ inputs.pb_clash_w }}-${{ inputs.tag }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/benchmark-tier1.yml
+++ b/.github/workflows/benchmark-tier1.yml
@@ -41,6 +41,10 @@ on:
         description: "FLEXAIDDS_PB_CLASH_WEIGHT (P1 clash steer; empty/0 = off)"
         required: false
         default: ""
+      seed:
+        description: "FLEXAID_SEED (single-D; fixed GA seed for determinism). Empty = time(0)."
+        required: false
+        default: ""
 
 concurrency:
   # Include the sweep inputs so distinct (F, pocket, clash) points run in
@@ -53,7 +57,8 @@ jobs:
   tier1-benchmark:
     name: Tier-1 Benchmark (${{ inputs.dataset || 'astex_diverse' }})
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    # Clean build (~20 min, no cache) + 2 targets x ~17 min docking + overhead.
+    timeout-minutes: 70
     permissions:
       contents: read
       pull-requests: write   # required by marocchino/sticky-pull-request-comment
@@ -104,18 +109,14 @@ jobs:
           echo "CC=gcc-14" >> "$GITHUB_ENV"
           echo "CXX=g++-14" >> "$GITHUB_ENV"
 
-      - name: Cache build
-        id: cache-build
-        uses: actions/cache@v6
-        with:
-          path: build
-          key: tier1-build-${{ runner.os }}-${{ hashFiles('CMakeLists.txt', 'LIB/**/*.cpp', 'LIB/**/*.h') }}
-          restore-keys: |
-            tier1-build-${{ runner.os }}-
-
-      - name: Build FlexAIDdS (fast profile)
-        if: steps.cache-build.outputs.cache-hit != 'true'
+      # NO build cache on this experiment branch. The restore-keys prefix
+      # fallback restored a stale build/ and incremental cmake --build did not
+      # recompile changed sources -- proven this run (CF.pb_clash absent though
+      # the writer emits it unconditionally). A correctness experiment must
+      # compile from clean, so the cache step is removed and the build always runs.
+      - name: Build FlexAIDdS (fast profile, clean)
         run: |
+          rm -rf build
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DFLEXAIDS_USE_CUDA=OFF \
@@ -149,17 +150,25 @@ jobs:
       # FLEXAIDDS_BENCHMARK_DATA env var above points the runner there.
 
       - name: Run tier-1 benchmark
-        timeout-minutes: 25
+        # 2 targets x ~17 min each; give headroom over the ~34 min floor.
+        timeout-minutes: 45
         env:
           PYTHONPATH: ${{ github.workspace }}/python
           # Scoring switches forwarded from workflow_dispatch inputs. All read at
           # RUNTIME via std::getenv (vcfunction.cpp:948, top.cpp:534/543), so no
-          # rebuild is needed and the ccache/cache hazard does not apply. Empty
-          # string => COM_FLOOR F<=0 skipped, weights atof("")=0 off => the
-          # engine is bit-identical to a run with these unset (default behaviour).
+          # rebuild is needed. Empty string => COM_FLOOR F<=0 skipped, weights
+          # atof("")=0 off => the engine is bit-identical to a run with these unset.
           FLEXAIDDS_COM_FLOOR: ${{ inputs.com_floor }}
           FLEXAIDDS_PB_POCKET_WEIGHT: ${{ inputs.pb_pocket_w }}
           FLEXAIDDS_PB_CLASH_WEIGHT: ${{ inputs.pb_clash_w }}
+          # Determinism (ops/launch_comfloor.sh). A fixed seed + single-thread +
+          # no parallel restarts/elitism makes every cell a matched comparison and
+          # makes G3' (a repeat is bit-identical) testable. FLEXAID_SEED is single-D
+          # (RngSeed.h:28); empty => time(0) fallback (gaboom.cpp:337).
+          FLEXAID_SEED: ${{ inputs.seed }}
+          OMP_NUM_THREADS: "1"
+          FLEXAIDDS_PARALLEL_RESTARTS: "0"
+          FLEXAIDDS_SEED_ELITISM: "0"
         run: |
           # Provenance sidecar: record exactly which switches this run used, next
           # to the artifacts it produced. The run manifest records omp_threads but
@@ -173,6 +182,10 @@ jobs:
             "com_floor": "${{ inputs.com_floor }}",
             "pb_pocket_weight": "${{ inputs.pb_pocket_w }}",
             "pb_clash_weight": "${{ inputs.pb_clash_w }}",
+            "flexaid_seed": "${{ inputs.seed }}",
+            "omp_num_threads": "1",
+            "parallel_restarts": "0",
+            "seed_elitism": "0",
             "tier1_subset_size_input": "${{ inputs.tier1_subset_size }}",
             "dataset": "${{ env.DATASET }}"
           }

--- a/.github/workflows/benchmark-tier1.yml
+++ b/.github/workflows/benchmark-tier1.yml
@@ -29,9 +29,24 @@ on:
         description: "Number of targets (overrides YAML default)"
         required: false
         default: "5"
+      com_floor:
+        description: "FLEXAIDDS_COM_FLOOR F (soft floor on CF.com; empty/0 = off, unchanged)"
+        required: false
+        default: ""
+      pb_pocket_w:
+        description: "FLEXAIDDS_PB_POCKET_WEIGHT (P1 pocket steer; empty/0 = off)"
+        required: false
+        default: ""
+      pb_clash_w:
+        description: "FLEXAIDDS_PB_CLASH_WEIGHT (P1 clash steer; empty/0 = off)"
+        required: false
+        default: ""
 
 concurrency:
-  group: bench-tier1-${{ github.workflow }}-${{ github.ref }}
+  # Include the sweep inputs so distinct (F, pocket, clash) points run in
+  # parallel instead of cancelling each other; a re-dispatch of the SAME point
+  # still supersedes its stale run.
+  group: bench-tier1-${{ github.workflow }}-${{ github.ref }}-${{ inputs.com_floor }}-${{ inputs.pb_pocket_w }}-${{ inputs.pb_clash_w }}
   cancel-in-progress: true
 
 jobs:
@@ -137,7 +152,31 @@ jobs:
         timeout-minutes: 25
         env:
           PYTHONPATH: ${{ github.workspace }}/python
+          # Scoring switches forwarded from workflow_dispatch inputs. All read at
+          # RUNTIME via std::getenv (vcfunction.cpp:948, top.cpp:534/543), so no
+          # rebuild is needed and the ccache/cache hazard does not apply. Empty
+          # string => COM_FLOOR F<=0 skipped, weights atof("")=0 off => the
+          # engine is bit-identical to a run with these unset (default behaviour).
+          FLEXAIDDS_COM_FLOOR: ${{ inputs.com_floor }}
+          FLEXAIDDS_PB_POCKET_WEIGHT: ${{ inputs.pb_pocket_w }}
+          FLEXAIDDS_PB_CLASH_WEIGHT: ${{ inputs.pb_clash_w }}
         run: |
+          # Provenance sidecar: record exactly which switches this run used, next
+          # to the artifacts it produced. The run manifest records omp_threads but
+          # nothing about scoring config; without this, N sweep artifacts are
+          # indistinguishable except by run id. Uploaded with the results below.
+          mkdir -p "$RESULTS_DIR"
+          cat > "$RESULTS_DIR/_sweep_config.json" <<JSON
+          {
+            "git_sha": "${{ github.sha }}",
+            "run_id": "${{ github.run_id }}",
+            "com_floor": "${{ inputs.com_floor }}",
+            "pb_pocket_weight": "${{ inputs.pb_pocket_w }}",
+            "pb_clash_weight": "${{ inputs.pb_clash_w }}",
+            "tier1_subset_size_input": "${{ inputs.tier1_subset_size }}",
+            "dataset": "${{ env.DATASET }}"
+          }
+          JSON
           python -m benchmarks.run \
             --dataset "$DATASET" \
             --tier 1 \
@@ -152,6 +191,11 @@ jobs:
           name: tier1-results-${{ env.DATASET }}-${{ github.run_id }}
           path: |
             ${{ env.RESULTS_DIR }}/
+          # A green upload that delivered zero files is a green lie: fail loudly
+          # instead. The _sweep_config.json sidecar guarantees >=1 file even when
+          # the docking loop is killed at the cap, so this fires only on a real
+          # collection failure, not on an expected cap-kill.
+          if-no-files-found: error
           retention-days: 30
 
       - name: Parse report for PR comment

--- a/RESEARCH/COM_FLOOR_REFERENCE_CONFIG_2026_08_01.md
+++ b/RESEARCH/COM_FLOOR_REFERENCE_CONFIG_2026_08_01.md
@@ -1,0 +1,50 @@
+# Validated reference config: COM floor + P1 steer (2026-08-01)
+
+**Status:** validated on the RIGID target 1gpk; does NOT yet generalize to the flexible
+target 1mq6 (see #356). Promoted as the reference config for the COM-floor docking regime,
+NOT (yet) as a global engine default.
+
+## The config
+
+```
+FLEXAIDDS_COM_FLOOR        = 130     # soft floor on CF.com (vcfunction.cpp), S=5 fixed
+FLEXAIDDS_PB_POCKET_WEIGHT = 1.0     # P1 GA-time pocket steer (top.cpp)
+FLEXAIDDS_PB_CLASH_WEIGHT  = 1.0     # P1 GA-time clash steer  (top.cpp)
+# determinism (as swept):
+FLEXAID_SEED = 42 · OMP_NUM_THREADS = 1 · FLEXAIDDS_PARALLEL_RESTARTS = 0 · FLEXAIDDS_SEED_ELITISM = 0
+```
+
+## Evidence (corrected in-place RMSD metric, PR #354; clean build @ b352ca54)
+
+Tier-1 astex_diverse sweep, 2 targets (1gpk, 1mq6), run `30715200428`:
+
+```
+cell                docking_power_top1
+baseline (OFF)          0.000
+P1-only (floor off)     0.000     <- P1 alone insufficient
+F = 130                 0.500     <- docks 1gpk (rank-1 1.60 A); 1mq6 misses
+F = 20000 .. 100000     0.000     <- above threshold, floor reverts to baseline
+```
+
+Per target at F=130:
+
+```
+1gpk (0 rot bonds):  rank-1 1.60 A, best-of-10 0.77 A  -> PASS (search + score both work)
+1mq6 (10 rot bonds): rank-1 11.03 A, best-of-10 ~4.5 A -> FAIL at SEARCH (see #356)
+```
+
+## Findings
+
+1. The COM floor at low F makes the engine dock a rigid ligand end-to-end — the score ranks
+   the near-native pose #1. First green docking_power of the effort.
+2. The floor is necessary (P1 alone = 0) and sharply F-thresholded (works at 130, reverts by 2e4).
+3. Flexible-ligand docking fails at the search stage, not scoring (#356).
+4. `mean_rmsd` is byte-identical (2.278) across all cells — the runner's INI-pollution bug;
+   `docking_power` is the trustworthy metric (it moved 0->0.5). Separate follow-up.
+
+## Scope caveat for promotion
+
+`docking_power = 0.5` is 1 of 2 targets, below the 0.70 Astex bar. Do NOT flip the global
+engine getenv defaults to this config: it is validated only on rigid ligands and regresses
+flexible-ligand docking. Promote as the documented reference for the rigid regime and the
+Tier-1 investigation; gate/engine default changes wait on #356.

--- a/benchmarks/datasets/astex_diverse.yaml
+++ b/benchmarks/datasets/astex_diverse.yaml
@@ -31,7 +31,7 @@ zenodo_doi: ""
 download_url: "https://www.ccdc.cam.ac.uk/community/freeprod/astex-diverse-set/"
 data_format: pdb
 tier: 2
-tier1_subset_size: 1
+tier1_subset_size: 2
 
 structural_states:
   - holo

--- a/ops/launch_comfloor.sh
+++ b/ops/launch_comfloor.sh
@@ -32,7 +32,17 @@ export FLEXAIDDS_BINARY="${ENGINE}"
 export FLEXAIDDS_VCT_R0=4.0
 export FLEXAIDDS_ELECTION_ENTROPY=0
 export FLEXAIDDS_SEED_ELITISM=0
-export FLEXAIDDS_COM_FLOOR=130   # softplus floor at -130, S=5 transition in binary
+
+# Promoted reference config (COM floor + the P1 pocket/clash steer it enables,
+# plus the determinism knobs).  Sourced rather than duplicated so this campaign
+# cannot drift from the configuration that was actually measured.
+#
+# NOTE: this script previously set FLEXAIDDS_COM_FLOOR=130 alone.  That is only
+# half the configuration -- the 2026-08-01 sweep shows the floor WITHOUT the P1
+# weights, and P1 without the floor, both score docking_power_top1 = 0.000.
+set -a
+. "${REPO}/ops/reference_config.env"
+set +a
 
 echo ""
 echo "active FLEXAIDDS_* :"

--- a/ops/reference_config.env
+++ b/ops/reference_config.env
@@ -1,0 +1,55 @@
+# reference_config.env — the promoted FlexAIDdS reference docking configuration.
+#
+# Source this file; do not copy the values around.  It is the single source of
+# truth for "the configuration that docks", so that a result can always be
+# attributed to an exact, named config.
+#
+#   set -a; . ops/reference_config.env; set +a
+#
+# ---------------------------------------------------------------------------
+# PROVENANCE — what this config is, and what it is not
+# ---------------------------------------------------------------------------
+#
+# Promoted 2026-08-01 on Bonhomme's call, from the 9-cell x 2-target
+# deterministic sweep run on a clean build with the corrected RMSD metric
+# (#354, in-place not Kabsch; #357, input structure excluded from the pose set).
+#
+#   cell                       docking_power_top1 (2 targets)
+#   baseline (all switches off)      0.000
+#   P1 only, floor off               0.000    <- P1 alone is NOT sufficient
+#   F = 130   + P1                   0.500    <- this config
+#   F = 20000 + P1                   0.000  }
+#   F = 40000 + P1                   0.000  }  above the threshold the floor
+#   F = 60000 + P1                   0.000  }  stops biting and the result
+#   F = 80000 + P1                   0.000  }  reverts to baseline
+#   F = 100000 + P1                  0.000  }
+#
+#   per target at F = 130:   1gpk  rank-1 1.60 A, best 0.77 A   PASS
+#                            1mq6  rank-1 11.03 A, best 4.5 A   miss (see #358)
+#
+# HONEST SCOPE.  docking_power_top1 = 0.5 is one target of two, against an
+# Astex bar of 0.70.  This config is the best measured configuration and the
+# first that docks anything end to end -- it is NOT a validated production
+# default and it does NOT mean benchmarking is ready.  1gpk is among the most
+# rigid ligands in Astex (0 rotatable bonds); 1mq6 (10 rotatable bonds) fails
+# in the SEARCH, which no value of F can fix.  See issue #358.
+#
+# The useful floor range is bounded below 2e4 and was only sampled at 130.
+# The threshold between 130 and 20000 is uncharacterised.
+
+# --- scoring: the COM floor, and the pocket/clash steer it enables ----------
+# The floor bounds the unbounded-below CF.com term so the orientation-aware
+# steer can out-vote it (see LIB/vcfunction.cpp, the COM floor comment block).
+# Both halves are required: the sweep shows P1 alone gives 0.000.
+FLEXAIDDS_COM_FLOOR=130
+FLEXAIDDS_PB_POCKET_WEIGHT=1.0
+FLEXAIDDS_PB_CLASH_WEIGHT=1.0
+
+# --- determinism -----------------------------------------------------------
+# Required to attribute a difference to the dial rather than the draw.
+# FLEXAID_SEED is single-D and is the ONLY determinism seed (METHODOLOGY.md:27).
+# Threading and parallel restarts both break reproducibility on their own.
+FLEXAID_SEED=42
+OMP_NUM_THREADS=1
+FLEXAIDDS_PARALLEL_RESTARTS=0
+FLEXAIDDS_SEED_ELITISM=0

--- a/python/flexaidds/benchmark.py
+++ b/python/flexaidds/benchmark.py
@@ -93,8 +93,17 @@ def pic50_to_dg(pic50: float, temperature_K: float = 298.15) -> float:
 def extract_ligand_coords_from_pdb(pdb_path: Path) -> np.ndarray:
     """Extract ligand heavy-atom coordinates from a PDB file.
 
-    Selects HETATM records excluding HOH, returns (N, 3) array sorted
-    by atom name for deterministic ordering.
+    Selects HETATM records excluding HOH.  Returns an (N, 3) array in
+    **file order** — not sorted by atom name.
+
+    File order is load-bearing for docking RMSD.  FlexAID writes the
+    optimizable residue's HETATM block in the same topology order as the
+    input ligand (SDF/MOL2), and the benchmark reference is also read in
+    file order.  Sorting by atom name breaks that correspondence: FlexAID
+    names atoms ``C 0``, ``O 1``, … while the crystal PDB uses ``C1``,
+    ``O1``, …, and lexicographic sort reorders both differently.  On 1gpk
+    that alone turned a true ~1.6 Å pose into a ~4.7 Å number even after
+    the Kabsch bug was removed.
     """
     atoms = []
     with open(pdb_path) as fh:
@@ -107,18 +116,15 @@ def extract_ligand_coords_from_pdb(pdb_path: Path) -> np.ndarray:
             element = line[76:78].strip() if len(line) > 77 else ""
             if element == "H":
                 continue
-            atom_name = line[12:16].strip()
             x = float(line[30:38])
             y = float(line[38:46])
             z = float(line[46:54])
-            atoms.append((atom_name, x, y, z))
+            atoms.append((x, y, z))
 
     if not atoms:
         raise ValueError(f"No ligand heavy atoms found in {pdb_path}")
 
-    atoms.sort(key=lambda a: a[0])
-    coords = np.array([[a[1], a[2], a[3]] for a in atoms], dtype=np.float64)
-    return coords
+    return np.array(atoms, dtype=np.float64)
 
 
 def extract_ligand_coords_from_mmcif(mmcif_string: str, ligand_id: str = "") -> np.ndarray:
@@ -232,9 +238,46 @@ def _tokenize_mmcif_line(line: str) -> List[str]:
 
 
 def compute_rmsd(coords_pred: np.ndarray, coords_ref: np.ndarray) -> float:
-    """Compute RMSD after optimal Kabsch alignment.
+    """Docking RMSD: in-place, in the receptor frame, NO superposition.
 
-    Both arrays must be (N, 3).  Returns RMSD in Angstrom.
+    This is the quantity the 2.0 A redocking criterion is defined on.  Both
+    poses are already expressed in the same (receptor) coordinate frame, so
+    the displacement between them *is* the error and must not be removed.
+
+    Do NOT superpose here.  Superposing before measuring discards exactly the
+    translation and rotation that docking is being scored on: a ligand placed
+    5 A outside the pocket and one placed on the crystal position differ only
+    by a rigid motion, so an aligned RMSD reports them as equally good.  That
+    bug shipped in this function and reported ~3.156 A for every pose of every
+    sweep cell on 1gpk -- for a 6.5 A miss and a ~1.3 A hit alike -- because
+    the ligand's internal conformation barely changes while its placement
+    changes by Angstroms.  See :func:`compute_rmsd_superposed` for the
+    conformer-shape comparison, which is a different question.
+
+    Both arrays must be (N, 3) with row i of each referring to the same atom.
+    Returns RMSD in Angstrom.
+    """
+    if coords_pred.shape != coords_ref.shape:
+        raise ValueError(
+            f"Shape mismatch: predicted {coords_pred.shape} vs "
+            f"reference {coords_ref.shape}."
+        )
+    n = coords_pred.shape[0]
+    if n == 0:
+        return 0.0
+
+    diff = coords_pred - coords_ref
+    return float(np.sqrt((diff * diff).sum() / n))
+
+
+def compute_rmsd_superposed(coords_pred: np.ndarray, coords_ref: np.ndarray) -> float:
+    """Shape-only RMSD after optimal Kabsch superposition.
+
+    Measures how well two conformers match *once placement is discarded*.
+    This answers "is it the same shape?", never "is it docked correctly?" --
+    use :func:`compute_rmsd` for the latter.  Note the result is not a metric
+    (it can violate the triangle inequality), so it must not be compared
+    against geometric bounds such as centre-of-mass separation.
     """
     if coords_pred.shape != coords_ref.shape:
         raise ValueError(

--- a/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
+++ b/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
@@ -31,7 +31,7 @@ zenodo_doi: ""
 download_url: "https://www.ccdc.cam.ac.uk/community/freeprod/astex-diverse-set/"
 data_format: pdb
 tier: 2
-tier1_subset_size: 1
+tier1_subset_size: 2
 
 structural_states:
   - holo

--- a/python/tests/test_benchmark.py
+++ b/python/tests/test_benchmark.py
@@ -17,6 +17,7 @@ from flexaidds.benchmark import (
     MethodResult,
     SystemBenchmarkResult,
     compute_rmsd,
+    compute_rmsd_superposed,
     enrichment_factor,
     extract_ligand_coords_from_mmcif,
     extract_ligand_coords_from_pdb,
@@ -171,10 +172,25 @@ class TestExtractPDB:
     def test_basic(self, sample_system):
         coords = extract_ligand_coords_from_pdb(sample_system.reference_pose_pdb_path)
         assert coords.shape == (3, 3)
-        # Sorted by atom name: C1, N1, O1
+        # File order (not name-sorted): C1, N1, O1 as written
         np.testing.assert_allclose(coords[0], [1.0, 2.0, 3.0])
         np.testing.assert_allclose(coords[1], [4.0, 5.0, 6.0])
         np.testing.assert_allclose(coords[2], [7.0, 8.0, 9.0])
+
+    def test_preserves_file_order_not_lexicographic_atom_names(self, tmp_path):
+        """FlexAID-style names must stay in write order, not C/O/N lex sort."""
+        # File order: O then C then N. Lex sort by name would be C, N, O.
+        pdb = tmp_path / "flexaid_style.pdb"
+        pdb.write_text(
+            "HETATM90001 O  1 HUP     1       1.000   0.000   0.000  1.00  0.00           O\n"
+            "HETATM90002 C  0 HUP     1       2.000   0.000   0.000  1.00  0.00           C\n"
+            "HETATM90003 N  2 HUP     1       3.000   0.000   0.000  1.00  0.00           N\n"
+            "END\n"
+        )
+        coords = extract_ligand_coords_from_pdb(pdb)
+        np.testing.assert_allclose(coords[0], [1.0, 0.0, 0.0])
+        np.testing.assert_allclose(coords[1], [2.0, 0.0, 0.0])
+        np.testing.assert_allclose(coords[2], [3.0, 0.0, 0.0])
 
     def test_empty_raises(self, tmp_path):
         empty = tmp_path / "empty.pdb"
@@ -219,37 +235,63 @@ class TestExtractMmcif:
 
 
 class TestComputeRmsd:
+    """Docking RMSD is in-place (no superposition). Placement is the signal."""
+
     def test_identity(self):
         coords = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         assert compute_rmsd(coords, coords) == pytest.approx(0.0, abs=1e-10)
 
-    def test_translation(self):
+    def test_translation_is_the_error(self):
         ref = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
-        # Pure translation → Kabsch should align → RMSD = 0
-        pred = ref + np.array([10.0, 20.0, 30.0])
-        assert compute_rmsd(pred, ref) == pytest.approx(0.0, abs=1e-8)
+        # Pure +5 Å translation: docking error is 5 Å, not 0.
+        pred = ref + np.array([5.0, 0.0, 0.0])
+        assert compute_rmsd(pred, ref) == pytest.approx(5.0, abs=1e-8)
+        # Superposed form still reports ~0 (shape match) — different question.
+        assert compute_rmsd_superposed(pred, ref) == pytest.approx(0.0, abs=1e-8)
 
-    def test_rotation(self):
+    def test_rotation_is_the_error(self):
         ref = np.array([[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
-        # 90-degree rotation about Z
         R = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-        pred = (ref @ R.T)
-        assert compute_rmsd(pred, ref) == pytest.approx(0.0, abs=1e-8)
+        pred = ref @ R.T
+        # In-place: non-zero. Superposed: ~0.
+        assert compute_rmsd(pred, ref) > 0.5
+        assert compute_rmsd_superposed(pred, ref) == pytest.approx(0.0, abs=1e-8)
 
-    def test_known_rmsd(self):
+    def test_known_single_atom(self):
         ref = np.array([[0.0, 0.0, 0.0]])
         pred = np.array([[1.0, 0.0, 0.0]])
-        # Single point: no rotation effect, RMSD = 1.0
-        # But with centering both are at origin → RMSD = 0
-        # (both single-point arrays center to origin)
-        assert compute_rmsd(pred, ref) == pytest.approx(0.0, abs=1e-10)
+        assert compute_rmsd(pred, ref) == pytest.approx(1.0, abs=1e-10)
 
     def test_two_points_known(self):
         ref = np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
         pred = np.array([[0.0, 0.0, 0.0], [2.0, 1.0, 0.0]])  # 1Å offset on one atom
-        rmsd = compute_rmsd(pred, ref)
-        # After Kabsch alignment this should be < 1.0
-        assert rmsd < 1.0
+        # In-place: sqrt((0 + 1)/2) = sqrt(0.5)
+        assert compute_rmsd(pred, ref) == pytest.approx(math.sqrt(0.5), abs=1e-10)
+
+    def test_kabsch_would_hide_pocket_miss(self):
+        """Regression: superposed RMSD collapsed every 1gpk pose to ~3.156 Å.
+
+        A rigid translation of a multi-atom ligand must stay visible to
+        ``compute_rmsd`` and invisible to ``compute_rmsd_superposed``.
+        """
+        ref = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        miss = ref + np.array([6.5, 0.0, 0.0])  # ligand left the pocket
+        hit = ref + np.array([0.1, 0.0, 0.0])  # near-native
+        assert compute_rmsd(miss, ref) == pytest.approx(6.5, abs=1e-8)
+        assert compute_rmsd(hit, ref) == pytest.approx(0.1, abs=1e-8)
+        # Superposed: both look like "same shape" → both ~0 (the old bug).
+        assert compute_rmsd_superposed(miss, ref) == pytest.approx(0.0, abs=1e-8)
+        assert compute_rmsd_superposed(hit, ref) == pytest.approx(0.0, abs=1e-8)
+        # The discriminator the gate needs: miss >> hit.
+        assert compute_rmsd(miss, ref) > 10 * compute_rmsd(hit, ref)
 
     def test_shape_mismatch(self):
         a = np.array([[1.0, 2.0, 3.0]])


### PR DESCRIPTION
## What

Promotes the validated **COM-floor reference config** (owner-approved) and lands the Tier-1
sweep harness that produced it.

**The result:** on the corrected RMSD metric, `FLEXAIDDS_COM_FLOOR=130` + P1 pocket/clash
steer (1.0) makes the engine dock the rigid target **1gpk end-to-end** — rank-1 pose 1.60 A,
`docking_power_top1 = 0.5` (1 of 2 targets). First green docking_power of the effort.

```
baseline / P1-only / F>=2e4   -> docking_power 0.0   (floor necessary + sharply F-thresholded)
F = 130                       -> docking_power 0.5   (docks 1gpk; 1mq6 fails at SEARCH, #356)
```

## Contents

- `RESEARCH/COM_FLOOR_REFERENCE_CONFIG_2026_08_01.md` — the validated config + evidence + scope caveat.
- Tier-1 harness fixes (real CI bugs found tonight):
  - subset 1->2 in the **CI-read** `benchmarks/datasets/astex_diverse.yaml` (the copy `run.py` reads).
  - timeouts raised (step 45->105, job 70->130): switch-on cells run ~3x slower, 1mq6 is the long pole.
  - clean build (no stale-binary cache), determinism knobs, per-cell provenance sidecar, sweep dispatch inputs.

## Scope caveat (please read before merge)

`docking_power = 0.5` is **1 of 2 targets**, below the 0.70 Astex bar, and validated only on a
**rigid** ligand. This PR promotes the config as the documented **reference for the rigid regime**
— it does **NOT** flip the global engine getenv defaults (that would regress flexible-ligand
docking, which fails at search — #356). A gate/engine-default change should wait on #356.

## Not in this PR
- `mean_rmsd` INI-pollution aggregate bug — separate follow-up (owner-approved, assigned).
- Flexible-ligand search fix — #356.

Raw per-pose RMSDs for independent verification are in benchmark run `30715200428`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
