### PR TITLE
Add: emit build commit, dirty flag and effective seed in pose REMARKs

### DIFF
--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -1,6 +1,18 @@
 #include "BindingMode.h"
 #include "fast_optics.hpp"
 #include "SoftBetaFreeEnergy.h"
+#include "RngSeed.h"
+
+// Build provenance, normally injected by CMakeLists.txt via
+// add_compile_definitions().  Defaulted here so a build outside CMake (or one
+// where git was unavailable and the rev-parse produced nothing) still compiles
+// and still emits an honest, obviously-unknown value rather than failing.
+#ifndef FLEXAIDS_GIT_COMMIT
+#define FLEXAIDS_GIT_COMMIT "unknown"
+#endif
+#ifndef FLEXAIDS_GIT_DIRTY
+#define FLEXAIDS_GIT_DIRTY 0
+#endif
 
 #include <algorithm>
 #include <cfloat>
@@ -638,6 +650,32 @@ void BindingMode::output_BindingMode(int num_result, char* end_strfile, char* tm
 	size_t remark_len = 0;
 	remark[0] = '\0';
 	safe_remark_cat(remark, "REMARK optimized structure\n", &remark_len);
+
+	// Provenance: which binary, and which random draw, produced this pose.
+	//
+	// This has to live in the REMARK block, not on stdout.  The benchmark
+	// runner invokes FlexAID with subprocess.run(capture_output=True) and
+	// discards stdout on success, so anything printed there is unrecoverable
+	// afterwards.  gaboom.cpp already prints "srand=%u" and the seed was still
+	// unreadable from every artifact of a 341-run campaign -- the pose files
+	// are what actually gets preserved and uploaded.
+	//
+	// FLEXAIDS_GIT_COMMIT / _DIRTY come from CMakeLists.txt.  Referencing them
+	// here is also what puts the commit string into the binary at all: an
+	// unused -D macro is never emitted, so nothing could read it before.
+	//
+	// The seed is the EFFECTIVE one: gaboom.cpp calls set_master_seed(tt)
+	// after resolving GB->seed / FLEXAID_SEED / time(0), so this reports the
+	// value actually used, including the time(0) fallback that is otherwise
+	// impossible to recover.
+	snprintf(tmpremark, MAX_REMARK,
+		"REMARK FLEXAID.commit=%s FLEXAID.dirty=%d FLEXAID.seed=%llu\n",
+		FLEXAIDS_GIT_COMMIT,
+		FLEXAIDS_GIT_DIRTY,
+		flexaids_rng::has_master_seed()
+			? static_cast<unsigned long long>(flexaids_rng::master_seed())
+			: 0ULL);
+	safe_remark_cat(remark, tmpremark, &remark_len);
 
 	if (pb_promotion) {
 		snprintf(tmpremark, MAX_REMARK,

--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -668,6 +668,13 @@ void BindingMode::output_BindingMode(int num_result, char* end_strfile, char* tm
 	// after resolving GB->seed / FLEXAID_SEED / time(0), so this reports the
 	// value actually used, including the time(0) fallback that is otherwise
 	// impossible to recover.
+	//
+	// KEEP THIS LINE NEAR THE HEAD OF THE BLOCK.  safe_remark_cat() appends
+	// sequentially and every call after the buffer is exhausted is a silent
+	// no-op, so truncation removes a contiguous TAIL.  A line near the head is
+	// therefore in the only region truncation cannot reach first -- which is
+	// where the line identifying the whole file belongs.  Moving it down would
+	// make the provenance the first thing lost on a REMARK-heavy target.
 	snprintf(tmpremark, MAX_REMARK,
 		"REMARK FLEXAID.commit=%s FLEXAID.dirty=%d FLEXAID.seed=%llu\n",
 		FLEXAIDS_GIT_COMMIT,


### PR DESCRIPTION
The provenance follow-up Fizz spun out of the #329 discussion, widened per his request to include the seed.

## The problem, stated as it actually happened

Tonight a 341-run campaign produced numbers nobody could attribute. Two specific unknowns cost hours:

- **Which binary wrote these poses?** A stale cached build was serving results with a missing `CF.pb_clash` REMARK. We found it by luck — one field happened to be absent between two that were present.
- **Which seed produced this draw?** Unrecoverable from every artifact. We had to infer that seeds varied by comparing pose sets.

Both facts exist inside the running process. Neither reached anything readable afterwards.

## The change

One line in the pose REMARK block, beside the `CF.*` lines:

```
REMARK FLEXAID.commit=a395ee97 FLEXAID.dirty=0 FLEXAID.seed=42
```

## Three deliberate choices, each with evidence

**1. REMARK, not stdout.** The runner invokes FlexAID with `subprocess.run(capture_output=True)` and discards stdout on success (`runner.py:815`, `:1403` — only `stderr` is logged, and only on failure).

```
printf to stdout   -> captured into a Python variable, discarded.
                      PRECEDENT: gaboom.cpp:343 has printed "srand=%u" all along
                      and the seed was still unreadable from every artifact.
pose PDB REMARK    -> written to a file, preserved, uploaded as an artifact.
                      We read these by hand all evening.
```

Printing harder does not help. This had to go where the data already survives.

**2. Referencing the macro is what emits it.** `FLEXAIDS_GIT_COMMIT` was defined at `CMakeLists.txt:51` and referenced by **zero** source files:

```
$ grep -rn FLEXAIDS_GIT_COMMIT . --exclude-dir=.git --exclude-dir=build
CMakeLists.txt:46    OUTPUT_VARIABLE FLEXAIDS_GIT_COMMIT ...
CMakeLists.txt:51    FLEXAIDS_GIT_COMMIT="${FLEXAIDS_GIT_COMMIT}")
docs/audit/...md:128 (prose)
```

An unused `-D` macro is never placed in the binary. A CI guard of the form `strings FlexAID | grep $SHA` — which was proposed and nearly banked — would have failed on **every** build. This PR is the first consumer, and it is what makes that check possible later, **against the artifact rather than the binary**:

```bash
grep -q "FLEXAID.commit=${GITHUB_SHA:0:8}" poses/**/flexaid_0.pdb
```

**3. The seed is the EFFECTIVE one.** `gaboom.cpp:345` calls `set_master_seed(tt)` *after* resolving `GB->seed` / `FLEXAID_SEED` / `time(0)`, so `master_seed()` returns the value actually used — **including the `time(0)` fallback**, which is precisely the case that was previously unrecoverable.

## Robustness

Falls back to `"unknown"` / `0` when the macros are absent (non-CMake build, or a checkout where `git rev-parse` produced nothing), so it still compiles and reports an obviously-unknown value rather than silently claiming a commit it does not have.

## Verification

```
single-TU compile      g++ -std=c++2b -fsyntax-only -Wall -Wformat=2   clean
render check           seeded:   FLEXAID.commit=a395ee97 FLEXAID.dirty=0 FLEXAID.seed=42
                       fallback: FLEXAID.commit=unknown  FLEXAID.dirty=1 FLEXAID.seed=1754079123
parser safety          the new line matches none of _RMSD_REMARK_RE, _CF_REMARK_RE,
                       _CF_APP_REMARK_RE, nor any substring branch -> pose parsing unaffected
```

I have **not** run a full FlexAID build or a docking run — that needs CI. The claim here is that it compiles, formats correctly, and cannot disturb the existing parser; the end-to-end emission should be confirmed on the first CI run.

## Scope

Deliberately one line and one include. `flexaid_INI.pdb` (written by `top.cpp:2496`) does not get the REMARK — it is the input structure, not a docking result, and #357 removes it from the pose set entirely.