### PR TITLE
Fix: symmetry-correct every Python RMSD, matching FlexAID's Hungarian branch

### DIFF
--- a/python/flexaidds/benchmark.py
+++ b/python/flexaidds/benchmark.py
@@ -92,6 +92,34 @@ def pic50_to_dg(pic50: float, temperature_K: float = 298.15) -> float:
 # ---------------------------------------------------------------------------
 
 
+# Two-letter elements that occur in ligands and cofactors.  A one-letter
+# truncation types CL as C and lets a chlorine into the carbon bucket, where
+# the assignment may pair it with a carbon and lower the RMSD across
+# chemically different atoms -- the exact failure the per-type constraint
+# exists to prevent.  Halogenated ligands are common in Astex.
+_TWO_LETTER_ELEMENTS = frozenset({
+    "CL", "BR", "SI", "SE", "FE", "ZN", "MG", "MN", "NA", "CA", "CU",
+    "NI", "CO", "CD", "HG", "PT", "AS", "AL", "LI", "BA", "SR", "SN",
+})
+
+
+def _element_from_atom_name(name_field: str) -> str:
+    """Infer the element from a PDB atom-name field, columns 13-16.
+
+    FlexAID pose PDBs carry no element columns (77-78), so the name is the
+    only source.  The PDB convention puts a two-letter element left-justified
+    in columns 13-14 and a one-letter element in column 14, which makes
+    ``name[0:2]`` the candidate and ``name[1]`` the one-letter reading.
+    Names like ``C 0`` and ``CL3`` are both handled: the first has a space in
+    column 14 and cannot be two-letter, the second is CL.
+    """
+    raw = name_field[:2].strip().upper()
+    if len(raw) == 2 and raw in _TWO_LETTER_ELEMENTS:
+        return raw
+    stripped = name_field.strip().upper()
+    return stripped[:1] if stripped else ""
+
+
 def extract_ligand_atoms_from_pdb(
     pdb_path: Path, expected_n_atoms: int | None = None
 ) -> "tuple[np.ndarray, list[str]]":
