### PR TITLE
Docs: correct the RMSD engine claim and record the two-harness divergence

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -38,20 +38,30 @@ numbers into other files — reference `METHODOLOGY.md §N`.
   / `_INI.pdb` RMSD as the result. In-place is what the engine does (`LIB/calc_rmsd.cpp:92-102`,
   and the same in the original FlexAID); a superposed value measures shape, not placement, and
   is not the quantity the 2.0 Å criterion is defined on.
-- **RMSD engine — read this before quoting a number.** There are TWO instruments and they are
-  not interchangeable:
-  - **In-repo metric** (`python/flexaidds/benchmark.py::compute_rmsd`, used by
-    `dataset_runner` and by every CI tier). In-place since #354. Ligand selected by residue
-    against the reference atom count since #363/#366 — *not* by unioning every non-water
-    HETATM, which merges cofactors into the ligand. **Symmetry correction is being added in
-    #365; until it lands this metric is positional and systematically overstates error on
-    symmetric ligands.**
-  - **Offline reference scorer** (`benchmarks/astex_repro/score_reference.py`): spyrmsd
-    graph-isomorphism, element-blocked Hungarian fallback when spyrmsd raises (logged).
-    **No workflow and no gate invokes it** — it is run by hand, after the fact.
-  - Consequence: a number produced by the gate and a number produced by
-    `score_reference.py` are different measurements. State which one you used. The two have
-    been observed to flip individual success calls (`docs/audit/26h-swarm/9971dff7e.md`).
+- **RMSD engine — read this before quoting a number.** There are **THREE** instruments in this
+  tree and they are not interchangeable. An unlabelled RMSD is not reportable:
+  1. **In-repo metric** — `python/flexaidds/benchmark.py::compute_rmsd`, used by
+     `dataset_runner` and by **every CI tier**. This is the gate. In-place since #354. Ligand
+     selected by residue against the reference atom count since #363/#366 — *not* by unioning
+     every non-water HETATM, which merges cofactors into the ligand. Symmetry correction added
+     in #365 (element-blocked assignment, `scipy`); **before #365 this metric was positional
+     and systematically overstated error on symmetric ligands.**
+  2. **Offline reference scorer** — `benchmarks/astex_repro/score_reference.py`: spyrmsd
+     graph-isomorphism, heavy atoms, pose selection on PDB serial ≥ 90000, element-blocked
+     Hungarian fallback only when spyrmsd raises (logged). Treat this as the strongest
+     instrument.
+  3. **Offline permissive scorer** — `benchmarks/astex_repro/score_offline.py`: element-blocked
+     Hungarian, no graph isomorphism. **The repo's own audit records it as over-permissive:
+     1HP0 reads success under `score_offline.py` and failure under `score_reference.py`**
+     (`docs/audit/26h-swarm/9971dff7e.md`). Do not quote it as a docking-power number.
+  - **Neither offline scorer is wired into anything.** Searched: `.github/workflows/`,
+    `benchmarks/` (including `run.py`), and `python/`. The only invocation recorded anywhere is
+    a manual one — `benchmarks/astex_repro/MONITORING.md:8` says "SCORING: python3
+    score_reference.py". So the strongest instrument is the one nothing runs, and the gate runs
+    the one no document described until this section.
+  - `score_offline.py`'s partial `poster_metric_results.csv` is still in-tree beside
+    `score_reference.py`'s. The audit's standing recommendation is to deprecate the permissive
+    one; until that happens, **check which CSV you are reading.**
 
 ---
 
@@ -69,7 +79,7 @@ simply different runs, and a number from one does not transfer to the other.
 | `intermolecular_clash_ratio` | 0.0 | 0.75 |
 | `coarse_init.enabled` | **OFF** | ON (hardcoded, `DatasetRunner.cpp:6036`) |
 | `mif_enabled` | **OFF** | ON (hardcoded, `DatasetRunner.cpp:6012`) |
-| retained poses | 10 | 51 per restart |
+| retained poses | 10 | 51 per restart *(OBSERVED, not cited: counted from two artifacts, no configuring parameter identified — do not treat as a configured divergence until one is)* |
 
 **The consequence that matters:** with `mif_enabled = 0` and `grid_prio_percent = 100.0`, the
 guard at `top.cpp:1836` makes `initialize_direct_mif` return immediately. **The gate docks

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -33,11 +33,78 @@ numbers into other files — reference `METHODOLOGY.md §N`.
 - **Security channel off for benchmarks:** `FLEXAIDDS_NO_SEC=1`.
 - **Thread rule:** workers × omp-threads ≤ physical P-cores. On this host use `--threads 1
   --omp-threads 4` (or 6). Never oversubscribe.
