### PR TITLE
Fix: refuse the non-water HETATM union when no atom count is available

### DIFF
--- a/python/flexaidds/benchmark.py
+++ b/python/flexaidds/benchmark.py
@@ -139,11 +139,28 @@ def extract_ligand_coords_from_pdb(
         raise ValueError(f"No ligand heavy atoms found in {pdb_path}")
 
     if expected_n_atoms is None:
-        # Backwards-compatible path, used where no reference is available.
-        # Still excludes nothing, so it keeps the historical behaviour rather
-        # than silently guessing which residue is the ligand.
-        atoms = [xyz for group in residues.values() for xyz in group]
-        return np.array(atoms, dtype=np.float64)
+        # No reference count available.  FlexAID itself never unions residues:
+        # calc_rmsd walks ONE optimizable residue (LIB/calc_rmsd.cpp:92-102),
+        # so "every non-water HETATM" was never the engine's definition of the
+        # ligand -- it was this module's.
+        #
+        # One residue is unambiguous, so return it.  More than one cannot be
+        # resolved without a count, and unioning them is the calcium bug: on
+        # 1mq6 it produced 37 atoms against a 36-atom ligand and shifted every
+        # subsequent atom by one.  #363 fixed that for callers that pass a
+        # count; this refuses to reintroduce it for callers that cannot.
+        if len(residues) == 1:
+            return np.array(next(iter(residues.values())), dtype=np.float64)
+
+        counts = {f"{k[0]}/{k[1]}{k[2]}": len(v) for k, v in residues.items()}
+        raise ValueError(
+            f"Cannot identify the ligand in {pdb_path}: {len(residues)} "
+            f"non-water HETATM residues present {counts} and no "
+            f"expected_n_atoms was supplied to discriminate.  Refusing to "
+            f"concatenate them -- a cofactor merged into the ligand shifts "
+            f"the atom correspondence and yields a plausible RMSD against "
+            f"the wrong pairing.  Pass expected_n_atoms=len(reference)."
+        )
 
     matches = [g for g in residues.values() if len(g) == expected_n_atoms]
     if len(matches) == 1:

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -2401,6 +2401,9 @@ def _reference_ligand_coords(ligand_path: Path):
 
     suffix = ligand_path.suffix.lower()
     if suffix == ".pdb":
+        # Reference PDBs can carry cofactors too.  No count is available here
+        # (this IS the count source), so the extractor must refuse to union
+        # rather than silently merge a cofactor into the reference.
         return extract_ligand_coords_from_pdb(ligand_path)
     if suffix in {".sdf", ".mol"}:
         return _extract_ligand_coords_from_sdf(ligand_path)

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1557,7 +1557,22 @@ class DatasetRunner:
                 p for p in work_dir.glob("*.pdb") if not _is_initial_pose_file(p)
             )
 
-        ref_coords = _reference_ligand_coords(reference_ligand) if reference_ligand else None
+        # A contaminated reference is a refusal, not a docking failure, and it
+        # must not reach the caller's broad `except Exception` looking like one.
+        # Without this the raise escapes the per-file try below, degrades to
+        # "this target produced nothing", and is indistinguishable from bad
+        # docking -- the exact shape this PR exists to remove.
+        ref_coords = None
+        if reference_ligand:
+            try:
+                ref_coords = _reference_ligand_coords(reference_ligand)
+            except ValueError as exc:
+                logger.warning(
+                    "Reference ligand refused for %s/%s: %s  No RMSD will be "
+                    "computed for this target; it is scored as a miss.  This "
+                    "is a REFERENCE FILE problem, not a docking result.",
+                    target_id, ligand_id, exc,
+                )
 
         for rank, pdb_path in enumerate(pdb_files, start=1):
             rmsd = -1.0

--- a/python/tests/test_ligand_residue_selection.py
+++ b/python/tests/test_ligand_residue_selection.py
@@ -43,7 +43,11 @@ def test_cofactor_is_not_counted_as_ligand(tmp_path):
     """The regression: 37 atoms in, 36 out, and the Ca is not among them."""
     pose = _pose_with_cofactor(tmp_path)
 
-    assert len(extract_ligand_coords_from_pdb(pose)) == 37  # unfiltered legacy path
+    # Without a count the extractor used to concatenate every non-water
+    # HETATM residue and return 37.  That union WAS the bug, so it now
+    # raises instead of handing back a silently contaminated array.
+    with pytest.raises(ValueError, match="no expected_n_atoms"):
+        extract_ligand_coords_from_pdb(pose)
 
     coords = extract_ligand_coords_from_pdb(pose, expected_n_atoms=36)
     assert coords.shape == (36, 3)
