### PR TITLE
Fix: select the ligand by residue, and fail rather than truncate on mismatch

### DIFF
--- a/python/flexaidds/benchmark.py
+++ b/python/flexaidds/benchmark.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+from collections import OrderedDict
+
 import numpy as np
 
 
@@ -90,7 +92,9 @@ def pic50_to_dg(pic50: float, temperature_K: float = 298.15) -> float:
 # ---------------------------------------------------------------------------
 
 
-def extract_ligand_coords_from_pdb(pdb_path: Path) -> np.ndarray:
+def extract_ligand_coords_from_pdb(
+    pdb_path: Path, expected_n_atoms: int | None = None
+) -> np.ndarray:
     """Extract ligand heavy-atom coordinates from a PDB file.
 
     Selects HETATM records excluding HOH.  Returns an (N, 3) array in
@@ -105,7 +109,17 @@ def extract_ligand_coords_from_pdb(pdb_path: Path) -> np.ndarray:
     that alone turned a true ~1.6 Å pose into a ~4.7 Å number even after
     the Kabsch bug was removed.
     """
-    atoms = []
+    # Group by residue.  A pose PDB is not ligand-only: FlexAID writes the
+    # receptor alongside it, and 36 of the 85 Astex receptors carry a
+    # non-water HETATM cofactor -- ions (CA, ZN, MG), and in four cases a
+    # 172-atom HEM.  "HETATM and not HOH" therefore collects the cofactor
+    # too.  On 1mq6 that produced 37 atoms against a 36-atom reference,
+    # with a calcium at index 0 shifting every subsequent atom by one.
+    #
+    # Selecting the LARGEST residue does not work either: HEM (172 atoms)
+    # would beat the 25-atom ligand on 1g9v.  The reference atom count is
+    # the only reliable discriminator, so callers that have it pass it.
+    residues: "OrderedDict[tuple, List[tuple]]" = OrderedDict()
     with open(pdb_path) as fh:
         for line in fh:
             if not line.startswith("HETATM"):
@@ -116,15 +130,32 @@ def extract_ligand_coords_from_pdb(pdb_path: Path) -> np.ndarray:
             element = line[76:78].strip() if len(line) > 77 else ""
             if element == "H":
                 continue
-            x = float(line[30:38])
-            y = float(line[38:46])
-            z = float(line[46:54])
-            atoms.append((x, y, z))
+            key = (resname, line[21:22], line[22:27].strip())
+            residues.setdefault(key, []).append(
+                (float(line[30:38]), float(line[38:46]), float(line[46:54]))
+            )
 
-    if not atoms:
+    if not residues:
         raise ValueError(f"No ligand heavy atoms found in {pdb_path}")
 
-    return np.array(atoms, dtype=np.float64)
+    if expected_n_atoms is None:
+        # Backwards-compatible path, used where no reference is available.
+        # Still excludes nothing, so it keeps the historical behaviour rather
+        # than silently guessing which residue is the ligand.
+        atoms = [xyz for group in residues.values() for xyz in group]
+        return np.array(atoms, dtype=np.float64)
+
+    matches = [g for g in residues.values() if len(g) == expected_n_atoms]
+    if len(matches) == 1:
+        return np.array(matches[0], dtype=np.float64)
+
+    counts = {f"{k[0]}/{k[1]}{k[2]}": len(v) for k, v in residues.items()}
+    raise ValueError(
+        f"Cannot identify the ligand in {pdb_path}: expected a residue with "
+        f"{expected_n_atoms} heavy atoms, found {len(matches)} candidates "
+        f"among {counts}.  Refusing to guess -- a wrong residue silently "
+        f"produces a plausible RMSD on a shifted atom correspondence."
+    )
 
 
 def extract_ligand_coords_from_mmcif(mmcif_string: str, ligand_id: str = "") -> np.ndarray:

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -2449,18 +2449,19 @@ def _pose_rmsd_vs_reference(pose_pdb: Path, ref_coords) -> float:
     from flexaidds.benchmark import compute_rmsd, extract_ligand_coords_from_pdb
 
     try:
-        pred = extract_ligand_coords_from_pdb(pose_pdb)
+        pred = extract_ligand_coords_from_pdb(pose_pdb, expected_n_atoms=len(ref_coords))
     except ValueError:
         return -1.0
     if pred.shape != ref_coords.shape:
-        n = min(len(pred), len(ref_coords))
-        if n < 3:
-            return -1.0
-        pred = pred[:n]
-        ref = ref_coords[:n]
-    else:
-        ref = ref_coords
+        # Do NOT truncate.  The previous behaviour trimmed both arrays to the
+        # shorter length and computed an RMSD anyway, which silently compared
+        # atom i of one molecule against atom i+1 of the other whenever the
+        # extra atom sat at the front.  On 1mq6 that reported 6.49 A where the
+        # true best-of-10 is 7.18 A -- a plausible number, in the optimistic
+        # direction, indistinguishable from a measurement.  A count mismatch
+        # here is a bug in selection, not a condition to work around.
+        return -1.0
     try:
-        return compute_rmsd(pred, ref)
+        return compute_rmsd(pred, ref_coords)
     except ValueError:
         return -1.0

--- a/python/tests/test_ligand_residue_selection.py
+++ b/python/tests/test_ligand_residue_selection.py
@@ -1,0 +1,108 @@
+"""The ligand is one residue in the pose file, not every non-water HETATM.
+
+FlexAID writes the receptor alongside the docked ligand.  36 of the 85 Astex
+Diverse receptors carry a non-water HETATM cofactor -- ions in most cases, a
+172-atom HEM in four.  Selecting "HETATM and not HOH" therefore collects the
+cofactor as if it were part of the ligand.
+
+On 1mq6 that yields 37 atoms against a 36-atom reference, with a calcium at
+index 0 shifting every subsequent atom by one position.  The old caller then
+truncated both arrays to the shorter length and computed an RMSD anyway --
+producing 6.49 A where the true best-of-10 is 7.18 A.  Optimistic, plausible,
+and indistinguishable from a measurement.
+
+Both halves are pinned here: correct selection, and refusal to guess.
+"""
+
+import numpy as np
+import pytest
+
+from flexaidds.benchmark import extract_ligand_coords_from_pdb
+
+
+def _het(serial, name, resname, chain, resseq, xyz, element):
+    x, y, z = xyz
+    return (
+        f"HETATM{serial:>5} {name:<4}{resname:>3} {chain}{resseq:>4}    "
+        f"{x:8.3f}{y:8.3f}{z:8.3f}  1.00  0.00          {element:>2}\n"
+    )
+
+
+def _pose_with_cofactor(tmp_path, n_ligand=36):
+    """A pose file shaped like 1mq6's: one Ca ion, then the ligand."""
+    p = tmp_path / "flexaid_0.pdb"
+    body = _het(1, "CA", "CA", "A", 1, (0.0, 0.0, 0.0), "Ca")
+    for i in range(n_ligand):
+        body += _het(2 + i, f"C {i}", "XLD", "A", 2, (float(i), 0.0, 0.0), "C")
+    body += "END\n"
+    p.write_text(body)
+    return p
+
+
+def test_cofactor_is_not_counted_as_ligand(tmp_path):
+    """The regression: 37 atoms in, 36 out, and the Ca is not among them."""
+    pose = _pose_with_cofactor(tmp_path)
+
+    assert len(extract_ligand_coords_from_pdb(pose)) == 37  # unfiltered legacy path
+
+    coords = extract_ligand_coords_from_pdb(pose, expected_n_atoms=36)
+    assert coords.shape == (36, 3)
+    # the calcium sat at the origin; the ligand starts at x=0 too, so check
+    # the *last* atom instead -- it must be the 36th ligand atom, not the 35th
+    assert coords[-1][0] == pytest.approx(35.0)
+
+
+def test_correspondence_is_not_shifted(tmp_path):
+    """The consequence the atom count only hints at.
+
+    With the cofactor included, atom i of the pose is atom i-1 of the ligand.
+    Comparing against a reference then measures the wrong pairs.
+    """
+    pose = _pose_with_cofactor(tmp_path)
+    ref = np.array([[float(i), 0.0, 0.0] for i in range(36)])
+
+    good = extract_ligand_coords_from_pdb(pose, expected_n_atoms=36)
+    assert np.allclose(good, ref)  # exact correspondence, zero RMSD
+
+    contaminated = extract_ligand_coords_from_pdb(pose)[:36]
+    assert not np.allclose(contaminated, ref)  # every atom off by one
+
+
+def test_refuses_to_guess_when_no_residue_matches(tmp_path):
+    """A mismatch is a bug in selection, not a condition to work around."""
+    pose = _pose_with_cofactor(tmp_path)
+    with pytest.raises(ValueError, match="Cannot identify the ligand"):
+        extract_ligand_coords_from_pdb(pose, expected_n_atoms=99)
+
+
+def test_refuses_to_guess_when_two_residues_match(tmp_path):
+    """Ambiguity must fail loudly rather than take the first."""
+    p = tmp_path / "two.pdb"
+    body = ""
+    for r, resname in enumerate(("LIG", "XLD")):
+        for i in range(5):
+            body += _het(
+                1 + r * 5 + i, f"C {i}", resname, "A", r + 1, (float(i), 0.0, 0.0), "C"
+            )
+    p.write_text(body + "END\n")
+    with pytest.raises(ValueError, match="found 2 candidates"):
+        extract_ligand_coords_from_pdb(p, expected_n_atoms=5)
+
+
+def test_a_large_cofactor_does_not_win(tmp_path):
+    """Why 'pick the biggest residue' is not the fix.
+
+    1g9v carries a 172-atom HEM against a 25-atom ligand.  Size selects the
+    cofactor; the reference atom count selects the ligand.
+    """
+    p = tmp_path / "hem.pdb"
+    body = ""
+    for i in range(172):
+        body += _het(1 + i, f"C {i}", "HEM", "A", 1, (float(i), 1.0, 0.0), "C")
+    for i in range(25):
+        body += _het(200 + i, f"C {i}", "LIG", "A", 2, (float(i), 0.0, 0.0), "C")
+    p.write_text(body + "END\n")
+
+    coords = extract_ligand_coords_from_pdb(p, expected_n_atoms=25)
+    assert coords.shape == (25, 3)
+    assert coords[0][1] == pytest.approx(0.0)  # the ligand's y, not HEM's