-- **RMSD reporting:** report **rank-0 elected pose RMSD** (the elected `_0.pdb`), symmetry-corrected,
-  heavy-atom, 2.0 Å cutoff. NEVER report seed-elitism / `_INI.pdb` RMSD as the result.
-- **RMSD engine:** spyrmsd 0.9.0 in the `python` conda env
-  (`/Users/lp.more/.claude-science/conda/envs/python/bin/python`). Fallback: element-blocked
-  Hungarian only if spyrmsd raises (must be logged).
+- **RMSD reporting:** report **rank-0 elected pose RMSD** (the elected `_0.pdb`), heavy-atom,
+  2.0 Å cutoff, **in-place in the receptor frame — never superposed**. NEVER report seed-elitism
+  / `_INI.pdb` RMSD as the result. In-place is what the engine does (`LIB/calc_rmsd.cpp:92-102`,
+  and the same in the original FlexAID); a superposed value measures shape, not placement, and
+  is not the quantity the 2.0 Å criterion is defined on.
+- **RMSD engine — read this before quoting a number.** There are TWO instruments and they are
+  not interchangeable:
+  - **In-repo metric** (`python/flexaidds/benchmark.py::compute_rmsd`, used by
+    `dataset_runner` and by every CI tier). In-place since #354. Ligand selected by residue
+    against the reference atom count since #363/#366 — *not* by unioning every non-water
+    HETATM, which merges cofactors into the ligand. **Symmetry correction is being added in
+    #365; until it lands this metric is positional and systematically overstates error on
+    symmetric ligands.**
+  - **Offline reference scorer** (`benchmarks/astex_repro/score_reference.py`): spyrmsd
+    graph-isomorphism, element-blocked Hungarian fallback when spyrmsd raises (logged).
+    **No workflow and no gate invokes it** — it is run by hand, after the fact.
+  - Consequence: a number produced by the gate and a number produced by
+    `score_reference.py` are different measurements. State which one you used. The two have
+    been observed to flip individual success calls (`docs/audit/26h-swarm/9971dff7e.md`).
+
+---
+
+## 0.1 The CI gate and the campaign path are NOT the same experiment
+
+Two harnesses invoke the same engine with different configuration. Neither is wrong; they are
+simply different runs, and a number from one does not transfer to the other.
+
+| | **CI / tier1 gate** | **Campaign** |
+|---|---|---|
+| entry point | `python -m benchmarks.run` (`.github/workflows/benchmark-tier1.yml`) | `benchmark_datasets` → `DatasetRunner` |
+| config file | **none** — the engine takes its compiled-in defaults | writes `dock_config.json` |
+| `permeability` | 1.0 (`top.cpp:601`) | 0.9 |
+| `normalize_area` | 0 (`top.cpp:585`) | true |
+| `intermolecular_clash_ratio` | 0.0 | 0.75 |
+| `coarse_init.enabled` | **OFF** | ON (hardcoded, `DatasetRunner.cpp:6036`) |
+| `mif_enabled` | **OFF** | ON (hardcoded, `DatasetRunner.cpp:6012`) |
+| retained poses | 10 | 51 per restart |
+
+**The consequence that matters:** with `mif_enabled = 0` and `grid_prio_percent = 100.0`, the
+guard at `top.cpp:1836` makes `initialize_direct_mif` return immediately. **The gate docks
+without ever building its pocket field.** Every green tier1 tick to date passed under that
+configuration.
+
+Rules that follow:
+
+- **Never compare an RMSD from one path against an RMSD from the other** without stating the
+  divergences above. On 1mq6 the two paths differ by 7.5 Å and the cause is not yet isolated —
+  four of the six divergences can move a centroid.
+- A cross-path result is not evidence until the divergence responsible has been ablated.
+- Changing either harness's defaults is a methodology change: it lands here first.
+
+## 0.2 Provenance — what a receipt must capture
+
+Three tiers, by how a parameter can be recovered after the fact:
+
+| tier | example | recoverable from |
+|---|---|---|
+| **FIXED** | anything written to `dock_config.json` | the artifact |
+| **VARIABLE** | the COM floor, via `CF.com` in the pose | the poses themselves |
+| **LOST** | `permeability`, `pb_pocket_weight`, `pb_clash_weight` | **nothing** |
+
+**The rule, in one line: anything that goes through `getenv` and nowhere else is gone the moment
+the shell exits.** Those three are read from the environment and never written to any config or
+receipt, so a completed run cannot be told apart from one at different weights.
+
+- **Every run MUST emit its `getenv`-only scoring environment beside its results** (sidecar or
+  `RUN_RECEIPT`). This blocked two separate investigations that had the artifacts in hand.
+- The two harnesses currently capture **disjoint** provenance fields, so cross-path comparison
+  has no common provenance even where both wrote something.
+- `ops/reference_config.env` pins `FLEXAIDDS_PARALLEL_RESTARTS=0` but **not**
+  `FLEXAIDDS_RESTARTS` — a campaign run against it silently takes the compiled-in default of 5,
+  not the published Astex 10. Pin it explicitly in any run you intend to publish.
 
 ---
 