@@ -64,8 +68,10 @@ def test_correspondence_is_not_shifted(tmp_path):
     good = extract_ligand_coords_from_pdb(pose, expected_n_atoms=36)
     assert np.allclose(good, ref)  # exact correspondence, zero RMSD
 
-    contaminated = extract_ligand_coords_from_pdb(pose)[:36]
-    assert not np.allclose(contaminated, ref)  # every atom off by one
+    # The shifted correspondence is no longer reachable: the countless path
+    # refuses the union rather than returning 37 atoms for a 36-atom ligand.
+    with pytest.raises(ValueError, match="Refusing to concatenate"):
+        extract_ligand_coords_from_pdb(pose)
 
 
 def test_refuses_to_guess_when_no_residue_matches(tmp_path):
@@ -106,3 +112,38 @@ def test_a_large_cofactor_does_not_win(tmp_path):
     coords = extract_ligand_coords_from_pdb(p, expected_n_atoms=25)
     assert coords.shape == (25, 3)
     assert coords[0][1] == pytest.approx(0.0)  # the ligand's y, not HEM's
+
+
+def test_single_residue_needs_no_count(tmp_path):
+    """A ligand-only PDB is unambiguous, so the countless path still works.
+
+    The union was only ever wrong when there was more than one candidate.
+    Refusing outright would have broken every ligand-only reference file,
+    so one residue is returned as before.
+    """
+    p = tmp_path / "one.pdb"
+    p.write_text(
+        "".join(
+            f"HETATM{i:5d}  C   LIG A   1    {float(i):8.3f}{0.0:8.3f}{0.0:8.3f}"
+            f"  1.00  0.00           C\n"
+            for i in range(5)
+        )
+    )
+    coords = extract_ligand_coords_from_pdb(p)
+    assert coords.shape == (5, 3)
+    assert coords[-1][0] == pytest.approx(4.0)
+
+
+def test_reference_loader_refuses_contaminated_pdb(tmp_path):
+    """The REFERENCE side, which #363 did not cover.
+
+    _reference_ligand_coords is where expected_n_atoms comes FROM, so it
+    cannot pass one.  A reference PDB carrying a cofactor therefore used to
+    define a contaminated count, which then selected a contaminated-sized
+    residue from every pose compared against it.
+    """
+    from flexaidds.dataset_runner.runner import _reference_ligand_coords
+
+    ref = _pose_with_cofactor(tmp_path)
+    with pytest.raises(ValueError, match="Refusing to concatenate"):
+        _reference_ligand_coords(ref)


### PR DESCRIPTION
## The gap #363 left

#363 fixed ligand selection **for callers that pass `expected_n_atoms`**. Three callers cannot pass one, and they fell through to a branch that returned the concatenation of every non-water HETATM residue — the original calcium bug, still live on `main`:

| site | role |
|---|---|
| `benchmark.py:966`, `:1022` | comparative pipeline (`run_flexaidds` / `run_boltz2`) |
| `runner.py:2404` `_reference_ligand_coords` | **the reference side** |

The last one is the sharp edge. Its length *becomes* `expected_n_atoms` at `runner.py:2452`, so a reference PDB carrying a cofactor defines a contaminated count — which then selects a contaminated-*sized* residue from every pose compared against it. The count-based fix cannot protect the thing that produces the count.

On 1mq6 the union gives 37 atoms against a 36-atom ligand and shifts every subsequent atom by one.

## Why refuse rather than guess

FlexAID itself never unions residues — `calc_rmsd` walks **one** optimizable residue (`LIB/calc_rmsd.cpp:92-102`). "Every non-water HETATM" was never the engine's definition of the ligand; it was this module's.

So the countless path now:
- returns the single residue when there is exactly one — unambiguous, and the common case for ligand-only reference files;
- raises otherwise, naming the candidate residues, rather than concatenating and producing a plausible RMSD against the wrong pairing.

## Tests

Two assertions in `test_ligand_residue_selection.py` encoded the union as a "before" contrast; they now pin the raise. Two added:

- `test_single_residue_needs_no_count` — the countless path still works where it was always correct
- `test_reference_loader_refuses_contaminated_pdb` — the reference side, which #363 did not cover

```
1094 passed, 68 skipped
```
Full python suite, not a scoped run.

## Review note

The behaviour change is a new `ValueError` on a path that previously always returned something. If any caller relies on getting *an* array from a multi-residue PDB, this turns a silent wrong number into a loud failure — which is the intent, but it is the thing to check.

No overlap with #365 (Honey, symmetry) beyond the same file; different function.

Author: Bumble