### PR DESCRIPTION
## The bug

A pose PDB is not ligand-only. FlexAID writes the receptor alongside the docked ligand, and **36 of the 85 Astex Diverse receptors carry a non-water HETATM cofactor** — ions in most cases, a 172-atom HEM in four. `extract_ligand_coords_from_pdb` selected "HETATM and not HOH", so the cofactor was collected as ligand atoms.

On `1mq6` that yields **37 atoms against a 36-atom reference**, with a calcium at index 0 shifting every subsequent atom by one.

## The dangerous half

`_pose_rmsd_vs_reference` then truncated both arrays to the shorter length and computed an RMSD anyway. It does not drop the target — **it manufactures a plausible number on a shifted correspondence.**

Measured on the real 1mq6 poses:

```
 pose   shipped (truncated, shifted)   correct (residue-selected)
   0          7.238                        10.273
   2          6.961                         7.822
 best-of-10   6.490                          7.178
```

Optimistic, and indistinguishable from a measurement. The `n < 3` guard shows the author knew truncation was unsafe; the line was drawn at three atoms instead of at any mismatch at all.

## The fix

- `extract_ligand_coords_from_pdb(path, expected_n_atoms=None)` groups by residue and selects the one whose heavy-atom count matches the reference.
- Ambiguity (0 or >1 candidates) **raises** with the candidate counts, rather than guessing.
- The caller passes `len(ref_coords)` and **returns `-1.0` on mismatch instead of truncating**.

**Why not "pick the largest residue":** HEM (172 atoms) would beat `1g9v`'s 25-atom ligand. The reference atom count is the only reliable discriminator.

## Verification

- `1mq6` extract: 37 → 36 atoms; RMSD `10.273 Å`, matching the value computed by hand from the artifact.
- 5 new regression tests, including the shifted-correspondence consequence and the HEM case.
- **Full Python suite: 1092 passed, 68 skipped.**

## What this changes in the reported numbers

Affected targets move from a fabricated value to a real one, and the real ones are worse. `1mq6` rank-1 becomes a measured `10.27 Å` miss. **The score will not improve; the honesty will.**

`1gpk` was never affected (18 vs 18, no cofactor) — which is why every clean result so far comes from the one target that could not trigger this.

## Not in scope

The `-1.0` sentinel (verified safe), #356, and the provenance of the circulating `11.03` figure, which remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