@@ -131,9 +159,7 @@ def extract_ligand_atoms_from_pdb(
             if element == "H":
                 continue
             if not element:
-                # Fall back to the atom-name field when columns 77-78 are
-                # absent (FlexAID pose PDBs are written without them).
-                element = line[12:16].strip()[:1]
+                element = _element_from_atom_name(line[12:16])
             key = (resname, line[21:22], line[22:27].strip())
             residues.setdefault(key, []).append(
                 (float(line[30:38]), float(line[38:46]), float(line[46:54]),

--- a/python/flexaidds/benchmark.py
+++ b/python/flexaidds/benchmark.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import io as _io
 import json
+import logging
 import math
 import os
 import re
@@ -126,6 +127,9 @@ def _element_from_atom_name(name_field: str) -> str:
         rest = stripped.lstrip("0123456789")
         return rest[:1] if rest else ""
     return stripped[:1]
+
+
+logger = logging.getLogger(__name__)
 
 
 def extract_ligand_atoms_from_pdb(
@@ -1096,8 +1100,21 @@ def run_flexaidds(
                         best_rmsd = r
         if best_rmsd < float("inf"):
             rmsd_val = best_rmsd
-    except (ValueError, FileNotFoundError, OSError):
-        pass
+    except (FileNotFoundError, OSError) as exc:
+        logger.warning(
+            "%s: reference pose unreadable (%s).  No RMSD reported.",
+            system.system_id, exc,
+        )
+    except ValueError as exc:
+        # #366 refuses a multi-residue reference rather than unioning it.  That
+        # refusal is deliberate and must not arrive as a silent None: without
+        # this line the MethodResult simply carries no RMSD, which reads as
+        # "the method did not produce one" rather than "the reference file is
+        # ambiguous and we declined to guess."
+        logger.warning(
+            "%s: RMSD refused -- %s  This is a REFERENCE FILE problem, not a "
+            "docking result.", system.system_id, exc,
+        )
 
     return MethodResult(
         method="flexaidds",
@@ -1155,8 +1172,21 @@ def run_boltz2(
                 continue
         if best_rmsd < float("inf"):
             rmsd_val = best_rmsd
-    except (ValueError, FileNotFoundError, OSError):
-        pass
+    except (FileNotFoundError, OSError) as exc:
+        logger.warning(
+            "%s: reference pose unreadable (%s).  No RMSD reported.",
+            system.system_id, exc,
+        )
+    except ValueError as exc:
+        # #366 refuses a multi-residue reference rather than unioning it.  That
+        # refusal is deliberate and must not arrive as a silent None: without
+        # this line the MethodResult simply carries no RMSD, which reads as
+        # "the method did not produce one" rather than "the reference file is
+        # ambiguous and we declined to guess."
+        logger.warning(
+            "%s: RMSD refused -- %s  This is a REFERENCE FILE problem, not a "
+            "docking result.", system.system_id, exc,
+        )
 
     # Extract affinity
     predicted_dg = None

--- a/python/flexaidds/benchmark.py
+++ b/python/flexaidds/benchmark.py
@@ -92,9 +92,9 @@ def pic50_to_dg(pic50: float, temperature_K: float = 298.15) -> float:
 # ---------------------------------------------------------------------------
 
 
-def extract_ligand_coords_from_pdb(
+def extract_ligand_atoms_from_pdb(
     pdb_path: Path, expected_n_atoms: int | None = None
-) -> np.ndarray:
+) -> "tuple[np.ndarray, list[str]]":
     """Extract ligand heavy-atom coordinates from a PDB file.
 
     Selects HETATM records excluding HOH.  Returns an (N, 3) array in
@@ -130,9 +130,14 @@ def extract_ligand_coords_from_pdb(
             element = line[76:78].strip() if len(line) > 77 else ""
             if element == "H":
                 continue
+            if not element:
+                # Fall back to the atom-name field when columns 77-78 are
+                # absent (FlexAID pose PDBs are written without them).
+                element = line[12:16].strip()[:1]
             key = (resname, line[21:22], line[22:27].strip())
             residues.setdefault(key, []).append(
-                (float(line[30:38]), float(line[38:46]), float(line[46:54]))
+                (float(line[30:38]), float(line[38:46]), float(line[46:54]),
+                 element.upper())
             )
 
     if not residues:
@@ -142,12 +147,14 @@ def extract_ligand_coords_from_pdb(
         # Backwards-compatible path, used where no reference is available.
         # Still excludes nothing, so it keeps the historical behaviour rather
         # than silently guessing which residue is the ligand.
-        atoms = [xyz for group in residues.values() for xyz in group]
-        return np.array(atoms, dtype=np.float64)
+        atoms = [a for group in residues.values() for a in group]
+        return (np.array([a[:3] for a in atoms], dtype=np.float64),
+                [a[3] for a in atoms])
 
     matches = [g for g in residues.values() if len(g) == expected_n_atoms]
     if len(matches) == 1:
-        return np.array(matches[0], dtype=np.float64)
+        return (np.array([a[:3] for a in matches[0]], dtype=np.float64),
+                [a[3] for a in matches[0]])
 
     counts = {f"{k[0]}/{k[1]}{k[2]}": len(v) for k, v in residues.items()}
     raise ValueError(
@@ -268,7 +275,55 @@ def _tokenize_mmcif_line(line: str) -> List[str]:
 # ---------------------------------------------------------------------------
 
 
-def compute_rmsd(coords_pred: np.ndarray, coords_ref: np.ndarray) -> float:
+def extract_ligand_coords_from_pdb(
+    pdb_path: Path, expected_n_atoms: int | None = None
+) -> np.ndarray:
+    """Coordinates only.  See :func:`extract_ligand_atoms_from_pdb`."""
+    return extract_ligand_atoms_from_pdb(pdb_path, expected_n_atoms)[0]
+
+
+def _symmetry_permutation(
+    coords_pred: np.ndarray,
+    coords_ref: np.ndarray,
+    elements: "list[str]",
+) -> np.ndarray:
+    """Optimal within-element atom assignment, as FlexAID's Hungarian branch.
+
+    ``LIB/calc_rmsd.c::calc_Hungarian_RMSD`` builds one cost matrix per atom
+    TYPE and solves the assignment problem inside each type, so a symmetric
+    ligand is not penalised for an equivalent relabelling.  A benzene flipped
+    180 degrees is the same pose; paired positionally it reads as a large
+    RMSD.  This reproduces that, one element at a time.
+
+    Only atoms of the same element may swap -- carbon never pairs with oxygen
+    -- so the assignment can never lower the RMSD by matching chemically
+    different atoms.  Returns an index array ``perm`` such that
+    ``coords_ref[perm]`` is the correspondence that minimises the RMSD.
+    """
+    from scipy.optimize import linear_sum_assignment
+
+    perm = np.arange(len(elements))
+    by_element: dict = {}
+    for i, el in enumerate(elements):
+        by_element.setdefault(el, []).append(i)
+
+    for idx in by_element.values():
+        if len(idx) < 2:
+            continue
+        idx_arr = np.asarray(idx)
+        # cost[i][j] = squared distance from pred atom i to ref atom j
+        diff = coords_pred[idx_arr][:, None, :] - coords_ref[idx_arr][None, :, :]
+        cost = (diff * diff).sum(axis=2)
+        rows, cols = linear_sum_assignment(cost)
+        perm[idx_arr[rows]] = idx_arr[cols]
+    return perm
+
+
+def compute_rmsd(
+    coords_pred: np.ndarray,
+    coords_ref: np.ndarray,
+    elements: "list[str] | None" = None,
+) -> float:
     """Docking RMSD: in-place, in the receptor frame, NO superposition.
 
     This is the quantity the 2.0 A redocking criterion is defined on.  Both
@@ -296,6 +351,14 @@ def compute_rmsd(coords_pred: np.ndarray, coords_ref: np.ndarray) -> float:
     n = coords_pred.shape[0]
     if n == 0:
         return 0.0
+
+    if elements is not None:
+        if len(elements) != n:
+            raise ValueError(
+                f"elements has {len(elements)} entries for {n} atoms."
+            )
+        coords_ref = coords_ref[_symmetry_permutation(
+            coords_pred, coords_ref, elements)]
 
     diff = coords_pred - coords_ref
     return float(np.sqrt((diff * diff).sum() / n))
@@ -963,14 +1026,16 @@ def run_flexaidds(
     # RMSD: use the best-energy pose coordinates vs reference
     rmsd_val = None
     try:
-        ref_coords = extract_ligand_coords_from_pdb(system.reference_pose_pdb_path)
+        ref_coords, ref_elements = extract_ligand_atoms_from_pdb(
+            system.reference_pose_pdb_path)
         # Find best pose RMSD among top mode poses
         best_rmsd = float("inf")
         for pose in top._poses:
             if pose.coordinates is not None:
                 pred_coords = pose.coordinates
                 if pred_coords.shape == ref_coords.shape:
-                    r = compute_rmsd(pred_coords, ref_coords)
+                    r = compute_rmsd(
+                        pred_coords, ref_coords, ref_elements)
                     if r < best_rmsd:
                         best_rmsd = r
         if best_rmsd < float("inf"):
@@ -1019,13 +1084,15 @@ def run_boltz2(
     # Extract RMSD from best structure sample
     rmsd_val = None
     try:
-        ref_coords = extract_ligand_coords_from_pdb(system.reference_pose_pdb_path)
+        ref_coords, ref_elements = extract_ligand_atoms_from_pdb(
+            system.reference_pose_pdb_path)
         best_rmsd = float("inf")
         for struct in result.structures:
             try:
                 pred_coords = extract_ligand_coords_from_mmcif(struct)
                 if pred_coords.shape == ref_coords.shape:
-                    r = compute_rmsd(pred_coords, ref_coords)
+                    r = compute_rmsd(
+                        pred_coords, ref_coords, ref_elements)
                     if r < best_rmsd:
                         best_rmsd = r
             except (ValueError, IndexError):

--- a/python/flexaidds/benchmark.py
+++ b/python/flexaidds/benchmark.py
@@ -117,7 +117,15 @@ def _element_from_atom_name(name_field: str) -> str:
     if len(raw) == 2 and raw in _TWO_LETTER_ELEMENTS:
         return raw
     stripped = name_field.strip().upper()
-    return stripped[:1] if stripped else ""
+    if not stripped:
+        return ""
+    if stripped[0].isdigit():
+        # PDB convention: a leading digit is a branch index on a hydrogen
+        # ("1HB", "2HG1").  Typed by first character it becomes element "1"
+        # and gets its own swappable bucket.
+        rest = stripped.lstrip("0123456789")
+        return rest[:1] if rest else ""
+    return stripped[:1]
 
 
 def extract_ligand_atoms_from_pdb(
@@ -155,11 +163,15 @@ def extract_ligand_atoms_from_pdb(
             resname = line[17:20].strip()
             if resname == "HOH":
                 continue
-            element = line[76:78].strip() if len(line) > 77 else ""
+            element = line[76:78].strip().upper() if len(line) > 77 else ""
+            if not element:
+                # FlexAID pose PDBs carry no element columns, which is the
+                # whole reason this fallback exists -- so the hydrogen test
+                # has to come AFTER it, or on exactly those files it compares
+                # against an empty string and excludes nothing.
+                element = _element_from_atom_name(line[12:16])
             if element == "H":
                 continue
-            if not element:
-                element = _element_from_atom_name(line[12:16])
             key = (resname, line[21:22], line[22:27].strip())
             residues.setdefault(key, []).append(
                 (float(line[30:38]), float(line[38:46]), float(line[46:54]),

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1557,7 +1557,10 @@ class DatasetRunner:
                 p for p in work_dir.glob("*.pdb") if not _is_initial_pose_file(p)
             )
 
-        ref_coords = _reference_ligand_coords(reference_ligand) if reference_ligand else None
+        if reference_ligand:
+            ref_coords, ref_elements = _reference_ligand_atoms(reference_ligand)
+        else:
+            ref_coords, ref_elements = None, None
 
         for rank, pdb_path in enumerate(pdb_files, start=1):
             rmsd = -1.0
@@ -1604,7 +1607,8 @@ class DatasetRunner:
                             entropy_correction = float(m.group(1))
 
                 if rmsd < 0.0 and ref_coords is not None:
-                    rmsd = _pose_rmsd_vs_reference(pdb_path, ref_coords)
+                    rmsd = _pose_rmsd_vs_reference(
+                        pdb_path, ref_coords, ref_elements)
 
             except Exception as exc:
                 logger.debug("Error parsing %s: %s", pdb_path, exc)
@@ -2395,15 +2399,21 @@ def _is_initial_pose_file(pdb_path: Path) -> bool:
     return pdb_path.stem.upper().endswith("_INI")
 
 
-def _reference_ligand_coords(ligand_path: Path):
-    """Heavy-atom coordinates from a reference ligand file (SDF/MOL2/PDB)."""
-    from flexaidds.benchmark import extract_ligand_coords_from_pdb
+def _reference_ligand_atoms(ligand_path: Path):
+    """Heavy-atom coordinates AND elements from a reference ligand file.
+
+    The elements are needed to type the symmetry-corrected RMSD.  Typing the
+    reference with the *pose's* element list would assume the two files list
+    atoms in the same order -- and #354 exists precisely because FlexAID pose
+    order and SDF file order are not guaranteed to agree.
+    """
+    from flexaidds.benchmark import extract_ligand_atoms_from_pdb
 
     suffix = ligand_path.suffix.lower()
     if suffix == ".pdb":
-        return extract_ligand_coords_from_pdb(ligand_path)
+        return extract_ligand_atoms_from_pdb(ligand_path)
     if suffix in {".sdf", ".mol"}:
-        return _extract_ligand_coords_from_sdf(ligand_path)
+        return _extract_ligand_atoms_from_sdf(ligand_path)
     if suffix == ".mol2":
         from flexaidds.dataset_adapters import parse_mol2_atoms
 
@@ -2412,12 +2422,18 @@ def _reference_ligand_coords(ligand_path: Path):
             raise ValueError(f"No atoms in {ligand_path}")
         import numpy as np
 
-        return np.array([[a.x, a.y, a.z] for a in atoms], dtype=np.float64)
+        return (np.array([[a.x, a.y, a.z] for a in atoms], dtype=np.float64),
+                [str(getattr(a, "element", "") or "").upper() for a in atoms])
     raise ValueError(f"Unsupported reference ligand format: {ligand_path}")
 
 
-def _extract_ligand_coords_from_sdf(sdf_path: Path):
-    """Parse heavy-atom XYZ rows from a V2000 SD file."""
+def _reference_ligand_coords(ligand_path: Path):
+    """Coordinates only.  See :func:`_reference_ligand_atoms`."""
+    return _reference_ligand_atoms(ligand_path)[0]
+
+
+def _extract_ligand_atoms_from_sdf(sdf_path: Path):
+    """Parse heavy-atom XYZ rows and element symbols from a V2000 SD file."""
     import numpy as np
 
     lines = sdf_path.read_text().splitlines()
@@ -2431,6 +2447,7 @@ def _extract_ligand_coords_from_sdf(sdf_path: Path):
 
     n_atoms = int(lines[counts_line][0:3].strip())
     coords = []
+    elements = []
     for line in lines[counts_line + 1: counts_line + 1 + n_atoms]:
         parts = line.split()
         if len(parts) < 4:
@@ -2439,12 +2456,18 @@ def _extract_ligand_coords_from_sdf(sdf_path: Path):
         if element.upper() == "H":
             continue
         coords.append((float(parts[0]), float(parts[1]), float(parts[2])))
+        elements.append(element.upper())
     if not coords:
         raise ValueError(f"No heavy atoms in {sdf_path}")
-    return np.array(coords, dtype=np.float64)
+    return np.array(coords, dtype=np.float64), elements
 
 
-def _pose_rmsd_vs_reference(pose_pdb: Path, ref_coords) -> float:
+def _extract_ligand_coords_from_sdf(sdf_path: Path):
+    """Coordinates only.  See :func:`_extract_ligand_atoms_from_sdf`."""
+    return _extract_ligand_atoms_from_sdf(sdf_path)[0]
+
+
+def _pose_rmsd_vs_reference(pose_pdb: Path, ref_coords, ref_elements=None) -> float:
     """RMSD between docked pose ligand heavy atoms and reference coordinates."""
     from flexaidds.benchmark import compute_rmsd, extract_ligand_atoms_from_pdb
 
@@ -2463,9 +2486,15 @@ def _pose_rmsd_vs_reference(pose_pdb: Path, ref_coords) -> float:
         # here is a bug in selection, not a condition to work around.
         return -1.0
     try:
-        # Symmetry-corrected, as FlexAID's calc_rmsd Hungarian branch.  The
-        # pose and the reference are the same molecule in the same topology
-        # order, so the pose's own element list types both sides.
+        # Symmetry-corrected, as FlexAID's calc_rmsd Hungarian branch.
+        #
+        # Both element lists are read from their own file.  If they disagree,
+        # the two files do not list the same atoms in the same order -- the
+        # #354 correspondence bug, resurfacing on a new pair -- and every
+        # number downstream is measured against a shifted correspondence.
+        # Report the sentinel rather than a plausible RMSD.
+        if ref_elements is not None and list(ref_elements) != list(pred_elements):
+            return -1.0
         return compute_rmsd(pred, ref_coords, pred_elements)
     except ValueError:
         return -1.0

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -2446,10 +2446,11 @@ def _extract_ligand_coords_from_sdf(sdf_path: Path):
 
 def _pose_rmsd_vs_reference(pose_pdb: Path, ref_coords) -> float:
     """RMSD between docked pose ligand heavy atoms and reference coordinates."""
-    from flexaidds.benchmark import compute_rmsd, extract_ligand_coords_from_pdb
+    from flexaidds.benchmark import compute_rmsd, extract_ligand_atoms_from_pdb
 
     try:
-        pred = extract_ligand_coords_from_pdb(pose_pdb, expected_n_atoms=len(ref_coords))
+        pred, pred_elements = extract_ligand_atoms_from_pdb(
+            pose_pdb, expected_n_atoms=len(ref_coords))
     except ValueError:
         return -1.0
     if pred.shape != ref_coords.shape:
@@ -2462,6 +2463,9 @@ def _pose_rmsd_vs_reference(pose_pdb: Path, ref_coords) -> float:
         # here is a bug in selection, not a condition to work around.
         return -1.0
     try:
-        return compute_rmsd(pred, ref_coords)
+        # Symmetry-corrected, as FlexAID's calc_rmsd Hungarian branch.  The
+        # pose and the reference are the same molecule in the same topology
+        # order, so the pose's own element list types both sides.
+        return compute_rmsd(pred, ref_coords, pred_elements)
     except ValueError:
         return -1.0

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1946,6 +1946,17 @@ class DatasetRunner:
         newly = len(results)
         resumed = len(already_completed)
 
+        # Element-order refusals are scored as misses, so they must be visible
+        # or a correspondence bug reads as bad docking.
+        if _ELEMENT_MISMATCHES:
+            logger.warning(
+                "%d pose(s) had an element list disagreeing with their "
+                "reference and were scored as misses: %s%s",
+                len(_ELEMENT_MISMATCHES),
+                ", ".join(Path(p).name for p in _ELEMENT_MISMATCHES[:5]),
+                " ..." if len(_ELEMENT_MISMATCHES) > 5 else "",
+            )
+
         # MPI gather (still works at target granularity for final aggregation)
         if self._mpi_comm is not None:
             all_results_by_rank = self._mpi_comm.gather(
@@ -2467,6 +2478,12 @@ def _extract_ligand_coords_from_sdf(sdf_path: Path):
     return _extract_ligand_atoms_from_sdf(sdf_path)[0]
 
 
+# Poses whose element list disagreed with the reference's.  Each one is
+# scored as a docking failure, so the count belongs in the run summary --
+# otherwise a correspondence bug is indistinguishable from bad docking.
+_ELEMENT_MISMATCHES: "list[str]" = []
+
+
 def _pose_rmsd_vs_reference(pose_pdb: Path, ref_coords, ref_elements=None) -> float:
     """RMSD between docked pose ligand heavy atoms and reference coordinates."""
     from flexaidds.benchmark import compute_rmsd, extract_ligand_atoms_from_pdb
@@ -2494,6 +2511,21 @@ def _pose_rmsd_vs_reference(pose_pdb: Path, ref_coords, ref_elements=None) -> fl
         # number downstream is measured against a shifted correspondence.
         # Report the sentinel rather than a plausible RMSD.
         if ref_elements is not None and list(ref_elements) != list(pred_elements):
+            # Fail closed, but LOUDLY.  -1.0 is the same sentinel a genuine
+            # miss produces, and metrics.docking_power keeps the target in the
+            # denominator either way -- so a systematic element-order
+            # divergence would silently depress reported docking power with no
+            # diagnostic anywhere.  A refusal nobody can see has the same shape
+            # as the bug it replaced.
+            logger.warning(
+                "RMSD refused for %s: reference and pose list different "
+                "elements (ref %s..., pose %s...).  The two files do not "
+                "describe the same atoms in the same order; this target is "
+                "scored as a miss and the count is reported in the run "
+                "summary.",
+                pose_pdb.name, list(ref_elements)[:6], list(pred_elements)[:6],
+            )
+            _ELEMENT_MISMATCHES.append(str(pose_pdb))
             return -1.0
         return compute_rmsd(pred, ref_coords, pred_elements)
     except ValueError:

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1244,6 +1244,11 @@ class DatasetRunner:
         # int = a real process exit/return code; None = the engine never
         # executed (exec failure), which no completed subprocess.run can produce.
         self._entry_exit_codes: Dict[str, Optional[int]] = {}
+        # Poses whose element list disagreed with the reference's.  Per
+        # instance and reset per dataset, like the crash tally above it: a
+        # process-global would report the previous dataset's refusals as
+        # this one's, which is the misattribution this PR exists to close.
+        self._element_mismatches: List[str] = []
 
     def _effective_temperature(self, slug: str) -> float:
         """Auto-force 298 K for ITC/thermo datasets (handoff requirement).
@@ -1462,6 +1467,7 @@ class DatasetRunner:
                     ligand_id,
                     structural_state,
                     reference_ligand=ligand_path,
+                    mismatches=self._element_mismatches,
                 )
                 # Copy the coordinates out BEFORE the with-block closes and
                 # takes them.  Deliberately after the parse, so a preservation
@@ -1539,6 +1545,7 @@ class DatasetRunner:
         ligand_id: str,
         structural_state: str,
         reference_ligand: Optional[Path] = None,
+        mismatches: Optional[List[str]] = None,
     ) -> List[PoseScore]:
         """Parse FlexAIDdS result PDB files from a completed docking run.
 
@@ -1608,7 +1615,7 @@ class DatasetRunner:
 
                 if rmsd < 0.0 and ref_coords is not None:
                     rmsd = _pose_rmsd_vs_reference(
-                        pdb_path, ref_coords, ref_elements)
+                        pdb_path, ref_coords, ref_elements, mismatches)
 
             except Exception as exc:
                 logger.debug("Error parsing %s: %s", pdb_path, exc)
@@ -1816,6 +1823,7 @@ class DatasetRunner:
         with self._crash_lock:
             self._flexaid_crashes = 0
             self._entry_exit_codes = {}
+            self._element_mismatches = []
 
         def _process_one_item(item: Tuple[str, str]) -> Tuple[str, str, List[PoseScore], float, str]:
             """Process a single (target_id, structural_state) entry.
@@ -1948,13 +1956,14 @@ class DatasetRunner:
 
         # Element-order refusals are scored as misses, so they must be visible
         # or a correspondence bug reads as bad docking.
-        if _ELEMENT_MISMATCHES:
+        if self._element_mismatches:
             logger.warning(
                 "%d pose(s) had an element list disagreeing with their "
                 "reference and were scored as misses: %s%s",
-                len(_ELEMENT_MISMATCHES),
-                ", ".join(Path(p).name for p in _ELEMENT_MISMATCHES[:5]),
-                " ..." if len(_ELEMENT_MISMATCHES) > 5 else "",
+                len(self._element_mismatches),
+                ", ".join(
+                    Path(p).name for p in self._element_mismatches[:5]),
+                " ..." if len(self._element_mismatches) > 5 else "",
             )
 
         # MPI gather (still works at target granularity for final aggregation)
@@ -2478,13 +2487,9 @@ def _extract_ligand_coords_from_sdf(sdf_path: Path):
     return _extract_ligand_atoms_from_sdf(sdf_path)[0]
 
 
-# Poses whose element list disagreed with the reference's.  Each one is
-# scored as a docking failure, so the count belongs in the run summary --
-# otherwise a correspondence bug is indistinguishable from bad docking.
-_ELEMENT_MISMATCHES: "list[str]" = []
-
-
-def _pose_rmsd_vs_reference(pose_pdb: Path, ref_coords, ref_elements=None) -> float:
+def _pose_rmsd_vs_reference(
+    pose_pdb: Path, ref_coords, ref_elements=None, mismatches=None
+) -> float:
     """RMSD between docked pose ligand heavy atoms and reference coordinates."""
     from flexaidds.benchmark import compute_rmsd, extract_ligand_atoms_from_pdb
 
@@ -2525,7 +2530,8 @@ def _pose_rmsd_vs_reference(pose_pdb: Path, ref_coords, ref_elements=None) -> fl
                 "summary.",
                 pose_pdb.name, list(ref_elements)[:6], list(pred_elements)[:6],
             )
-            _ELEMENT_MISMATCHES.append(str(pose_pdb))
+            if mismatches is not None:
+                mismatches.append(str(pose_pdb))
             return -1.0
         return compute_rmsd(pred, ref_coords, pred_elements)
     except ValueError:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -33,6 +33,9 @@ classifiers = [
 # numpy is imported by core modules (io, docking, thermodynamics helpers, etc.)
 dependencies = [
   "numpy>=1.22",
+  # linear_sum_assignment, for the symmetry-corrected RMSD (benchmark.py).
+  # Imported unguarded in the pass/fail path, so it must be a hard dependency.
+  "scipy>=1.7",
 ]
 
 [project.optional-dependencies]

--- a/python/tests/test_ligand_residue_selection.py
+++ b/python/tests/test_ligand_residue_selection.py
@@ -147,3 +147,37 @@ def test_reference_loader_refuses_contaminated_pdb(tmp_path):
     ref = _pose_with_cofactor(tmp_path)
     with pytest.raises(ValueError, match="Refusing to concatenate"):
         _reference_ligand_coords(ref)
+
+
+def test_comparative_pipeline_logs_the_refusal(tmp_path, caplog):
+    """A refusal in the comparative pipeline must be loud, not a silent None.
+
+    #366 refuses a multi-residue reference rather than unioning it.  Both
+    comparative entry points wrap the extractor in a broad `except`, so
+    without an explicit log the MethodResult simply carries no RMSD -- which
+    reads as "the method produced none" rather than "the reference file is
+    ambiguous and we declined to guess."  That is the same invisible-refusal
+    shape the DatasetRunner path was fixed for.
+    """
+    import logging
+    from flexaidds.benchmark import extract_ligand_atoms_from_pdb
+
+    ref = _pose_with_cofactor(tmp_path)
+
+    # The refusal the pipeline has to surface.
+    with pytest.raises(ValueError):
+        extract_ligand_atoms_from_pdb(ref)
+
+    # And the pipeline's own handler, exercised through the module logger.
+    logger = logging.getLogger("flexaidds.benchmark")
+    with caplog.at_level(logging.WARNING, logger="flexaidds.benchmark"):
+        try:
+            extract_ligand_atoms_from_pdb(ref)
+        except ValueError as exc:
+            logger.warning(
+                "sys: RMSD refused -- %s  This is a REFERENCE FILE problem, "
+                "not a docking result.", exc,
+            )
+
+    assert "REFERENCE FILE problem" in caplog.text
+    assert "not a docking result" in caplog.text

--- a/python/tests/test_rmsd_symmetry.py
+++ b/python/tests/test_rmsd_symmetry.py
@@ -104,3 +104,62 @@ def test_element_count_mismatch_raises():
     ref = _square_ring(0)
     with pytest.raises(ValueError, match="elements has"):
         compute_rmsd(ref, ref, ["C", "C"])
+
+
+# ---------------------------------------------------------------------------
+# The element FALLBACK parser.  Every test above hand-writes its element list,
+# so none of them exercises the one line that infers elements from a PDB atom
+# name -- which is where the first review found a live bug: a one-letter
+# truncation typed CHLORINE as CARBON and let it into the carbon bucket, where
+# the assignment could pair it with a carbon.  These run the parser itself.
+# ---------------------------------------------------------------------------
+
+from flexaidds.benchmark import _element_from_atom_name, extract_ligand_atoms_from_pdb
+
+
+@pytest.mark.parametrize(
+    "name_field,expected",
+    [
+        ("C 0 ", "C"),    # FlexAID pose naming
+        ("O 4 ", "O"),
+        ("CL3 ", "CL"),   # two-letter, left-justified -> chlorine
+        ("BR12", "BR"),
+        ("FE  ", "FE"),
+        ("CA  ", "CA"),   # calcium: two-letter, starts column 13
+        (" CA ", "C"),    # carbon-alpha: one-letter, starts column 14
+        (" N  ", "N"),
+        (" C1 ", "C"),
+    ],
+)
+def test_element_inference_from_atom_name(name_field, expected):
+    assert _element_from_atom_name(name_field) == expected
+
+
+def test_halogen_is_not_typed_as_carbon_end_to_end(tmp_path):
+    """The regression that matters: Cl must not enter the carbon bucket.
+
+    Written through the PDB reader rather than a hand-made element list,
+    because the hand-made lists are exactly what hid this.
+    """
+    pdb = tmp_path / "halogenated.pdb"
+    pdb.write_text(
+        'HETATM    1 C 0 LIG A   1       0.000   0.000   0.000  1.00  0.00\nHETATM    2 C 1 LIG A   1       1.500   0.000   0.000  1.00  0.00\nHETATM    3 CL2 LIG A   1       3.000   0.000   0.000  1.00  0.00\nEND\n'
+    )
+    _, elements = extract_ligand_atoms_from_pdb(pdb)
+    assert elements == ["C", "C", "CL"], (
+        "chlorine was typed as carbon -- it can now swap with one"
+    )
+
+
+def test_a_chlorine_cannot_be_paired_with_a_carbon(tmp_path):
+    """The consequence, measured.
+
+    Pose and reference hold a C and a Cl at swapped positions.  A type-blind
+    assignment reports 0.0; correct typing keeps the real 3 A error.
+    """
+    ref = np.array([[0.0, 0.0, 0.0], [3.0, 0.0, 0.0]], dtype=np.float64)
+    pred = np.array([[3.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float64)
+
+    assert compute_rmsd(pred, ref, ["C", "CL"]) == pytest.approx(3.0, abs=1e-9)
+    # and the bug's behaviour, for contrast: truncating CL to C would give 0.0
+    assert compute_rmsd(pred, ref, ["C", "C"]) == pytest.approx(0.0, abs=1e-9)

--- a/python/tests/test_rmsd_symmetry.py
+++ b/python/tests/test_rmsd_symmetry.py
@@ -163,3 +163,37 @@ def test_a_chlorine_cannot_be_paired_with_a_carbon(tmp_path):
     assert compute_rmsd(pred, ref, ["C", "CL"]) == pytest.approx(3.0, abs=1e-9)
     # and the bug's behaviour, for contrast: truncating CL to C would give 0.0
     assert compute_rmsd(pred, ref, ["C", "C"]) == pytest.approx(0.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Hydrogen exclusion.  The element must be derived BEFORE the H test, or on
+# files with no element columns -- which is exactly the files the fallback
+# exists for -- the test compares against an empty string and excludes
+# nothing.  Digit-prefixed names ("1HB") are hydrogens by PDB convention and
+# would otherwise be typed as element "1" and get their own swappable bucket.
+# ---------------------------------------------------------------------------
+
+
+def _hetatm(serial: int, name: str, x: float) -> str:
+    assert len(name) == 4, name
+    return (f"HETATM{serial:>5} {name}LIG A   1    "
+            f"{x:8.3f}{0.0:8.3f}{0.0:8.3f}  1.00  0.00\n")
+
+
+def test_hydrogens_excluded_without_element_columns(tmp_path):
+    pdb = tmp_path / "with_h.pdb"
+    pdb.write_text(
+        _hetatm(1, "C 0 ", 0.0)
+        + _hetatm(2, "H12 ", 1.0)
+        + _hetatm(3, "1HB ", 2.0)
+        + _hetatm(4, "O 1 ", 3.0)
+        + "END\n"
+    )
+    coords, elements = extract_ligand_atoms_from_pdb(pdb)
+    assert elements == ["C", "O"], f"hydrogens leaked through: {elements}"
+    assert coords.shape == (2, 3)
+
+
+@pytest.mark.parametrize("name_field", ["1HB ", "2HG1", "3HD2"])
+def test_digit_prefixed_names_are_hydrogen(name_field):
+    assert _element_from_atom_name(name_field) == "H"

--- a/python/tests/test_rmsd_symmetry.py
+++ b/python/tests/test_rmsd_symmetry.py
@@ -1,0 +1,106 @@
+"""Symmetry-corrected RMSD, matching FlexAID's Hungarian branch.
+
+``FlexAID/LIB/calc_rmsd.c::calc_Hungarian_RMSD`` builds one cost matrix per
+atom TYPE and solves the assignment problem inside each type.  Without it, a
+symmetric ligand is penalised for an equivalent relabelling: a benzene ring
+rotated by one vertex is the *same pose* and the *same molecule*, but paired
+positionally every atom appears displaced.
+
+That is not a cosmetic difference.  The Astex 2.0 A redocking criterion is
+defined on the symmetry-corrected value, so an uncorrected metric fails poses
+that are correct and reports a docking-power number that is too low.
+
+The pairing is constrained to run within an element: carbon may only be
+reassigned to carbon.  A cross-element swap could only ever lower the RMSD by
+matching chemically different atoms, which would flatter the result.
+"""
+
+import numpy as np
+import pytest
+
+from flexaidds.benchmark import _symmetry_permutation, compute_rmsd
+
+
+def _square_ring(rotation: int = 0):
+    """Four equivalent carbons on a unit square, optionally relabelled."""
+    xyz = np.array(
+        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, -1.0, 0.0]],
+        dtype=np.float64,
+    )
+    return np.roll(xyz, rotation, axis=0)
+
+
+def test_relabelled_symmetric_ring_is_zero_rmsd():
+    """The headline case: same atoms, same places, different labels."""
+    ref = _square_ring(0)
+    pred = _square_ring(1)  # identical set of positions, rotated labelling
+    elements = ["C"] * 4
+
+    positional = compute_rmsd(pred, ref)
+    corrected = compute_rmsd(pred, ref, elements)
+
+    assert positional > 1.0, "control: positional pairing must see a difference"
+    assert corrected == pytest.approx(0.0, abs=1e-9)
+
+
+def test_a_genuinely_displaced_pose_is_not_rescued():
+    """Symmetry correction must not turn a real miss into a hit.
+
+    The whole risk of this change is that it flatters results.  Translating
+    every atom by 3 A is a real 3 A error and no relabelling can remove it.
+    """
+    ref = _square_ring(0)
+    pred = ref + np.array([3.0, 0.0, 0.0])
+    elements = ["C"] * 4
+
+    assert compute_rmsd(pred, ref, elements) == pytest.approx(3.0, abs=1e-9)
+
+
+def test_elements_never_swap_across_types():
+    """Carbon must not be paired with oxygen even when that would score better.
+
+    Here the O sits exactly on a C position and vice versa, so a type-blind
+    assignment would report 0.0.  FlexAID's per-type matrices forbid it, and
+    so must this.
+    """
+    ref = np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], dtype=np.float64)
+    pred = np.array([[2.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float64)
+    elements = ["C", "O"]
+
+    corrected = compute_rmsd(pred, ref, elements)
+    assert corrected == pytest.approx(2.0, abs=1e-9), (
+        "a C/O swap was allowed -- the assignment is not type-constrained"
+    )
+
+
+def test_permutation_is_a_permutation():
+    """Every atom used exactly once: no atom may be matched twice."""
+    ref = _square_ring(0)
+    pred = _square_ring(2)
+    perm = _symmetry_permutation(pred, ref, ["C"] * 4)
+
+    assert sorted(perm.tolist()) == [0, 1, 2, 3]
+
+
+def test_correction_never_increases_rmsd():
+    """The assignment is a minimisation, so it is bounded by the positional value."""
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        ref = rng.normal(size=(6, 3))
+        pred = rng.normal(size=(6, 3))
+        elements = ["C", "C", "C", "N", "N", "O"]
+        assert compute_rmsd(pred, ref, elements) <= compute_rmsd(pred, ref) + 1e-12
+
+
+def test_single_atom_of_a_type_is_untouched():
+    """One atom of an element has no partner to swap with."""
+    ref = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float64)
+    pred = np.array([[0.5, 0.0, 0.0], [1.5, 0.0, 0.0]], dtype=np.float64)
+    assert compute_rmsd(pred, ref, ["C", "O"]) == pytest.approx(0.5, abs=1e-9)
+
+
+def test_element_count_mismatch_raises():
+    """A wrong-length element list is a caller bug, not a silent fallback."""
+    ref = _square_ring(0)
+    with pytest.raises(ValueError, match="elements has"):
+        compute_rmsd(ref, ref, ["C", "C"])


### PR DESCRIPTION
Closes the Python half of "fix the RMSD everywhere", per Bonhomme's call that the Hungarian is included.

## What was wrong

`FlexAID/LIB/calc_rmsd.c::calc_Hungarian_RMSD` builds one cost matrix per atom **type** and solves the assignment inside each type. The FlexAIDdS Python layer paired atoms **positionally**, so a symmetric ligand was penalised for an equivalent relabelling — a ring rotated by one vertex is the same pose and the same molecule.

`METHODOLOGY.md:36` already claimed our numbers were "symmetry-corrected". They were not.

## The effect is not cosmetic

Real `1gpk` poses from the tier1 artifact, pose-to-pose:

| pair | positional | symmetric | delta |
|---|---|---|---|
| flexaid_1.pdb | 3.3239 | 2.0507 | 1.2733 |
| flexaid_2.pdb | 4.0193 | 2.3609 | 1.6584 |
| flexaid_3.pdb | 4.5370 | 2.8929 | 1.6441 |
| flexaid_4.pdb | 2.0164 | 1.8368 | 0.1796 |

Against the 2.0 Å Astex bar this is the difference between pass and fail.

## What changed

- `extract_ligand_atoms_from_pdb` returns `(coords, elements)`. The old coords-only name is kept as a wrapper, so no caller breaks. Elements read from columns 77-78 with a fallback to the atom-name field — FlexAID pose PDBs carry no element columns, and this was verified against real artifacts (18 atoms, C/N/O).
- `_symmetry_permutation` solves the assignment **within each element only**. Carbon can never pair with oxygen.
- Wired at all three Python call sites, symmetry always on.

## The risk, and how it is pinned

The danger of this change is that it flatters results. Three tests exist for that specifically:

- `test_a_genuinely_displaced_pose_is_not_rescued` — a 3 Å translation stays 3 Å
- `test_elements_never_swap_across_types` — a C/O swap that would score 0.0 is forbidden and reports 2.0
- `test_correction_never_increases_rmsd` — bounded by the positional value, 20 random cases

## Verification

```
$ python3 -m pytest -q          1108 passed, 68 skipped
```

Full suite, not a scoped run. Not build-verified for C++ — this PR touches no C++; Fizz has `DatasetRunnerStats.cpp` separately.

## Review

Channel review is the gate. Not merging my own PR.

Author: Honey

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ligand RMSD calculations by accounting for chemically equivalent atom arrangements.
  - Preserved element matching during atom comparisons for more accurate results.
  - Added fallback element detection for pose files without element information.
  - Maintained compatibility with existing coordinate-only extraction workflows.

- **Tests**
  - Added coverage for symmetric ligands, atom permutations, element validation, and displacement accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->