### PR TITLE
Add: record the pose-election outcome beside the RMSD it explains

### DIFF
--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -7032,6 +7032,23 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                             auto s = p.find_last_of('/');
                             return s == std::string::npos ? p : p.substr(s + 1);
                         };
+                        // Record the election outcome in the result row, beside the
+                        // RMSD it explains.  Same values the [CONSENSUS] line below
+                        // prints; that line is stderr-only, and CI discards stderr on
+                        // success, so the log cannot be the system of record.
+                        result.election_mode = high_entropy_gate ? "entropy-midwall"
+                                             : low_entropy_gate  ? "entropy-contact"
+                                                                 : "consensus";
+                        result.consensus_count = (sel_i >= 0) ? consensus[sel_i] : -1;
+                        // Demoted == the elected pose is not the CF-best candidate in
+                        // the pool.  Defined against min-CF rather than pool order so
+                        // it does not depend on how the pool happens to be sorted.
+                        int cf_best_i = -1;
+                        for (size_t i = 0; i < pool.size(); ++i)
+                            if (cf_best_i < 0 || pool[i].cf < pool[cf_best_i].cf)
+                                cf_best_i = static_cast<int>(i);
+                        result.rank0_demoted =
+                            (sel_i >= 0 && cf_best_i >= 0 && sel_i != cf_best_i);
                         std::cerr << "  [CONSENSUS] " << entry.pdb_id
                                   << ": mode="
                                   << (high_entropy_gate ? "entropy-midwall" :
@@ -7750,6 +7767,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                            "tencom_pose_sha256,eigen_n_modes,elected_H_vib,"
                            "cf_native,best_cluster_rmsd,conditional_scanned_pool_ceiling,best_cluster_idx,"
                            "seed_echo,pose_source,"
+                           "election_mode,consensus_count,rank0_demoted,"
                            "cf_top1_pose_path,cf_top1_score,cf_top1_rmsd,cf_top1_pose_sha256,"
                            "entropy_top1_pose_path,entropy_top1_score,entropy_top1_rmsd,entropy_top1_pose_sha256,"
                            "H_rep_rank0,H_pop,H_rep_mean,D_vib,"
@@ -7810,6 +7828,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                         << result.best_cluster_idx << ","
                         << (result.seed_echo ? 1 : 0) << ","
                         << result.pose_source << ","
+                        << result.election_mode << ","
+                        << result.consensus_count << ","
+                        << (result.rank0_demoted ? 1 : 0) << ","
                         << "\"" << result.cf_top1_pose_path << "\","
                         << (std::isnan(result.cf_top1_score) ? "NA" : std::to_string(result.cf_top1_score)) << ","
                         << result.cf_top1_rmsd << ","
@@ -8212,6 +8233,9 @@ void DatasetRunner::write_report(const BenchmarkReport& report,
                 << r.best_cluster_idx << ","
                 << (r.seed_echo ? 1 : 0) << ","
                 << r.pose_source << ","
+                << r.election_mode << ","
+                << r.consensus_count << ","
+                << (r.rank0_demoted ? 1 : 0) << ","
                 << "\"" << r.cf_top1_pose_path << "\","
                 << (std::isnan(r.cf_top1_score) ? "NA" : std::to_string(r.cf_top1_score)) << ","
                 << r.cf_top1_rmsd << ","

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -7032,23 +7032,6 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                             auto s = p.find_last_of('/');
                             return s == std::string::npos ? p : p.substr(s + 1);
                         };
-                        // Record the election outcome in the result row, beside the
-                        // RMSD it explains.  Same values the [CONSENSUS] line below
-                        // prints; that line is stderr-only, and CI discards stderr on
-                        // success, so the log cannot be the system of record.
-                        result.election_mode = high_entropy_gate ? "entropy-midwall"
-                                             : low_entropy_gate  ? "entropy-contact"
-                                                                 : "consensus";
-                        result.consensus_count = (sel_i >= 0) ? consensus[sel_i] : -1;
-                        // Demoted == the elected pose is not the CF-best candidate in
-                        // the pool.  Defined against min-CF rather than pool order so
-                        // it does not depend on how the pool happens to be sorted.
-                        int cf_best_i = -1;
-                        for (size_t i = 0; i < pool.size(); ++i)
-                            if (cf_best_i < 0 || pool[i].cf < pool[cf_best_i].cf)
-                                cf_best_i = static_cast<int>(i);
-                        result.rank0_demoted =
-                            (sel_i >= 0 && cf_best_i >= 0 && sel_i != cf_best_i);
                         std::cerr << "  [CONSENSUS] " << entry.pdb_id
                                   << ": mode="
                                   << (high_entropy_gate ? "entropy-midwall" :
@@ -7078,6 +7061,16 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                             // winner's CF is thermodynamically worse than the INI's
                             // CF, protect the INI from the override.
                             {
+                                // CF-best candidate in the pool, for rank0_demoted.
+                                // Defined against min-CF rather than pool order so the
+                                // field does not change meaning if the pool is re-sorted.
+                                // Ties resolve to the first index, so an elected pose
+                                // tied on CF reads as demoted -- rare, and documented
+                                // rather than special-cased.
+                                int cf_best_i = -1;
+                                for (size_t i = 0; i < pool.size(); ++i)
+                                    if (cf_best_i < 0 || pool[i].cf < pool[cf_best_i].cf)
+                                        cf_best_i = static_cast<int>(i);
                                 const std::string ini_sfx = "_INI.pdb";
                                 const bool elected_is_ini =
                                     best_pose_pdb.size() >= ini_sfx.size() &&
@@ -7098,11 +7091,30 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                                                                     : "consensus")
                                               << " override (winner CF="
                                               << pool[best_i].cf << ")\n";
+                                    // The override was VETOED: the reported pose is the
+                                    // protected INI seed, not pool[best_i].  Recording
+                                    // the gate mode here would name a rule that did not
+                                    // decide this pose.
+                                    result.election_mode   = "guard-protected";
+                                    result.consensus_count = -1;  // INI is not in the pool
+                                    result.rank0_demoted   = false;
                                 } else {
                                     best_pose_pdb = pool[best_i].path;
                                     // Keep best_score describing the SAME pose now reported.
                                     if (std::isfinite(pool[best_i].cf))
                                         result.best_score = pool[best_i].cf;
+                                    // Record against the ELECTED pose (best_i), not the
+                                    // incumbent it replaced (sel_i).  The stderr line
+                                    // above prints both deliberately -- consensus= for
+                                    // the winner, sel_consensus= for the incumbent -- and
+                                    // these fields describe the pose whose RMSD lands on
+                                    // this row.
+                                    result.election_mode = high_entropy_gate ? "entropy-midwall"
+                                                         : low_entropy_gate  ? "entropy-contact"
+                                                                             : "consensus";
+                                    result.consensus_count = consensus[best_i];
+                                    result.rank0_demoted =
+                                        (cf_best_i >= 0 && best_i != cf_best_i);
                                 }
                             }
                         }