@@ -77,7 +144,8 @@ Purpose: prove a determinism/perf change does not regress docking accuracy.
 - **Engine selection:** `FLEXAIDDS_BINARY=<engine>`; `benchmark_datasets --benchmark astex
   --only-codes <list>` subsets targets. (Direct-CLI per-target is acceptable when the harness's
   oracle-site guard blocks a blind run — document which was used.)
-- **Metric:** top-1 rank-0 RMSD, spyrmsd, 2.0 Å. Report per-target and aggregate success.
+- **Metric:** top-1 rank-0 RMSD, 2.0 Å, in-place. Name the instrument (§0: in-repo metric vs
+  `score_reference.py`) — an unlabelled RMSD is not reportable.
 - **Acceptance:** candidate within noise of baseline; **no target flips success→fail** attributable
   to the change. A full landing decision uses the full 85 × 10-restart protocol; a fast pre-check
   may use a documented subset.


### PR DESCRIPTION
Slice C. Docs only — no code.

## 1. `METHODOLOGY.md` described an instrument the gate never runs

§0 said the metric was **"symmetry-corrected"** and named **spyrmsd 0.9.0** as the engine. Neither is what the gate executes.

spyrmsd is not absent — `benchmarks/astex_repro/score_reference.py` uses it (graph-isomorphism, Hungarian fallback, logged). But **no workflow and no gate invokes that file.** It is run by hand, after the fact. The gate uses `python/flexaidds/benchmark.py::compute_rmsd`, which is positional until #365 lands.

So there are two instruments, they disagree — `docs/audit/26h-swarm/9971dff7e.md` records success calls flipping between them — and the document named one while the gate ran the other. §0 now describes both, says which path uses which, and requires any reported RMSD to name its instrument. §3's metric line gets the same treatment.

§0 also now states **in-place, receptor frame, never superposed** explicitly, with the engine citation (`LIB/calc_rmsd.cpp:92-102`). That is what the original FlexAID does and what the 2.0 Å criterion is defined on.

## 2. New §0.1 — the gate and the campaign are not the same experiment

Six divergent parameters, tabulated. The gate passes **no config file at all**, so it takes compiled-in defaults. The one that matters:

```
top.cpp:454   grid_prio_percent = 100.0f
top.cpp:1836  if (!(FA->mif_enabled || FA->grid_prio_percent < 100.0f)) return;
```

`mif_enabled = 0` and `100.0 < 100.0` are both false — **`initialize_direct_mif` returns immediately. The PR gate docks without ever building its pocket field.**

## 3. New §0.2 — provenance

FIXED (in `dock_config.json`) / VARIABLE (recoverable from the poses via `CF.com`) / LOST (`getenv`-only). `permeability`, `pb_pocket_weight`, `pb_clash_weight` are LOST: a finished run cannot be distinguished from one at different weights. This blocked two investigations that had the artifacts in hand.

Also records that `ops/reference_config.env` pins `FLEXAIDDS_PARALLEL_RESTARTS` but **not** `FLEXAIDDS_RESTARTS`, so a campaign run against it silently takes the compiled-in 5 rather than the published Astex 10.

## Verification

Every line number re-checked at this HEAD rather than carried from discussion:

```
top.cpp:601   FA->permeability=1.0;
top.cpp:585   FA->normalize_area=0;
top.cpp:454   FA->grid_prio_percent = 100.0f;
top.cpp:1836  if (!(FA->mif_enabled || FA->grid_prio_percent < 100.0f)) return;
DatasetRunner.cpp:6012  "mif_enabled": true
DatasetRunner.cpp:6036  "coarse_init" ... "enabled": true
```

The last two were **reversed** in the channel discussion; the table here has them the right way round.

## Note

The §0 wording says #365 is landing. If #365 is revised or dropped, that sentence needs revising with it — it is the one forward-looking claim in the file.

Author: Bumble