--- a/LIB/DatasetRunner.h
+++ b/LIB/DatasetRunner.h
@@ -256,8 +256,15 @@ struct DockingResult {
     // this pose.
     std::string election_mode{""};   // "consensus" | "entropy-midwall" | "entropy-contact"
                                      // | "guard-protected" | ""
-    int  consensus_count{-1};        // cross-restart votes for the ELECTED pose;
-                                     // -1 = no election, or elected pose not in the pool
+    // consensus_count == -1 is AMBIGUOUS ON ITS OWN and must be read together
+    // with election_mode:
+    //     election_mode ""                -> no election ran (pool < 2 candidates)
+    //     election_mode "guard-protected" -> election ran and was VETOED; the
+    //                                        elected INI seed is not in the pool,
+    //                                        so it has no vote count
+    // Reading this column alone cannot distinguish "nothing happened" from
+    // "an override was overruled".
+    int  consensus_count{-1};        // cross-restart votes for the ELECTED pose
     bool rank0_demoted{false};       // true when the elected pose is not the min-CF one
     // Separate estimands: generator CF top-1 vs entropy/consensus reranked top-1
     std::string cf_top1_pose_path;

--- a/LIB/DatasetRunner.h
+++ b/LIB/DatasetRunner.h
@@ -246,10 +246,19 @@ struct DockingResult {
     // vote, so at restarts < k it can never fire.  Comparing runs across restart
     // counts therefore varies the rule as well as the search budget, which is
     // exactly what these fields make visible.
+    // These describe the pose actually REPORTED, so they are set where the
+    // election applies its result -- after the v124 guard resolves, not before.
+    // Recording them earlier names the incumbent pose the election replaced.
+    //
     // "" when no election ran (single candidate / election block skipped).
+    // "guard-protected" when the v124 guard VETOED the override and kept the INI
+    // seed: naming the gate mode there would credit a rule that did not decide
+    // this pose.
     std::string election_mode{""};   // "consensus" | "entropy-midwall" | "entropy-contact"
-    int  consensus_count{-1};        // votes for the elected pose; -1 = not elected
-    bool rank0_demoted{false};       // true when the elected pose is not CF rank-0
+                                     // | "guard-protected" | ""
+    int  consensus_count{-1};        // cross-restart votes for the ELECTED pose;
+                                     // -1 = no election, or elected pose not in the pool
+    bool rank0_demoted{false};       // true when the elected pose is not the min-CF one
     // Separate estimands: generator CF top-1 vs entropy/consensus reranked top-1
     std::string cf_top1_pose_path;
     std::string cf_top1_pose_sha256;

--- a/LIB/DatasetRunner.h
+++ b/LIB/DatasetRunner.h
@@ -233,6 +233,23 @@ struct DockingResult {
     bool  seed_echo{false};
     // Pose provenance: "ini_elitism" | "ga_cluster" | "cf_rank0" | "softbeta" | ""
     std::string pose_source{""};
+    // ── Pose-election outcome ────────────────────────────────────────────
+    // Which rule actually elected the reported pose, and what the cross-restart
+    // consensus vote was.  These were previously emitted only to std::cerr
+    // (the "[CONSENSUS]" line), so a successful run -- whose stderr CI discards
+    // -- kept the elected RMSD but discarded the rule that produced it.  Two
+    // runs with identical configs can elect different poses; without these the
+    // artifact cannot say why.  Recorded beside rmsd_to_crystal for that reason.
+    //
+    // Note the election rule is not independent of FLEXAIDDS_RESTARTS: the
+    // consensus veto needs cluster_consensus_k (default 3) distinct restarts to
+    // vote, so at restarts < k it can never fire.  Comparing runs across restart
+    // counts therefore varies the rule as well as the search budget, which is
+    // exactly what these fields make visible.
+    // "" when no election ran (single candidate / election block skipped).
+    std::string election_mode{""};   // "consensus" | "entropy-midwall" | "entropy-contact"
+    int  consensus_count{-1};        // votes for the elected pose; -1 = not elected
+    bool rank0_demoted{false};       // true when the elected pose is not CF rank-0
     // Separate estimands: generator CF top-1 vs entropy/consensus reranked top-1
     std::string cf_top1_pose_path;
     std::string cf_top1_pose_sha256;


### PR DESCRIPTION
## What

The rule that elects the reported pose was emitted **only to `std::cerr`** — the `[CONSENSUS]` line at `DatasetRunner.cpp:7035`. Three rules can fire (`consensus`, `entropy-midwall`, `entropy-contact`), and which one fired determines which pose becomes rank-1.

That is a scientific decision recorded in a log stream, not in any file the number travels in.

CI is the worst case:

```python
# python/flexaidds/dataset_runner/runner.py
if result.returncode != 0:      # the ONLY guard around stderr
    ...
# returncode == 0 -> stderr never read, never logged, discarded
```

**Successful runs — precisely the ones whose numbers get published — discard the election record by design.**

## The change

Three fields on `DockingResult`, emitted in **both** the per-complex `result.csv` and the aggregate `_results.csv`, next to `rmsd_to_crystal`:

| field | meaning |
|---|---|
| `election_mode` | which rule elected the pose (`""` if no election ran) |
| `consensus_count` | cross-restart votes for the elected pose (`-1` = none) |
| `rank0_demoted` | true when the elected pose is not the CF-best one |

`rank0_demoted` is defined against the **minimum-CF** candidate rather than pool order, so it does not depend on how the pool happens to be sorted.

## Why it matters beyond bookkeeping

It makes a confound *visible* rather than *inferable*. The consensus veto needs `cluster_consensus_k` (default **3**) distinct restarts to vote:

```
R=1   1 restart  -> consensus <= 1, and 1 < 3 always -> veto STRUCTURALLY DEAD
R=5   up to 5 voters  -> veto can fire
R=10  up to 10 voters -> veto can fire
```

So a run at `FLEXAIDDS_RESTARTS=1` elects under a rule that a run at 5 or 10 does not share. **Comparing across restart counts varies the election rule as well as the search budget.** With these fields the artifact states which rule applied, instead of leaving the next reader to derive it from source.

## Not needed

`cluster_consensus_k` itself requires no change — `RUN_RECEIPT.json` already embeds the full ProtocolConfig snapshot (`receipt.protocol = protocol_cfg_`), and `ProtocolConfig::to_json` emits it at `ProtocolConfig.cpp:389`.

## Scope

**C++ path only.** The Python/CI path has no `RUN_RECEIPT.json` at all (`grep -rn RUN_RECEIPT python/` -> no matches), so it needs a different home for the same three facts. Honey is taking that half.

## Verification

- `g++ -std=c++26 -fsyntax-only LIB/DatasetRunner.cpp` -> **exit 0**
- Control: planting a bogus token at the edited line produces errors naming it, confirming the check reaches the changed region rather than bailing earlier
- **Full build + `ctest` NOT yet run** — a parallel build would contend with a three-arm docking experiment currently running on this machine and corrupt its wall-clock timings, which are also being used for shard sizing. Should be run before merge.
- Additive only; no existing column moves.

Author: Bumble

🤖 Generated with [Claude Code](https://claude.com/claude-code)