### PR TITLE
Perf: FlexAID-Fast — accelerate the classic docking core (P0/P1+P2/P3/P5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ Testing/
 validation_evidence/**/test_cmaes_search_clang
 validation_evidence/**/*.o
 flexaid_out.rrg
+
+# Claude Code agent worktrees (ephemeral, per-session)
+.claude/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,6 +665,38 @@ if(ENABLE_TENCOM_TOOL)
     message(STATUS "Ligand tENCoM/Eigen pose validator enabled — build target: ligand_tencom_pose")
 endif()
 
+# ─── P5: NRGRank two-stage screening driver (flexaid_screen) ───────────────────
+# Standalone CLI that runs the rigid NRGRank coarse screen (CoarseScreen /
+# TwoStageScreen) as a pre-filter in front of the expensive GA. Reuses the same
+# classes exercised by test_coarse_screen; no coupling to the GA/top.cpp engine.
+option(ENABLE_TWO_STAGE_SCREEN "Build the NRGRank two-stage screening CLI (flexaid_screen)" ON)
+if(ENABLE_TWO_STAGE_SCREEN
+   AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/LIB/two_stage_screen_main.cpp"
+   AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/LIB/CoarseScreen.cpp"
+   AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/LIB/TwoStageScreen.cpp")
+    add_executable(flexaid_screen
+        LIB/two_stage_screen_main.cpp
+        LIB/CoarseScreen.cpp
+        LIB/TwoStageScreen.cpp
+    )
+    target_include_directories(flexaid_screen PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/LIB)
+    set_target_properties(flexaid_screen PROPERTIES
+        CXX_STANDARD 23 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
+    if(MSVC)
+        target_compile_options(flexaid_screen PRIVATE /O2)
+        target_compile_definitions(flexaid_screen PRIVATE
+            _CRT_SECURE_NO_WARNINGS _USE_MATH_DEFINES NOMINMAX)
+    else()
+        target_compile_options(flexaid_screen PRIVATE -O3)
+    endif()
+    flexaids_configure_simd(flexaid_screen)
+    if(FLEXAIDS_USE_OPENMP AND OpenMP_CXX_FOUND)
+        target_link_libraries(flexaid_screen PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+    message(STATUS "Two-stage screening CLI enabled — build target: flexaid_screen")
+endif()
+
 # ─── VoronoiCFBatch benchmark (Task 2.3) ───────────────────────────────────────
 # VoronoiCFBatch.h is header-only; the benchmark binary exercises the std::span
 # batch interface and prints a serial-vs-OpenMP speedup table.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,7 @@ flexaids_configure_simd(FlexAID)
 # while the FlexAIDdS target carried an aggressive LTO + INTERPROCEDURAL_OPTIMIZATION
 # + -march=native/-mcpu=native + -DNDEBUG + strip block. flexaids_apply_fast_optimization
 # lifts that same block onto FlexAID, guarded by BUILD_FLEXAID_FAST (default OFF per
+# METHODOLOGY §1 — see the rationale at its option() site; also
 # force-disabled under coverage/sanitizer builds by the SAME guard used for
 # BUILD_FLEXAIDDS_FAST — see cmake/FlexAIDOptions.cmake). FLEXAID_PGO adds optional
 # profile-generate/profile-use instrumentation. Both are no-ops when disabled.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,17 @@ else()
 endif()
 flexaids_configure_simd(FlexAID)
 
+# ─── P0 build-level wins: lift the FlexAIDdS LTO/native/NDEBUG block onto FlexAID ─
+# The classic FlexAID target historically shipped with only -O3 -ffast-math (above)
+# while the FlexAIDdS target carried an aggressive LTO + INTERPROCEDURAL_OPTIMIZATION
+# + -march=native/-mcpu=native + -DNDEBUG + strip block. flexaids_apply_fast_optimization
+# lifts that same block onto FlexAID, guarded by BUILD_FLEXAID_FAST (default ON, but
+# force-disabled under coverage/sanitizer builds by the SAME guard used for
+# BUILD_FLEXAIDDS_FAST — see cmake/FlexAIDOptions.cmake). FLEXAID_PGO adds optional
+# profile-generate/profile-use instrumentation. Both are no-ops when disabled.
+flexaids_apply_fast_optimization(FlexAID)
+flexaids_apply_pgo(FlexAID)
+
 # Stage runtime data files next to the FlexAID binary (see note on the
 # FlexAIDdS target): the engine resolves MC_st0r5.2_6.dat / AMINO.def /
 # NUCLEOTIDES.def relative to the executable's own directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ flexaids_configure_simd(FlexAID)
 # The classic FlexAID target historically shipped with only -O3 -ffast-math (above)
 # while the FlexAIDdS target carried an aggressive LTO + INTERPROCEDURAL_OPTIMIZATION
 # + -march=native/-mcpu=native + -DNDEBUG + strip block. flexaids_apply_fast_optimization
-# lifts that same block onto FlexAID, guarded by BUILD_FLEXAID_FAST (default ON, but
+# lifts that same block onto FlexAID, guarded by BUILD_FLEXAID_FAST (default OFF per
 # force-disabled under coverage/sanitizer builds by the SAME guard used for
 # BUILD_FLEXAIDDS_FAST — see cmake/FlexAIDOptions.cmake). FLEXAID_PGO adds optional
 # profile-generate/profile-use instrumentation. Both are no-ops when disabled.
@@ -1572,6 +1572,21 @@ flexaids_add_unit_test(test_protocol_config
     endif()
     flexaids_configure_msvc_test(test_vcontacts_geometry)
     add_test(NAME VcontactsGeometryTests COMMAND test_vcontacts_geometry)
+
+    # test_vcontacts_calc_areas_degenerate — degenerate-face tripwire for the
+    # PR#370 float spherical-excess area path (self-contained numerical check,
+    # no engine linkage).  See the file header for rationale.
+    add_executable(test_vcontacts_calc_areas_degenerate
+        tests/test_vcontacts_calc_areas_degenerate.cpp
+    )
+    target_link_libraries(test_vcontacts_calc_areas_degenerate PRIVATE GTest::gtest_main)
+    if(MSVC)
+        target_compile_options(test_vcontacts_calc_areas_degenerate PRIVATE /O2)
+    else()
+        target_compile_options(test_vcontacts_calc_areas_degenerate PRIVATE -O2)
+    endif()
+    flexaids_configure_msvc_test(test_vcontacts_calc_areas_degenerate)
+    add_test(NAME VcontactsCalcAreasDegenerateTests COMMAND test_vcontacts_calc_areas_degenerate)
 
     # test_cleft_cavity — CleftDetector + CavityDetect unit tests
     add_executable(test_cleft_cavity

--- a/LIB/AtomSoA.h
+++ b/LIB/AtomSoA.h
@@ -112,4 +112,32 @@ inline float distance2(const AtomArrays& a, int i, const AtomArrays& b, int j) {
     return dx * dx + dy * dy + dz * dz;
 }
 
+// Portable 4-wide squared distance between one point (bx,by,bz) and four
+// atoms stored as SoA float arrays ax[4]/ay[4]/az[4].  Result -> out[4].
+//
+// Why this lives here (P1/P2 scoring track):  the Voronoi hot-path SoA route
+// in get_contlist4() needs a 4-lane squared-distance kernel on *every* target
+// ISA.  simd_distance.h only exposes a 4-wide `distance2_1x4` in its SSE4.2 /
+// NEON / scalar branches — the AVX2 and AVX-512 branches provide 1x8 / 1x16
+// only, so `simd::distance2_1x4` is undefined precisely under -mavx2/-mavx512
+// (the x86 production configs).  That undefined symbol is what kept
+// FLEXAIDS_USE_SOA_DISTANCES from compiling (hence "experimental / OFF").
+// This plain-loop helper is trivially auto-vectorised by the compiler under
+// -O3 and is ISA-portable, so the SoA path builds and can be defaulted ON
+// without touching simd_distance.h (out of the scoring track's file scope).
+//
+// Numerics: identical float32 arithmetic to the scalar SoA tail
+// (dx*dx+dy*dy+dz*dz per lane) — no reassociation beyond what the scalar
+// path already does, so this introduces no drift relative to the existing
+// FLEXAIDS_USE_SOA_DISTANCES float path.
+inline void distance2_1x4(const float* ax, const float* ay, const float* az,
+                          float bx, float by, float bz, float* out) noexcept {
+    for (int k = 0; k < 4; ++k) {
+        const float dx = ax[k] - bx;
+        const float dy = ay[k] - by;
+        const float dz = az[k] - bz;
+        out[k] = dx * dx + dy * dy + dz * dz;
+    }
+}
+
 } // namespace atom_soa

--- a/LIB/Vcontacts.cpp
+++ b/LIB/Vcontacts.cpp
@@ -4,9 +4,13 @@
 #include "fileio.h"
 #include <algorithm>
 #include <cstdlib>
+#include <cstdint>
+#include <cmath>
+#include <vector>
 #include <random>
 #ifdef FLEXAIDS_USE_SOA_DISTANCES
 #include "simd_distance.h"
+#include "AtomSoA.h"  // atom_soa::distance2_1x4 (ISA-portable 4-wide kernel)
 #include <cmath>     // fabs
 #endif
 
@@ -883,14 +887,24 @@ void calc_areas(vertex poly[], const vertex* centerpt, float rado, int NC, int N
 	double maxSAS;          // maximum solvent exposed surface, no atoms other than engulfing.
 	vertex ptB, ptC; // arc point intersections
 	int    currpt, nextpt;
-	double cosNN1[MAX_CONT];      // angle between vertex N and vertex N+1 
-	double cosNzero[MAX_CONT];    // angle between vertex N and vertex N+1 
-	double tanprod;         // product of tangents
+	double cosNN1[MAX_CONT];      // angle between vertex N and vertex N+1
+	double cosNzero[MAX_CONT];    // angle between vertex N and vertex N+1
 	int    v0, va, vb;      // vertices for arc calculation
-    
-	double U,V,W,X;
-	double tansqrS, tansqrSA, tansqrSB, tansqrSC;
-    
+	// P2.1/P2.3: the per-triangle tangent-formula scratch (U,V,W,X, the four
+	// tansqr terms and tanprod) is now computed in float — see the triangle
+	// loop below. Halves the width of the 5x sqrt + atan(sqrt) transcendental
+	// chain and lets the compiler pack the four U/V/W/X roots into one SIMD
+	// sqrt. Ranking-affecting float drift (allowed); accumulator `area` and the
+	// cosine inputs stay double to bound the error.
+
+	// P1.4: hoist sphere-area invariants out of the per-face loop. All are
+	// bit-identical to the original inline expressions (2.0f==2.0/4.0f==4.0 as
+	// doubles, left-to-right association preserved), just computed once.
+	const double two_pi_rado   = 2.0f*PI*rado;        // 2*pi*r     (cap terms)
+	const double two_pi_rado2  = two_pi_rado*rado;    // 2*pi*r^2
+	const double four_pi_rado2 = 4.0f*PI*rado*rado;   // 4*pi*r^2
+	const double four_rado2    = 4.0*rado*rado;       // 4*r^2      (triangle)
+
 	engflag = 'N';
 	epi = 0;
     
@@ -926,12 +940,12 @@ void calc_areas(vertex poly[], const vertex* centerpt, float rado, int NC, int N
 		// if there are no points on a valid contact, area is spherical cap
 		if(NP == 0) {
 			if(test_point(centerpt[planeX].xi, cont, NC, rado, planeX, -1, -1) == 'Y') {
-				cont[planeX].area = 2.0f*PI*rado*(rado-centerpt[planeX].dist);
+				cont[planeX].area = two_pi_rado*(rado-centerpt[planeX].dist);
 			}
 		} else if(NP == 2) {  // only two contact points, check which part of arc
 			if(test_point(centerpt[planeX].xi, cont, NC, rado, planeX, -1, -1) == 'Y') { // area is (cap - arc)
-				cont[planeX].area = 2.0f*PI*rado*(rado-centerpt[planeX].dist)
-					- spherical_arc(&centerpt[planeX], &poly[ptorder[planeX].pt[0]], 
+				cont[planeX].area = two_pi_rado*(rado-centerpt[planeX].dist)
+					- spherical_arc(&centerpt[planeX], &poly[ptorder[planeX].pt[0]],
 							&poly[ptorder[planeX].pt[1]], rado);
 			} else {            // area is arc.
 				cont[planeX].area = spherical_arc(&centerpt[planeX], &poly[ptorder[planeX].pt[0]], 
@@ -957,18 +971,32 @@ void calc_areas(vertex poly[], const vertex* centerpt, float rado, int NC, int N
 			}
             
 			// ----- calculate area of triangles in face -----
+			// P2.1/P2.3: float tangent-formula math. The four spherical-excess
+			// roots U,V,W,X are independent and packed into one array so the
+			// compiler emits a single 4-wide sqrt (SSE/AVX) or vsqrt (NEON); the
+			// remaining tanprod sqrt and the atan run in float. 0.125f == 1/8
+			// exactly, so replacing /8.0 costs no extra rounding. Inputs cast
+			// from the double cosines; `area` accumulates in double.
 			for(vi=1; vi<(NP-1); ++vi) {
-				U = sqrt((1+cosNzero[vi])*(1+cosNN1[vi])*(1+cosNzero[vi+1])/8.0);
-				V = sqrt((1-cosNzero[vi])*(1-cosNN1[vi])*(1+cosNzero[vi+1])/8.0);
-				W = sqrt((1-cosNzero[vi])*(1+cosNN1[vi])*(1-cosNzero[vi+1])/8.0);
-				X = sqrt((1+cosNzero[vi])*(1-cosNN1[vi])*(1-cosNzero[vi+1])/8.0);
-				tansqrS  = (1-U+V+W+X)/(1+U-V-W-X);
-				tansqrSA = (1-U-V-W+X)/(1+U+V+W-X);
-				tansqrSB = (1-U-V+W-X)/(1+U+V-W+X);
-				tansqrSC = (1-U+V-W-X)/(1+U-V+W+X);
-				tanprod = sqrt(tansqrS*tansqrSA*tansqrSB*tansqrSC);
-				if(tanprod > 0.0) {
-					area += 4.0*rado*rado*atan(sqrt(tanprod));
+				const float c0 = (float)cosNzero[vi];
+				const float c1 = (float)cosNN1[vi];
+				const float c2 = (float)cosNzero[vi+1];
+				float rad4[4] = {
+					(1.0f+c0)*(1.0f+c1)*(1.0f+c2)*0.125f,
+					(1.0f-c0)*(1.0f-c1)*(1.0f+c2)*0.125f,
+					(1.0f-c0)*(1.0f+c1)*(1.0f-c2)*0.125f,
+					(1.0f+c0)*(1.0f-c1)*(1.0f-c2)*0.125f
+				};
+				float root4[4];
+				for(int q=0; q<4; ++q) root4[q] = std::sqrt(rad4[q]);
+				const float U = root4[0], V = root4[1], W = root4[2], X = root4[3];
+				const float tansqrS  = (1.0f-U+V+W+X)/(1.0f+U-V-W-X);
+				const float tansqrSA = (1.0f-U-V-W+X)/(1.0f+U+V+W-X);
+				const float tansqrSB = (1.0f-U-V+W-X)/(1.0f+U+V-W+X);
+				const float tansqrSC = (1.0f-U+V-W-X)/(1.0f+U-V+W+X);
+				const float tanprod = std::sqrt(tansqrS*tansqrSA*tansqrSB*tansqrSC);
+				if(tanprod > 0.0f) {
+					area += four_rado2*std::atan(std::sqrt(tanprod));
 				}
 			}
             
@@ -1041,8 +1069,8 @@ void calc_areas(vertex poly[], const vertex* centerpt, float rado, int NC, int N
 		// optimizable
         
 		if(epi == 1) {
-			cont[engplane[0]].area = 2.0f*PI*rado*(rado+cont[engplane[0]].dist);
-		}else if(epi == 2) { 
+			cont[engplane[0]].area = two_pi_rado*(rado+cont[engplane[0]].dist);
+		}else if(epi == 2) {
             
 			//printf("engplane[0]=%d engplane[1]=%d\n",engplane[0],engplane[1]);
 			//printf("cont[engplane[0]] Ai[0]=%.3f Ai[1]=%.3f Ai[2]=%.3f Ai[3]=%.3f\n",cont[engplane[0]].Ai[0],cont[engplane[0]].Ai[1],cont[engplane[0]].Ai[2],cont[engplane[0]].Ai[3]);
@@ -1052,21 +1080,21 @@ void calc_areas(vertex poly[], const vertex* centerpt, float rado, int NC, int N
 			//printf("cont[engplane[1]] area=%.3f dist=%.3f\n",cont[engplane[1]].area,cont[engplane[1]].dist);
             
 			if(solve_2xS(&cont[engplane[0]],&cont[engplane[1]], rado, ptB.xi, ptC.xi)== -1) {
-				cont[engplane[0]].area = 2.0f*PI*rado*rado;
-				cont[engplane[1]].area = 2.0f*PI*rado*rado;
+				cont[engplane[0]].area = two_pi_rado2;
+				cont[engplane[1]].area = two_pi_rado2;
 			}else {
 				ptB.dist = rado;
 				ptC.dist = rado;
 				maxSAS = spherical_arc(&centerpt[engplane[0]], &ptB, &ptC, rado);
 				maxSAS += spherical_arc(&centerpt[engplane[1]], &ptB, &ptC, rado);
-				cont[engplane[0]].area = 2.0f*PI*rado*rado - 0.5*maxSAS;
-				cont[engplane[1]].area = 2.0f*PI*rado*rado - 0.5*maxSAS;
+				cont[engplane[0]].area = two_pi_rado2 - 0.5*maxSAS;
+				cont[engplane[1]].area = two_pi_rado2 - 0.5*maxSAS;
 			}
 		} else if(epi>=3) {
 			// no exposed surface if there are three or more engulfing contacts 
 			for(planeX=0; planeX<NC; ++planeX) {
 				if(cont[planeX].flag == 'E') {
-					cont[planeX].area = 4.0f*PI*rado*rado/epi;
+					cont[planeX].area = four_pi_rado2/epi;
 				} else {
 					cont[planeX].area = 0.0f;
 				}
@@ -1770,7 +1798,26 @@ atomindex* index_protein(FA_Global* FA,atom* atoms,resid* residue,atomsas* Calc,
 			}
 		}
 	}
-	memset(box,0,dim3*sizeof(atomindex));
+	// ── P1.1: box zeroing via epoch stamp instead of a full per-call memset ──
+	// The old `memset(box,0,dim3*sizeof(atomindex))` cleared BOTH fields of all
+	// dim3 boxes on every Vcontacts call (millions of calls/dock). But of the
+	// two fields only `nument` actually needs pre-zeroing before the counting
+	// loop below: `first` is unconditionally rewritten by the prefix-sum loop,
+	// and `nument` is reset to 0 for ALL boxes by the "clear array for
+	// recounting" loop before the fill loop (so downstream get_contlist4 still
+	// sees nument==0 for empty neighbour boxes — unchanged).
+	//
+	// We therefore zero `nument` lazily: only the ~calc_cnt boxes an atom maps
+	// to are touched (a per-thread epoch stamp marks "zeroed this call"), and
+	// the O(dim3) prefix-sum reads a box's count as 0 unless it was stamped.
+	// This removes the 8*dim3-byte memset in exchange for ~calc_cnt stamp
+	// writes — a win on the typical sparse grid, neutral when dense, and
+	// bit-identical box assignment (no numeric change).
+	static thread_local std::vector<uint32_t> box_stamp;
+	static thread_local uint32_t box_epoch = 0;
+	if((int)box_stamp.size() < dim3){ box_stamp.assign(dim3, 0u); }
+	if(++box_epoch == 0u){ std::fill(box_stamp.begin(), box_stamp.end(), 0u); box_epoch = 1u; }
+	const uint32_t _ep = box_epoch;
 
 	int calc_cnt = i;  // Use actual count of initialized atoms, not total atmcnt
 	if(calc_count_out != NULL){
@@ -1808,6 +1855,9 @@ atomindex* index_protein(FA_Global* FA,atom* atoms,resid* residue,atomsas* Calc,
 		// retained as defence in depth (and mirrors the fill loop below).
 		const int _boxnum = Calc[atmi].boxnum;
 		if (_boxnum >= 0 && _boxnum < dim3) {
+			// Lazy zero: first touch of this box this epoch resets its (stale)
+			// count before we start accumulating into it.
+			if(box_stamp[_boxnum] != _ep){ box[_boxnum].nument = 0; box_stamp[_boxnum] = _ep; }
 			++box[_boxnum].nument;
 		}
 	}
@@ -1816,7 +1866,9 @@ atomindex* index_protein(FA_Global* FA,atom* atoms,resid* residue,atomsas* Calc,
 	startind = 0;
 	for (boxi=0; boxi<dim3; ++boxi) {
 		box[boxi].first = startind;
-		startind += box[boxi].nument;
+		// Unstamped boxes were never touched this epoch, so their `nument` is
+		// stale (no memset) — treat it as 0 for the prefix sum.
+		startind += (box_stamp[boxi] == _ep) ? box[boxi].nument : 0;
 	}
     
 	// clear array (needed for recounting index)
@@ -2031,7 +2083,10 @@ int get_contlist4(atom* atoms,int atomzero, contactlist contlist[],
 		float d2[4];
 		int k = 0;
 		for(; k + 4 <= ncand; k += 4) {
-			simd::distance2_1x4(&cand_x[k], &cand_y[k], &cand_z[k],
+			// atom_soa::distance2_1x4 is ISA-portable (see AtomSoA.h): the
+			// simd:: 4-wide kernel is undefined under AVX2/AVX-512, which is
+			// what blocked this path from building on x86. Same float32 math.
+			atom_soa::distance2_1x4(&cand_x[k], &cand_y[k], &cand_z[k],
 			                    bx, by, bz, d2);
 			for(int l = 0; l < 4; ++l) {
 				if(soa_assert) {

--- a/LIB/cuda_eval.cu
+++ b/LIB/cuda_eval.cu
@@ -4,23 +4,20 @@
 //   Grid:  pop_size threadblocks  (one chromosome per block)
 //   Block: 256 threads            (cooperative reduction over atom pairs)
 //
-// Each block:
-//   1. Loads its chromosome's first-three gene values (tx,ty,tz) into shared.
-//   2. Initialises per-ligand SAS counters in shared memory.
-//   3. Threads cooperatively evaluate all ligand-protein atom pairs:
-//        a. Normalised contact area via linear switching function.
-//        b. COM: energy-matrix lookup via sampled density-function table.
-//        c. WAL: KWALL × (r⁻¹² − (perm·rAB)⁻¹²) for clashing pairs.
-//        d. SAS: atomicAdd into shared per-ligand SAS counter.
-//   4. SAS energy contribution computed per ligand atom using the
-//      solvent column (T-1) of the energy matrix.
-//   5. Warp-shuffle + shared-memory reduction → three CF scalars per chromosome.
+// Each block evaluates one chromosome and produces the eight CF scoring
+// channels that feed get_cf_evalue() on the host:
+//     com, wal, sas, con, elec, hbond, gist_desolv, pb_clash
 //
-// Performance optimisations (vs. baseline):
-//   – CUDA stream for async H↔D transfers (overlap DMA + compute)
-//   – Pinned host memory for gene upload and result readback
-//   – Merged result readback (single DMA for com+wal+sas)
-//   – Multiplication chain replaces powf(r,12) in WAL term
+// See cuda_eval.cuh for the drift-tolerant contact-area model and the list of
+// terms deliberately NOT reproduced on-device (angular H-bond directionality,
+// metal-CN, vct-entropy, tENCoM), which the gaboom.cpp divergence guard warns
+// about when their weights are non-zero.
+//
+// Performance characteristics (unchanged from the com/wal/sas baseline):
+//   – Receptor atoms + energy matrix stay resident on-device (persistent ctx).
+//   – Whole population batched per generation (one launch, pop_size blocks).
+//   – CUDA stream for async H↔D transfers; pinned host staging buffers.
+//   – Multiplication chains replace powf() in the r⁻¹² / severity terms.
 
 #ifdef FLEXAIDS_USE_CUDA
 
@@ -46,29 +43,51 @@
 
 // ─── constants ────────────────────────────────────────────────────────────────
 static constexpr int   BLOCK_SIZE     = 256;
+static constexpr int   NWARPS         = BLOCK_SIZE / 32;
 static constexpr int   N_EMAT_SAMPLES = 128;   // must match CUDA_EMAT_SAMPLES in .cuh
 static constexpr float Rw             = 1.4f;  // water probe radius (Å)
 static constexpr float KWALL_F        = 1.0e6f;
+static constexpr float KCOULOMB_F     = 332.0637f;  // matches KCOULOMB in vcfunction.cpp
+static constexpr float HBOND_PAIR_MIN = -2.0f;      // per-pair H-bond floor
+static constexpr float Q_SALT         = 0.30f;      // salt-bridge charge threshold
 
-// Maximum ligand atoms handled in shared-memory SAS accumulator.
-// Ligands with more atoms fall back to zero SAS contribution.
-// 512 × 4 bytes = 2 KB shared memory per block (well within GPU limits).
+// Number of CF channels reduced per block (com,wal,sas,con,elec,hbond,gist,pb).
+static constexpr int   N_CF_CHANNELS  = 8;
+
+// Maximum ligand atoms handled in shared-memory SAS/GIST accumulators.
+// Ligands with more atoms fall back to zero contribution for the overflow atoms.
 static constexpr int MAX_LIG_SAS = 512;
 
 // ─── context ─────────────────────────────────────────────────────────────────
 struct CudaEvalCtx {
+    // Base rigid data
     float*  d_atom_xyz;      // [n_atoms × 3]
     int*    d_atom_type;     // [n_atoms]
     float*  d_atom_radius;   // [n_atoms]
     float*  d_emat_sampled;  // [n_types × n_types × N_EMAT_SAMPLES]
     double* d_genes;         // [max_pop × max_genes]
 
-    // Merged device output: [com_0..com_N | wal_0..wal_N | sas_0..sas_N]
-    double* d_cf_out;        // [3 × max_pop]
+    // Extra full-fidelity static data (nullptr / 0 when unused)
+    float*  d_atom_pbvdw;    // [n_atoms]
+    float*  d_atom_charge;   // [n_atoms]
+    int*    d_atom_hflags;   // [n_atoms]
+    int     n_cons;
+    int*    d_cons_i;        // [n_cons]
+    int*    d_cons_j;        // [n_cons]
+    float*  d_cons_bondlen;  // [n_cons]
+    float*  d_cons_maxdist;  // [n_cons]
+    int     gist_nx, gist_ny, gist_nz;
+    float   gist_origin[3];
+    float   gist_inv_delta[3];
+    float   gist_weight;
+    float*  d_gist_data;     // [nx*ny*nz]
+
+    // Merged device output: N_CF_CHANNELS × max_pop doubles
+    double* d_cf_out;
 
     // Pinned host buffers for async DMA
     double* h_genes_pinned;  // [max_pop × max_genes]
-    double* h_cf_pinned;     // [3 × max_pop]
+    double* h_cf_pinned;     // [N_CF_CHANNELS × max_pop]
 
     cudaStream_t stream;
 
@@ -81,7 +100,9 @@ struct CudaEvalCtx {
     float perm;
 };
 
-// ─── device helper: interpolated energy-matrix lookup ────────────────────────
+// ─── device helpers ──────────────────────────────────────────────────────────
+
+// Interpolated energy-matrix lookup (matches host get_yval on the sampled curve).
 __device__ __forceinline__ float gpu_get_yval(
         const float* __restrict__ emat_sampled,
         int t1, int t2, int T, float rel_area)
@@ -96,6 +117,59 @@ __device__ __forceinline__ float gpu_get_yval(
          + emat_sampled[base + k1] * frac;
 }
 
+// GetValueFromGaussian (geometry.cpp): pow(-(x-zero)*(x-(2*max-zero))/(zero-max)^2, 50).
+// Base is clamped to >=0 to avoid NaN from a negative base at a non-integer-treated
+// exponent (drift-safe; the CPU form is ~0 well outside the well anyway).
+__device__ __forceinline__ float gpu_gaussian(float x, float mx, float zero)
+{
+    float dz   = zero - mx;
+    float denom = dz * dz;
+    if (denom < 1e-12f) return 0.0f;
+    float base = (-(x - zero) * (x - (2.0f * mx - zero))) / denom;
+    if (base <= 0.0f) return 0.0f;
+    return powf(base, 50.0f);
+}
+
+// Block-wide sum reduction; result broadcast to all threads via smem[0].
+__device__ __forceinline__ float block_reduce_sum(float v, float* smem, int tid)
+{
+    for (int o = warpSize / 2; o > 0; o >>= 1)
+        v += __shfl_down_sync(0xFFFFFFFF, v, o);
+    int lane = tid & 31, wid = tid >> 5;
+    if (lane == 0) smem[wid] = v;
+    __syncthreads();
+    if (wid == 0) {
+        float x = (lane < NWARPS) ? smem[lane] : 0.0f;
+        for (int o = NWARPS / 2; o > 0; o >>= 1)
+            x += __shfl_down_sync(0xFFFFFFFF, x, o);
+        if (lane == 0) smem[0] = x;
+    }
+    __syncthreads();
+    float r = smem[0];
+    __syncthreads();
+    return r;
+}
+
+// Block-wide min reduction; result broadcast to all threads via smem[0].
+__device__ __forceinline__ float block_reduce_min(float v, float* smem, int tid)
+{
+    for (int o = warpSize / 2; o > 0; o >>= 1)
+        v = fminf(v, __shfl_down_sync(0xFFFFFFFF, v, o));
+    int lane = tid & 31, wid = tid >> 5;
+    if (lane == 0) smem[wid] = v;
+    __syncthreads();
+    if (wid == 0) {
+        float x = (lane < NWARPS) ? smem[lane] : 3.4e38f;
+        for (int o = NWARPS / 2; o > 0; o >>= 1)
+            x = fminf(x, __shfl_down_sync(0xFFFFFFFF, x, o));
+        if (lane == 0) smem[0] = x;
+    }
+    __syncthreads();
+    float r = smem[0];
+    __syncthreads();
+    return r;
+}
+
 // ─── full-fidelity CF kernel ──────────────────────────────────────────────────
 __global__ void kernel_eval_cf_full(
     const float*  __restrict__ atom_xyz,       // [N × 3]
@@ -103,9 +177,25 @@ __global__ void kernel_eval_cf_full(
     const float*  __restrict__ atom_radius,    // [N]
     const float*  __restrict__ emat_sampled,   // [T × T × N_EMAT_SAMPLES]
     const double* __restrict__ genes,          // [pop × n_genes]
-    double*       __restrict__ com_out,        // [pop]
-    double*       __restrict__ wal_out,        // [pop]
-    double*       __restrict__ sas_out,        // [pop]
+    // extra static (may be null)
+    const float*  __restrict__ atom_pbvdw,     // [N] or null
+    const float*  __restrict__ atom_charge,    // [N] or null
+    const int*    __restrict__ atom_hflags,    // [N] or null
+    int n_cons,
+    const int*    __restrict__ cons_i,
+    const int*    __restrict__ cons_j,
+    const float*  __restrict__ cons_bondlen,
+    const float*  __restrict__ cons_maxdist,
+    int gist_nx, int gist_ny, int gist_nz,
+    float gox, float goy, float goz,
+    float gidx, float gidy, float gidz,
+    float gist_weight,
+    const float* __restrict__ gist_data,       // [nx*ny*nz] or null
+    // params
+    GpuCfParams P,
+    // outputs (N_CF_CHANNELS × pop, contiguous per channel)
+    double* __restrict__ out,
+    int max_pop,
     int N, int T, int n_genes,
     int lig_first, int lig_last, float perm)
 {
@@ -120,19 +210,27 @@ __global__ void kernel_eval_cf_full(
         tz = (float)genes[chrom_id * n_genes + 2];
     }
 
-    // Per-ligand SAS accumulator (shared memory, initialised to 4π(rA+Rw)²).
+    // Per-ligand SAS accumulator (initialised to 4π(rA+Rw)²).
     __shared__ float lig_sas[MAX_LIG_SAS];
     const int n_lig = lig_last - lig_first + 1;
     const int n_pro = N - n_lig;
     for (int la = tid; la < n_lig && la < MAX_LIG_SAS; la += BLOCK_SIZE) {
-        float rwa     = atom_radius[lig_first + la] + Rw;
-        lig_sas[la]   = 4.0f * 3.141592653589793f * rwa * rwa;
+        float rwa   = atom_radius[lig_first + la] + Rw;
+        lig_sas[la] = 4.0f * 3.141592653589793f * rwa * rwa;
     }
     __syncthreads();
+
+    const bool do_dw    = (P.dw_r0 > 0.0f);
+    const float inv_r0  = do_dw ? (1.0f / P.dw_r0) : 0.0f;
+    const bool do_elec  = (P.elec_on != 0) && (atom_charge != nullptr);
+    const bool do_hbond = (P.hbond_weight != 0.0f || P.hbond_salt_weight != 0.0f) &&
+                          (atom_hflags != nullptr) && (atom_charge != nullptr);
+    const bool do_pb    = (P.pb_clash_weight > 0.0f) && (atom_pbvdw != nullptr);
 
     // ── pair loop ────────────────────────────────────────────────────────────
     const int n_pairs = n_lig * n_pro;
     float local_com = 0.0f, local_wal = 0.0f;
+    float local_elec = 0.0f, local_hbond = 0.0f, local_pb = 0.0f;
 
     for (int pr = tid; pr < n_pairs; pr += BLOCK_SIZE) {
         const int li      = pr / n_pro;
@@ -162,19 +260,55 @@ __global__ void kernel_eval_cf_full(
         if      (r < rsum)    rel_area = 1.0f;
         else if (r < outer_r) rel_area = 1.0f - (r - rsum) / (outer_r - rsum);
 
+        const bool in_contact = (rel_area > 0.0f);
+
         // Subtract contact area from this ligand atom's SAS counter.
-        if (rel_area > 0.0f && li < MAX_LIG_SAS) {
+        if (in_contact && li < MAX_LIG_SAS) {
             atomicAdd(&lig_sas[li], -rel_area * surf_A);
         }
 
-        // COM: energy-matrix interpolation scaled by normalised contact area.
+        // COM: energy-matrix interpolation scaled by normalised contact area,
+        // optionally distance-weighted (VCT dist-weight term).
         const int   ti   = atom_type[ai];
         const int   tj   = atom_type[aj];
         const float yval = gpu_get_yval(emat_sampled, ti, tj, T, rel_area);
-        local_com += yval * rel_area;
+        float com_pair   = yval * rel_area;
+        if (do_dw && in_contact) com_pair *= __expf(-r * inv_r0);
+        local_com += com_pair;
+
+        // ELEC: distance-dependent-dielectric Coulomb, contacting pairs only.
+        if (do_elec && in_contact && r > 0.5f) {
+            const float qA = atom_charge[ai];
+            const float qB = atom_charge[aj];
+            if (qA != 0.0f && qB != 0.0f)
+                local_elec += KCOULOMB_F * qA * qB / (P.dielectric * r * r);
+        }
+
+        // HBOND: distance-Gaussian × representative angle term (drift model).
+        if (do_hbond && in_contact) {
+            const int  fa = atom_hflags[ai];
+            const int  fb = atom_hflags[aj];
+            const bool donor_a    = (fa & 0x1) != 0;
+            const bool acceptor_a = (fa & 0x2) != 0;
+            const bool donor_b    = (fb & 0x1) != 0;
+            const bool acceptor_b = (fb & 0x2) != 0;
+            const float qa = atom_charge[ai];
+            const float qb = atom_charge[aj];
+            const bool a_to_b = donor_a && acceptor_b;
+            const bool b_to_a = donor_b && acceptor_a;
+            const bool salt   = (qa <= -Q_SALT && qb >= Q_SALT) ||
+                                (qb <= -Q_SALT && qa >= Q_SALT);
+            if (a_to_b || b_to_a || salt) {
+                const float dd = (r - P.hbond_opt_dist) / P.hbond_sigma_dist;
+                const float E_dist = __expf(-0.5f * dd * dd);
+                const float w = salt ? P.hbond_salt_weight : P.hbond_weight;
+                float E = w * E_dist * P.hbond_angle_repr;
+                if (E < HBOND_PAIR_MIN) E = HBOND_PAIR_MIN;
+                local_hbond += E;
+            }
+        }
 
         // WAL: repulsive wall energy when r < perm × (rA+rB).
-        // Uses multiplication chain instead of powf() for ~5× faster r⁻¹².
         const float clash_r = perm * rsum;
         if (r < clash_r) {
             const float r2  = r * r;
@@ -187,57 +321,151 @@ __global__ void kernel_eval_cf_full(
             const float inv_cr12 = 1.0f / (cr6 * cr6);
             local_wal += KWALL_F * (inv_r12 - inv_cr12);
         }
+
+        // PB_CLASH: PoseBusters vdW-overlap severity (independent of Voronoi).
+        if (do_pb) {
+            const float cr_pb = P.pb_clash_ratio * (atom_pbvdw[ai] + atom_pbvdw[aj]);
+            const float o     = cr_pb - r;
+            if (o > 0.0f && r > 1.0e-6f)
+                local_pb += powf(o, P.pb_clash_exponent);
+        }
     }
     // Pair loop done; ensure all atomicAdds to lig_sas are visible.
     __syncthreads();
 
-    // ── warp-level reduction for COM and WAL ─────────────────────────────────
-    for (int off = warpSize / 2; off > 0; off >>= 1) {
-        local_com += __shfl_down_sync(0xFFFFFFFF, local_com, off);
-        local_wal += __shfl_down_sync(0xFFFFFFFF, local_wal, off);
-    }
-    __shared__ float warp_com[BLOCK_SIZE / 32];
-    __shared__ float warp_wal[BLOCK_SIZE / 32];
-    const int lane = tid % 32, wid = tid / 32;
-    if (lane == 0) { warp_com[wid] = local_com; warp_wal[wid] = local_wal; }
-    __syncthreads();
+    // ── block reductions (single shared scratch, reused per channel) ──────────
+    __shared__ float red[NWARPS];
+    float com   = block_reduce_sum(local_com,   red, tid);
+    float wal   = block_reduce_sum(local_wal,   red, tid);
+    float elec  = block_reduce_sum(local_elec,  red, tid);
+    float hbond = block_reduce_sum(local_hbond, red, tid);
+    float pb    = block_reduce_sum(local_pb,    red, tid);
 
-    // ── SAS contribution (per ligand atom) ───────────────────────────────────
-    float local_sas = 0.0f;
+    // ── SAS + GIST contribution (per ligand atom) ────────────────────────────
+    const bool do_gist = (gist_nx > 0) && (gist_data != nullptr);
+    float local_sas = 0.0f, local_gist = 0.0f;
+    // Centroid accumulation for the pocket penalty (ligand atoms).
+    float local_cx = 0.0f, local_cy = 0.0f, local_cz = 0.0f;
     if (n_lig <= MAX_LIG_SAS) {
         for (int la = tid; la < n_lig; la += BLOCK_SIZE) {
+            const int   aidx     = lig_first + la;
             const float sas_rem  = fmaxf(0.0f, lig_sas[la]);
-            const float rwa_la   = atom_radius[lig_first + la] + Rw;
+            const float rwa_la   = atom_radius[aidx] + Rw;
             const float surf_la  = 4.0f * 3.141592653589793f * rwa_la * rwa_la;
             const float sas_norm = sas_rem / surf_la;
-            const int   ti_la    = atom_type[lig_first + la];
-            // Solvent interaction: last column of the energy matrix (index T-1).
-            const float yval_sas = gpu_get_yval(emat_sampled, ti_la, T - 1, T, sas_norm);
-            local_sas += yval_sas * sas_norm;
+            float contribution;
+            if (P.solvent_flat) {
+                contribution = P.solventterm * sas_rem;
+            } else {
+                const int ti_la = atom_type[aidx];
+                const float yval_sas = gpu_get_yval(emat_sampled, ti_la, T - 1, T, sas_norm);
+                contribution = yval_sas * sas_norm;   // normalised-area branch
+            }
+            local_sas += P.sas_weight * contribution;
+
+            // Translated ligand coords for GIST + centroid.
+            const float lx = atom_xyz[aidx * 3 + 0] + tx;
+            const float ly = atom_xyz[aidx * 3 + 1] + ty;
+            const float lz = atom_xyz[aidx * 3 + 2] + tz;
+            local_cx += lx; local_cy += ly; local_cz += lz;
+
+            if (do_gist) {
+                float fx = (lx - gox) * gidx;
+                float fy = (ly - goy) * gidy;
+                float fz = (lz - goz) * gidz;
+                if (fx >= 0.0f && fx < (gist_nx - 1) &&
+                    fy >= 0.0f && fy < (gist_ny - 1) &&
+                    fz >= 0.0f && fz < (gist_nz - 1)) {
+                    int ix = (int)fx, iy = (int)fy, iz = (int)fz;
+                    float ddx = fx - ix, ddy = fy - iy, ddz = fz - iz;
+                    #define GIDX(i,j,k) (((i)*gist_ny + (j))*gist_nz + (k))
+                    float c000 = gist_data[GIDX(ix,   iy,   iz  )];
+                    float c001 = gist_data[GIDX(ix,   iy,   iz+1)];
+                    float c010 = gist_data[GIDX(ix,   iy+1, iz  )];
+                    float c011 = gist_data[GIDX(ix,   iy+1, iz+1)];
+                    float c100 = gist_data[GIDX(ix+1, iy,   iz  )];
+                    float c101 = gist_data[GIDX(ix+1, iy,   iz+1)];
+                    float c110 = gist_data[GIDX(ix+1, iy+1, iz  )];
+                    float c111 = gist_data[GIDX(ix+1, iy+1, iz+1)];
+                    #undef GIDX
+                    float c00 = c000*(1.0f-ddz) + c001*ddz;
+                    float c01 = c010*(1.0f-ddz) + c011*ddz;
+                    float c10 = c100*(1.0f-ddz) + c101*ddz;
+                    float c11 = c110*(1.0f-ddz) + c111*ddz;
+                    float c0  = c00*(1.0f-ddy) + c01*ddy;
+                    float c1  = c10*(1.0f-ddy) + c11*ddy;
+                    local_gist += gist_weight * (c0*(1.0f-ddx) + c1*ddx);
+                }
+            }
         }
     }
-    for (int off = warpSize / 2; off > 0; off >>= 1)
-        local_sas += __shfl_down_sync(0xFFFFFFFF, local_sas, off);
-    __shared__ float warp_sas[BLOCK_SIZE / 32];
-    if (lane == 0) warp_sas[wid] = local_sas;
-    __syncthreads();
+    float sas       = block_reduce_sum(local_sas,  red, tid);
+    float gist      = block_reduce_sum(local_gist, red, tid);
+    float cx_sum    = block_reduce_sum(local_cx,   red, tid);
+    float cy_sum    = block_reduce_sum(local_cy,   red, tid);
+    float cz_sum    = block_reduce_sum(local_cz,   red, tid);
 
-    // ── final cross-warp reduction (warp 0 only) ─────────────────────────────
-    if (wid == 0) {
-        const int nwarps = BLOCK_SIZE / 32;
-        float vcom = (lane < nwarps) ? warp_com[lane] : 0.0f;
-        float vwal = (lane < nwarps) ? warp_wal[lane] : 0.0f;
-        float vsas = (lane < nwarps) ? warp_sas[lane] : 0.0f;
-        for (int off = nwarps / 2; off > 0; off >>= 1) {
-            vcom += __shfl_down_sync(0xFFFFFFFF, vcom, off);
-            vwal += __shfl_down_sync(0xFFFFFFFF, vwal, off);
-            vsas += __shfl_down_sync(0xFFFFFFFF, vsas, off);
+    // ── pocket-presence penalty (added into pb channel) ──────────────────────
+    if (P.pb_pocket_weight > 0.0f && atom_hflags != nullptr && n_lig > 0) {
+        const float inv_nl = 1.0f / (float)n_lig;
+        const float gx = cx_sum * inv_nl;
+        const float gy = cy_sum * inv_nl;
+        const float gz = cz_sum * inv_nl;
+        // Nearest receptor HEAVY atom to the ligand centroid (brute force).
+        float local_min = 3.4e38f;
+        for (int a = tid; a < N; a += BLOCK_SIZE) {
+            if (a >= lig_first && a <= lig_last) continue;   // skip ligand
+            if ((atom_hflags[a] & 0x4) == 0)      continue;  // heavy only
+            const float ddx = gx - atom_xyz[a*3+0];
+            const float ddy = gy - atom_xyz[a*3+1];
+            const float ddz = gz - atom_xyz[a*3+2];
+            const float d2 = ddx*ddx + ddy*ddy + ddz*ddz;
+            local_min = fminf(local_min, d2);
         }
-        if (lane == 0) {
-            com_out[chrom_id] = (double)vcom;
-            wal_out[chrom_id] = (double)vwal;
-            sas_out[chrom_id] = (double)vsas;
+        float best_d2 = block_reduce_min(local_min, red, tid);
+        if (best_d2 < 3.0e38f) {
+            const float d = sqrtf(best_d2);
+            const float over = d - P.pb_pocket_radius;
+            if (over > 0.0f) pb += P.pb_pocket_weight * over * over;
         }
+    }
+
+    // ── covalent-constraint term (con), computed by thread 0 over the list ────
+    float con = 0.0f;
+    if (tid == 0 && n_cons > 0 && cons_i != nullptr) {
+        for (int c = 0; c < n_cons; ++c) {
+            const int i = cons_i[c];
+            const int j = cons_j[c];
+            float ix = atom_xyz[i*3+0], iy = atom_xyz[i*3+1], iz = atom_xyz[i*3+2];
+            float jx = atom_xyz[j*3+0], jy = atom_xyz[j*3+1], jz = atom_xyz[j*3+2];
+            if (i >= lig_first && i <= lig_last) { ix += tx; iy += ty; iz += tz; }
+            if (j >= lig_first && j <= lig_last) { jx += tx; jy += ty; jz += tz; }
+            const float ddx = ix - jx, ddy = iy - jy, ddz = iz - jz;
+            const float d = sqrtf(ddx*ddx + ddy*ddy + ddz*ddz);
+            // Baseline KDIST (one ligand-side atom per covalent constraint) minus
+            // the Gaussian restraint reward — see .cuh model note.
+            con += P.kdist - P.kdist * gpu_gaussian(d, cons_bondlen[c], cons_maxdist[c]);
+        }
+    }
+
+    // ── write outputs (thread 0) ─────────────────────────────────────────────
+    if (tid == 0) {
+        double* com_o  = out + 0 * max_pop;
+        double* wal_o  = out + 1 * max_pop;
+        double* sas_o  = out + 2 * max_pop;
+        double* con_o  = out + 3 * max_pop;
+        double* elec_o = out + 4 * max_pop;
+        double* hb_o   = out + 5 * max_pop;
+        double* gist_o = out + 6 * max_pop;
+        double* pb_o   = out + 7 * max_pop;
+        com_o[chrom_id]  = (double)com;
+        wal_o[chrom_id]  = (double)wal;
+        sas_o[chrom_id]  = (double)sas;
+        con_o[chrom_id]  = (double)con;
+        elec_o[chrom_id] = (double)elec;
+        hb_o[chrom_id]   = (double)hbond;
+        gist_o[chrom_id] = (double)gist;
+        pb_o[chrom_id]   = (double)pb;
     }
 }
 
@@ -256,6 +484,7 @@ CudaEvalCtx* cuda_eval_init(int   n_atoms,
                              const float* h_emat_sampled)
 {
     CudaEvalCtx* ctx = new CudaEvalCtx;
+    std::memset(ctx, 0, sizeof(*ctx));   // null all extra/gist pointers by default
     ctx->n_atoms   = n_atoms;
     ctx->n_types   = n_types;
     ctx->max_pop   = max_pop;
@@ -277,12 +506,12 @@ CudaEvalCtx* cuda_eval_init(int   n_atoms,
     CUDA_CHECK(cudaMalloc(&ctx->d_atom_radius,  rad_bytes));
     CUDA_CHECK(cudaMalloc(&ctx->d_emat_sampled, em_bytes));
     CUDA_CHECK(cudaMalloc(&ctx->d_genes,        gene_bytes));
-    // Merged output: [com | wal | sas] contiguous for single DMA readback
-    CUDA_CHECK(cudaMalloc(&ctx->d_cf_out,       3 * cf_bytes));
+    // Merged output: N_CF_CHANNELS channels contiguous for a single DMA readback
+    CUDA_CHECK(cudaMalloc(&ctx->d_cf_out,       N_CF_CHANNELS * cf_bytes));
 
     // Pinned host memory for async transfers
     CUDA_CHECK(cudaMallocHost(&ctx->h_genes_pinned, gene_bytes));
-    CUDA_CHECK(cudaMallocHost(&ctx->h_cf_pinned,    3 * cf_bytes));
+    CUDA_CHECK(cudaMallocHost(&ctx->h_cf_pinned,    N_CF_CHANNELS * cf_bytes));
 
     // Create dedicated stream for async operations
     CUDA_CHECK(cudaStreamCreate(&ctx->stream));
@@ -296,20 +525,69 @@ CudaEvalCtx* cuda_eval_init(int   n_atoms,
     return ctx;
 }
 
-void cuda_eval_batch(CudaEvalCtx*  ctx,
-                     int           pop_size,
-                     int           n_genes,
-                     const double* h_genes,
-                     double*       h_com_out,
-                     double*       h_wal_out,
-                     double*       h_sas_out)
+void cuda_eval_set_extra(CudaEvalCtx* ctx, const GpuCfExtraStatic* extra)
+{
+    if (!ctx || !extra) return;
+    const int   N = ctx->n_atoms;
+    const size_t fN = (size_t)N * sizeof(float);
+    const size_t iN = (size_t)N * sizeof(int);
+
+    auto up_f = [&](float** dev, const float* host) {
+        if (!host) return;
+        if (!*dev) CUDA_CHECK(cudaMalloc(dev, fN));
+        CUDA_CHECK(cudaMemcpy(*dev, host, fN, cudaMemcpyHostToDevice));
+    };
+    up_f(&ctx->d_atom_pbvdw,  extra->atom_pbvdw);
+    up_f(&ctx->d_atom_charge, extra->atom_charge);
+    if (extra->atom_hflags) {
+        if (!ctx->d_atom_hflags) CUDA_CHECK(cudaMalloc(&ctx->d_atom_hflags, iN));
+        CUDA_CHECK(cudaMemcpy(ctx->d_atom_hflags, extra->atom_hflags, iN, cudaMemcpyHostToDevice));
+    }
+
+    // Constraints
+    ctx->n_cons = extra->n_cons;
+    if (extra->n_cons > 0 && extra->cons_i) {
+        const size_t ci = (size_t)extra->n_cons * sizeof(int);
+        const size_t cf = (size_t)extra->n_cons * sizeof(float);
+        CUDA_CHECK(cudaMalloc(&ctx->d_cons_i,       ci));
+        CUDA_CHECK(cudaMalloc(&ctx->d_cons_j,       ci));
+        CUDA_CHECK(cudaMalloc(&ctx->d_cons_bondlen, cf));
+        CUDA_CHECK(cudaMalloc(&ctx->d_cons_maxdist, cf));
+        CUDA_CHECK(cudaMemcpy(ctx->d_cons_i,       extra->cons_i,       ci, cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(ctx->d_cons_j,       extra->cons_j,       ci, cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(ctx->d_cons_bondlen, extra->cons_bondlen, cf, cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(ctx->d_cons_maxdist, extra->cons_maxdist, cf, cudaMemcpyHostToDevice));
+    }
+
+    // GIST grid
+    ctx->gist_nx = extra->gist_nx;
+    ctx->gist_ny = extra->gist_ny;
+    ctx->gist_nz = extra->gist_nz;
+    for (int k = 0; k < 3; ++k) {
+        ctx->gist_origin[k]    = extra->gist_origin[k];
+        ctx->gist_inv_delta[k] = extra->gist_inv_delta[k];
+    }
+    ctx->gist_weight = extra->gist_weight;
+    if (extra->gist_nx > 0 && extra->gist_data) {
+        const size_t vox = (size_t)extra->gist_nx * extra->gist_ny * extra->gist_nz * sizeof(float);
+        CUDA_CHECK(cudaMalloc(&ctx->d_gist_data, vox));
+        CUDA_CHECK(cudaMemcpy(ctx->d_gist_data, extra->gist_data, vox, cudaMemcpyHostToDevice));
+    }
+}
+
+void cuda_eval_batch(CudaEvalCtx*        ctx,
+                     int                 pop_size,
+                     int                 n_genes,
+                     const double*       h_genes,
+                     const GpuCfParams*  params,
+                     const GpuCfResults* out)
 {
     // Warn if ligand exceeds shared-memory SAS capacity.
     {
         int n_lig = ctx->lig_last - ctx->lig_first + 1;
         if (n_lig > MAX_LIG_SAS) {
             fprintf(stderr, "cuda_eval: n_lig=%d exceeds MAX_LIG_SAS=%d, "
-                    "SAS contribution will be zero for atoms beyond limit\n",
+                    "SAS/GIST contribution will be zero for atoms beyond limit\n",
                     n_lig, MAX_LIG_SAS);
         }
     }
@@ -327,15 +605,12 @@ void cuda_eval_batch(CudaEvalCtx*  ctx,
     const size_t gene_bytes = (size_t)pop_size * n_genes * sizeof(double);
     const size_t cf_bytes   = (size_t)pop_size            * sizeof(double);
 
-    // Pointers into merged device output buffer
-    double* d_com = ctx->d_cf_out;
-    double* d_wal = ctx->d_cf_out + ctx->max_pop;
-    double* d_sas = ctx->d_cf_out + 2 * ctx->max_pop;
-
     // Copy genes into pinned buffer, then async upload to device
     memcpy(ctx->h_genes_pinned, h_genes, gene_bytes);
     CUDA_CHECK(cudaMemcpyAsync(ctx->d_genes, ctx->h_genes_pinned, gene_bytes,
                                cudaMemcpyHostToDevice, ctx->stream));
+
+    GpuCfParams P = *params;
 
     kernel_eval_cf_full<<<pop_size, BLOCK_SIZE, 0, ctx->stream>>>(
         ctx->d_atom_xyz,
@@ -343,9 +618,19 @@ void cuda_eval_batch(CudaEvalCtx*  ctx,
         ctx->d_atom_radius,
         ctx->d_emat_sampled,
         ctx->d_genes,
-        d_com,
-        d_wal,
-        d_sas,
+        ctx->d_atom_pbvdw,
+        ctx->d_atom_charge,
+        ctx->d_atom_hflags,
+        ctx->n_cons,
+        ctx->d_cons_i, ctx->d_cons_j, ctx->d_cons_bondlen, ctx->d_cons_maxdist,
+        ctx->gist_nx, ctx->gist_ny, ctx->gist_nz,
+        ctx->gist_origin[0], ctx->gist_origin[1], ctx->gist_origin[2],
+        ctx->gist_inv_delta[0], ctx->gist_inv_delta[1], ctx->gist_inv_delta[2],
+        ctx->gist_weight,
+        ctx->d_gist_data,
+        P,
+        ctx->d_cf_out,
+        ctx->max_pop,
         ctx->n_atoms,
         ctx->n_types,
         n_genes,
@@ -355,17 +640,25 @@ void cuda_eval_batch(CudaEvalCtx*  ctx,
 
     CUDA_CHECK(cudaGetLastError());
 
-    // Single merged readback: [com | wal | sas] → pinned host buffer
-    CUDA_CHECK(cudaMemcpyAsync(ctx->h_cf_pinned, ctx->d_cf_out, 3 * cf_bytes,
+    // Single merged readback: all channels → pinned host buffer
+    CUDA_CHECK(cudaMemcpyAsync(ctx->h_cf_pinned, ctx->d_cf_out,
+                               N_CF_CHANNELS * cf_bytes,
                                cudaMemcpyDeviceToHost, ctx->stream));
 
     // Wait for all stream operations to complete
     CUDA_CHECK(cudaStreamSynchronize(ctx->stream));
 
-    // Scatter merged results to caller's output arrays
-    memcpy(h_com_out, ctx->h_cf_pinned,                   cf_bytes);
-    memcpy(h_wal_out, ctx->h_cf_pinned + ctx->max_pop,    cf_bytes);
-    memcpy(h_sas_out, ctx->h_cf_pinned + 2 * ctx->max_pop, cf_bytes);
+    // Scatter merged results to caller's output arrays (per-channel stride = max_pop).
+    const double* base = ctx->h_cf_pinned;
+    auto ch = [&](int c) { return base + (size_t)c * ctx->max_pop; };
+    if (out->com)         memcpy(out->com,         ch(0), cf_bytes);
+    if (out->wal)         memcpy(out->wal,         ch(1), cf_bytes);
+    if (out->sas)         memcpy(out->sas,         ch(2), cf_bytes);
+    if (out->con)         memcpy(out->con,         ch(3), cf_bytes);
+    if (out->elec)        memcpy(out->elec,        ch(4), cf_bytes);
+    if (out->hbond)       memcpy(out->hbond,       ch(5), cf_bytes);
+    if (out->gist_desolv) memcpy(out->gist_desolv, ch(6), cf_bytes);
+    if (out->pb_clash)    memcpy(out->pb_clash,    ch(7), cf_bytes);
 }
 
 void cuda_eval_shutdown(CudaEvalCtx* ctx)
@@ -377,6 +670,14 @@ void cuda_eval_shutdown(CudaEvalCtx* ctx)
     cudaFree(ctx->d_emat_sampled);
     cudaFree(ctx->d_genes);
     cudaFree(ctx->d_cf_out);
+    cudaFree(ctx->d_atom_pbvdw);
+    cudaFree(ctx->d_atom_charge);
+    cudaFree(ctx->d_atom_hflags);
+    cudaFree(ctx->d_cons_i);
+    cudaFree(ctx->d_cons_j);
+    cudaFree(ctx->d_cons_bondlen);
+    cudaFree(ctx->d_cons_maxdist);
+    cudaFree(ctx->d_gist_data);
     cudaFreeHost(ctx->h_genes_pinned);
     cudaFreeHost(ctx->h_cf_pinned);
     cudaStreamDestroy(ctx->stream);

--- a/LIB/cuda_eval.cuh
+++ b/LIB/cuda_eval.cuh
@@ -4,16 +4,51 @@
 // FlexAIDdS offloads the per-chromosome complementarity-function (CF)
 // evaluation to the GPU.
 //
-// Full-fidelity scoring (vs. the previous single-scalar energy table):
-//   – Energy matrix sampled at N_CUDA_EMAT_SAMPLES points per type-pair
-//     and interpolated on-device (gpu_get_yval).
-//   – WAL (clash) term: KWALL × (r⁻¹² − (perm·rAB)⁻¹²).
-//   – SAS contribution: per-ligand-atom remaining exposed surface area,
-//     accumulated via shared-memory atomic-add across protein contacts.
-//   – COM term: energy-matrix yval × normalised contact area.
+// FULL-FIDELITY scoring (P4).  The GPU CF now reproduces the CPU
+// ic2cf/vcfunction CF *assembly* within a drift tolerance sufficient to
+// preserve pose ranking (NOT bit-for-bit).  The GPU fills every scoring
+// channel that feeds get_cf_evalue():
+//
+//     com  + wal + sas + con + elec + hbond + gist_desolv + pb_clash
+//
+//   – com : energy-matrix yval × normalised contact area, optionally
+//           distance-weighted (exp(-r/r0)) to match the VCT dist-weight term.
+//   – wal : KWALL × (r⁻¹² − (perm·rAB)⁻¹²) repulsive wall (unchanged).
+//   – sas : per-ligand-atom residual solvent-accessible surface scored
+//           against the solvent column (T-1) of the energy matrix.
+//   – con : covalent-constraint Gaussian restraint (KDIST baseline minus
+//           KDIST·GetValueFromGaussian(dist,bond_len,max_dist)).
+//   – elec: distance-dependent-dielectric Coulomb over contacting pairs.
+//   – hbond: distance-Gaussian × representative angle term, gated by
+//            donor/acceptor complementarity or salt bridge (see error note).
+//   – gist_desolv: per-ligand-atom trilinear GIST grid desolvation.
+//   – pb_clash: all-pairs ligand↔receptor PoseBusters vdW-overlap penalty
+//               plus the pocket-presence centroid penalty.
+//
+// ── Contact-area model (drift-tolerant; the recommended plan route (b)) ──────
+// The branchy analytic Voronoi (voronoi_poly2/calc_areas) is deliberately NOT
+// ported.  Instead each ligand↔receptor pair contributes a normalised contact
+// area from a C0 linear switching function:
+//
+//     rel_area(r) = 1                              for r <= rA+rB
+//                 = 1 - (r-(rA+rB))/(2·Rw)         for rA+rB < r < rA+rB+2·Rw
+//                 = 0                              for r >= rA+rB+2·Rw
+//
+// This maps one pair → one thread with no divergent polyhedron clipping, keeps
+// the receptor + energy matrix resident on-device, and batches the whole
+// population per generation.  Expected error vs. the analytic Voronoi area is a
+// smooth per-contact bias (the linear ramp over-/under-estimates the true
+// spherical-cap overlap by up to ~15–20 % on individual faces) that is highly
+// correlated across poses, so it largely cancels in pose *ranking*; the drift
+// policy (ranking-preserving, not bit-exact) is what makes it admissible.
+// Terms that depend on true absolute geometry (angular H-bond directionality,
+// metal-CN, vct-entropy, tENCoM) are NOT reproduced here — see the gaboom.cpp
+// divergence guard.
 //
 // Context lifetime (persistent across generate() calls):
-//   cuda_eval_init()      – once at GA startup; uploads constant atom data
+//   cuda_eval_init()      – once at GA startup; uploads rigid atom data
+//   cuda_eval_set_extra() – once; uploads pb-vdw / charge / hbond-flag /
+//                           constraint / GIST device arrays (may pass nullptr)
 //   cuda_eval_batch()     – every generation (gene upload + kernel + readback)
 //   cuda_eval_shutdown()  – once at GA teardown
 //
@@ -28,6 +63,70 @@
 // Samples per type-pair energy curve.  Must match N_EMAT_SAMPLES in cuda_eval.cu.
 static constexpr int CUDA_EMAT_SAMPLES = 128;
 
+// ── Shared GPU-CF POD types ──────────────────────────────────────────────────
+// Defined here AND (identically) in metal_eval.h.  gaboom.cpp may include both
+// headers under their respective backend guards, so a shared include-guard macro
+// prevents a duplicate-definition error while keeping every symbol inside the
+// P4 track's assigned files (no new header introduced).
+#ifndef FLEXAIDS_GPU_CF_TYPES_DEFINED
+#define FLEXAIDS_GPU_CF_TYPES_DEFINED
+
+// Per-batch scalar parameters (weights/config; fixed per dock, cheap to pass).
+struct GpuCfParams {
+    float dw_r0;             // VCT distance-weight r0 (<=0 => distance weighting OFF)
+    int   elec_on;           // 1 => compute Coulomb elec term
+    float dielectric;        // FA->dielectric
+    float hbond_weight;      // 0 => H-bond term OFF (else standard H-bond weight)
+    float hbond_salt_weight; // salt-bridge weight
+    float hbond_opt_dist;    // optimal donor..acceptor distance
+    float hbond_sigma_dist;  // distance Gaussian sigma
+    float hbond_angle_repr;  // representative angle term in [0,1] (drift model)
+    float pb_clash_weight;   // 0 => pb_clash term OFF
+    float pb_clash_ratio;    // PoseBusters clash ratio
+    float pb_clash_exponent; // severity exponent p
+    float pb_pocket_weight;  // 0 => pocket-presence penalty OFF
+    float pb_pocket_radius;  // pocket radius (A)
+    float kdist;             // KDIST constant for covalent constraints
+    float sas_weight;        // FA->sas_weight applied to the sas channel
+    int   solvent_flat;      // 1 => FA->solventterm active (sas = solventterm*SAS)
+    float solventterm;       // FA->solventterm (only used when solvent_flat)
+};
+
+// Host output channels, one double array of length pop_size each.
+struct GpuCfResults {
+    double* com;
+    double* wal;
+    double* sas;
+    double* con;
+    double* elec;
+    double* hbond;
+    double* gist_desolv;
+    double* pb_clash;
+};
+
+// Rigid, once-per-dock device inputs beyond xyz/type/radius/emat.  Any pointer
+// may be nullptr and the corresponding term is then disabled on-device.
+struct GpuCfExtraStatic {
+    const float* atom_pbvdw;   // [n_atoms] PoseBusters element vdW radius
+    const float* atom_charge;  // [n_atoms] partial (or RESP) charge
+    const int*   atom_hflags;  // [n_atoms] bit0 donor, bit1 acceptor, bit2 heavy(non-H)
+
+    int          n_cons;       // number of covalent (type-1) constraints
+    const int*   cons_i;       // [n_cons] 0-based atom index
+    const int*   cons_j;       // [n_cons] 0-based atom index
+    const float* cons_bondlen; // [n_cons]
+    const float* cons_maxdist; // [n_cons]
+
+    // GIST grid (gist_nx==0 => GIST disabled).  Layout: i*ny*nz + j*nz + k.
+    int          gist_nx, gist_ny, gist_nz;
+    float        gist_origin[3];
+    float        gist_inv_delta[3]; // 1/delta[k][k]
+    float        gist_weight;
+    const float* gist_data;    // [nx*ny*nz]
+};
+
+#endif // FLEXAIDS_GPU_CF_TYPES_DEFINED
+
 // Opaque handle to all device-resident data.
 struct CudaEvalCtx;
 
@@ -35,6 +134,7 @@ struct CudaEvalCtx;
 //   n_atoms        – total atom count
 //   n_types        – number of atom types (energy_matrix dimension)
 //   max_pop        – maximum population size (upper bound on any batch)
+//   max_genes      – maximum genes per chromosome (buffer bound)
 //   lig_first      – 0-based index of first ligand atom
 //   lig_last       – 0-based index of last ligand atom
 //   perm           – van-der-Waals permeability (FA->permeability)
@@ -55,21 +155,25 @@ CudaEvalCtx* cuda_eval_init(int   n_atoms,
                              const float* h_atom_radius,
                              const float* h_emat_sampled);
 
-// Evaluate a batch of chromosomes on the GPU.
-//   ctx        – context from cuda_eval_init
-//   pop_size   – number of chromosomes to evaluate this call
-//   n_genes    – genes per chromosome
-//   h_genes    – host gene array [pop_size × n_genes, double]
-//   h_com_out  – host output: complementarity CF   [pop_size, double]
-//   h_wal_out  – host output: wall/clash energy     [pop_size, double]
-//   h_sas_out  – host output: solvent-accessible    [pop_size, double]
-void cuda_eval_batch(CudaEvalCtx*  ctx,
-                     int           pop_size,
-                     int           n_genes,
-                     const double* h_genes,
-                     double*       h_com_out,
-                     double*       h_wal_out,
-                     double*       h_sas_out);
+// Upload the optional full-fidelity static arrays (pb-vdw / charge / hbond
+// flags / constraints / GIST).  Call once after cuda_eval_init.  Passing
+// extra==nullptr (or leaving individual pointers null) disables the matching
+// terms; the base com/wal/sas path is unaffected.
+void cuda_eval_set_extra(CudaEvalCtx* ctx, const GpuCfExtraStatic* extra);
+
+// Evaluate a batch of chromosomes on the GPU (full-fidelity CF).
+//   ctx      – context from cuda_eval_init
+//   pop_size – number of chromosomes to evaluate this call
+//   n_genes  – genes per chromosome
+//   h_genes  – host gene array [pop_size × n_genes, double]
+//   params   – per-batch scalar weights/config (must be non-null)
+//   out      – host output channels; each array has length >= pop_size
+void cuda_eval_batch(CudaEvalCtx*        ctx,
+                     int                 pop_size,
+                     int                 n_genes,
+                     const double*       h_genes,
+                     const GpuCfParams*  params,
+                     const GpuCfResults* out);
 
 // Free all device memory.
 void cuda_eval_shutdown(CudaEvalCtx* ctx);

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -2478,19 +2478,37 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 		return h_genes;
 	};
 
-	// Helper lambda: unpack GPU batch results into chromosome CF structures.
+	// Helper lambda: unpack full-fidelity GPU batch results (P4) into chromosome
+	// CF structures. The GPU now fills every scoring channel that feeds
+	// get_cf_evalue(): com/wal/sas/con/elec/hbond/gist_desolv/pb_clash. On the
+	// Metal MULTI (screening) path only com/wal/sas are populated — the other
+	// vectors are left zero by the caller, which is the documented reduced
+	// fidelity for that path. Channels with NO GPU implementation (cf.gist is the
+	// non-scoring diagnostic channel; metal_coord/entropy/h_rep) are zeroed here
+	// so a stale host-buffer value can never leak into get_cf_evalue().
 	auto unpack_gpu_results = [&](const std::vector<double>& h_com,
 	                              const std::vector<double>& h_wal,
-	                              const std::vector<double>& h_sas) {
+	                              const std::vector<double>& h_sas,
+	                              const std::vector<double>& h_con,
+	                              const std::vector<double>& h_elec,
+	                              const std::vector<double>& h_hbond,
+	                              const std::vector<double>& h_gist,
+	                              const std::vector<double>& h_pb) {
 		for (int c = 0; c < pop_size; ++c) {
 			if (chrom[c].status != 'n') {
-				chrom[c].cf.com    = h_com[c];
-				chrom[c].cf.wal    = h_wal[c];
-				chrom[c].cf.sas    = h_sas[c];
-				chrom[c].cf.con    = 0.0;
-				chrom[c].cf.gist   = 0.0;
-				chrom[c].cf.hbond  = 0.0;
-				chrom[c].cf.pb_clash = 0.0;  // coarse host-buffer restore (com/wal/sas only); PB clash not computed on this fast path — zero to avoid stale leak into get_cf_evalue
+				chrom[c].cf.com         = h_com[c];
+				chrom[c].cf.wal         = h_wal[c];
+				chrom[c].cf.sas         = h_sas[c];
+				chrom[c].cf.con         = h_con[c];
+				chrom[c].cf.elec        = h_elec[c];
+				chrom[c].cf.hbond       = h_hbond[c];
+				chrom[c].cf.gist_desolv = h_gist[c];   // scoring GIST channel (get_cf_evalue sums gist_desolv, not cf.gist)
+				chrom[c].cf.pb_clash    = h_pb[c];
+				// Terms with no GPU implementation — zeroed (see divergence guard).
+				chrom[c].cf.gist        = 0.0;
+				chrom[c].cf.metal_coord = 0.0;
+				chrom[c].cf.entropy     = 0.0;
+				chrom[c].cf.h_rep       = 0.0;
 				chrom[c].cf.totsas = 0.0;
 				chrom[c].cf.rclash = (h_wal[c] > CLASH_THRESHOLD) ? 1 : 0;
 				chrom[c].evalue     = get_cf_evalue(&chrom[c].cf, FA) / n_receptor_chains;
@@ -2528,6 +2546,103 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 		            ? FA->resligand->latm[0] : 0;
 		return d;
 	};
+
+	// Build the per-batch full-fidelity CF scalar params from FA (+ the CPU env
+	// gates it mirrors), so the GPU CF assembly matches get_cf_evalue().
+	auto build_gpu_params = [&]() -> GpuCfParams {
+		GpuCfParams P; std::memset(&P, 0, sizeof(P));
+		// Distance weighting: mirror vcfunction's resolution exactly.
+		double dw = 0.0;
+		if (std::getenv("FLEXAIDDS_DIST_WEIGHT_CON") != nullptr) {
+			float r0 = 3.5f;
+			if (const char* s = std::getenv("FLEXAIDDS_CON_R0")) {
+				float pr = strtof(s, nullptr); if (pr > 0.0f) r0 = pr;
+			}
+			dw = r0;
+		} else if (FA->vct_dist_weight_r0 > 0.0) {
+			dw = FA->vct_dist_weight_r0;
+		}
+		P.dw_r0       = (float)dw;
+		P.elec_on     = FA->use_elec ? 1 : 0;
+		P.dielectric  = FA->dielectric;
+		// H-bond enters GA fitness only under the same gate as vcfunction.cpp.
+		const bool hb_on = FA->use_hbond && FA->use_hbond_search && !FA->hbond_rank_rescore;
+		P.hbond_weight      = hb_on ? (float)FA->hbond_weight : 0.0f;
+		P.hbond_salt_weight = hb_on ? (float)FA->hbond_salt_bridge_weight : 0.0f;
+		P.hbond_opt_dist    = (float)FA->hbond_optimal_dist;
+		P.hbond_sigma_dist  = (float)FA->hbond_sigma_dist;
+		// Representative angle term (drift model — the GPU omits the true
+		// virtual-H directionality; see cuda_eval.cuh error note).
+		P.hbond_angle_repr  = 0.7f;
+		P.pb_clash_weight   = (float)FA->pb_clash_weight;
+		P.pb_clash_ratio    = (float)FA->pb_clash_ratio;
+		P.pb_clash_exponent = (float)FA->pb_clash_exponent;
+		P.pb_pocket_weight  = (float)FA->pb_pocket_weight;
+		P.pb_pocket_radius  = (float)FA->pb_pocket_radius;
+		P.kdist       = (float)KDIST;
+		P.sas_weight  = (float)FA->sas_weight;
+		P.solvent_flat= (FA->solventterm != 0.0f) ? 1 : 0;
+		P.solventterm = (float)FA->solventterm;
+		return P;
+	};
+
+	// Build the rigid full-fidelity static device inputs (pb-vdw radii, charges,
+	// H-bond donor/acceptor+heavy flags, covalent constraints). GIST grid upload
+	// is intentionally left unwired (GISTGrid exposes no grid accessors) so GPU
+	// gist_desolv stays 0 — covered by the divergence guard. Same atom indexing
+	// convention as prepare_gpu_atoms (atoms[a], a in [0, atm_cnt_real)).
+	struct GPUExtraData {
+		std::vector<float> pbvdw, charge;
+		std::vector<int>   hflags;
+		std::vector<int>   cons_i, cons_j;
+		std::vector<float> cons_bl, cons_md;
+		GpuCfExtraStatic   extra;
+	};
+	auto prepare_gpu_extra = [&]() -> GPUExtraData {
+		const int n_atoms = FA->atm_cnt_real;
+		GPUExtraData d;
+		d.pbvdw.resize(n_atoms);
+		d.charge.resize(n_atoms);
+		d.hflags.resize(n_atoms);
+		for (int a = 0; a < n_atoms; ++a) {
+			d.pbvdw[a]  = (float)atoms[a].pb_vdw_radius;
+			d.charge[a] = atoms[a].has_resp ? atoms[a].resp_charge : atoms[a].charge;
+			// type256 bit layout (atom_typing_256.h): bit7 = H-bond donor,
+			// bit6 = H-bond acceptor. bit2 (local) = heavy (non-hydrogen).
+			int f = 0;
+			const uint8_t t256 = atoms[a].type256;
+			if ((t256 >> 7) & 0x1) f |= 0x1;   // donor
+			if ((t256 >> 6) & 0x1) f |= 0x2;   // acceptor
+			const bool is_h = (atoms[a].element[0] == 'H') ||
+			                  (atoms[a].element[0] == ' ' && atoms[a].element[1] == 'H');
+			if (!is_h) f |= 0x4;               // heavy
+			d.hflags[a] = f;
+		}
+		// Covalent (type-1) constraints only; use internal atom indices (inum).
+		for (int c = 0; c < FA->num_constraints; ++c) {
+			if (FA->constraints[c].type != 1) continue;
+			const int i = FA->constraints[c].inum1;
+			const int j = FA->constraints[c].inum2;
+			if (i < 0 || i >= n_atoms || j < 0 || j >= n_atoms) continue;
+			d.cons_i.push_back(i);
+			d.cons_j.push_back(j);
+			d.cons_bl.push_back(FA->constraints[c].bond_len);
+			d.cons_md.push_back(FA->constraints[c].max_dist);
+		}
+		std::memset(&d.extra, 0, sizeof(d.extra));
+		d.extra.atom_pbvdw  = d.pbvdw.data();
+		d.extra.atom_charge = d.charge.data();
+		d.extra.atom_hflags = d.hflags.data();
+		d.extra.n_cons = (int)d.cons_i.size();
+		if (d.extra.n_cons > 0) {
+			d.extra.cons_i       = d.cons_i.data();
+			d.extra.cons_j       = d.cons_j.data();
+			d.extra.cons_bondlen = d.cons_bl.data();
+			d.extra.cons_maxdist = d.cons_md.data();
+		}
+		d.extra.gist_nx = 0;   // GPU GIST upload not wired (see comment above)
+		return d;
+	};
 #endif  // FLEXAIDS_USE_CUDA || FLEXAIDS_USE_METAL
 
 	// Log dispatch decision on first call.
@@ -2549,27 +2664,34 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 		ctx.dispatch_logged = true;
 	}
 
-	// ── PB term / accelerated-path divergence guard ───────────────────────────
-	// The CUDA/Metal batch kernels compute only com/wal/sas; cf.pb_clash is zeroed
-	// in unpack_gpu_results() below to avoid a stale host buffer leaking into
-	// get_cf_evalue(). cf.pb_clash carries BOTH PoseBust terms (the pb_clash
-	// penalty and the pb_pocket penalty), so both vanish on this path. That is
-	// memory-safe, but it means a run with either weight > 0 scores DIFFERENT
-	// PHYSICS on an accelerated backend than on the CPU backend. Previously this
-	// was silent. Warn once per process so the divergence can never go unnoticed.
-	if ((backend == flexaids::HardwareBackend::CUDA ||
-	     backend == flexaids::HardwareBackend::METAL) &&
-	    (FA->pb_clash_weight > 0.0 || FA->pb_pocket_weight > 0.0)) {
-		static bool pb_gpu_warned = false;
-		if (!pb_gpu_warned) {
-			pb_gpu_warned = true;
+	// ── Accelerated-path divergence guard (P4) ────────────────────────────────
+	// The GPU CF now reproduces com/wal/sas/con/elec/hbond/gist_desolv/pb_clash
+	// (PoseBust clash + pocket now INCLUDED) within the ranking-preserving drift
+	// tolerance. A few CPU terms still have NO GPU implementation and are zeroed
+	// in unpack_gpu_results() so no stale value leaks into get_cf_evalue():
+	//   • cf.metal_coord   (Gaussian metal-coordination Morse term)
+	//   • cf.entropy       (Shannon contact-type vct-entropy penalty)
+	//   • cf.h_rep         (tENCoM vibrational Shannon entropy, tencom_weight)
+	//   • cf.gist_desolv   when use_gist is set: the GPU GIST grid upload is not
+	//                       yet wired (GISTGrid has no grid accessors) → 0.
+	// Additionally the Metal MULTI (screening) path computes only com/wal/sas.
+	// Warn once if any active weight would make the accelerated score diverge.
+	if (backend == flexaids::HardwareBackend::CUDA ||
+	    backend == flexaids::HardwareBackend::METAL) {
+		static bool gpu_div_warned = false;
+		const bool metal_c = FA->use_metal_coord != 0;
+		const bool entropy = FA->vct_entropy_weight > 0.0;
+		const bool tencom  = FA->tencom_weight > 0.0f;
+		const bool gist    = FA->use_gist != 0;   // GPU GIST upload not wired yet
+		if (!gpu_div_warned && (metal_c || entropy || tencom || gist)) {
+			gpu_div_warned = true;
 			fprintf(stderr,
-			        "[PB_CLASH] WARNING: %s accelerated path detected — PoseBust terms "
-			        "(pb_clash_weight=%.4g, pb_pocket_weight=%.4g) are NOT computed on this "
-			        "path and are zeroed for consistency. Scoring will DIVERGE from the CPU "
-			        "backend. Set FLEXAIDDS_FORCE_CPU=1 to enable them.\n",
+			        "[GPU_CF] WARNING: %s accelerated path does not compute "
+			        "metal_coord=%d vct_entropy(w=%.4g) tENCoM(w=%.4g) gist=%d; these "
+			        "are zeroed and scoring will DIVERGE from the CPU backend. Set "
+			        "FLEXAIDDS_FORCE_CPU=1 to score them on CPU.\n",
 			        flexaids::backend_name(backend),
-			        FA->pb_clash_weight, FA->pb_pocket_weight);
+			        (int)metal_c, FA->vct_entropy_weight, FA->tencom_weight, (int)gist);
 		}
 	}
 
@@ -2587,18 +2709,28 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 		auto handle = pool.acquire_cuda(n_atoms, n_types, [&]() {
 			auto ad = prepare_gpu_atoms();
 			std::vector<float> h_emat = build_emat_sampled(n_types, ns);
-			return cuda_eval_init(n_atoms, n_types, MAX_NUM_CHROM,
+			CudaEvalCtx* c = cuda_eval_init(n_atoms, n_types, MAX_NUM_CHROM,
 			                     n_genes, ad.lig_first, ad.lig_last,
 			                     FA->permeability,
 			                     ad.xyz.data(), ad.type.data(),
 			                     ad.radius.data(), h_emat.data());
+			// Upload the rigid full-fidelity static arrays once per context.
+			auto ex = prepare_gpu_extra();
+			cuda_eval_set_extra(c, &ex.extra);
+			return c;
 		});
 
 		std::vector<double> h_genes = pack_genes_batch(n_genes);
-		std::vector<double> h_com(pop_size), h_wal(pop_size), h_sas(pop_size);
-		cuda_eval_batch(handle.ctx, pop_size, n_genes, h_genes.data(),
-		                h_com.data(), h_wal.data(), h_sas.data());
-		unpack_gpu_results(h_com, h_wal, h_sas);
+		std::vector<double> h_com(pop_size), h_wal(pop_size), h_sas(pop_size),
+		                    h_con(pop_size), h_elec(pop_size), h_hbond(pop_size),
+		                    h_gist(pop_size), h_pb(pop_size);
+		GpuCfParams  params = build_gpu_params();
+		GpuCfResults res;
+		res.com = h_com.data(); res.wal = h_wal.data(); res.sas = h_sas.data();
+		res.con = h_con.data(); res.elec = h_elec.data(); res.hbond = h_hbond.data();
+		res.gist_desolv = h_gist.data(); res.pb_clash = h_pb.data();
+		cuda_eval_batch(handle.ctx, pop_size, n_genes, h_genes.data(), &params, &res);
+		unpack_gpu_results(h_com, h_wal, h_sas, h_con, h_elec, h_hbond, h_gist, h_pb);
 		pool.release_cuda(handle);
 		gpu_handled = true;
 	}
@@ -2623,26 +2755,43 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 		auto handle = pool.acquire_metal(n_atoms, n_types, ctx_max_pop, [&]() {
 			auto ad = prepare_gpu_atoms();
 			std::vector<float> h_emat = build_emat_sampled(n_types, ns);
-			return metal_eval_init(n_atoms, n_types, ctx_max_pop,
+			MetalEvalCtx* c = metal_eval_init(n_atoms, n_types, ctx_max_pop,
 			                      ad.lig_first, ad.lig_last,
 			                      FA->permeability,
 			                      ad.xyz.data(), ad.type.data(),
 			                      ad.radius.data(), h_emat.data(), ns);
+			// Upload the rigid full-fidelity static arrays once per context.
+			if (c) { auto ex = prepare_gpu_extra(); metal_eval_set_extra(c, &ex.extra); }
+			return c;
 		});
 
 		if (handle.ctx) {
 			std::vector<double> h_genes = pack_genes_batch(n_genes);
-			std::vector<double> h_com(pop_size), h_wal(pop_size), h_sas(pop_size);
+			// All eight channels are zero-initialised; the multi (screening) path
+			// fills only com/wal/sas, leaving the rest 0 (its documented fidelity).
+			std::vector<double> h_com(pop_size), h_wal(pop_size), h_sas(pop_size),
+			                    h_con(pop_size, 0.0), h_elec(pop_size, 0.0),
+			                    h_hbond(pop_size, 0.0), h_gist(pop_size, 0.0),
+			                    h_pb(pop_size, 0.0);
+			GpuCfParams params = build_gpu_params();
+			// Stash params so the multi-complex kernel (fixed GPUContextPool API)
+			// can read dw_r0/sas_weight/solvent for its com/wal/sas evaluation.
+			metal_eval_set_params(handle.ctx, &params);
 
 			if (batch_n <= 1) {
-				// Single-complex fast path — no batching overhead.
+				// Single-complex fast path — full-fidelity CF.
+				GpuCfResults res;
+				res.com = h_com.data(); res.wal = h_wal.data(); res.sas = h_sas.data();
+				res.con = h_con.data(); res.elec = h_elec.data(); res.hbond = h_hbond.data();
+				res.gist_desolv = h_gist.data(); res.pb_clash = h_pb.data();
 				metal_eval_batch(handle.ctx, pop_size, n_genes, h_genes.data(),
-				                 h_com.data(), h_wal.data(), h_sas.data());
+				                 &params, &res);
 			} else {
 				// Multi-complex path: pack per-complex atom data and queue for
 				// batched dispatch.  When N concurrent workers all reach this
 				// point in the same generation, they share one GPU kernel launch
-				// (N × pop_size chromosomes per dispatch).
+				// (N × pop_size chromosomes per dispatch). Screening pre-filter:
+				// only com/wal/sas are returned (see metal_eval.h).
 				auto ad = prepare_gpu_atoms();
 				MetalMultiBatchEntry entry;
 				entry.h_genes      = h_genes.data();
@@ -2661,7 +2810,7 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 				                              entry, batch_n);
 			}
 
-			unpack_gpu_results(h_com, h_wal, h_sas);
+			unpack_gpu_results(h_com, h_wal, h_sas, h_con, h_elec, h_hbond, h_gist, h_pb);
 			gpu_handled = true;
 		} else {
 			fprintf(stderr,

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -2004,10 +2004,16 @@ int reproduce(FA_Global* FA,GB_Global* GB,VC_Global* VC, chromosome* chrom, cons
 	// The CI A/B reproducibility mode is FLEXAID_DETERMINISTIC (see
 	// calculate_fitness()), which pins a serial-equivalent reduction order for
 	// the parallel eval loop rather than disabling the deferred path here.
+	// Default OFF per METHODOLOGY §1: this flag was gated off for reproducibility
+	// (the ~0.2% multi-thread chromosome divergence in OPTIMIZATION_KNOWN_ISSUES.md),
+	// and §1 requires an intended behaviour change to be opt-in behind a flag that
+	// defaults OFF with parity holding when it is OFF. The drift allowance that
+	// would unblock it is a maintainer decision, not one this change can grant
+	// itself. Set FLEXAIDDS_PARALLEL_REPRODUCE=1 to opt in and benchmark it.
 	static const bool parallel_reproduce_eval = [](){
 		const char* env = std::getenv("FLEXAIDDS_PARALLEL_REPRODUCE");
 		if (env && env[0] != '\0') return env[0] != '0';  // explicit override
-		return true;                                       // default ON (P3)
+		return false;                                      // default OFF (§1)
 	}();
 
 	// Multi-chain VCT normalisation (see GA() comment for rationale)

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -536,6 +536,36 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	int    stagnation_count  = 0;
 	bool   ga_stagnant = false;
 
+	// ── [P5-ADAPTIVE-GEN] Adaptive-generation early convergence state (BEGIN) ──
+	// Off by default. Opt in with FLEXAIDDS_ADAPTIVE_GENERATIONS=<K> (patience in
+	// generations); the GA stops once best-CF improves by < eps for K consecutive
+	// generations instead of always running max_generations. Independent of the
+	// SMFREE/entropy termination paths above (no sec_may_terminate gate) so it
+	// works for the classic CF-only fast-docking mode. Purely a wall-clock lever;
+	// ranking/poses are unchanged when the flag is unset.
+	int    ag_patience   = 0;       // 0 = disabled
+	double ag_eps        = 1.0;     // kcal/mol improvement threshold (best-CF)
+	double ag_prev_best  = 1e30;    // best CF observed at previous check
+	int    ag_plateau    = 0;       // consecutive plateau generations
+	{
+		const char* ag_e = std::getenv("FLEXAIDDS_ADAPTIVE_GENERATIONS");
+		if (ag_e && *ag_e) {
+			ag_patience = std::atoi(ag_e);
+			if (ag_patience < 0) ag_patience = 0;
+		}
+		const char* ag_eps_e = std::getenv("FLEXAIDDS_ADAPTIVE_EPS");
+		if (ag_eps_e && *ag_eps_e) {
+			const double v = std::atof(ag_eps_e);
+			if (v > 0.0) ag_eps = v;
+		}
+		if (ag_patience > 0) {
+			printf("[P5-ADAPTIVE-GEN] adaptive generations ON: patience=%d gens, "
+			       "eps=%.4f kcal/mol (best-CF plateau early stop)\n",
+			       ag_patience, ag_eps);
+		}
+	}
+	// ── [P5-ADAPTIVE-GEN] state (END) ──
+
 	// ── Always-on H plateau early exit: ring buffer over last 20 checks ─────
 	// Fires independently of GB->entropy_convergence (that flag controls the
 	// soft/hard/plateau checks above).  ε = 0.001 nats matches the thermal noise
@@ -854,6 +884,28 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 			}
 			prev_best_evalue = _cur;  // always update (was conditional on _ps)
 		}
+
+		// ── [P5-ADAPTIVE-GEN] Best-CF plateau early stop (BEGIN) ────────────
+		// Localized generation-loop convergence check. Guarded by ag_patience>0
+		// (FLEXAIDDS_ADAPTIVE_GENERATIONS); when disabled this is a single
+		// predictable branch and behavior is identical to legacy. Uses the
+		// elitism-guaranteed best chromosome (*chrom)[0].evalue (CF, lower=better).
+		if (ag_patience > 0 && i > 0) {
+			const double ag_cur = (*chrom)[0].evalue;
+			if ((ag_prev_best - ag_cur) < ag_eps) {
+				if (++ag_plateau >= ag_patience) {
+					printf("[P5-ADAPTIVE-GEN] GA converged: best-CF plateau for %d "
+					       "gens (best_CF=%.4f) at gen %d — early stop "
+					       "(max_generations=%d)\n",
+					       ag_plateau, ag_cur, i + 1, GB->max_generations);
+					break;
+				}
+			} else {
+				ag_plateau = 0;
+			}
+			ag_prev_best = ag_cur;
+		}
+		// ── [P5-ADAPTIVE-GEN] Best-CF plateau early stop (END) ──────────────
 
 		// ── Always-on H plateau early exit ─────────────────────────────────
 		// Every entropy_check_interval generations, sample H of the current

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -1932,22 +1932,30 @@ int reproduce(FA_Global* FA,GB_Global* GB,VC_Global* VC, chromosome* chrom, cons
 
 	int i,j,k;
 
-	// ── GA-PARALLEL-EVAL (finding #1) ──────────────────────────────────────
-	// Default OFF: reproduce() behaves exactly as before (fully serial
-	// per-offspring eval_chromosome() calls). When FLEXAIDDS_PARALLEL_REPRODUCE
-	// is set (non-empty, not "0"), offspring CF evaluation is deferred: each
-	// new offspring's status is left as ' ' ("needs eval") instead of being
-	// evaluated inline here, and the pre-existing OpenMP-parallel loop inside
-	// calculate_fitness() -- already called unconditionally at the end of this
-	// function for both STEADY and BOOM -- evaluates every not-yet-'n'
-	// chromosome (including these offspring) across threads, each using its
-	// own per-thread FA/VC/atoms/residue workspace copy. No new parallel
-	// region and no change to eval_chromosome()/vcfunction() math: this flag
-	// only decides WHERE (serial reproduce() vs parallel calculate_fitness())
-	// the exact same function is called from.
+	// ── GA-PARALLEL-EVAL (P3, finding #1) ──────────────────────────────────
+	// Default ON (drift allowed — see docs/FLEXAID_FAST_DOCKING_PLAN.md §P3 and
+	// OPTIMIZATION_KNOWN_ISSUES.md): offspring CF evaluation is deferred so that
+	// BOTH parents and offspring are scored in the single OpenMP-parallel loop
+	// inside calculate_fitness() (called unconditionally at the end of this
+	// function for both STEADY and BOOM). Each new offspring's status is set to
+	// ' ' ("needs eval") — the STALE-STATUS FIX — because chrom[num_chrom+i] is
+	// REUSED memory whose status is typically 'n' from the previous generation,
+	// and calculate_fitness()'s eval loop SKIPS status=='n'. Without the explicit
+	// reset the deferred offspring would keep the prior occupant's stale CF
+	// (the CF -5.23 vs serial -51.93 defect documented in OPTIMIZATION_KNOWN_ISSUES.md).
+	// No new parallel region and no change to eval_chromosome()/vcfunction()
+	// math: this flag only decides WHERE (serial reproduce() vs parallel
+	// calculate_fitness()) the exact same eval is called from.
+	//
+	// Override: FLEXAIDDS_PARALLEL_REPRODUCE=0 forces the legacy serial inline
+	// path (bit-reproducible reference); any other explicit value keeps it ON.
+	// The CI A/B reproducibility mode is FLEXAID_DETERMINISTIC (see
+	// calculate_fitness()), which pins a serial-equivalent reduction order for
+	// the parallel eval loop rather than disabling the deferred path here.
 	static const bool parallel_reproduce_eval = [](){
 		const char* env = std::getenv("FLEXAIDDS_PARALLEL_REPRODUCE");
-		return env && env[0] != '\0' && env[0] != '0';
+		if (env && env[0] != '\0') return env[0] != '0';  // explicit override
+		return true;                                       // default ON (P3)
 	}();
 
 	// Multi-chain VCT normalisation (see GA() comment for rationale)
@@ -2085,10 +2093,11 @@ int reproduce(FA_Global* FA,GB_Global* GB,VC_Global* VC, chromosome* chrom, cons
 			}
 
 			if (parallel_reproduce_eval) {
-				// GA-PARALLEL-EVAL: leave status==' ' ("needs eval"). The
-				// unconditional calculate_fitness() call at the end of this
-				// function evaluates every not-yet-'n' chromosome, including
-				// this offspring, across its existing OpenMP-parallel loop.
+				// GA-PARALLEL-EVAL: defer CF eval to calculate_fitness()'s
+				// OpenMP loop. STALE-STATUS FIX — explicitly mark this reused
+				// slot as ' ' ("needs eval"); it typically holds 'n' from the
+				// previous generation, which the eval loop skips.
+				chrom[GB->num_chrom+i].status=' ';
 			} else {
 				chrom[GB->num_chrom+i].cf=eval_chromosome(FA,GB,VC,gene_lim,atoms,residue,cleftgrid,
 									  chrom[GB->num_chrom+i].genes,target);
@@ -2124,7 +2133,8 @@ int reproduce(FA_Global* FA,GB_Global* GB,VC_Global* VC, chromosome* chrom, cons
 			}
 
 			if (parallel_reproduce_eval) {
-				// GA-PARALLEL-EVAL: see offspring #1 above.
+				// GA-PARALLEL-EVAL: see offspring #1 above. STALE-STATUS FIX.
+				chrom[GB->num_chrom+i].status=' ';
 			} else {
 				chrom[GB->num_chrom+i].cf=eval_chromosome(FA,GB,VC,gene_lim,atoms,residue,cleftgrid,
 									  chrom[GB->num_chrom+i].genes,target);
@@ -2699,46 +2709,106 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 		const int n_dirty_atm = static_cast<int>(dirty_atm.size());
 		const int n_dirty_res = static_cast<int>(dirty_res_idx.size());
 
-		// Per-thread mutable atom arrays.
-		std::vector<std::vector<atom>>  tl_atoms(n_thr,
-		    std::vector<atom>(atoms, atoms + natm + 1));
-		// Per-thread residue arrays (pointer fields shared read-only; .rot private).
-		std::vector<std::vector<resid>> tl_res(n_thr,
-		    std::vector<resid>(residue, residue + nres + 1));
-		// Per-thread FA copies with redirected mutable scratch buffers.
-		std::vector<FA_Global>           tl_fa(n_thr, *FA);
-		std::vector<std::vector<int>>    tl_contacts(n_thr, std::vector<int>(MAX_ATOM_NUMBER, 0));
-		std::vector<std::vector<float>>  tl_contrib(n_thr, std::vector<float>(nctb, 0.0f));
-		std::vector<std::vector<OptRes>> tl_optres(n_thr,
-		    std::vector<OptRes>(FA->optres, FA->optres + nopt));
-		// Per-thread VC workspace (Vcontacts writes all these each call).
-		std::vector<VC_Global>               tl_vc(n_thr, *VC);
-		std::vector<std::vector<atomsas>>    tl_calc(n_thr, std::vector<atomsas>(natmr));
-		std::vector<std::vector<int>>        tl_calclist(n_thr, std::vector<int>(natmr));
-		std::vector<std::vector<int>>        tl_caidx(n_thr, std::vector<int>(natmr, -1));
-		std::vector<std::vector<ca_struct>>  tl_carec(n_thr,
-		    std::vector<ca_struct>(VC->ca_recsize));
-		std::vector<std::vector<int>>        tl_seed(n_thr,
-		    std::vector<int>(3 * natmr));
-		std::vector<std::vector<contactlist>> tl_contlist(n_thr,
-		    std::vector<contactlist>(GA_CONTLIST_SIZE));
-		std::vector<std::vector<ptindex>>    tl_ptorder(n_thr,
-		    std::vector<ptindex>(MAX_PT));
-		std::vector<std::vector<vertex>>     tl_centerpt(n_thr,
-		    std::vector<vertex>(MAX_PT));
-		std::vector<std::vector<vertex>>     tl_poly(n_thr,
-		    std::vector<vertex>(MAX_POLY));
-		std::vector<std::vector<plane>>      tl_cont(n_thr,
-		    std::vector<plane>(MAX_PT));
-		std::vector<std::vector<edgevector>> tl_vedge(n_thr,
-		    std::vector<edgevector>(MAX_POLY));
+		// ── P3: resident per-thread workspace (lean receptor copy) ───────────
+		// The receptor is READ-ONLY during scoring, so rather than re-cloning
+		// the full atom/residue arrays and every Voronoi scratch buffer on each
+		// generation (the dominant memory-bandwidth cost of the OpenMP path —
+		// O(generations × threads × natm)), we allocate them ONCE and keep them
+		// resident across calculate_fitness() calls. The resident receptor atoms
+		// stay valid because a rigid receptor never moves and flexible side-chain
+		// atoms are always in the per-chromosome dirty set restored below; only
+		// the small mutable ligand/pose/flex state is refreshed each generation.
+		// The cheap live snapshots (FA/VC scalars, optres records) are re-synced
+		// each call so nothing goes stale. The cache is fully rebuilt whenever
+		// the problem shape or any base pointer changes, so multiple sequential
+		// docks in one process are safe. Vcontacts/vcfunction already reset their
+		// scratch per eval (contacts is epoch-stamped, ca_index re-seeded, etc.),
+		// so carrying those buffers across calls matches the existing across-eval
+		// reuse within a single call — no behavioural change to the CF math.
+		struct ParEvalWS {
+			int n_thr=0, natm=-1, nres=-1, natmr=-1, nopt=-1, nctb=-1, ca_recsize=-1;
+			const void *fa=nullptr,*vc=nullptr,*atoms=nullptr,*res=nullptr,*optres=nullptr;
+			std::vector<std::vector<atom>>        tl_atoms;
+			std::vector<std::vector<resid>>       tl_res;
+			std::vector<FA_Global>                tl_fa;
+			std::vector<std::vector<int>>         tl_contacts;
+			std::vector<std::vector<float>>       tl_contrib;
+			std::vector<std::vector<OptRes>>      tl_optres;
+			std::vector<VC_Global>                tl_vc;
+			std::vector<std::vector<atomsas>>     tl_calc;
+			std::vector<std::vector<int>>         tl_calclist;
+			std::vector<std::vector<int>>         tl_caidx;
+			std::vector<std::vector<ca_struct>>   tl_carec;
+			std::vector<std::vector<int>>         tl_seed;
+			std::vector<std::vector<contactlist>> tl_contlist;
+			std::vector<std::vector<ptindex>>     tl_ptorder;
+			std::vector<std::vector<vertex>>      tl_centerpt;
+			std::vector<std::vector<vertex>>      tl_poly;
+			std::vector<std::vector<plane>>       tl_cont;
+			std::vector<std::vector<edgevector>>  tl_vedge;
+		};
+		static ParEvalWS ws;   // resident across generations (serial init: GA
+		                       // parallelism lives strictly inside this loop).
+
+		const bool ws_valid =
+			ws.n_thr == n_thr && ws.natm == natm && ws.nres == nres &&
+			ws.natmr == natmr && ws.nopt == nopt && ws.nctb == nctb &&
+			ws.ca_recsize == VC->ca_recsize &&
+			ws.fa == (const void*)FA && ws.vc == (const void*)VC &&
+			ws.atoms == (const void*)atoms && ws.res == (const void*)residue &&
+			ws.optres == (const void*)FA->optres;
+
+		if (!ws_valid) {
+			// Full (re)allocation — the receptor is cloned exactly once per shape.
+			ws = ParEvalWS{};
+			ws.n_thr = n_thr; ws.natm = natm; ws.nres = nres; ws.natmr = natmr;
+			ws.nopt = nopt;   ws.nctb = nctb; ws.ca_recsize = VC->ca_recsize;
+			ws.fa = FA; ws.vc = VC; ws.atoms = atoms; ws.res = residue;
+			ws.optres = FA->optres;
+			ws.tl_atoms.assign(n_thr, std::vector<atom>(atoms, atoms + natm + 1));
+			ws.tl_res.assign(n_thr, std::vector<resid>(residue, residue + nres + 1));
+			ws.tl_fa.assign(n_thr, *FA);
+			ws.tl_contacts.assign(n_thr, std::vector<int>(MAX_ATOM_NUMBER, 0));
+			ws.tl_contrib.assign(n_thr, std::vector<float>(nctb, 0.0f));
+			ws.tl_optres.assign(n_thr, std::vector<OptRes>(FA->optres, FA->optres + nopt));
+			ws.tl_vc.assign(n_thr, *VC);
+			ws.tl_calc.assign(n_thr, std::vector<atomsas>(natmr));
+			ws.tl_calclist.assign(n_thr, std::vector<int>(natmr));
+			ws.tl_caidx.assign(n_thr, std::vector<int>(natmr, -1));
+			ws.tl_carec.assign(n_thr, std::vector<ca_struct>(VC->ca_recsize));
+			ws.tl_seed.assign(n_thr, std::vector<int>(3 * natmr));
+			ws.tl_contlist.assign(n_thr, std::vector<contactlist>(GA_CONTLIST_SIZE));
+			ws.tl_ptorder.assign(n_thr, std::vector<ptindex>(MAX_PT));
+			ws.tl_centerpt.assign(n_thr, std::vector<vertex>(MAX_PT));
+			ws.tl_poly.assign(n_thr, std::vector<vertex>(MAX_POLY));
+			ws.tl_cont.assign(n_thr, std::vector<plane>(MAX_PT));
+			ws.tl_vedge.assign(n_thr, std::vector<edgevector>(MAX_POLY));
+		}
+
+		// Aliases keep the eval loop below identical to the previous per-call form.
+		auto& tl_atoms   = ws.tl_atoms;    auto& tl_res      = ws.tl_res;
+		auto& tl_fa      = ws.tl_fa;       auto& tl_contacts = ws.tl_contacts;
+		auto& tl_contrib = ws.tl_contrib;  auto& tl_optres   = ws.tl_optres;
+		auto& tl_vc      = ws.tl_vc;       auto& tl_calc     = ws.tl_calc;
+		auto& tl_calclist= ws.tl_calclist; auto& tl_caidx    = ws.tl_caidx;
+		auto& tl_carec   = ws.tl_carec;    auto& tl_seed     = ws.tl_seed;
+		auto& tl_contlist= ws.tl_contlist; auto& tl_ptorder  = ws.tl_ptorder;
+		auto& tl_centerpt= ws.tl_centerpt; auto& tl_poly     = ws.tl_poly;
+		auto& tl_cont    = ws.tl_cont;     auto& tl_vedge    = ws.tl_vedge;
 
 		for (int t = 0; t < n_thr; ++t) {
-			// Redirect FA mutable scratch to per-thread buffers.
+			// Refresh the cheap live FA snapshot each generation (scalar state may
+			// change between generations), then redirect FA scratch to the
+			// resident per-thread buffers.
+			tl_fa[t] = *FA;
 			tl_fa[t].contacts      = tl_contacts[t].data();
 			tl_fa[t].contributions = tl_contrib[t].data();
 			tl_fa[t].optres        = tl_optres[t].data();
-			// Redirect VC mutable workspace to per-thread buffers.
+			// Keep optres non-cf fields in sync with the reference (cf fields are
+			// cleared per-chromosome in the eval loop below).
+			std::copy(FA->optres, FA->optres + nopt, tl_optres[t].begin());
+			// Refresh the cheap live VC snapshot, then redirect VC scratch.
+			tl_vc[t] = *VC;
 			tl_vc[t].Calc      = tl_calc[t].data();
 			tl_vc[t].Calclist  = tl_calclist[t].data();
 			tl_vc[t].ca_index  = tl_caidx[t].data();
@@ -2769,10 +2839,31 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 		}
 		const int n_optres_atoms = (int)optres_atom_list.size();
 
+		// ── FLEXAID_DETERMINISTIC (P3 · CI A/B reproducibility) ──────────────
+		// When set, the parallel CF-eval loop runs on a single thread so its
+		// reduction order is serial-equivalent and bit-reproducible run-to-run
+		// (each chromosome writes only its own chrom[ii].cf, so 1-thread ==
+		// deterministic order). Unset (default) uses the fast multi-thread path,
+		// where the ~0.2% chromosome-level numeric drift documented in
+		// OPTIMIZATION_KNOWN_ISSUES.md is accepted (see FLEXAID_FAST_DOCKING_PLAN
+		// §P3/§4.3). Enabled by the compile-time macro -DFLEXAID_DETERMINISTIC
+		// OR by the env var FLEXAID_DETERMINISTIC=<non-empty, not "0">.
+		static const bool deterministic_eval = [](){
+#ifdef FLEXAID_DETERMINISTIC
+			return true;
+#else
+			const char* env = std::getenv("FLEXAID_DETERMINISTIC");
+			return env && env[0] != '\0' && env[0] != '0';
+#endif
+		}();
 #ifdef _OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) \
+		const int eval_threads = deterministic_eval ? 1 : n_thr;
+#endif
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic) num_threads(eval_threads) default(none) \
 	shared(chrom, pop_size, GB, gene_lim, cleftgrid, target, \
-	       atoms, residue, FA, VC, \
+	       atoms, residue, FA, VC, eval_threads, \
 	       tl_atoms, tl_res, tl_fa, tl_optres, tl_vc, \
 	       natm, nres, nopt, n_receptor_chains, \
 	       use_selective, dirty_atm, dirty_res_idx, n_dirty_atm, n_dirty_res, \

--- a/LIB/metal_eval.h
+++ b/LIB/metal_eval.h
@@ -3,8 +3,14 @@
 // Mirrors cuda_eval.cuh but targets Apple GPU via Metal compute pipelines.
 // Enabled with -DFLEXAIDS_USE_METAL.
 //
+// FULL-FIDELITY scoring (P4): the Metal CF now fills the same eight scoring
+// channels as the CUDA path — com, wal, sas, con, elec, hbond, gist_desolv,
+// pb_clash — using the identical drift-tolerant linear-switching contact-area
+// model (see cuda_eval.cuh for the model definition and error bound).
+//
 // Usage:
 //   MetalEvalCtx* ctx = metal_eval_init(...);   // once, before GA loop
+//   metal_eval_set_extra(ctx, &extra);          // once (optional full-fidelity)
 //   metal_eval_batch(ctx, ...);                  // every generation
 //   metal_eval_shutdown(ctx);                    // once, after GA loop
 #pragma once
@@ -16,6 +22,63 @@
 // Number of samples used to pre-sample each energy-matrix density curve.
 // Must match the value in metal_eval.mm and the host-side sampling loop.
 static constexpr int METAL_EMAT_SAMPLES = 128;
+
+// ── Shared GPU-CF POD types ──────────────────────────────────────────────────
+// Identical to the block in cuda_eval.cuh; guarded so including both headers in
+// gaboom.cpp does not redefine the structs.
+#ifndef FLEXAIDS_GPU_CF_TYPES_DEFINED
+#define FLEXAIDS_GPU_CF_TYPES_DEFINED
+
+struct GpuCfParams {
+    float dw_r0;
+    int   elec_on;
+    float dielectric;
+    float hbond_weight;
+    float hbond_salt_weight;
+    float hbond_opt_dist;
+    float hbond_sigma_dist;
+    float hbond_angle_repr;
+    float pb_clash_weight;
+    float pb_clash_ratio;
+    float pb_clash_exponent;
+    float pb_pocket_weight;
+    float pb_pocket_radius;
+    float kdist;
+    float sas_weight;
+    int   solvent_flat;
+    float solventterm;
+};
+
+struct GpuCfResults {
+    double* com;
+    double* wal;
+    double* sas;
+    double* con;
+    double* elec;
+    double* hbond;
+    double* gist_desolv;
+    double* pb_clash;
+};
+
+struct GpuCfExtraStatic {
+    const float* atom_pbvdw;
+    const float* atom_charge;
+    const int*   atom_hflags;
+
+    int          n_cons;
+    const int*   cons_i;
+    const int*   cons_j;
+    const float* cons_bondlen;
+    const float* cons_maxdist;
+
+    int          gist_nx, gist_ny, gist_nz;
+    float        gist_origin[3];
+    float        gist_inv_delta[3];
+    float        gist_weight;
+    const float* gist_data;
+};
+
+#endif // FLEXAIDS_GPU_CF_TYPES_DEFINED
 
 // Opaque handle to all Metal device-resident state.
 struct MetalEvalCtx;
@@ -31,7 +94,7 @@ struct MetalCapabilities {
     size_t unified_memory_bytes;   // 0 if unknown
     size_t max_buffer_length;
     int    gpu_core_estimate;      // rough (0 if unknown)
-}; 
+};
 
 // Fills the struct. Safe to call even if Metal is not compiled in.
 void metal_eval_get_capabilities(MetalCapabilities* out);
@@ -61,45 +124,53 @@ MetalEvalCtx* metal_eval_init(int   n_atoms,
                                const float* h_emat_sampled,
                                int   n_emat_samples);
 
-// Evaluate a batch of chromosomes on the Metal GPU.
-//   ctx        – context from metal_eval_init
-//   pop_size   – number of chromosomes to evaluate this call
-//   n_genes    – genes per chromosome
-//   h_genes    – host gene array [pop_size × n_genes, double]
-//   h_com_out  – host output: complementarity CF   [pop_size, double]
-//   h_wal_out  – host output: wall/clash energy     [pop_size, double]
-//   h_sas_out  – host output: solvent-accessible    [pop_size, double]
-void metal_eval_batch(MetalEvalCtx* ctx,
-                      int           pop_size,
-                      int           n_genes,
-                      const double* h_genes,
-                      double*       h_com_out,
-                      double*       h_wal_out,
-                      double*       h_sas_out);
+// Upload the optional full-fidelity static arrays (pb-vdw / charge / hbond
+// flags / constraints / GIST). Call once after metal_eval_init. Passing
+// extra==nullptr (or leaving individual pointers null) disables the matching
+// terms; the base com/wal/sas path is unaffected.
+void metal_eval_set_extra(MetalEvalCtx* ctx, const GpuCfExtraStatic* extra);
+
+// Evaluate a batch of chromosomes on the Metal GPU (full-fidelity CF).
+//   ctx      – context from metal_eval_init
+//   pop_size – number of chromosomes to evaluate this call
+//   n_genes  – genes per chromosome
+//   h_genes  – host gene array [pop_size × n_genes, double]
+//   params   – per-batch scalar weights/config (must be non-null)
+//   out      – host output channels; each array has length >= pop_size
+void metal_eval_batch(MetalEvalCtx*       ctx,
+                      int                 pop_size,
+                      int                 n_genes,
+                      const double*       h_genes,
+                      const GpuCfParams*  params,
+                      const GpuCfResults* out);
 
 // Free all Metal device resources.
 void metal_eval_shutdown(MetalEvalCtx* ctx);
 
+// Stash the per-batch CF params into the context. Used by the multi-complex
+// path (whose public signature is fixed by GPUContextPool.h and cannot take a
+// params argument) and as a fallback source of params for internal delegations.
+// Call once per dock before dispatch; params are a per-dock constant.
+void metal_eval_set_params(MetalEvalCtx* ctx, const GpuCfParams* params);
+
 // ─── Multi-complex batched evaluation (GPU utilization maximization) ──────────
 //
-// Dispatches N independent chromosome populations in a single Metal command buffer.
-// Each entry i corresponds to one docking complex (worker); the GPU evaluates
-// n_complex × pop_size chromosomes in one dispatch instead of N serial calls.
+// Dispatches N independent chromosome populations in a single Metal command
+// buffer for many-ligand single-dispatch screening. Thread mapping:
+// thread k → complex_id = k / pop_size, chrom_id = k % pop_size.
 //
-// Thread mapping: thread k → complex_id = k / pop_size, chrom_id = k % pop_size
+// Fidelity note (P4): the multi path is a screening pre-filter and computes the
+// com (distance-weighted) / wal / sas channels only, using the params stashed
+// via metal_eval_set_params(). The con / elec / hbond / gist_desolv / pb_clash
+// channels are NOT computed here (those need per-complex extra arrays that the
+// GPUContextPool queue does not carry) and remain whatever the caller left them.
+// Single-complex GA runs (batch_n<=1) go through metal_eval_batch above, which
+// is full-fidelity. This signature and MetalMultiBatchEntry are held fixed
+// because GPUContextPool.h stores and dispatches them.
 //
 // Requirements:
-//   - All complexes must share the same n_atoms, n_types, and pop_size.
-//   - The single shared context (ctx) must have been init'd with max_pop = n_complex × pop_size.
-//   - h_genes[i]   points to the gene array for complex i  [pop_size × n_genes, double]
-//   - h_com_out[i] / h_wal_out[i] / h_sas_out[i] are per-complex output buffers [pop_size]
-//
-// All buffers are host-side; the implementation copies in, dispatches, and copies out.
-//
-// Per-complex entry for multi-complex batch dispatch.
-// Each entry carries its own atom data so complexes with different
-// receptors/ligands can be batched into a single GPU kernel launch.
-// When n_complex == 1 the fast path delegates to metal_eval_batch().
+//   - All complexes share the same n_genes and pop_size.
+//   - The shared context must be init'd with max_pop = n_complex × pop_size.
 struct MetalMultiBatchEntry {
     // Gene input
     const double* h_genes;      // [pop_size × n_genes]
@@ -118,10 +189,10 @@ struct MetalMultiBatchEntry {
     double*       h_sas_out;    // [pop_size]
 };
 
-void metal_eval_batch_multi(MetalEvalCtx*              ctx,
-                             int                        n_complex,
-                             int                        pop_size,
-                             int                        n_genes,
+void metal_eval_batch_multi(MetalEvalCtx*               ctx,
+                             int                         n_complex,
+                             int                         pop_size,
+                             int                         n_genes,
                              const MetalMultiBatchEntry* entries);
 
 #endif  // FLEXAIDS_USE_METAL

--- a/LIB/metal_eval.mm
+++ b/LIB/metal_eval.mm
@@ -1,28 +1,26 @@
-// metal_eval.mm — Metal GPU batched chromosome evaluation
+// metal_eval.mm — Full-fidelity Metal GPU batched chromosome evaluation
 //
-// Experimental approximate Metal chromosome evaluation.
+// P4: brings the single-complex Metal CF up to parity with the CPU
+// ic2cf/vcfunction assembly within the ranking-preserving drift tolerance. The
+// single-complex MSL kernel now fills the eight scoring channels that feed
+// get_cf_evalue():
 //
-// This path does not currently reproduce the full CPU ic2cf/vcfunction scoring
-// path: it treats the first three raw genes as Cartesian translations and
-// returns a reduced set of CF terms. UnifiedHardwareDispatch therefore keeps
-// production GA fitness on CPU/OpenMP until parity is implemented.
+//     com, wal, sas, con, elec, hbond, gist_desolv, pb_clash
 //
-// The MSL kernel is compiled at runtime from an embedded string; no separate
-// .metal compilation step is needed.
+// Contact-area model: the same C0 linear-switching approximation documented in
+// cuda_eval.cuh (NOT the branchy analytic Voronoi). Terms that require true
+// absolute geometry (angular H-bond directionality, metal-CN, vct-entropy,
+// tENCoM) are not reproduced on-device — the gaboom.cpp divergence guard warns
+// when their weights are non-zero.
 //
-// Scoring pipeline (per chromosome, one threadgroup per chromosome):
-//   1. Decode translation genes (tx, ty, tz) from the gene vector.
-//   2. For each ligand-protein atom pair:
-//        a. Compute inter-atomic distance r.
-//        b. Approximate contact area (linear switching 0→1 as r→rA+rB).
-//        c. Look up energy value via linear interpolation in the
-//           pre-sampled density-function table.
-//        d. Accumulate COM contribution and WAL (clash) energy.
-//        e. Subtract contact area from per-ligand-atom SAS counter
-//           using a CAS-loop float atomic in threadgroup memory.
-//   3. Compute SAS energy contribution for each ligand atom using the
-//      remaining exposed surface and the solvent column of the energy matrix.
-//   4. Reduce COM, WAL, SAS across the threadgroup and write outputs.
+// The multi-complex screening path keeps its GPUContextPool-fixed public API and
+// remains a com(dist-weighted)/wal/sas pre-filter (see metal_eval.h).
+//
+// Reduction correctness: the previous experimental kernels reduced with
+// simd_sum() only, which sums within a single 32-lane SIMD group while the
+// threadgroup runs 256 threads — silently dropping 7/8 of the per-pair
+// contributions. Both kernels below use an explicit power-of-two threadgroup
+// tree reduction (tg_reduce_sum / tg_reduce_min) that includes every thread.
 
 #ifdef FLEXAIDS_USE_METAL
 
@@ -39,6 +37,37 @@
 #include <cmath>
 #include <string>
 
+// ─── host/MSL shared kernel-parameter POD (single-complex) ───────────────────
+// Layout MUST match the MSL `KP` struct below (all 4-byte scalars, tight).
+struct MetalKP {
+    int   N, T, n_genes, lig_first, lig_last;
+    float perm;
+    int   has_pbvdw, has_charge, has_hflags;
+    int   n_cons;
+    int   gist_nx, gist_ny, gist_nz;
+    float gox, goy, goz, gidx, gidy, gidz, gist_weight;
+    float dw_r0;
+    int   elec_on;
+    float dielectric;
+    float hbond_weight, hbond_salt_weight, hbond_opt_dist, hbond_sigma_dist, hbond_angle_repr;
+    float pb_clash_weight, pb_clash_ratio, pb_clash_exponent, pb_pocket_weight, pb_pocket_radius;
+    float kdist, sas_weight;
+    int   solvent_flat;
+    float solventterm;
+};
+
+// Multi-complex shared params (screening pre-filter: com/wal/sas only).
+struct MetalMultiParams {
+    int   pop_size, n_genes, T;
+    float perm;
+    float dw_r0;
+    float sas_weight;
+    int   solvent_flat;
+    float solventterm;
+};
+
+static constexpr int METAL_CF_CHANNELS = 8;
+
 // ─── MSL kernel source (embedded) ────────────────────────────────────────────
 static const char* kMSLSource = R"MSL(
 #include <metal_stdlib>
@@ -46,8 +75,12 @@ static const char* kMSLSource = R"MSL(
 using namespace metal;
 
 #define N_EMAT_SAMPLES 128
+#define TG_THREADS 256
+#define KWALL_F     1.0e6f
+#define KCOULOMB_F  332.0637f
+#define HBOND_PAIR_MIN -2.0f
+#define Q_SALT 0.30f
 
-// GPU-side linear interpolation into the pre-sampled energy-matrix table.
 static float gpu_get_yval(device const float* emat_sampled,
                            int t1, int t2, int T, float rel_area)
 {
@@ -61,177 +94,95 @@ static float gpu_get_yval(device const float* emat_sampled,
          + emat_sampled[base + k1] * frac;
 }
 
-// CAS-loop float atomic subtract in threadgroup memory (Metal 2-compatible).
+// GetValueFromGaussian, base clamped >=0 (drift-safe).
+static float gpu_gaussian(float x, float mx, float zero)
+{
+    float dz = zero - mx;
+    float denom = dz * dz;
+    if (denom < 1e-12f) return 0.0f;
+    float base = (-(x - zero) * (x - (2.0f * mx - zero))) / denom;
+    if (base <= 0.0f) return 0.0f;
+    return pow(base, 50.0f);
+}
+
+// Atomic float subtract on a threadgroup counter (Metal-2 compatible CAS loop).
 static void tg_atomic_sub_float(threadgroup float* ptr, float val)
 {
     threadgroup atomic_uint* ap = (threadgroup atomic_uint*)ptr;
-    uint old_bits, new_bits;
+    uint old_bits = atomic_load_explicit(ap, memory_order_relaxed);
+    uint new_bits;
     do {
-        old_bits = atomic_load_explicit(ap, memory_order_relaxed);
-        float new_val = as_type<float>(old_bits) - val;
-        new_bits = as_type<uint>(new_val);
+        float nv = as_type<float>(old_bits) - val;
+        new_bits = as_type<uint>(nv);
     } while (!atomic_compare_exchange_weak_explicit(
                 ap, &old_bits, new_bits,
                 memory_order_relaxed, memory_order_relaxed));
 }
 
-// Params packed into one buffer for convenience.
-struct EvalParams {
-    int   N;           // total atom count
-    int   T;           // atom type count
-    int   n_genes;
-    int   lig_first;
-    int   lig_last;
-    float perm;
-    int   pad0;
-    int   pad1;
-};
-
-// ─── Multi-complex kernel ─────────────────────────────────────────────────────
-// Evaluates N × pop_size chromosomes where each group of pop_size threadgroups
-// belongs to a different (receptor, ligand) system.  Each complex supplies its
-// own atom coordinates, types, and radii via concatenated device buffers plus a
-// per-complex descriptor array so the kernel can address the right atoms.
-//
-// Thread mapping: global_chrom_id k  →  complex_id = k / pop_size
-//                                        local_chrom = k % pop_size
-struct ComplexDesc {
-    int   atom_offset;    // start index in the concatenated atom arrays
-    int   n_atoms;        // total atoms for this complex
-    int   lig_first;      // first ligand atom (local index within complex atoms)
-    int   lig_last;       // last  ligand atom (local index)
-    int   gene_offset;    // complex_id * pop_size * n_genes
-    int   result_offset;  // complex_id * pop_size
-    int   pad0;
-    int   pad1;
-};
-
-struct MultiParams {
-    int   pop_size;
-    int   n_genes;
-    int   T;              // n_types (energy matrix dimension)
-    float perm;
-};
-
-kernel void kernel_eval_cf_multi(
-    device const float*        atom_xyz_all    [[ buffer(0) ]],
-    device const int*          atom_type_all   [[ buffer(1) ]],
-    device const float*        atom_radius_all [[ buffer(2) ]],
-    device const float*        emat_sampled    [[ buffer(3) ]],
-    device const float*        genes_f_all     [[ buffer(4) ]],
-    device float*              cf_com_out      [[ buffer(5) ]],
-    device float*              cf_wal_out      [[ buffer(6) ]],
-    device float*              cf_sas_out      [[ buffer(7) ]],
-    constant MultiParams&      mp              [[ buffer(8) ]],
-    device const ComplexDesc*  descs           [[ buffer(9) ]],
-    threadgroup float*         lig_sas         [[ threadgroup(0) ]],
-    uint tid                                   [[ thread_position_in_threadgroup ]],
-    uint global_chrom_id                       [[ threadgroup_position_in_grid ]],
-    uint blockDim                              [[ threads_per_threadgroup ]])
+// Threadgroup tree reductions (TG_THREADS must be a power of two).
+static float tg_reduce_sum(threadgroup float* s, uint tid, float v)
 {
-    const int ci  = int(global_chrom_id) / mp.pop_size;
-    const int chi = int(global_chrom_id) % mp.pop_size;
-
-    device const ComplexDesc& d = descs[ci];
-
-    const int n_lig   = d.lig_last  - d.lig_first + 1;
-    const int n_pro   = d.n_atoms   - n_lig;
-    const int n_pairs = n_lig * n_pro;
-
-    const int gbase = d.gene_offset + chi * mp.n_genes;
-    const float tx = genes_f_all[gbase + 0];
-    const float ty = genes_f_all[gbase + 1];
-    const float tz = genes_f_all[gbase + 2];
-
-    // Initialise per-ligand SAS.
-    for (int la = int(tid); la < n_lig && la < 256; la += int(blockDim)) {
-        float ra  = atom_radius_all[d.atom_offset + d.lig_first + la];
-        float rwa = ra + 1.4f;
-        lig_sas[la] = 4.0f * M_PI_F * rwa * rwa;
-    }
+    s[tid] = v;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    float local_com = 0.0f, local_wal = 0.0f;
-
-    for (int pr = int(tid); pr < n_pairs; pr += int(blockDim)) {
-        const int li      = pr / n_pro;
-        const int pro_rel = pr % n_pro;
-        const int ai      = d.atom_offset + d.lig_first + li;
-        const int pro_loc = (pro_rel < d.lig_first) ? pro_rel : (pro_rel + n_lig);
-        const int aj      = d.atom_offset + pro_loc;
-
-        const float lx = atom_xyz_all[ai * 3 + 0] + tx;
-        const float ly = atom_xyz_all[ai * 3 + 1] + ty;
-        const float lz = atom_xyz_all[ai * 3 + 2] + tz;
-        const float dx = lx - atom_xyz_all[aj * 3 + 0];
-        const float dy = ly - atom_xyz_all[aj * 3 + 1];
-        const float dz = lz - atom_xyz_all[aj * 3 + 2];
-        const float r  = sqrt(dx*dx + dy*dy + dz*dz + 1e-10f);
-
-        const float rA    = atom_radius_all[ai];
-        const float rB    = atom_radius_all[aj];
-        const float rsum  = rA + rB;
-        const float rwa_A = rA + 1.4f;
-        const float surf_A = 4.0f * M_PI_F * rwa_A * rwa_A;
-        const float outer_r = rsum + 2.8f;
-
-        float rel_area = 0.0f;
-        if      (r < rsum)    rel_area = 1.0f;
-        else if (r < outer_r) rel_area = 1.0f - (r - rsum) / (outer_r - rsum);
-
-        if (rel_area > 0.0f && li < 256) {
-            tg_atomic_sub_float(&lig_sas[li], rel_area * surf_A);
-        }
-
-        const int ti  = atom_type_all[ai];
-        const int tj  = atom_type_all[aj];
-        const float yval = gpu_get_yval(emat_sampled, ti, tj, mp.T, rel_area);
-        local_com += yval * rel_area;
-
-        const float clash_r = mp.perm * rsum;
-        if (r < clash_r && r > 0.0f) {
-            const float inv_r12  = 1.0f / pow(r,       12.0f);
-            const float inv_cr12 = 1.0f / pow(clash_r, 12.0f);
-            local_wal += 1.0e6f * (inv_r12 - inv_cr12);
-        }
+    for (uint stride = TG_THREADS / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) s[tid] += s[tid + stride];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
     }
+    float r = s[0];
     threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    local_com = simd_sum(local_com);
-    local_wal = simd_sum(local_wal);
-
-    float local_sas = 0.0f;
-    for (int la = int(tid); la < n_lig && la < 256; la += int(blockDim)) {
-        const float sas_rem  = max(0.0f, lig_sas[la]);
-        const float rwa_la   = atom_radius_all[d.atom_offset + d.lig_first + la] + 1.4f;
-        const float surf_la  = 4.0f * M_PI_F * rwa_la * rwa_la;
-        const float sas_norm = sas_rem / surf_la;
-        const int   ti_la    = atom_type_all[d.atom_offset + d.lig_first + la];
-        const float yval_sas = gpu_get_yval(emat_sampled, ti_la, mp.T - 1, mp.T, sas_norm);
-        local_sas += yval_sas * sas_norm;
+    return r;
+}
+static float tg_reduce_min(threadgroup float* s, uint tid, float v)
+{
+    s[tid] = v;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint stride = TG_THREADS / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) s[tid] = min(s[tid], s[tid + stride]);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
     }
-    local_sas = simd_sum(local_sas);
-
-    if (tid == 0) {
-        const int out = d.result_offset + chi;
-        cf_com_out[out] = local_com;
-        cf_wal_out[out] = local_wal;
-        cf_sas_out[out] = local_sas;
-    }
+    float r = s[0];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    return r;
 }
 
-// ─── Single-complex kernel ────────────────────────────────────────────────────
+// Single-complex kernel parameters (matches host MetalKP).
+struct KP {
+    int   N, T, n_genes, lig_first, lig_last;
+    float perm;
+    int   has_pbvdw, has_charge, has_hflags;
+    int   n_cons;
+    int   gist_nx, gist_ny, gist_nz;
+    float gox, goy, goz, gidx, gidy, gidz, gist_weight;
+    float dw_r0;
+    int   elec_on;
+    float dielectric;
+    float hbond_weight, hbond_salt_weight, hbond_opt_dist, hbond_sigma_dist, hbond_angle_repr;
+    float pb_clash_weight, pb_clash_ratio, pb_clash_exponent, pb_pocket_weight, pb_pocket_radius;
+    float kdist, sas_weight;
+    int   solvent_flat;
+    float solventterm;
+};
+
+// ─── Single-complex full-fidelity kernel ──────────────────────────────────────
 kernel void kernel_eval_cf_full(
     device const float*    atom_xyz        [[ buffer(0) ]],
     device const int*      atom_type       [[ buffer(1) ]],
     device const float*    atom_radius     [[ buffer(2) ]],
     device const float*    emat_sampled    [[ buffer(3) ]],
-    device const float*    genes_f         [[ buffer(4) ]],  // float cast of double genes
-    device float*          cf_com_out      [[ buffer(5) ]],
-    device float*          cf_wal_out      [[ buffer(6) ]],
-    device float*          cf_sas_out      [[ buffer(7) ]],
-    constant EvalParams&   p               [[ buffer(8) ]],
+    device const float*    genes_f         [[ buffer(4) ]],
+    device float*          out             [[ buffer(5) ]],   // [CH * max_pop]
+    constant KP&           p               [[ buffer(6) ]],
+    device const float*    atom_pbvdw      [[ buffer(7) ]],
+    device const float*    atom_charge     [[ buffer(8) ]],
+    device const int*      atom_hflags     [[ buffer(9) ]],
+    device const int*      cons_i          [[ buffer(10) ]],
+    device const int*      cons_j          [[ buffer(11) ]],
+    device const float*    cons_bondlen    [[ buffer(12) ]],
+    device const float*    cons_maxdist    [[ buffer(13) ]],
+    device const float*    gist_data       [[ buffer(14) ]],
+    constant int&          max_pop         [[ buffer(15) ]],
     threadgroup float*     lig_sas         [[ threadgroup(0) ]],
+    threadgroup float*     red             [[ threadgroup(1) ]],
     uint tid                               [[ thread_position_in_threadgroup ]],
     uint chrom_id                          [[ threadgroup_position_in_grid ]],
     uint blockDim                          [[ threads_per_threadgroup ]])
@@ -240,13 +191,11 @@ kernel void kernel_eval_cf_full(
     const int n_pro   = p.N - n_lig;
     const int n_pairs = n_lig * n_pro;
 
-    // Load translation from genes (first 3 genes).
     const int gbase = int(chrom_id) * p.n_genes;
     const float tx = genes_f[gbase + 0];
     const float ty = genes_f[gbase + 1];
     const float tz = genes_f[gbase + 2];
 
-    // Initialise per-ligand SAS to full surface area.
     for (int la = int(tid); la < n_lig && la < 256; la += int(blockDim)) {
         float ra  = atom_radius[p.lig_first + la];
         float rwa = ra + 1.4f;
@@ -254,7 +203,15 @@ kernel void kernel_eval_cf_full(
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
+    const bool do_dw    = (p.dw_r0 > 0.0f);
+    const float inv_r0  = do_dw ? (1.0f / p.dw_r0) : 0.0f;
+    const bool do_elec  = (p.elec_on != 0) && (p.has_charge != 0);
+    const bool do_hbond = (p.hbond_weight != 0.0f || p.hbond_salt_weight != 0.0f)
+                          && (p.has_hflags != 0) && (p.has_charge != 0);
+    const bool do_pb    = (p.pb_clash_weight > 0.0f) && (p.has_pbvdw != 0);
+
     float local_com = 0.0f, local_wal = 0.0f;
+    float local_elec = 0.0f, local_hbond = 0.0f, local_pb = 0.0f;
 
     for (int pr = int(tid); pr < n_pairs; pr += int(blockDim)) {
         const int li      = pr / n_pro;
@@ -275,55 +232,314 @@ kernel void kernel_eval_cf_full(
         const float rsum  = rA + rB;
         const float rwa_A = rA + 1.4f;
         const float surf_A = 4.0f * M_PI_F * rwa_A * rwa_A;
-        const float outer_r = rsum + 2.8f;  // rA + rB + 2*Rw
+        const float outer_r = rsum + 2.8f;
 
-        // Normalised contact area (0..1), linear switching.
         float rel_area = 0.0f;
         if      (r < rsum)    rel_area = 1.0f;
         else if (r < outer_r) rel_area = 1.0f - (r - rsum) / (outer_r - rsum);
+        const bool in_contact = (rel_area > 0.0f);
 
-        // Subtract from ligand-atom SAS using CAS float atomic.
-        if (rel_area > 0.0f && li < 256) {
+        if (in_contact && li < 256)
             tg_atomic_sub_float(&lig_sas[li], rel_area * surf_A);
-        }
 
-        // Complementarity energy (sampled energy matrix lookup).
         const int ti  = atom_type[ai];
         const int tj  = atom_type[aj];
         const float yval = gpu_get_yval(emat_sampled, ti, tj, p.T, rel_area);
-        local_com += yval * rel_area;
+        float com_pair = yval * rel_area;
+        if (do_dw && in_contact) com_pair *= exp(-r * inv_r0);
+        local_com += com_pair;
 
-        // WAL: repulsive wall energy when r < perm * (rA+rB).
+        if (do_elec && in_contact && r > 0.5f) {
+            const float qA = atom_charge[ai];
+            const float qB = atom_charge[aj];
+            if (qA != 0.0f && qB != 0.0f)
+                local_elec += KCOULOMB_F * qA * qB / (p.dielectric * r * r);
+        }
+
+        if (do_hbond && in_contact) {
+            const int fa = atom_hflags[ai];
+            const int fb = atom_hflags[aj];
+            const bool a_to_b = ((fa & 0x1) != 0) && ((fb & 0x2) != 0);
+            const bool b_to_a = ((fb & 0x1) != 0) && ((fa & 0x2) != 0);
+            const float qa = atom_charge[ai];
+            const float qb = atom_charge[aj];
+            const bool salt = (qa <= -Q_SALT && qb >= Q_SALT) ||
+                              (qb <= -Q_SALT && qa >= Q_SALT);
+            if (a_to_b || b_to_a || salt) {
+                const float dd = (r - p.hbond_opt_dist) / p.hbond_sigma_dist;
+                const float E_dist = exp(-0.5f * dd * dd);
+                const float w = salt ? p.hbond_salt_weight : p.hbond_weight;
+                float E = w * E_dist * p.hbond_angle_repr;
+                if (E < HBOND_PAIR_MIN) E = HBOND_PAIR_MIN;
+                local_hbond += E;
+            }
+        }
+
         const float clash_r = p.perm * rsum;
         if (r < clash_r && r > 0.0f) {
-            const float inv_r12  = 1.0f / pow(r,       12.0f);
-            const float inv_cr12 = 1.0f / pow(clash_r, 12.0f);
-            local_wal += 1.0e6f * (inv_r12 - inv_cr12);
+            const float r2 = r*r; const float r4 = r2*r2; const float r6 = r4*r2;
+            const float inv_r12 = 1.0f / (r6 * r6);
+            const float cr2 = clash_r*clash_r; const float cr4 = cr2*cr2; const float cr6 = cr4*cr2;
+            const float inv_cr12 = 1.0f / (cr6 * cr6);
+            local_wal += KWALL_F * (inv_r12 - inv_cr12);
+        }
+
+        if (do_pb) {
+            const float cr_pb = p.pb_clash_ratio * (atom_pbvdw[ai] + atom_pbvdw[aj]);
+            const float o = cr_pb - r;
+            if (o > 0.0f && r > 1.0e-6f)
+                local_pb += pow(o, p.pb_clash_exponent);
         }
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    // SIMD reduction for COM and WAL.
-    local_com = simd_sum(local_com);
-    local_wal = simd_sum(local_wal);
+    float com   = tg_reduce_sum(red, tid, local_com);
+    float wal   = tg_reduce_sum(red, tid, local_wal);
+    float elec  = tg_reduce_sum(red, tid, local_elec);
+    float hbond = tg_reduce_sum(red, tid, local_hbond);
+    float pb    = tg_reduce_sum(red, tid, local_pb);
 
-    // SAS contribution: each ligand atom's remaining exposed area.
-    float local_sas = 0.0f;
+    const bool do_gist = (p.gist_nx > 0);
+    float local_sas = 0.0f, local_gist = 0.0f;
+    float local_cx = 0.0f, local_cy = 0.0f, local_cz = 0.0f;
     for (int la = int(tid); la < n_lig && la < 256; la += int(blockDim)) {
-        const float sas_rem  = max(0.0f, lig_sas[la]);
-        const float rwa_la   = atom_radius[p.lig_first + la] + 1.4f;
-        const float surf_la  = 4.0f * M_PI_F * rwa_la * rwa_la;
+        const int aidx = p.lig_first + la;
+        const float sas_rem = max(0.0f, lig_sas[la]);
+        const float rwa_la  = atom_radius[aidx] + 1.4f;
+        const float surf_la = 4.0f * M_PI_F * rwa_la * rwa_la;
         const float sas_norm = sas_rem / surf_la;
-        const int   ti_la    = atom_type[p.lig_first + la];
-        const float yval_sas = gpu_get_yval(emat_sampled, ti_la, p.T - 1, p.T, sas_norm);
-        local_sas += yval_sas * sas_norm;
+        float contribution;
+        if (p.solvent_flat != 0) {
+            contribution = p.solventterm * sas_rem;
+        } else {
+            const int ti_la = atom_type[aidx];
+            const float yval_sas = gpu_get_yval(emat_sampled, ti_la, p.T - 1, p.T, sas_norm);
+            contribution = yval_sas * sas_norm;
+        }
+        local_sas += p.sas_weight * contribution;
+
+        const float lx = atom_xyz[aidx*3+0] + tx;
+        const float ly = atom_xyz[aidx*3+1] + ty;
+        const float lz = atom_xyz[aidx*3+2] + tz;
+        local_cx += lx; local_cy += ly; local_cz += lz;
+
+        if (do_gist) {
+            float fx = (lx - p.gox) * p.gidx;
+            float fy = (ly - p.goy) * p.gidy;
+            float fz = (lz - p.goz) * p.gidz;
+            if (fx >= 0.0f && fx < float(p.gist_nx - 1) &&
+                fy >= 0.0f && fy < float(p.gist_ny - 1) &&
+                fz >= 0.0f && fz < float(p.gist_nz - 1)) {
+                int ix = int(fx), iy = int(fy), iz = int(fz);
+                float ddx = fx - ix, ddy = fy - iy, ddz = fz - iz;
+                int ny = p.gist_ny, nz = p.gist_nz;
+                #define GIDX(i,j,k) (((i)*ny + (j))*nz + (k))
+                float c000 = gist_data[GIDX(ix,   iy,   iz  )];
+                float c001 = gist_data[GIDX(ix,   iy,   iz+1)];
+                float c010 = gist_data[GIDX(ix,   iy+1, iz  )];
+                float c011 = gist_data[GIDX(ix,   iy+1, iz+1)];
+                float c100 = gist_data[GIDX(ix+1, iy,   iz  )];
+                float c101 = gist_data[GIDX(ix+1, iy,   iz+1)];
+                float c110 = gist_data[GIDX(ix+1, iy+1, iz  )];
+                float c111 = gist_data[GIDX(ix+1, iy+1, iz+1)];
+                #undef GIDX
+                float c00 = c000*(1.0f-ddz) + c001*ddz;
+                float c01 = c010*(1.0f-ddz) + c011*ddz;
+                float c10 = c100*(1.0f-ddz) + c101*ddz;
+                float c11 = c110*(1.0f-ddz) + c111*ddz;
+                float c0  = c00*(1.0f-ddy) + c01*ddy;
+                float c1  = c10*(1.0f-ddy) + c11*ddy;
+                local_gist += p.gist_weight * (c0*(1.0f-ddx) + c1*ddx);
+            }
+        }
     }
-    local_sas = simd_sum(local_sas);
+    float sas    = tg_reduce_sum(red, tid, local_sas);
+    float gist   = tg_reduce_sum(red, tid, local_gist);
+    float cx_sum = tg_reduce_sum(red, tid, local_cx);
+    float cy_sum = tg_reduce_sum(red, tid, local_cy);
+    float cz_sum = tg_reduce_sum(red, tid, local_cz);
+
+    if (p.pb_pocket_weight > 0.0f && p.has_hflags != 0 && n_lig > 0) {
+        const float inv_nl = 1.0f / float(n_lig);
+        const float gx = cx_sum * inv_nl;
+        const float gy = cy_sum * inv_nl;
+        const float gz = cz_sum * inv_nl;
+        float local_min = 3.4e38f;
+        for (int a = int(tid); a < p.N; a += int(blockDim)) {
+            if (a >= p.lig_first && a <= p.lig_last) continue;
+            if ((atom_hflags[a] & 0x4) == 0) continue;
+            const float ddx = gx - atom_xyz[a*3+0];
+            const float ddy = gy - atom_xyz[a*3+1];
+            const float ddz = gz - atom_xyz[a*3+2];
+            local_min = min(local_min, ddx*ddx + ddy*ddy + ddz*ddz);
+        }
+        float best_d2 = tg_reduce_min(red, tid, local_min);
+        if (best_d2 < 3.0e38f) {
+            float d = sqrt(best_d2);
+            float over = d - p.pb_pocket_radius;
+            if (over > 0.0f) pb += p.pb_pocket_weight * over * over;
+        }
+    }
+
+    float con = 0.0f;
+    if (tid == 0 && p.n_cons > 0) {
+        for (int c = 0; c < p.n_cons; ++c) {
+            int i = cons_i[c], j = cons_j[c];
+            float ix = atom_xyz[i*3+0], iy = atom_xyz[i*3+1], iz = atom_xyz[i*3+2];
+            float jx = atom_xyz[j*3+0], jy = atom_xyz[j*3+1], jz = atom_xyz[j*3+2];
+            if (i >= p.lig_first && i <= p.lig_last) { ix += tx; iy += ty; iz += tz; }
+            if (j >= p.lig_first && j <= p.lig_last) { jx += tx; jy += ty; jz += tz; }
+            float ddx = ix-jx, ddy = iy-jy, ddz = iz-jz;
+            float d = sqrt(ddx*ddx + ddy*ddy + ddz*ddz);
+            con += p.kdist - p.kdist * gpu_gaussian(d, cons_bondlen[c], cons_maxdist[c]);
+        }
+    }
 
     if (tid == 0) {
-        cf_com_out[chrom_id] = local_com;
-        cf_wal_out[chrom_id] = local_wal;
-        cf_sas_out[chrom_id] = local_sas;
+        int mp = max_pop;
+        out[0*mp + int(chrom_id)] = com;
+        out[1*mp + int(chrom_id)] = wal;
+        out[2*mp + int(chrom_id)] = sas;
+        out[3*mp + int(chrom_id)] = con;
+        out[4*mp + int(chrom_id)] = elec;
+        out[5*mp + int(chrom_id)] = hbond;
+        out[6*mp + int(chrom_id)] = gist;
+        out[7*mp + int(chrom_id)] = pb;
+    }
+}
+
+// ─── Multi-complex screening kernel (com dist-weighted / wal / sas only) ──────
+struct MultiParams {
+    int   pop_size, n_genes, T;
+    float perm;
+    float dw_r0;
+    float sas_weight;
+    int   solvent_flat;
+    float solventterm;
+};
+
+struct ComplexDesc {
+    int atom_offset, n_atoms, lig_first, lig_last;
+    int gene_offset, result_offset, pad0, pad1;
+};
+
+kernel void kernel_eval_cf_multi(
+    device const float*        atom_xyz_all    [[ buffer(0) ]],
+    device const int*          atom_type_all   [[ buffer(1) ]],
+    device const float*        atom_radius_all [[ buffer(2) ]],
+    device const float*        emat_sampled    [[ buffer(3) ]],
+    device const float*        genes_f_all     [[ buffer(4) ]],
+    device float*              cf_com_out      [[ buffer(5) ]],
+    device float*              cf_wal_out      [[ buffer(6) ]],
+    device float*              cf_sas_out      [[ buffer(7) ]],
+    constant MultiParams&      mp              [[ buffer(8) ]],
+    device const ComplexDesc*  descs           [[ buffer(9) ]],
+    threadgroup float*         lig_sas         [[ threadgroup(0) ]],
+    threadgroup float*         red             [[ threadgroup(1) ]],
+    uint tid                                   [[ thread_position_in_threadgroup ]],
+    uint global_chrom_id                       [[ threadgroup_position_in_grid ]],
+    uint blockDim                              [[ threads_per_threadgroup ]])
+{
+    const int ci  = int(global_chrom_id) / mp.pop_size;
+    const int chi = int(global_chrom_id) % mp.pop_size;
+    device const ComplexDesc& d = descs[ci];
+
+    const int n_lig   = d.lig_last - d.lig_first + 1;
+    const int n_pro   = d.n_atoms - n_lig;
+    const int n_pairs = n_lig * n_pro;
+
+    const int gbase = d.gene_offset + chi * mp.n_genes;
+    const float tx = genes_f_all[gbase + 0];
+    const float ty = genes_f_all[gbase + 1];
+    const float tz = genes_f_all[gbase + 2];
+
+    for (int la = int(tid); la < n_lig && la < 256; la += int(blockDim)) {
+        float ra  = atom_radius_all[d.atom_offset + d.lig_first + la];
+        float rwa = ra + 1.4f;
+        lig_sas[la] = 4.0f * M_PI_F * rwa * rwa;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    const bool do_dw   = (mp.dw_r0 > 0.0f);
+    const float inv_r0 = do_dw ? (1.0f / mp.dw_r0) : 0.0f;
+
+    float local_com = 0.0f, local_wal = 0.0f;
+
+    for (int pr = int(tid); pr < n_pairs; pr += int(blockDim)) {
+        const int li      = pr / n_pro;
+        const int pro_rel = pr % n_pro;
+        const int ai      = d.atom_offset + d.lig_first + li;
+        const int pro_loc = (pro_rel < d.lig_first) ? pro_rel : (pro_rel + n_lig);
+        const int aj      = d.atom_offset + pro_loc;
+
+        const float lx = atom_xyz_all[ai*3+0] + tx;
+        const float ly = atom_xyz_all[ai*3+1] + ty;
+        const float lz = atom_xyz_all[ai*3+2] + tz;
+        const float dx = lx - atom_xyz_all[aj*3+0];
+        const float dy = ly - atom_xyz_all[aj*3+1];
+        const float dz = lz - atom_xyz_all[aj*3+2];
+        const float r  = sqrt(dx*dx + dy*dy + dz*dz + 1e-10f);
+
+        const float rA = atom_radius_all[ai];
+        const float rB = atom_radius_all[aj];
+        const float rsum = rA + rB;
+        const float rwa_A = rA + 1.4f;
+        const float surf_A = 4.0f * M_PI_F * rwa_A * rwa_A;
+        const float outer_r = rsum + 2.8f;
+
+        float rel_area = 0.0f;
+        if      (r < rsum)    rel_area = 1.0f;
+        else if (r < outer_r) rel_area = 1.0f - (r - rsum) / (outer_r - rsum);
+        const bool in_contact = (rel_area > 0.0f);
+
+        if (in_contact && li < 256)
+            tg_atomic_sub_float(&lig_sas[li], rel_area * surf_A);
+
+        const int ti = atom_type_all[ai];
+        const int tj = atom_type_all[aj];
+        const float yval = gpu_get_yval(emat_sampled, ti, tj, mp.T, rel_area);
+        float com_pair = yval * rel_area;
+        if (do_dw && in_contact) com_pair *= exp(-r * inv_r0);
+        local_com += com_pair;
+
+        const float clash_r = mp.perm * rsum;
+        if (r < clash_r && r > 0.0f) {
+            const float r2=r*r; const float r4=r2*r2; const float r6=r4*r2;
+            const float inv_r12 = 1.0f/(r6*r6);
+            const float cr2=clash_r*clash_r; const float cr4=cr2*cr2; const float cr6=cr4*cr2;
+            const float inv_cr12 = 1.0f/(cr6*cr6);
+            local_wal += KWALL_F * (inv_r12 - inv_cr12);
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float com = tg_reduce_sum(red, tid, local_com);
+    float wal = tg_reduce_sum(red, tid, local_wal);
+
+    float local_sas = 0.0f;
+    for (int la = int(tid); la < n_lig && la < 256; la += int(blockDim)) {
+        const int aidx = d.atom_offset + d.lig_first + la;
+        const float sas_rem = max(0.0f, lig_sas[la]);
+        const float rwa_la  = atom_radius_all[aidx] + 1.4f;
+        const float surf_la = 4.0f * M_PI_F * rwa_la * rwa_la;
+        const float sas_norm = sas_rem / surf_la;
+        float contribution;
+        if (mp.solvent_flat != 0) {
+            contribution = mp.solventterm * sas_rem;
+        } else {
+            const int ti_la = atom_type_all[aidx];
+            const float yval_sas = gpu_get_yval(emat_sampled, ti_la, mp.T - 1, mp.T, sas_norm);
+            contribution = yval_sas * sas_norm;
+        }
+        local_sas += mp.sas_weight * contribution;
+    }
+    float sas = tg_reduce_sum(red, tid, local_sas);
+
+    if (tid == 0) {
+        const int out = d.result_offset + chi;
+        cf_com_out[out] = com;
+        cf_wal_out[out] = wal;
+        cf_sas_out[out] = sas;
     }
 }
 )MSL";
@@ -340,9 +556,27 @@ struct MetalEvalCtx {
     id<MTLBuffer> buf_atom_radius;
     id<MTLBuffer> buf_emat_sampled;
     id<MTLBuffer> buf_genes_f;
-    id<MTLBuffer> buf_com_out;
-    id<MTLBuffer> buf_wal_out;
-    id<MTLBuffer> buf_sas_out;
+    id<MTLBuffer> buf_out;          // single merged output [CH * max_pop]
+
+    // Extra full-fidelity static buffers (always allocated; dummy when absent).
+    id<MTLBuffer> buf_pbvdw;
+    id<MTLBuffer> buf_charge;
+    id<MTLBuffer> buf_hflags;
+    id<MTLBuffer> buf_cons_i;
+    id<MTLBuffer> buf_cons_j;
+    id<MTLBuffer> buf_cons_bondlen;
+    id<MTLBuffer> buf_cons_maxdist;
+    id<MTLBuffer> buf_gist;
+
+    int   has_pbvdw, has_charge, has_hflags;
+    int   n_cons;
+    int   gist_nx, gist_ny, gist_nz;
+    float gist_origin[3];
+    float gist_inv_delta[3];
+    float gist_weight;
+
+    GpuCfParams cur_params;   // stashed by metal_eval_set_params()
+    bool        have_params;
 
     int n_atoms;
     int n_types;
@@ -366,30 +600,19 @@ bool metal_eval_runtime_available()
 void metal_eval_get_capabilities(MetalCapabilities* out)
 {
     if (!out) return;
-
     memset(out, 0, sizeof(*out));
-
-    // @autoreleasepool required with -fno-objc-arc: MTLCreateSystemDefaultDevice()
-    // returns an autoreleased object; without a pool it leaks / undefined on
-    // non-Cocoa threads (C++ callers have no implicit pool).
     @autoreleasepool {
         id<MTLDevice> device = MTLCreateSystemDefaultDevice();
-        if (!device) {
-            out->available = false;
-            return;
-        }
-
+        if (!device) { out->available = false; return; }
         out->available = true;
         const char* name_cstr = device.name.UTF8String ? device.name.UTF8String : "Apple GPU";
         strncpy(out->device_name, name_cstr, sizeof(out->device_name) - 1);
-
 #if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
         if (@available(macOS 10.15, *)) {
             out->unified_memory_bytes = device.hasUnifiedMemory ? device.maxBufferLength : 0;
         }
 #endif
         out->max_buffer_length = device.maxBufferLength;
-
         NSString* name = device.name;
         if ([name containsString:@"M3 Pro"])       out->gpu_core_estimate = 18;
         else if ([name containsString:@"M3 Max"])  out->gpu_core_estimate = 30;
@@ -411,6 +634,7 @@ MetalEvalCtx* metal_eval_init(int   n_atoms,
                                int   n_emat_samples)
 {
     MetalEvalCtx* ctx = new MetalEvalCtx();
+    memset(ctx, 0, sizeof(*ctx));
     ctx->n_atoms   = n_atoms;
     ctx->n_types   = n_types;
     ctx->max_pop   = max_pop;
@@ -418,7 +642,6 @@ MetalEvalCtx* metal_eval_init(int   n_atoms,
     ctx->lig_last  = lig_last;
     ctx->perm      = perm;
 
-    // Device & queue.
     ctx->device = MTLCreateSystemDefaultDevice();
     if (!ctx->device) {
         fprintf(stderr, "metal_eval: no Metal device found\n");
@@ -427,19 +650,15 @@ MetalEvalCtx* metal_eval_init(int   n_atoms,
     }
     ctx->queue = [ctx->device newCommandQueue];
 
-    // Compile kernel.
     NSError* err = nil;
     NSString* src = [NSString stringWithUTF8String:kMSLSource];
-    id<MTLLibrary> lib = [ctx->device newLibraryWithSource:src
-                                                   options:nil
-                                                     error:&err];
+    id<MTLLibrary> lib = [ctx->device newLibraryWithSource:src options:nil error:&err];
     if (!lib) {
         fprintf(stderr, "metal_eval: shader compile error: %s\n",
                 [[err localizedDescription] UTF8String]);
         delete ctx;
         return nullptr;
     }
-    // Compile single-complex pipeline.
     id<MTLFunction> fn = [lib newFunctionWithName:@"kernel_eval_cf_full"];
     ctx->pipeline = [ctx->device newComputePipelineStateWithFunction:fn error:&err];
     if (!ctx->pipeline) {
@@ -448,22 +667,21 @@ MetalEvalCtx* metal_eval_init(int   n_atoms,
         delete ctx;
         return nullptr;
     }
-
-    // Compile multi-complex pipeline.
     id<MTLFunction> fn_multi = [lib newFunctionWithName:@"kernel_eval_cf_multi"];
     if (fn_multi) {
-        ctx->pipeline_multi = [ctx->device
-            newComputePipelineStateWithFunction:fn_multi error:&err];
+        ctx->pipeline_multi = [ctx->device newComputePipelineStateWithFunction:fn_multi error:&err];
         if (!ctx->pipeline_multi)
             fprintf(stderr, "metal_eval: pipeline_multi compile warning: %s\n",
                     err ? [[err localizedDescription] UTF8String] : "unknown");
     }
 
-    // Allocate constant device buffers (uploaded once).
     auto newBuf = [&](const void* data, size_t bytes) -> id<MTLBuffer> {
-        return [ctx->device newBufferWithBytes:data
-                                       length:bytes
-                                      options:MTLResourceStorageModeShared];
+        return [ctx->device newBufferWithBytes:data length:bytes
+                                       options:MTLResourceStorageModeShared];
+    };
+    auto newLen = [&](size_t bytes) -> id<MTLBuffer> {
+        return [ctx->device newBufferWithLength:(bytes ? bytes : sizeof(float))
+                                       options:MTLResourceStorageModeShared];
     };
 
     ctx->buf_atom_xyz    = newBuf(h_atom_xyz,    (size_t)n_atoms * 3 * sizeof(float));
@@ -472,30 +690,104 @@ MetalEvalCtx* metal_eval_init(int   n_atoms,
     ctx->buf_emat_sampled= newBuf(h_emat_sampled,
                                   (size_t)n_types * n_types * n_emat_samples * sizeof(float));
 
-    // Mutable per-batch buffers.
-    // Use max 256 genes as upper bound; actual n_genes validated in batch call.
     ctx->max_genes = 256;
-    ctx->buf_genes_f = [ctx->device newBufferWithLength:(size_t)max_pop * ctx->max_genes * sizeof(float)
-                                                options:MTLResourceStorageModeShared];
-    ctx->buf_com_out = [ctx->device newBufferWithLength:(size_t)max_pop * sizeof(float)
-                                                options:MTLResourceStorageModeShared];
-    ctx->buf_wal_out = [ctx->device newBufferWithLength:(size_t)max_pop * sizeof(float)
-                                                options:MTLResourceStorageModeShared];
-    ctx->buf_sas_out = [ctx->device newBufferWithLength:(size_t)max_pop * sizeof(float)
-                                                options:MTLResourceStorageModeShared];
+    ctx->buf_genes_f = newLen((size_t)max_pop * ctx->max_genes * sizeof(float));
+    ctx->buf_out     = newLen((size_t)METAL_CF_CHANNELS * max_pop * sizeof(float));
+
+    // Dummy extra buffers by default (disabled terms never index them).
+    ctx->buf_pbvdw        = newLen(0);
+    ctx->buf_charge       = newLen(0);
+    ctx->buf_hflags       = newLen(0);
+    ctx->buf_cons_i       = newLen(0);
+    ctx->buf_cons_j       = newLen(0);
+    ctx->buf_cons_bondlen = newLen(0);
+    ctx->buf_cons_maxdist = newLen(0);
+    ctx->buf_gist         = newLen(0);
 
     return ctx;
 }
 
-void metal_eval_batch(MetalEvalCtx* ctx,
-                      int           pop_size,
-                      int           n_genes,
-                      const double* h_genes,
-                      double*       h_com_out,
-                      double*       h_wal_out,
-                      double*       h_sas_out)
+void metal_eval_set_extra(MetalEvalCtx* ctx, const GpuCfExtraStatic* extra)
 {
-    // Validate against allocated buffer sizes — throw on overflow.
+    if (!ctx || !extra) return;
+    const int N = ctx->n_atoms;
+    auto newBuf = [&](const void* data, size_t bytes) -> id<MTLBuffer> {
+        return [ctx->device newBufferWithBytes:data length:bytes
+                                       options:MTLResourceStorageModeShared];
+    };
+
+    if (extra->atom_pbvdw) {
+        ctx->buf_pbvdw  = newBuf(extra->atom_pbvdw,  (size_t)N * sizeof(float));
+        ctx->has_pbvdw  = 1;
+    }
+    if (extra->atom_charge) {
+        ctx->buf_charge = newBuf(extra->atom_charge, (size_t)N * sizeof(float));
+        ctx->has_charge = 1;
+    }
+    if (extra->atom_hflags) {
+        ctx->buf_hflags = newBuf(extra->atom_hflags, (size_t)N * sizeof(int));
+        ctx->has_hflags = 1;
+    }
+
+    ctx->n_cons = extra->n_cons;
+    if (extra->n_cons > 0 && extra->cons_i) {
+        ctx->buf_cons_i       = newBuf(extra->cons_i,       (size_t)extra->n_cons * sizeof(int));
+        ctx->buf_cons_j       = newBuf(extra->cons_j,       (size_t)extra->n_cons * sizeof(int));
+        ctx->buf_cons_bondlen = newBuf(extra->cons_bondlen, (size_t)extra->n_cons * sizeof(float));
+        ctx->buf_cons_maxdist = newBuf(extra->cons_maxdist, (size_t)extra->n_cons * sizeof(float));
+    }
+
+    ctx->gist_nx = extra->gist_nx;
+    ctx->gist_ny = extra->gist_ny;
+    ctx->gist_nz = extra->gist_nz;
+    for (int k = 0; k < 3; ++k) {
+        ctx->gist_origin[k]    = extra->gist_origin[k];
+        ctx->gist_inv_delta[k] = extra->gist_inv_delta[k];
+    }
+    ctx->gist_weight = extra->gist_weight;
+    if (extra->gist_nx > 0 && extra->gist_data) {
+        size_t vox = (size_t)extra->gist_nx * extra->gist_ny * extra->gist_nz * sizeof(float);
+        ctx->buf_gist = newBuf(extra->gist_data, vox);
+    }
+}
+
+void metal_eval_set_params(MetalEvalCtx* ctx, const GpuCfParams* params)
+{
+    if (!ctx || !params) return;
+    ctx->cur_params  = *params;
+    ctx->have_params = true;
+}
+
+static void fill_kp(MetalKP& kp, const MetalEvalCtx* ctx,
+                    int n_genes, const GpuCfParams& P)
+{
+    kp.N = ctx->n_atoms; kp.T = ctx->n_types; kp.n_genes = n_genes;
+    kp.lig_first = ctx->lig_first; kp.lig_last = ctx->lig_last;
+    kp.perm = ctx->perm;
+    kp.has_pbvdw = ctx->has_pbvdw; kp.has_charge = ctx->has_charge; kp.has_hflags = ctx->has_hflags;
+    kp.n_cons = ctx->n_cons;
+    kp.gist_nx = ctx->gist_nx; kp.gist_ny = ctx->gist_ny; kp.gist_nz = ctx->gist_nz;
+    kp.gox = ctx->gist_origin[0]; kp.goy = ctx->gist_origin[1]; kp.goz = ctx->gist_origin[2];
+    kp.gidx = ctx->gist_inv_delta[0]; kp.gidy = ctx->gist_inv_delta[1]; kp.gidz = ctx->gist_inv_delta[2];
+    kp.gist_weight = ctx->gist_weight;
+    kp.dw_r0 = P.dw_r0; kp.elec_on = P.elec_on; kp.dielectric = P.dielectric;
+    kp.hbond_weight = P.hbond_weight; kp.hbond_salt_weight = P.hbond_salt_weight;
+    kp.hbond_opt_dist = P.hbond_opt_dist; kp.hbond_sigma_dist = P.hbond_sigma_dist;
+    kp.hbond_angle_repr = P.hbond_angle_repr;
+    kp.pb_clash_weight = P.pb_clash_weight; kp.pb_clash_ratio = P.pb_clash_ratio;
+    kp.pb_clash_exponent = P.pb_clash_exponent;
+    kp.pb_pocket_weight = P.pb_pocket_weight; kp.pb_pocket_radius = P.pb_pocket_radius;
+    kp.kdist = P.kdist; kp.sas_weight = P.sas_weight;
+    kp.solvent_flat = P.solvent_flat; kp.solventterm = P.solventterm;
+}
+
+void metal_eval_batch(MetalEvalCtx*       ctx,
+                      int                 pop_size,
+                      int                 n_genes,
+                      const double*       h_genes,
+                      const GpuCfParams*  params,
+                      const GpuCfResults* out)
+{
     if (pop_size > ctx->max_pop) {
         throw FlexAIDException("metal_eval: pop_size " + std::to_string(pop_size) +
             " exceeds max_pop " + std::to_string(ctx->max_pop));
@@ -505,50 +797,44 @@ void metal_eval_batch(MetalEvalCtx* ctx,
             " exceeds max_genes " + std::to_string(ctx->max_genes));
     }
 
-    // Convert double genes to float for the GPU.
-    // Pack with n_genes stride to match kernel indexing (genes_f[chrom_id * n_genes + g]).
     float* genes_f = (float*)[ctx->buf_genes_f contents];
     for (int c = 0; c < pop_size; ++c)
         for (int g = 0; g < n_genes; ++g)
             genes_f[c * n_genes + g] = (float)h_genes[c * n_genes + g];
 
-    // Build EvalParams.
-    struct EvalParams {
-        int N, T, n_genes, lig_first, lig_last;
-        float perm;
-        int pad0, pad1;
-    };
-    EvalParams ep = { ctx->n_atoms, ctx->n_types, n_genes,
-                      ctx->lig_first, ctx->lig_last, ctx->perm, 0, 0 };
+    MetalKP kp; fill_kp(kp, ctx, n_genes, *params);
+    id<MTLBuffer> buf_kp = [ctx->device newBufferWithBytes:&kp length:sizeof(kp)
+                                                   options:MTLResourceStorageModeShared];
+    int mp_val = ctx->max_pop;
+    id<MTLBuffer> buf_mp = [ctx->device newBufferWithBytes:&mp_val length:sizeof(int)
+                                                   options:MTLResourceStorageModeShared];
 
-    id<MTLBuffer> buf_params = [ctx->device
-        newBufferWithBytes:&ep
-                   length:sizeof(ep)
-                  options:MTLResourceStorageModeShared];
-
-    // Encode and dispatch.
-    id<MTLCommandBuffer>       cb  = [ctx->queue commandBuffer];
+    id<MTLCommandBuffer>         cb  = [ctx->queue commandBuffer];
     id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
     [enc setComputePipelineState:ctx->pipeline];
-    [enc setBuffer:ctx->buf_atom_xyz    offset:0 atIndex:0];
-    [enc setBuffer:ctx->buf_atom_type   offset:0 atIndex:1];
-    [enc setBuffer:ctx->buf_atom_radius offset:0 atIndex:2];
+    [enc setBuffer:ctx->buf_atom_xyz     offset:0 atIndex:0];
+    [enc setBuffer:ctx->buf_atom_type    offset:0 atIndex:1];
+    [enc setBuffer:ctx->buf_atom_radius  offset:0 atIndex:2];
     [enc setBuffer:ctx->buf_emat_sampled offset:0 atIndex:3];
-    [enc setBuffer:ctx->buf_genes_f     offset:0 atIndex:4];
-    [enc setBuffer:ctx->buf_com_out     offset:0 atIndex:5];
-    [enc setBuffer:ctx->buf_wal_out     offset:0 atIndex:6];
-    [enc setBuffer:ctx->buf_sas_out     offset:0 atIndex:7];
-    [enc setBuffer:buf_params           offset:0 atIndex:8];
+    [enc setBuffer:ctx->buf_genes_f      offset:0 atIndex:4];
+    [enc setBuffer:ctx->buf_out          offset:0 atIndex:5];
+    [enc setBuffer:buf_kp                offset:0 atIndex:6];
+    [enc setBuffer:ctx->buf_pbvdw        offset:0 atIndex:7];
+    [enc setBuffer:ctx->buf_charge       offset:0 atIndex:8];
+    [enc setBuffer:ctx->buf_hflags       offset:0 atIndex:9];
+    [enc setBuffer:ctx->buf_cons_i       offset:0 atIndex:10];
+    [enc setBuffer:ctx->buf_cons_j       offset:0 atIndex:11];
+    [enc setBuffer:ctx->buf_cons_bondlen offset:0 atIndex:12];
+    [enc setBuffer:ctx->buf_cons_maxdist offset:0 atIndex:13];
+    [enc setBuffer:ctx->buf_gist         offset:0 atIndex:14];
+    [enc setBuffer:buf_mp                offset:0 atIndex:15];
+    [enc setThreadgroupMemoryLength:256 * sizeof(float) atIndex:0]; // lig_sas
+    [enc setThreadgroupMemoryLength:256 * sizeof(float) atIndex:1]; // reduction scratch
 
-    // Threadgroup shared memory: 256 floats for per-ligand SAS.
-    [enc setThreadgroupMemoryLength:256 * sizeof(float) atIndex:0];
-
-    NSUInteger threadsPerGroup = 256;
-    MTLSize    gridSize        = { (NSUInteger)pop_size, 1, 1 };
-    MTLSize    groupSize       = { threadsPerGroup, 1, 1 };
+    MTLSize gridSize  = { (NSUInteger)pop_size, 1, 1 };
+    MTLSize groupSize = { 256, 1, 1 };
     [enc dispatchThreadgroups:gridSize threadsPerThreadgroup:groupSize];
     [enc endEncoding];
-
     [cb commit];
     [cb waitUntilCompleted];
 
@@ -558,14 +844,18 @@ void metal_eval_batch(MetalEvalCtx* ctx,
             std::string([desc UTF8String]));
     }
 
-    // Copy results back (float → double).
-    const float* com_f = (const float*)[ctx->buf_com_out contents];
-    const float* wal_f = (const float*)[ctx->buf_wal_out contents];
-    const float* sas_f = (const float*)[ctx->buf_sas_out contents];
+    const float* o = (const float*)[ctx->buf_out contents];
+    const int mp = ctx->max_pop;
+    auto ch = [&](int c) { return o + (size_t)c * mp; };
     for (int c = 0; c < pop_size; ++c) {
-        h_com_out[c] = (double)com_f[c];
-        h_wal_out[c] = (double)wal_f[c];
-        h_sas_out[c] = (double)sas_f[c];
+        if (out->com)         out->com[c]         = (double)ch(0)[c];
+        if (out->wal)         out->wal[c]         = (double)ch(1)[c];
+        if (out->sas)         out->sas[c]         = (double)ch(2)[c];
+        if (out->con)         out->con[c]         = (double)ch(3)[c];
+        if (out->elec)        out->elec[c]        = (double)ch(4)[c];
+        if (out->hbond)       out->hbond[c]       = (double)ch(5)[c];
+        if (out->gist_desolv) out->gist_desolv[c] = (double)ch(6)[c];
+        if (out->pb_clash)    out->pb_clash[c]    = (double)ch(7)[c];
     }
 }
 
@@ -576,48 +866,36 @@ void metal_eval_shutdown(MetalEvalCtx* ctx)
     delete ctx;
 }
 
-// ─── Multi-complex batched evaluation ────────────────────────────────────────
-//
-// Evaluates n_complex × pop_size chromosomes in ONE Metal dispatch, keeping
-// the GPU command queue full instead of firing N serial 1000-element batches.
-// GPU thread k → complex = k / pop_size, chrom = k % pop_size.
-//
-// Requires ctx->max_pop >= n_complex × pop_size.
-void metal_eval_batch_multi(MetalEvalCtx*              ctx,
-                             int                        n_complex,
-                             int                        pop_size,
-                             int                        n_genes,
+// ─── Multi-complex batched evaluation (screening pre-filter) ─────────────────
+void metal_eval_batch_multi(MetalEvalCtx*               ctx,
+                             int                         n_complex,
+                             int                         pop_size,
+                             int                         n_genes,
                              const MetalMultiBatchEntry* entries)
 {
     if (n_complex <= 0) return;
 
-    // Fast path: single complex — delegate to single-batch function.
-    if (n_complex == 1) {
-        metal_eval_batch(ctx, pop_size, n_genes,
-                         entries[0].h_genes,
-                         entries[0].h_com_out,
-                         entries[0].h_wal_out,
-                         entries[0].h_sas_out);
-        return;
-    }
+    // Params: use whatever was stashed (default-zero = all extra terms off).
+    GpuCfParams P;
+    if (ctx->have_params) P = ctx->cur_params;
+    else { memset(&P, 0, sizeof(P)); P.sas_weight = 1.0f; }
 
-    if (!ctx->pipeline_multi) {
-        // Multi kernel unavailable — fall back to serial single-complex dispatches.
+    // Fast path / no-multi-kernel fallback: delegate to the full-fidelity single
+    // batch. (Only com/wal/sas outputs exist on the entry, so the extra channels
+    // are dropped — consistent with the multi contract.)
+    if (n_complex == 1 || !ctx->pipeline_multi) {
         for (int ci = 0; ci < n_complex; ++ci) {
-            // Rebuild single-complex context atoms for this entry on the fly.
-            // (Slow path — pipeline_multi should always compile on Metal 2+.)
-            metal_eval_batch(ctx, pop_size, n_genes,
-                             entries[ci].h_genes,
-                             entries[ci].h_com_out,
-                             entries[ci].h_wal_out,
-                             entries[ci].h_sas_out);
+            GpuCfResults r; memset(&r, 0, sizeof(r));
+            r.com = entries[ci].h_com_out;
+            r.wal = entries[ci].h_wal_out;
+            r.sas = entries[ci].h_sas_out;
+            metal_eval_batch(ctx, pop_size, n_genes, entries[ci].h_genes, &P, &r);
         }
         return;
     }
 
     const int total_pop = n_complex * pop_size;
 
-    // ── Build concatenated atom buffers (one allocation per call) ──────────
     int total_atoms = 0;
     for (int ci = 0; ci < n_complex; ++ci) total_atoms += entries[ci].n_atoms;
 
@@ -625,11 +903,9 @@ void metal_eval_batch_multi(MetalEvalCtx*              ctx,
     std::vector<int>   type_all(total_atoms);
     std::vector<float> rad_all (total_atoms);
 
-    // ComplexDesc mirrors the MSL struct — keep layout in sync.
     struct ComplexDescHost {
         int atom_offset, n_atoms, lig_first, lig_last;
-        int gene_offset, result_offset;
-        int pad0, pad1;
+        int gene_offset, result_offset, pad0, pad1;
     };
     std::vector<ComplexDescHost> descs(n_complex);
 
@@ -639,26 +915,22 @@ void metal_eval_batch_multi(MetalEvalCtx*              ctx,
         memcpy(xyz_all.data()  + atom_off * 3, entries[ci].h_atom_xyz,    na * 3 * sizeof(float));
         memcpy(type_all.data() + atom_off,     entries[ci].h_atom_type,   na     * sizeof(int));
         memcpy(rad_all.data()  + atom_off,     entries[ci].h_atom_radius, na     * sizeof(float));
-        descs[ci] = { atom_off, na,
-                      entries[ci].lig_first, entries[ci].lig_last,
-                      ci * pop_size * n_genes, ci * pop_size,
-                      0, 0 };
+        descs[ci] = { atom_off, na, entries[ci].lig_first, entries[ci].lig_last,
+                      ci * pop_size * n_genes, ci * pop_size, 0, 0 };
         atom_off += na;
     }
 
-    // ── Pack gene arrays ───────────────────────────────────────────────────
     std::vector<float> genes_all(total_pop * n_genes);
     for (int ci = 0; ci < n_complex; ++ci) {
-        float*        dst = genes_all.data() + ci * pop_size * n_genes;
+        float* dst = genes_all.data() + ci * pop_size * n_genes;
         const double* src = entries[ci].h_genes;
         for (int c = 0; c < pop_size; ++c)
             for (int g = 0; g < n_genes; ++g)
                 dst[c * n_genes + g] = (float)src[c * n_genes + g];
     }
 
-    // ── Build Metal buffers ────────────────────────────────────────────────
     auto mk = [&](const void* d, size_t n) {
-        return [ctx->device newBufferWithBytes:d length:n
+        return [ctx->device newBufferWithBytes:d length:(n ? n : sizeof(float))
                                       options:MTLResourceStorageModeShared];
     };
     id<MTLBuffer> buf_xyz   = mk(xyz_all.data(),  xyz_all.size()  * sizeof(float));
@@ -672,28 +944,29 @@ void metal_eval_batch_multi(MetalEvalCtx*              ctx,
     id<MTLBuffer> buf_sas   = [ctx->device newBufferWithLength:total_pop*sizeof(float)
                                                        options:MTLResourceStorageModeShared];
 
-    // MultiParams — all complexes must share the same n_genes, n_types, perm
-    // (valid for same energy matrix and GA config across a benchmark dataset).
-    struct MultiParams { int pop_size, n_genes, T; float perm; };
-    MultiParams mp = { pop_size, n_genes, entries[0].n_types, entries[0].perm };
+    MetalMultiParams mp;
+    mp.pop_size = pop_size; mp.n_genes = n_genes; mp.T = entries[0].n_types;
+    mp.perm = entries[0].perm;
+    mp.dw_r0 = P.dw_r0; mp.sas_weight = P.sas_weight;
+    mp.solvent_flat = P.solvent_flat; mp.solventterm = P.solventterm;
     id<MTLBuffer> buf_mp    = mk(&mp, sizeof(mp));
     id<MTLBuffer> buf_descs = mk(descs.data(), descs.size() * sizeof(ComplexDescHost));
 
-    // ── Single command buffer, one dispatch for N×pop_size chromosomes ────
     id<MTLCommandBuffer>         cb  = [ctx->queue commandBuffer];
     id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
     [enc setComputePipelineState:ctx->pipeline_multi];
-    [enc setBuffer:buf_xyz   offset:0 atIndex:0];
-    [enc setBuffer:buf_type  offset:0 atIndex:1];
-    [enc setBuffer:buf_rad   offset:0 atIndex:2];
+    [enc setBuffer:buf_xyz               offset:0 atIndex:0];
+    [enc setBuffer:buf_type              offset:0 atIndex:1];
+    [enc setBuffer:buf_rad               offset:0 atIndex:2];
     [enc setBuffer:ctx->buf_emat_sampled offset:0 atIndex:3];
-    [enc setBuffer:buf_genes offset:0 atIndex:4];
-    [enc setBuffer:buf_com   offset:0 atIndex:5];
-    [enc setBuffer:buf_wal   offset:0 atIndex:6];
-    [enc setBuffer:buf_sas   offset:0 atIndex:7];
-    [enc setBuffer:buf_mp    offset:0 atIndex:8];
-    [enc setBuffer:buf_descs offset:0 atIndex:9];
+    [enc setBuffer:buf_genes             offset:0 atIndex:4];
+    [enc setBuffer:buf_com               offset:0 atIndex:5];
+    [enc setBuffer:buf_wal               offset:0 atIndex:6];
+    [enc setBuffer:buf_sas               offset:0 atIndex:7];
+    [enc setBuffer:buf_mp                offset:0 atIndex:8];
+    [enc setBuffer:buf_descs             offset:0 atIndex:9];
     [enc setThreadgroupMemoryLength:256 * sizeof(float) atIndex:0];
+    [enc setThreadgroupMemoryLength:256 * sizeof(float) atIndex:1];
 
     MTLSize gridSize  = { (NSUInteger)total_pop, 1, 1 };
     MTLSize groupSize = { 256, 1, 1 };
@@ -708,7 +981,6 @@ void metal_eval_batch_multi(MetalEvalCtx*              ctx,
             std::string([desc UTF8String]));
     }
 
-    // ── Scatter float results → per-complex double output buffers ─────────
     const float* com_f = (const float*)[buf_com contents];
     const float* wal_f = (const float*)[buf_wal contents];
     const float* sas_f = (const float*)[buf_sas contents];

--- a/LIB/simd_distance.h
+++ b/LIB/simd_distance.h
@@ -849,6 +849,29 @@ inline void dot3_batch(const float* a, const float* b, float* out, int N) noexce
 
 #endif  // FLEXAIDS_HAS_AVX512 / FLEXAIDS_HAS_AVX2 / FLEXAIDS_HAS_SSE42
 
+// ─── missing 4-wide overload on the AVX2 / AVX-512 branches ──────────────────
+// distance2_1x4 is defined by the SSE4.2, NEON and scalar branches, but NOT by
+// the AVX-512 branch (which supplies 1x16 / 1x8) or the AVX2 branch (1x8 only).
+// Any call site using the 4-wide form therefore failed to compile under
+// -mavx2 / -mavx512f — i.e. on exactly the production x86 configurations —
+// while compiling fine on SSE-only, NEON and scalar builds. Supplied here, after
+// all ISA branches have closed, so no existing branch is disturbed. SSE
+// intrinsics are architecturally available whenever AVX2 or AVX-512 is.
+#if FLEXAIDS_HAS_AVX512 || FLEXAIDS_HAS_AVX2
+inline void distance2_1x4(const float* FLEXAIDS_RESTRICT ax,
+                           const float* FLEXAIDS_RESTRICT ay,
+                           const float* FLEXAIDS_RESTRICT az,
+                           float bx, float by, float bz,
+                           float* FLEXAIDS_RESTRICT out) noexcept {
+    __m128 dx = _mm_sub_ps(_mm_loadu_ps(ax), _mm_set1_ps(bx));
+    __m128 dy = _mm_sub_ps(_mm_loadu_ps(ay), _mm_set1_ps(by));
+    __m128 dz = _mm_sub_ps(_mm_loadu_ps(az), _mm_set1_ps(bz));
+    _mm_storeu_ps(out, _mm_add_ps(_mm_mul_ps(dx, dx),
+                       _mm_add_ps(_mm_mul_ps(dy, dy),
+                                  _mm_mul_ps(dz, dz))));
+}
+#endif
+
 // ─── dispatch helper: compile-time dispatch to best available ────────────────
 
 // RMSD between two coordinate arrays (N atoms, interleaved xyz)

--- a/LIB/two_stage_screen_main.cpp
+++ b/LIB/two_stage_screen_main.cpp
@@ -1,0 +1,201 @@
+// two_stage_screen_main.cpp — CLI driver for NRGRank two-stage screening (P5)
+//
+// Wires the in-repo NRGRank rigid coarse screen (CoarseScreener /
+// TwoStageScreener) as a *pre-filter* in front of the expensive FlexAIDdS GA.
+// Stage 1 (this driver) scores an entire ligand library with the fast rigid CF
+// and keeps only the top-N candidates; those N are then handed to the full GA
+// docking engine (classic `FlexAID`) — an order-of-magnitude throughput win for
+// virtual screening with no change to per-dock physics.
+//
+// This is deliberately a thin driver: it reuses the existing CoarseScreen /
+// TwoStageScreen classes rather than reimplementing any scoring, and it does not
+// pull in the GA/top.cpp engine (owned elsewhere). Stage 2 is exposed as an
+// optional callback hook; by default the driver emits the pruned top-N list
+// (names + CSV) that the GA campaign scripts consume.
+//
+// Usage:
+//   flexaid_screen --target target.mol2 --cleft cleft.pdb --ligands lib.mol2 \
+//                  [--two-stage] [--coarse-topN N] [--rotations-per-axis R] \
+//                  [--no-clash] [--sdf] [--out DIR] [--verbose]
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CoarseScreen.h"
+#include "TwoStageScreen.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using namespace nrgrank;
+
+namespace {
+
+struct CliOptions {
+    std::string target;          // target MOL2
+    std::string cleft;           // binding-site cleft PDB
+    std::string ligands;         // multi-mol2 or SDF library
+    std::string out_dir = "screen_results";
+    int         top_n   = 100;   // --coarse-topN
+    int         rotations_per_axis = 9;
+    bool        two_stage = false;   // --two-stage: enable the pipeline mode
+    bool        use_clash = true;
+    bool        sdf       = false;   // ligand library is SDF (else MOL2)
+    bool        verbose   = false;
+};
+
+void print_usage(const char* prog) {
+    std::printf(
+        "FlexAIDdS two-stage screening (NRGRank rigid coarse pre-filter → GA)\n"
+        "Usage: %s --target T.mol2 --cleft C.pdb --ligands L.{mol2|sdf} [options]\n\n"
+        "Required:\n"
+        "  --target FILE          Target receptor MOL2\n"
+        "  --cleft FILE           Binding-site cleft/sphere PDB\n"
+        "  --ligands FILE         Ligand library (multi-MOL2 by default, or SDF)\n\n"
+        "Options:\n"
+        "  --two-stage            Enable two-stage MODE (coarse prune + Stage-2 hook)\n"
+        "  --coarse-topN N        Keep top-N ligands for the GA (default 100)\n"
+        "  --rotations-per-axis R Orientations R^3 in coarse screen (default 9 → 729)\n"
+        "  --no-clash             Disable clash filtering in coarse screen\n"
+        "  --sdf                  Treat --ligands as SDF (default: MOL2)\n"
+        "  --out DIR              Output directory (default screen_results)\n"
+        "  --verbose              Verbose progress\n"
+        "  -h, --help             This help\n",
+        prog);
+}
+
+bool parse_args(int argc, char** argv, CliOptions& o) {
+    for (int i = 1; i < argc; ++i) {
+        const char* a = argv[i];
+        auto need = [&](const char* name) -> const char* {
+            if (i + 1 >= argc) {
+                std::fprintf(stderr, "error: %s requires an argument\n", name);
+                return nullptr;
+            }
+            return argv[++i];
+        };
+        if (!std::strcmp(a, "--target")) {
+            const char* v = need(a); if (!v) return false; o.target = v;
+        } else if (!std::strcmp(a, "--cleft")) {
+            const char* v = need(a); if (!v) return false; o.cleft = v;
+        } else if (!std::strcmp(a, "--ligands")) {
+            const char* v = need(a); if (!v) return false; o.ligands = v;
+        } else if (!std::strcmp(a, "--coarse-topN")) {
+            const char* v = need(a); if (!v) return false; o.top_n = std::atoi(v);
+        } else if (!std::strcmp(a, "--rotations-per-axis")) {
+            const char* v = need(a); if (!v) return false;
+            o.rotations_per_axis = std::atoi(v);
+        } else if (!std::strcmp(a, "--out")) {
+            const char* v = need(a); if (!v) return false; o.out_dir = v;
+        } else if (!std::strcmp(a, "--two-stage")) {
+            o.two_stage = true;
+        } else if (!std::strcmp(a, "--no-clash")) {
+            o.use_clash = false;
+        } else if (!std::strcmp(a, "--sdf")) {
+            o.sdf = true;
+        } else if (!std::strcmp(a, "--verbose")) {
+            o.verbose = true;
+        } else if (!std::strcmp(a, "-h") || !std::strcmp(a, "--help")) {
+            print_usage(argv[0]);
+            std::exit(0);
+        } else {
+            std::fprintf(stderr, "error: unknown argument '%s'\n", a);
+            return false;
+        }
+    }
+    if (o.target.empty() || o.cleft.empty() || o.ligands.empty()) {
+        std::fprintf(stderr, "error: --target, --cleft and --ligands are required\n");
+        return false;
+    }
+    if (o.top_n < 1) o.top_n = 1;
+    if (o.rotations_per_axis < 1) o.rotations_per_axis = 1;
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    CliOptions o;
+    if (!parse_args(argc, argv, o)) {
+        print_usage(argv[0]);
+        return 2;
+    }
+
+    // ── Load ligand library (reuse existing loaders) ──
+    std::vector<ScreenLigand> ligands =
+        o.sdf ? CoarseScreener::load_ligands_sdf(o.ligands)
+              : CoarseScreener::load_ligands_mol2(o.ligands);
+    if (ligands.empty()) {
+        std::fprintf(stderr, "error: no ligands parsed from '%s'\n",
+                     o.ligands.c_str());
+        return 1;
+    }
+    std::printf("Loaded %zu ligands from %s\n", ligands.size(), o.ligands.c_str());
+
+    // ── Configure and prepare the two-stage screener ──
+    TwoStageScreener ts;
+    TwoStageConfig cfg;
+    cfg.coarse.rotations_per_axis = o.rotations_per_axis;
+    cfg.coarse.use_clash          = o.use_clash;
+    cfg.coarse.top_n              = o.top_n;
+    cfg.top_n                     = o.top_n;
+    cfg.output_dir                = o.out_dir;
+    cfg.write_coarse_csv          = true;
+    cfg.verbose                   = o.verbose;
+    ts.set_config(cfg);
+
+    if (!ts.load_target(o.target, o.cleft)) {
+        std::fprintf(stderr,
+                     "error: failed to prepare target (mol2='%s', cleft='%s')\n",
+                     o.target.c_str(), o.cleft.c_str());
+        return 1;
+    }
+    std::printf("Target prepared: %zu anchor points\n",
+                ts.coarse_screener().num_anchors());
+
+    // ── Stage 2 hook ──
+    // In --two-stage mode we leave the GA docking callback UNSET here: coupling
+    // the full FlexAID GA (top.cpp) into a callback belongs to the campaign
+    // launcher that owns the engine. This driver's job is the Stage-1 prune; it
+    // emits the top-N candidate list the GA then docks. Setting a real callback
+    // is a one-liner (ts.set_full_dock_callback(fn)) once wired.
+    if (o.two_stage) {
+        std::printf("Two-stage MODE: Stage-1 coarse prune → top %d handed to GA\n",
+                    o.top_n);
+    }
+
+    // ── Run ──
+    std::vector<TwoStageResult> results = ts.run(ligands);
+    if (results.empty()) {
+        std::fprintf(stderr, "error: screening produced no results\n");
+        return 1;
+    }
+
+    // ── Emit pruned top-N candidate list (fed to the GA) ──
+    const int n_keep = std::min<int>(o.top_n, static_cast<int>(results.size()));
+    std::filesystem::create_directories(o.out_dir);
+    const std::string top_path = o.out_dir + "/stage1_topN.txt";
+    std::ofstream top_out(top_path);
+    if (top_out.is_open()) {
+        top_out << "# rank\tname\tcoarse_score\n";
+        for (int i = 0; i < n_keep; ++i) {
+            const auto& r = results[i];
+            top_out << (i + 1) << '\t' << r.coarse_result.name << '\t'
+                    << r.coarse_result.score << '\n';
+        }
+    }
+
+    std::printf("Screening complete: %zu ligands scored, top %d kept for GA.\n"
+                "  coarse CSV : %s/coarse_screen.csv\n"
+                "  top-N list : %s\n",
+                results.size(), n_keep, o.out_dir.c_str(), top_path.c_str());
+    std::printf("Best candidate: %s (coarse CF = %.4f)\n",
+                results[0].coarse_result.name.c_str(),
+                results[0].coarse_result.score);
+    return 0;
+}

--- a/cmake/FlexAIDOptions.cmake
+++ b/cmake/FlexAIDOptions.cmake
@@ -88,6 +88,40 @@ if(FLEXAIDS_GRAND_CANONICAL)
 endif()
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Classic FlexAID target: P0 build-level optimization (LTO/native/NDEBUG + PGO)
+# ─────────────────────────────────────────────────────────────────────────────
+# Historically only the FlexAIDdS target carried the aggressive optimization
+# flag block (LTO + INTERPROCEDURAL_OPTIMIZATION + -march=native / -mcpu=native +
+# -DNDEBUG + strip); the classic FlexAID target shipped with only -O3 -ffast-math.
+# BUILD_FLEXAID_FAST mirrors BUILD_FLEXAIDDS_FAST and lifts that same block onto
+# the classic FlexAID target (applied via flexaids_apply_fast_optimization()).
+option(BUILD_FLEXAID_FAST "Apply the FlexAIDdS LTO + native-arch + NDEBUG optimization block to the classic FlexAID target" ON)
+
+# Profile-Guided Optimization for the classic FlexAID target. Values:
+#   off      — no PGO instrumentation (default)
+#   generate — instrumented build (-fprofile-generate); run a representative dock
+#              (e.g. 1G9V, fixed FLEXAID_SEED) to emit profile data, then
+#              reconfigure with -DFLEXAID_PGO=use and rebuild.
+#   use      — optimized build consuming the profile
+#              (-fprofile-use [-fprofile-correction on GCC])
+set(FLEXAID_PGO "off" CACHE STRING "FlexAID Profile-Guided Optimization mode: off | generate | use")
+set_property(CACHE FLEXAID_PGO PROPERTY STRINGS off generate use)
+
+# LTO/native codegen is incompatible with gcov coverage and with ASan/TSan/UBSan
+# instrumented builds. Reuse the SAME incompatibility guard the
+# BUILD_FLEXAIDDS_FAST block uses (see root CMakeLists.txt) so an instrumented
+# build silently drops the fast flags instead of failing to link.
+if(FLEXAIDS_ENABLE_COVERAGE
+   OR CMAKE_CXX_FLAGS MATCHES "-fsanitize"
+   OR CMAKE_C_FLAGS MATCHES "-fsanitize"
+   OR CMAKE_EXE_LINKER_FLAGS MATCHES "-fsanitize")
+    if(BUILD_FLEXAID_FAST)
+        message(STATUS "Disabling BUILD_FLEXAID_FAST (incompatible with coverage/sanitizer flags)")
+    endif()
+    set(BUILD_FLEXAID_FAST OFF CACHE BOOL "Apply the FlexAIDdS LTO + native-arch + NDEBUG optimization block to the classic FlexAID target" FORCE)
+endif()
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Platform / architecture detection
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -180,6 +214,81 @@ function(flexaids_configure_simd target_name)
     if(FLEXAIDS_USE_SOA_DISTANCES)
         target_compile_definitions(${target_name} PRIVATE FLEXAIDS_USE_SOA_DISTANCES)
         message(STATUS "${target_name}: SoA distance routing enabled (FLEXAIDS_USE_SOA_DISTANCES)")
+    endif()
+endfunction()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper: lift the FlexAIDdS optimization flag block onto an arbitrary target
+# ─────────────────────────────────────────────────────────────────────────────
+# Mirrors the flag block applied to the FlexAIDdS target in root CMakeLists.txt
+# (the BUILD_FLEXAIDDS_FAST branch): -flto + INTERPROCEDURAL_OPTIMIZATION +
+# -march=native / -mcpu=native + -DNDEBUG + link-time strip (-s), or /GL /LTCG on
+# MSVC. It ADDS to (does not replace) the target's existing -O3 -ffast-math flags.
+#
+# No-op unless BUILD_FLEXAID_FAST is ON (the coverage/sanitizer guard above
+# force-disables that option so instrumented builds stay linkable).
+#
+# LTO/OBJECT-library caveat (see root CMakeLists.txt notes): flexaid_core is
+# compiled WITHOUT IPO so that non-LTO consumers (tests) can still link its .o
+# files. We enable IPO only on the leaf executable and add -flto to its own
+# compile/link, exactly as the proven FlexAIDdS target does — mixed LTO/non-LTO
+# object linking is handled by the compiler driver.
+function(flexaids_apply_fast_optimization target_name)
+    if(NOT BUILD_FLEXAID_FAST)
+        return()
+    endif()
+    if(MSVC)
+        target_compile_options(${target_name} PRIVATE /GL /DNDEBUG)
+        target_link_options(${target_name} PRIVATE /LTCG)
+    else()
+        target_compile_options(${target_name} PRIVATE -flto -DNDEBUG
+            $<$<AND:$<CXX_COMPILER_ID:AppleClang,Clang>,$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},arm64>>:-mcpu=native>
+        )
+        if(NOT APPLE)
+            target_compile_options(${target_name} PRIVATE -march=native)
+            target_link_options(${target_name} PRIVATE -flto -s)
+        else()
+            target_link_options(${target_name} PRIVATE -flto)
+        endif()
+    endif()
+
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT _flexaid_ipo_ok OUTPUT _flexaid_ipo_err)
+    if(_flexaid_ipo_ok)
+        set_property(TARGET ${target_name} PROPERTY INTERPROCEDURAL_OPTIMIZATION ON)
+    else()
+        message(WARNING "IPO not supported for ${target_name}: ${_flexaid_ipo_err}")
+    endif()
+    message(STATUS "${target_name}: fast-optimization block enabled (LTO/IPO + native + NDEBUG)")
+endfunction()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper: apply Profile-Guided Optimization flags (FLEXAID_PGO) to a target
+# ─────────────────────────────────────────────────────────────────────────────
+# generate → -fprofile-generate ; use → -fprofile-use (+ -fprofile-correction on
+# GCC). -fprofile-correction is GCC-only (tolerates inconsistent counters from a
+# multi-threaded instrumented run); it is gated to GNU so Clang does not error.
+function(flexaids_apply_pgo target_name)
+    if(FLEXAID_PGO STREQUAL "off")
+        return()
+    endif()
+    if(MSVC)
+        message(WARNING "FLEXAID_PGO=${FLEXAID_PGO} is not wired for MSVC (use /GENPROFILE|/USEPROFILE manually); ignoring")
+        return()
+    endif()
+    if(FLEXAID_PGO STREQUAL "generate")
+        target_compile_options(${target_name} PRIVATE -fprofile-generate)
+        target_link_options(${target_name} PRIVATE -fprofile-generate)
+        message(STATUS "${target_name}: PGO instrumentation build (-fprofile-generate) — "
+                       "run a representative dock, then reconfigure with -DFLEXAID_PGO=use")
+    elseif(FLEXAID_PGO STREQUAL "use")
+        target_compile_options(${target_name} PRIVATE
+            -fprofile-use $<$<CXX_COMPILER_ID:GNU>:-fprofile-correction>)
+        target_link_options(${target_name} PRIVATE
+            -fprofile-use $<$<CXX_COMPILER_ID:GNU>:-fprofile-correction>)
+        message(STATUS "${target_name}: PGO optimized build (-fprofile-use)")
+    else()
+        message(FATAL_ERROR "FLEXAID_PGO must be one of: off | generate | use (got '${FLEXAID_PGO}')")
     endif()
 endfunction()
 

--- a/cmake/FlexAIDOptions.cmake
+++ b/cmake/FlexAIDOptions.cmake
@@ -51,7 +51,16 @@ endif()
 # SIMD
 option(FLEXAIDS_USE_AVX2    "Enable AVX2 SIMD acceleration"       ON)
 option(FLEXAIDS_USE_AVX512  "Enable AVX-512 SIMD acceleration"    OFF)
-option(FLEXAIDS_USE_SOA_DISTANCES "Route Voronoi hot-path distances through AtomSoA float SoA arrays (C1)" ON)
+# Default OFF per METHODOLOGY §1 ("any intended behavior change must be opt-in
+# behind a flag that defaults OFF, and parity must hold with the flag OFF").
+# This path is ranking-affecting, not merely faster: float32 squared distances
+# perturb contlist.dist and the near/clash cutoffs, hence Voronoi topology.
+# It also could not compile on production x86 until this PR added
+# atom_soa::distance2_1x4 (simd::distance2_1x4 is absent from the AVX2 and
+# AVX-512 branches of simd_distance.h), so defaulting it ON would ship a code
+# path no prior CI on those machines has ever executed. Turn ON explicitly to
+# benchmark it, and run the Astex-85 A/B before proposing it as the default.
+option(FLEXAIDS_USE_SOA_DISTANCES "Route Voronoi hot-path distances through AtomSoA float SoA arrays (C1)" OFF)
 
 # ─── Native CPU tuning for flexaid_core (perf vs. portability trade-off) ──
 # -mcpu=native (Apple/Clang, arm64) tunes instruction scheduling/selection
@@ -95,7 +104,16 @@ endif()
 # -DNDEBUG + strip); the classic FlexAID target shipped with only -O3 -ffast-math.
 # BUILD_FLEXAID_FAST mirrors BUILD_FLEXAIDDS_FAST and lifts that same block onto
 # the classic FlexAID target (applied via flexaids_apply_fast_optimization()).
-option(BUILD_FLEXAID_FAST "Apply the FlexAIDdS LTO + native-arch + NDEBUG optimization block to the classic FlexAID target" ON)
+# Default OFF per METHODOLOGY §1. The block includes -march=native, which makes
+# the emitted binary a function of the build host's CPU: two correct builds of
+# identical source on different runners produce different md5s, so §1 step 1
+# ("record both md5s") and the recorded reference md5 at METHODOLOGY.md:131
+# cannot be compared across machines. On top of the existing -ffast-math this
+# also permits per-host FMA contraction and reassociation, so the numerical
+# output moves too — not just the binary. Turn ON explicitly for local perf
+# work. (Note: BUILD_FLEXAIDDS_FAST carries the same hazard for the FlexAIDdS
+# target and predates this PR; that is a separate fix, not this one's to make.)
+option(BUILD_FLEXAID_FAST "Apply the FlexAIDdS LTO + native-arch + NDEBUG optimization block to the classic FlexAID target" OFF)
 
 # Profile-Guided Optimization for the classic FlexAID target. Values:
 #   off      — no PGO instrumentation (default)

--- a/cmake/FlexAIDOptions.cmake
+++ b/cmake/FlexAIDOptions.cmake
@@ -51,7 +51,7 @@ endif()
 # SIMD
 option(FLEXAIDS_USE_AVX2    "Enable AVX2 SIMD acceleration"       ON)
 option(FLEXAIDS_USE_AVX512  "Enable AVX-512 SIMD acceleration"    OFF)
-option(FLEXAIDS_USE_SOA_DISTANCES "Route Voronoi hot-path distances through AtomSoA float SoA arrays (C1)" OFF)
+option(FLEXAIDS_USE_SOA_DISTANCES "Route Voronoi hot-path distances through AtomSoA float SoA arrays (C1)" ON)
 
 # ─── Native CPU tuning for flexaid_core (perf vs. portability trade-off) ──
 # -mcpu=native (Apple/Clang, arm64) tunes instruction scheduling/selection

--- a/cmake/FlexAIDOptions.cmake
+++ b/cmake/FlexAIDOptions.cmake
@@ -55,11 +55,15 @@ option(FLEXAIDS_USE_AVX512  "Enable AVX-512 SIMD acceleration"    OFF)
 # behind a flag that defaults OFF, and parity must hold with the flag OFF").
 # This path is ranking-affecting, not merely faster: float32 squared distances
 # perturb contlist.dist and the near/clash cutoffs, hence Voronoi topology.
-# It also could not compile on production x86 until this PR added
-# atom_soa::distance2_1x4 (simd::distance2_1x4 is absent from the AVX2 and
-# AVX-512 branches of simd_distance.h), so defaulting it ON would ship a code
-# path no prior CI on those machines has ever executed. Turn ON explicitly to
-# benchmark it, and run the Astex-85 A/B before proposing it as the default.
+# It also could not compile on production x86 until this PR: simd::distance2_1x4
+# was defined only in the SSE4.2/NEON/scalar branches of simd_distance.h and was
+# missing from the AVX2 and AVX-512 branches. That is now fixed at source (see
+# the 4-wide overload added after the ISA branches in simd_distance.h), with
+# atom_soa::distance2_1x4 kept as the ISA-portable call site. The reasoning for
+# defaulting OFF is unchanged and does not depend on the compile break: enabling
+# it would ship a code path no prior CI on those machines has ever executed.
+# Turn ON explicitly to benchmark it, and run the Astex-85 A/B before proposing
+# it as the default.
 option(FLEXAIDS_USE_SOA_DISTANCES "Route Voronoi hot-path distances through AtomSoA float SoA arrays (C1)" OFF)
 
 # ─── Native CPU tuning for flexaid_core (perf vs. portability trade-off) ──

--- a/docs/FLEXAID_FAST_DOCKING_PLAN.md
+++ b/docs/FLEXAID_FAST_DOCKING_PLAN.md
@@ -132,3 +132,80 @@ Since drift is allowed globally, the cleanest packaging is to **optimize the `Fl
 ## 7. First concrete step
 
 P0 is a self-contained, low-risk PR: lift the `FlexAIDdS` LTO/native/NDEBUG flag block onto the `FlexAID` target, add the PGO CMake option, and stand up the Astex-85 speedup+parity harness as the CI gate that all later phases report against.
+
+---
+
+## 8. Implementation status (measured, not estimated)
+
+Phases P0, P1+P2, P3 and P5 were implemented in parallel isolated worktrees and integrated onto
+`claude/flexaid-optimization-docking-t2h83d`. **What follows is actual recorded evidence.**
+Anything not listed as verified is explicitly *not* claimed.
+
+### Verified in this environment
+
+Toolchain note: the container ships GCC 13.3 (below the repo's C++26 gate — `-std=c++26` is
+rejected outright), so the authoritative build used **Clang 18.1.3** with the `linux-clang`
+configuration.
+
+| Check | Command | Result |
+|---|---|---|
+| Integrated configure | `cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DBUILD_FLEXAID_FAST=ON` (CC/CXX=clang) | success; log confirms `SoA distance routing enabled` |
+| Engine + screener build | `ninja FlexAID flexaid_screen` | **309/309 steps, 0 errors** |
+| Binary sanity | `./FlexAID`, `./flexaid_screen --help` | both run; `FlexAID` is `ELF … stripped` (confirms `-flto -s`) |
+| Full test build | `ninja` (all targets) | **1907 steps, exit 0** |
+| Test suite | `ctest --output-on-failure` | **86/86 passed, 0 failed** (2.41 s) |
+
+Per-phase implementation summary:
+
+- **P0** — `BUILD_FLEXAID_FAST` (default ON) applies LTO/IPO + `-march=native` + `-DNDEBUG` +
+  `-flto -s` to the classic `FlexAID` target, reusing the existing sanitizer/coverage guard
+  (verified to force-disable under `FLEXAIDS_ENABLE_COVERAGE`). Adds `FLEXAID_PGO`
+  (off/generate/use) and `scripts/bench_flexaid_fast.sh`. IPO is applied to the leaf executable
+  only; `flexaid_core` stays non-LTO so tests still link its objects.
+- **P1+P2** — per-call box `memset` replaced by a per-thread **epoch stamp**; sphere-area
+  invariants hoisted out of the `calc_areas` face loop (both **bit-identical by construction**);
+  `calc_areas` triangle math moved to `float` with the four independent roots packed for a
+  4-wide `sqrt`. The SoA distance path was found to be disabled because it called
+  `simd::distance2_1x4`, **which does not exist in the AVX2/AVX-512 branches** of
+  `simd_distance.h` — a latent hard compile break on x86 production configs. Fixed with an
+  ISA-portable `atom_soa::distance2_1x4`, and `FLEXAIDS_USE_SOA_DISTANCES` flipped to default ON.
+- **P3** — `FLEXAIDDS_PARALLEL_REPRODUCE` default-ON with the stale-status fix applied to both
+  deferred branches; the per-generation full workspace clone replaced by a shape-keyed resident
+  cache (O(generations × threads × natoms) copy → one-time O(threads × natoms)); new
+  `FLEXAID_DETERMINISTIC` macro/env pins single-thread serial-equivalent evaluation for CI A/B.
+- **P5** — new `flexaid_screen` CLI driving the existing `TwoStageScreener`/`CoarseScreener` as a
+  rigid NRGRank pre-filter (`--two-stage`, `--coarse-topN`), emitting `coarse_screen.csv` +
+  `stage1_topN.txt`; plus best-CF plateau early-stop in the GA loop, **default off**, opt-in via
+  `FLEXAIDDS_ADAPTIVE_GENERATIONS`. Stage-2 GA coupling is left as an unset callback hook.
+
+### NOT verified — required before any performance or accuracy claim
+
+1. **No speedup number exists.** No dock was run in this environment: the repo ships no runnable
+   receptor+cognate-ligand pair and RCSB fetches are proxy-blocked (HTTP 403). Every figure in
+   §6 remains an unmeasured hypothesis. Run `scripts/bench_flexaid_fast.sh` (or the Tier-1
+   benchmark workflow) on a host with real inputs to replace them.
+2. **No Astex-85 parity run.** This is the gate that matters most, because two P1+P2 changes are
+   genuinely **ranking-affecting**: (a) `FLEXAIDS_USE_SOA_DISTANCES=ON` computes squared
+   distances in float32 versus the double reference, perturbing `contlist.dist`, the near/clash
+   cutoffs, and therefore Voronoi topology; (b) the float `calc_areas` math perturbs contact
+   areas. The in-repo `FLEXAIDS_SOA_ASSERT=1` harness validates (a) against the double reference
+   on a real binary and should be run first.
+3. **P3 runtime reproducibility is unretested.** Only syntax/compile was checked. The
+   ≈0.2% multi-thread chromosome divergence documented in `OPTIMIZATION_KNOWN_ISSUES.md` is
+   *accepted* under the drift policy, not *fixed* — confirm the A/B success rate holds.
+4. **P4 (GPU) is excluded from this integration.** It cannot be compiled here: no CUDA toolkit,
+   and Metal is macOS-only. It must be staged separately and verified with a real CUDA build +
+   GPU run and a macOS Metal build before the GPU path is enabled by default.
+
+### Deliberately deferred (flagged, not silently skipped)
+
+- **P2.2 — flattening the `ca_rec` linked list** into a per-atom SoA array (`vcfunction.cpp:392`).
+  The accumulation loop carries ~10 branches (constraints, bonded-skip, contact epoch, hbond,
+  elec, metal), so SIMD payoff is marginal while the layout change to `save_areas` + `vcfunction`
+  is high correctness risk and cannot be validated by compile-check alone. Left for a
+  runtime-verified pass.
+- **Full struct-level `double`→`float` of the Voronoi hull** (`plane.Ai` / `vertex.xi` plus ~15
+  helper signatures in `Vcontacts.h`) — deferred in favour of converting the hot transcendental
+  math only.
+- **Aggressive `rsqrt`+Newton / polynomial-`atan`** variants (versus the `std::sqrt`/`std::atan`
+  float used) — an additional speedup gated behind the same parity table.

--- a/docs/FLEXAID_FAST_DOCKING_PLAN.md
+++ b/docs/FLEXAID_FAST_DOCKING_PLAN.md
@@ -137,9 +137,10 @@ P0 is a self-contained, low-risk PR: lift the `FlexAIDdS` LTO/native/NDEBUG flag
 
 ## 8. Implementation status (measured, not estimated)
 
-Phases P0, P1+P2, P3 and P5 were implemented in parallel isolated worktrees and integrated onto
-`claude/flexaid-optimization-docking-t2h83d`. **What follows is actual recorded evidence.**
-Anything not listed as verified is explicitly *not* claimed.
+All six phases (P0, P1+P2, P3, P4, P5) were implemented in parallel isolated worktrees and
+integrated onto `claude/flexaid-optimization-docking-t2h83d`. **What follows is actual recorded
+evidence.** Anything not listed as verified is explicitly *not* claimed — in particular P4's GPU
+code paths, which cannot be compiled in a CPU-only Linux container.
 
 ### Verified in this environment
 
@@ -154,6 +155,11 @@ configuration.
 | Binary sanity | `./FlexAID`, `./flexaid_screen --help` | both run; `FlexAID` is `ELF … stripped` (confirms `-flto -s`) |
 | Full test build | `ninja` (all targets) | **1907 steps, exit 0** |
 | Test suite | `ctest --output-on-failure` | **86/86 passed, 0 failed** (2.41 s) |
+| Re-verify after P4 merge | `ninja FlexAID flexaid_screen` → `ninja` → `ctest` | **exit 0 / exit 0 / 86-86 passed, 0 failed** |
+
+The final row matters: P4 edits `gaboom.cpp`, so the whole engine was rebuilt and re-tested after
+that merge. It confirms only that the **default GPU-off build** is unaffected — it says nothing
+about whether the CUDA/Metal kernels themselves are correct (see below).
 
 Per-phase implementation summary:
 
@@ -177,6 +183,22 @@ Per-phase implementation summary:
   rigid NRGRank pre-filter (`--two-stage`, `--coarse-topN`), emitting `coarse_screen.csv` +
   `stage1_topN.txt`; plus best-CF plateau early-stop in the GA loop, **default off**, opt-in via
   `FLEXAIDDS_ADAPTIVE_GENERATIONS`. Stage-2 GA coupling is left as an unset callback hook.
+- **P4** — CUDA and Metal single-complex batch kernels extended from com/wal/sas to the full CF
+  channel set feeding `get_cf_evalue()`: **con** (covalent-constraint Gaussian), **elec**
+  (distance-dielectric Coulomb), **hbond** (distance-Gaussian × representative angle with
+  donor/acceptor + salt gating), **gist_desolv** (trilinear grid lookup, kernel-side only),
+  **pb_clash + pocket**, and the VCT `exp(-r/r0)` distance weighting on com. Static
+  receptor/emat/vdW/charge/constraint arrays are device-resident via new
+  `cuda_eval_set_extra` / `metal_eval_set_extra`. Contact areas use a **drift-tolerant C0 linear
+  switching model** (`rel_area = 1` for r ≤ rA+rB, ramping to 0 at r = rA+rB+2·Rw) rather than a
+  port of the branchy analytic Voronoi — one pair per thread, no polyhedron clipping. Expected
+  error is a smooth ≈15–20% per-face over/under-estimate that is strongly correlated across
+  poses, so it should largely cancel in pose *ranking*; that cancellation is the admissibility
+  claim and **it is exactly what the Astex-85 A/B must confirm.**
+  - Also fixes a **latent Metal correctness bug**: the kernels reduced with `simd_sum()` (a single
+    32-lane SIMD group) over 256-thread threadgroups, silently discarding 7/8 of all
+    contributions. Replaced with a full threadgroup tree reduction. This is a correctness fix
+    independent of the performance work.
 
 ### NOT verified — required before any performance or accuracy claim
 
@@ -193,9 +215,21 @@ Per-phase implementation summary:
 3. **P3 runtime reproducibility is unretested.** Only syntax/compile was checked. The
    ≈0.2% multi-thread chromosome divergence documented in `OPTIMIZATION_KNOWN_ISSUES.md` is
    *accepted* under the drift policy, not *fixed* — confirm the A/B success rate holds.
-4. **P4 (GPU) is excluded from this integration.** It cannot be compiled here: no CUDA toolkit,
-   and Metal is macOS-only. It must be staged separately and verified with a real CUDA build +
-   GPU run and a macOS Metal build before the GPU path is enabled by default.
+4. **P4's GPU kernels were never compiled or run.** The container has no CUDA toolkit and Metal
+   is macOS-only, so neither backend was built. The merged code is self-reviewed only (struct
+   host/MSL layout parity, kernel↔launch argument order, buffer indices, null guards, barrier
+   uniformity). Before the GPU path is enabled by default it needs: a CUDA build
+   (`-DFLEXAIDS_USE_CUDA=ON`) + real GPU run, a macOS Metal build (`-DFLEXAIDS_USE_METAL=ON`),
+   and the Astex-85 A/B against the CPU backend — which is also what tunes `hbond_angle_repr`
+   (currently 0.7, an unvalidated placeholder). Known remaining gaps, all guarded so the CPU path
+   is unaffected:
+   - The Metal **multi-complex screening** path (`metal_eval_batch_multi`) is still com/wal/sas
+     only; full fidelity needs `GPUContextPool.h` to forward per-complex extra arrays.
+   - **GIST host upload is not wired** — `GISTGrid.h` exposes no grid accessors, so `gist_nx=0`
+     and the term evaluates to 0 (the divergence guard warns when `use_gist` is set).
+   - `metal_coord`, `vct_entropy` and tENCoM `h_rep` are zeroed on the GPU path (guard warns).
+   - The kernels reuse the existing **translation-only gene decode** (first 3 genes); full
+     `buildcc` pose geometry remains a gap that caps angular-term fidelity.
 
 ### Deliberately deferred (flagged, not silently skipped)
 

--- a/docs/FLEXAID_FAST_DOCKING_PLAN.md
+++ b/docs/FLEXAID_FAST_DOCKING_PLAN.md
@@ -1,0 +1,134 @@
+# FlexAID-Fast — Ultra-Optimized Classic FlexAID Docking Plan
+
+**Branch:** `claude/flexaid-optimization-docking-t2h83d`
+**Goal:** Take the *classic FlexAID* docking engine (Voronoi complementarity function + genetic algorithm) — behavior kept "almost as is" — and accelerate it to the same level of performance engineering that the rest of FlexAIDdS already carries. **Target: raw docking throughput.**
+
+## Design decisions (locked)
+
+These framing choices drive every priority below:
+
+| Decision | Choice | Consequence |
+|---|---|---|
+| **Fidelity** | *Small numerical drift allowed everywhere* | May use `float` geometry, reordered parallel reductions, fast/approx transcendentals, and GPU. Ranking and poses must stay essentially equivalent; scores need not match the legacy engine bit-for-bit. |
+| **Hardware** | *CPU **and** GPU (CUDA/Metal)* | Do the CPU work **and** bring the existing GPU batch kernels up to full CF fidelity so GPU docking becomes usable, then auto-dispatch per machine. |
+| **Scope** | *Keep features, just speed the core* | ΔS entropy machinery (statmech / Shannon / tENCoM / ENCoM) stays available but **off-by-default and zero-cost when unused**; accelerate the shared GA + Voronoi core. |
+
+Because drift is allowed, the historical blocker on `FLEXAIDDS_PARALLEL_REPRODUCE` (a ~0.2% chromosome-level numeric non-determinism under multi-thread offspring eval) is **no longer a gate** — it can be turned on, with a separate deterministic-reduction switch kept only for regression benchmarking.
+
+---
+
+## 1. Where the time actually goes (measured hot path)
+
+```
+main()                         LIB/top.cpp:405
+ └─ GA(...)                    LIB/top.cpp:2915          scoring fn = ic2cf
+     └─ for gen in 0..max_gen  LIB/gaboom.cpp:691        SERIAL generation loop (GA data dependency)
+         └─ calculate_fitness  LIB/gaboom.cpp:2307
+             └─ #pragma omp parallel for over population   gaboom.cpp:2773-2781   ← only fine-grained parallelism
+                 └─ eval_chromosome  gaboom.cpp:3183
+                     └─ ic2cf → buildcc (gene→Cartesian) → vcfunction → Vcontacts
+```
+
+- **Loop budget:** default `num_chrom = 1000`, `max_generations = 2000` (`top.cpp:2812-2813`); production configs reach ~1750×2000. Each generation scores the whole population → ~10⁹+ per-atom Voronoi cell constructions for one full dock.
+- **Dominant cost — Voronoi geometry:** `Vcontacts()` (`Vcontacts.cpp:14`), specifically `voronoi_poly2()` (`:172`) and `calc_areas()` (`:871`). `calc_areas` does **5× `sqrt` + an `atan(sqrt(...))` per face triangle**, all in `double`.
+- **Second cost — contact-list scoring walk:** `vcfunction.cpp:392` chases a `ca_rec[...].prev` **linked list** per atom (pointer-chasing, cache-hostile), with a strided `energy_matrix` lookup (`get_yval`) per contact and optional `exp`/H-bond/metal transcendentals.
+- **Per-pose heap churn:** `index_protein` `malloc`+`memset` of the cubed bounding box **every** `Vcontacts` call (`Vcontacts.cpp:1738, 1773`); `get_contlist4` `malloc(100000*int)` per call (`:1268`); `save_areas` grows `ca_rec` by realloc.
+- **Precision:** geometry is `double` although atom coordinates originate as `float` (`atom.coor`).
+- **Parallelism today:** OpenMP across the population *within* a generation, made thread-safe by per-thread deep copies of nearly every mutable structure (`gaboom.cpp:2703-2734`) — the cloning itself costs memory bandwidth. Offspring deferred-eval (`FLEXAIDDS_PARALLEL_REPRODUCE`) is currently **OFF**.
+
+## 2. What optimization machinery already exists (reuse, don't reinvent)
+
+| Asset | State | Action |
+|---|---|---|
+| `flexaids_configure_simd()` + AVX2/512/NEON (`cmake/FlexAIDOptions.cmake`) | Applied to all targets | Reuse as-is |
+| `simd_distance.h` (920 lines, mature AVX-512/AVX2/NEON kernels) | Used only in clustering/RMSD/tENCoM — **not** CF scoring | Extend into scoring core |
+| SoA Voronoi path (`FLEXAIDS_USE_SOA_DISTANCES`, `VoronoiCFBatch_SoA.h`, `AtomSoA.h`) | Built but **default OFF**, experimental (`Vcontacts.cpp:1972`) | Finish + default ON |
+| `VoronoiCFBatch.h` span batch | Standalone, stub-CF benchmark only, dormant | Wire real `ic2cf` batch into GA |
+| CUDA/Metal batch eval (`cuda_eval.cu`, `metal_eval.mm`, `GPUContextPool`) | Dispatch-connected but **reduced fidelity** (com/wal/sas only; zeros clash/con/hbond/gist — `gaboom.cpp:2428-2432`) | Bring to full CF parity |
+| OpenMP GA population parallelism | **Real, default ON** (`gaboom.cpp:2773`) | Reduce per-thread copy cost |
+| LTO/IPO + `-march/-mcpu=native` + `-DNDEBUG` + `-s` | On `FlexAIDdS`/`tENCoM` **only**; classic `FlexAID` is `-O3 -ffast-math` (`CMakeLists.txt:225-235` vs `766-793`) | Apply to fast target |
+| `FLEXAIDDS_PARALLEL_REPRODUCE` (offspring deferred eval) | Gated OFF for reproducibility | Now unblocked by drift allowance |
+
+**Bottom line:** the reusable, production-grade pieces are the OpenMP per-thread-workspace scheme, the SIMD CMake helper, the `simd_distance.h` kernel library, and the `FlexAIDdS` LTO/native flag block. The batch/GPU/SoA layers are already built and tested but deliberately kept off the default CF path pending fidelity parity — which the drift allowance now grants us.
+
+---
+
+## 3. Phased plan (prioritized)
+
+Each phase is independently shippable, each guarded by the same acceptance gate (§4). Rough speedup estimates are *hypotheses to be measured*, not promises.
+
+### P0 — Build-level free wins  *(risk: none · est. 1.1–1.3×)*
+1. Give the classic `FlexAID` target the `FlexAIDdS` optimization flag block: `-flto`, CMake `INTERPROCEDURAL_OPTIMIZATION`, `-march=native` / `-mcpu=native`, `-DNDEBUG`, link `-s`. This is copying the block at `CMakeLists.txt:766-793` onto the `FlexAID` target (`:225-235`).
+2. Add **Profile-Guided Optimization (PGO)** as a CMake option: instrumented build → run a representative dock (e.g. 1G9V, fixed seed) → rebuild with the profile. A single tight hot loop is the ideal PGO case; typically 10–20%.
+3. Verify LTO doesn't break the `flexaid_core` OBJECT-library linkage caveat noted at `CMakeLists.txt:786-790` (link `.o` without `-flto`, or LTO the whole fast target as a monolith).
+
+### P1 — Eliminate per-pose allocation & exploit the rigid receptor  *(risk: low · est. 1.3–2×)*
+1. **Kill the per-call bounding-box `malloc`+`memset`** (`Vcontacts.cpp:1738, 1773`). The receptor index box is invariant across all poses (rigid receptor); allocate once and reuse via the existing `FA->vindex` / `hoist_receptor_index` caching path. Replace `memset`-per-call with **epoch stamping** (the repo already did `contacts memset→epoch`; extend the same trick to the box).
+2. **Per-thread scratch, allocated once**: `get_contlist4`'s `malloc(100000*int)` (`Vcontacts.cpp:1268`) and `ca_rec` growth become preallocated per-thread buffers.
+3. **Cache receptor-only Voronoi cells.** For a rigid receptor, receptor↔receptor contacts are pose-invariant; only ligand↔receptor and ligand↔ligand (+ flexible-residue) cells change. Recompute only moved atoms' cells; reuse the static receptor partition. (Ties into P5.)
+4. Hoist invariants out of the inner loop: `4πr²` sphere areas, `energy_matrix` row base pointers, radius+`Rw` sums.
+
+### P2 — Precision, data layout, and SIMD in the scoring core  *(risk: medium, drift allowed · est. 1.5–3×)*
+1. **`double` → `float` in Voronoi geometry** (`voronoi_poly2`, `calc_areas`). Halves memory traffic and doubles SIMD lane count. Allowed under the drift decision.
+2. **Flatten the contact linked list into a contiguous per-atom SoA array** (leveraging `AtomSoA.h` / `VoronoiCFBatch_SoA.h`). Stops pointer-chasing and makes the `com/wal/elec/hbond` accumulation vectorizable.
+3. **Vectorize `calc_areas`**: batch face triangles; replace `sqrt` with SIMD `rsqrt` (+1 Newton step) and `atan` with a polynomial approximation (drift allowed). Add an area kernel alongside the existing `simd_distance.h` kernels.
+4. **Default-enable and finish `FLEXAIDS_USE_SOA_DISTANCES`** (`Vcontacts.cpp:1972`), removing its experimental status.
+5. **Batch scoring across the population**: evaluate a generation's poses as a SoA batch (real `ic2cf`, not the `VoronoiCFBatch.h` stub) so the static receptor stays hot in cache and wide SIMD applies — the `cpu_eval.cpp` / batch scaffolding already exists but is GPU-gated.
+
+### P3 — Parallelism unlocked by the drift allowance  *(risk: medium · est. near-linear in cores)*
+1. **Turn on `FLEXAIDDS_PARALLEL_REPRODUCE`** (offspring deferred eval). The ~0.2% chromosome drift documented in `OPTIMIZATION_KNOWN_ISSUES.md` is now acceptable. Keep a `FLEXAID_DETERMINISTIC` reduction mode for regression benchmarking only.
+2. **Shrink the per-thread deep copy** (`gaboom.cpp:2703-2734`). The receptor state is read-only during scoring → share it across threads instead of cloning; clone only the small mutable ligand/pose/flex state. This is the biggest single lever on the existing OpenMP path's overhead.
+3. Confirm load balance (`schedule(dynamic)` already present) and NUMA-friendliness for many-core hosts.
+
+### P4 — Full-fidelity GPU CF + auto-dispatch  *(risk: high, largest ceiling · est. 5–20× on batch/screening)*
+1. **Close the GPU fidelity gap.** Current kernels compute only `com/wal/sas` and zero `pb_clash / con / hbond / gist` (`gaboom.cpp:2428-2432`), which is why the GPU path is off the default. Add the missing terms to `cuda_eval.cu` / `metal_eval.mm`.
+2. **Voronoi on GPU is branchy and unfriendly** — evaluate two routes and pick by measured parity:
+   - (a) direct port of the analytic Voronoi (accurate, poor GPU occupancy), vs
+   - (b) a **drift-tolerant contact-area model** (grid/neighbor-based or a per-pair area LUT) that reproduces the CF within tolerance and maps cleanly to GPU. The drift allowance makes (b) viable and is the recommended first attempt.
+3. **Keep receptor + energy matrix resident on device**; batch the whole population per generation (the `pack_genes_batch` → `cuda_eval_batch` scaffolding at `gaboom.cpp:2411, 2537` already exists). Use Metal's `metal_eval_batch_multi` for many-ligand single-dispatch screening.
+4. **Flip on auto-dispatch** in `UnifiedHardwareDispatch` once the Astex A/B parity gate (§4) passes: GPU when a fidelity-matched kernel exists, optimized CPU otherwise. `FLEXAIDDS_FORCE_CPU` stays as the escape hatch.
+
+### P5 — Throughput/algorithmic wins (biggest for screening)  *(risk: medium · est. 10–100× VS throughput)*
+1. **Two-stage screening**: use the in-repo NRGRank rigid `CoarseScreen` / `TwoStageScreen` (tests at `CMakeLists.txt:2799`) to prune a library before the expensive GA. Order-of-magnitude for virtual screening, no change to per-dock physics.
+2. **Adaptive generations / early convergence**: detect plateau in best-CF and stop the GA early instead of always running `max_generations`.
+3. **Incremental Voronoi** (with P1.3): recompute only moved-atom cells across generations where the ligand barely moves.
+
+### Cross-cutting — "keep features, zero-cost when off"
+Audit the GA hot path so entropy/thermodynamics code is **skipped**, not merely multiplied by zero, when disabled: confirm `statmech` / `ShannonThermoStack` / `tENCoM` / `encom` calls sit behind runtime flags that short-circuit before any per-pose work. This is what makes fast FlexAID genuinely "classic FlexAID" speed while retaining FlexAIDdS features on demand.
+
+---
+
+## 4. Acceptance gate (applies to every phase)
+
+Because drift is allowed, "correct" means **rank-and-pose-equivalent**, not bit-identical. Every optimization must clear:
+
+1. **Speedup:** wall-clock improvement on the reference dock (1G9V, fixed `FLEXAID_SEED`) and on an Astex-85 subset.
+2. **Parity:** on Astex-85 — success rate (top-pose RMSD < 2 Å) **non-regressing**, top-pose RMSD distribution unchanged within noise, best-CF within a stated tolerance band. Reuse `scripts/reproduce_astex85.sh`, `benchmarks/m3pro/`, and `.github/workflows/benchmark-tier1.yml` / `benchmark-tier2.yml` as the regression harness.
+3. **Determinism (benchmark mode only):** `FLEXAID_DETERMINISTIC` build reproduces run-to-run for CI A/B; production fast mode need not.
+4. **Build health:** fresh CMake build clean on Linux GCC/Clang + macOS Clang; `ctest` green; `-DNDEBUG` and LTO builds link.
+
+No phase merges without showing *both* a speedup number and a passing parity table — per the repo's "verify with actual execution" rule.
+
+## 5. Deliverable shape
+
+Since drift is allowed globally, the cleanest packaging is to **optimize the `FlexAID` target directly** (rather than fork a separate "fast" binary), exposing:
+- a `FLEXAIDDS_FORCE_CPU` / backend-select flag (already present) for CPU-vs-GPU,
+- a `FLEXAID_DETERMINISTIC` switch that pins serial-equivalent reductions for regression testing,
+- entropy features behind their existing runtime flags, off by default.
+
+## 6. Suggested sequencing & rough budget
+
+| Order | Phase | Effort | Est. incremental | Cumulative single-dock (CPU) |
+|---|---|---|---|---|
+| 1 | P0 build flags + PGO | days | 1.1–1.3× | ~1.2× |
+| 2 | P1 alloc removal + receptor cache | ~1 wk | 1.3–2× | ~2–2.5× |
+| 3 | P2 float + SoA + SIMD scoring | 2–3 wk | 1.5–3× | ~3–6× |
+| 4 | P3 parallel offspring + lean copies | ~1 wk | cores-bound | scales with cores |
+| 5 | P4 GPU full-fidelity CF | 3–5 wk | 5–20× (batch) | screening ceiling |
+| 6 | P5 two-stage + adaptive | 1–2 wk | 10–100× (VS) | throughput ceiling |
+
+**Honest expectation:** a realistic **~3–6× single-dock CPU speedup** by end of P3, and an **order-of-magnitude+ screening throughput** gain once P4/P5 land — all subject to the §4 parity gate. Estimates must be replaced with measured numbers as each phase completes.
+
+## 7. First concrete step
+
+P0 is a self-contained, low-risk PR: lift the `FlexAIDdS` LTO/native/NDEBUG flag block onto the `FlexAID` target, add the PGO CMake option, and stand up the Astex-85 speedup+parity harness as the CI gate that all later phases report against.

--- a/docs/FLEXAID_FAST_DOCKING_PLAN.md
+++ b/docs/FLEXAID_FAST_DOCKING_PLAN.md
@@ -42,7 +42,7 @@ main()                         LIB/top.cpp:405
 |---|---|---|
 | `flexaids_configure_simd()` + AVX2/512/NEON (`cmake/FlexAIDOptions.cmake`) | Applied to all targets | Reuse as-is |
 | `simd_distance.h` (920 lines, mature AVX-512/AVX2/NEON kernels) | Used only in clustering/RMSD/tENCoM — **not** CF scoring | Extend into scoring core |
-| SoA Voronoi path (`FLEXAIDS_USE_SOA_DISTANCES`, `VoronoiCFBatch_SoA.h`, `AtomSoA.h`) | Built but **default OFF**, experimental (`Vcontacts.cpp:1972`) | Finish + default ON |
+| SoA Voronoi path (`FLEXAIDS_USE_SOA_DISTANCES`, `VoronoiCFBatch_SoA.h`, `AtomSoA.h`) | Built but **default OFF**, experimental (`Vcontacts.cpp:1972`) | Finish; stays **default OFF** per METHODOLOGY §1 until an Astex-85 A/B and a degenerate-face test justify flipping it |
 | `VoronoiCFBatch.h` span batch | Standalone, stub-CF benchmark only, dormant | Wire real `ic2cf` batch into GA |
 | CUDA/Metal batch eval (`cuda_eval.cu`, `metal_eval.mm`, `GPUContextPool`) | Dispatch-connected but **reduced fidelity** (com/wal/sas only; zeros clash/con/hbond/gist — `gaboom.cpp:2428-2432`) | Bring to full CF parity |
 | OpenMP GA population parallelism | **Real, default ON** (`gaboom.cpp:2773`) | Reduce per-thread copy cost |
@@ -163,7 +163,7 @@ about whether the CUDA/Metal kernels themselves are correct (see below).
 
 Per-phase implementation summary:
 
-- **P0** — `BUILD_FLEXAID_FAST` (default ON) applies LTO/IPO + `-march=native` + `-DNDEBUG` +
+- **P0** — `BUILD_FLEXAID_FAST` (**default OFF** per METHODOLOGY §1; `-march=native` makes the binary host-dependent, so the §1 md5 comparison cannot cross machines) applies LTO/IPO + `-march=native` + `-DNDEBUG` +
   `-flto -s` to the classic `FlexAID` target, reusing the existing sanitizer/coverage guard
   (verified to force-disable under `FLEXAIDS_ENABLE_COVERAGE`). Adds `FLEXAID_PGO`
   (off/generate/use) and `scripts/bench_flexaid_fast.sh`. IPO is applied to the leaf executable
@@ -174,8 +174,8 @@ Per-phase implementation summary:
   4-wide `sqrt`. The SoA distance path was found to be disabled because it called
   `simd::distance2_1x4`, **which does not exist in the AVX2/AVX-512 branches** of
   `simd_distance.h` — a latent hard compile break on x86 production configs. Fixed with an
-  ISA-portable `atom_soa::distance2_1x4`, and `FLEXAIDS_USE_SOA_DISTANCES` flipped to default ON.
-- **P3** — `FLEXAIDDS_PARALLEL_REPRODUCE` default-ON with the stale-status fix applied to both
+  ISA-portable `atom_soa::distance2_1x4`, and `FLEXAIDS_USE_SOA_DISTANCES` remains **default OFF** per METHODOLOGY §1 — it is ranking-affecting and had never compiled on production x86 before this fix.
+- **P3** — `FLEXAIDDS_PARALLEL_REPRODUCE` **default OFF** per METHODOLOGY §1 (the drift allowance that would unblock it is a maintainer decision, not this change's to grant) with the stale-status fix applied to both
   deferred branches; the per-generation full workspace clone replaced by a shape-keyed resident
   cache (O(generations × threads × natoms) copy → one-time O(threads × natoms)); new
   `FLEXAID_DETERMINISTIC` macro/env pins single-thread serial-equivalent evaluation for CI A/B.

--- a/scripts/bench_flexaid_fast.sh
+++ b/scripts/bench_flexaid_fast.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# =============================================================================
+# bench_flexaid_fast.sh — P0 build-level speedup + parity harness for the
+#                         classic FlexAID docking target.
+#
+# WHAT IT DOES
+#   1. Configures + builds the `FlexAID` target TWICE from the current git HEAD:
+#        - baseline : -DBUILD_FLEXAID_FAST=OFF -DFLEXAID_PGO=off  (plain -O3 -ffast-math)
+#        - fast     : -DBUILD_FLEXAID_FAST=ON                     (LTO/IPO + -march=native
+#                                                                  + -DNDEBUG + strip)
+#      and records each build's wall-clock time.
+#   2. Runs ONE reference dock with each binary (fixed FLEXAID_SEED) and records
+#      the docking wall-clock time + speedup.
+#   3. Parity check: extracts best-CF (lowest `REMARK CF=` across output poses)
+#      and the top-pose file from each run and compares them. Under the repo's
+#      drift policy the two builds must stay rank/pose-equivalent, NOT bit-identical
+#      — so the check passes when |ΔCF| <= FLEXAID_BENCH_CF_TOL (default 0.50).
+#
+#   This script NEVER fabricates a number. If a phase cannot run (no reference
+#   input, binary missing, no CF in output) it says so and reports N/A.
+#
+# REFERENCE INPUT (a real receptor + ligand is required to run the dock phase)
+#   The classic `FlexAID` binary does NOT support --redock (that is FlexAIDdS-only),
+#   so it needs an on-disk receptor + cognate ligand. Resolution order:
+#     1. $FLEXAID_BENCH_RECEPTOR + $FLEXAID_BENCH_LIGAND         (explicit override)
+#     2. Astex 1G9V staged by scripts/reproduce_astex85.sh:
+#          $ASTEX_DIR/1G9V/1G9V_apo.pdb  +  $ASTEX_DIR/1G9V/1G9V_ligand.{sdf,mol2}
+#          (ASTEX_DIR defaults to ~/FlexAIDdS_reviewer_benchmark/astex_diverse)
+#     3. none found -> build timings are still reported; the dock+parity phase is
+#        SKIPPED with instructions to stage inputs first.
+#
+#   To stage the 1G9V reference set without hand-collecting files, run the Astex
+#   reproducer once (it downloads + preps apo receptors + cognate ligands):
+#       bash scripts/reproduce_astex85.sh          # full 85-target run, or
+#       # stop it after the "Astex download/prep" step to just stage inputs.
+#   then point this script at the staged files via $ASTEX_DIR or the explicit
+#   $FLEXAID_BENCH_RECEPTOR / $FLEXAID_BENCH_LIGAND overrides.
+#
+# USAGE
+#   bash scripts/bench_flexaid_fast.sh [--build-only] [--jobs N] [--keep]
+#
+# ENV OVERRIDES
+#   FLEXAID_BENCH_RECEPTOR   explicit receptor file (.pdb/.cif)
+#   FLEXAID_BENCH_LIGAND     explicit ligand file (.sdf/.mol2/.mol/.pdb)
+#   ASTEX_DIR                Astex staging dir (default ~/FlexAIDdS_reviewer_benchmark/astex_diverse)
+#   FLEXAID_SEED             fixed RNG seed for the dock (default 42)
+#   FLEXAID_BENCH_CF_TOL     |ΔCF| tolerance for parity PASS (default 0.50)
+#   FLEXAID_BENCH_EXTRA_ARGS extra args passed verbatim to the FlexAID dock
+#   FLEXAID_BENCH_TIMEOUT    per-dock timeout in seconds (default 3600)
+#   FLEXAID_BENCH_OUT        results/log dir (default <repo>/WRK/bench_flexaid_fast)
+# =============================================================================
+set -euo pipefail
+
+# ── repo-relative paths (no machine-specific absolutes; AGENTS.md hygiene) ────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+if command -v git >/dev/null 2>&1; then
+    _top="$(git -C "${REPO_ROOT}" rev-parse --show-toplevel 2>/dev/null || true)"
+    [[ -n "${_top}" ]] && REPO_ROOT="${_top}"
+fi
+
+# ── colour helpers ───────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'; GRN='\033[0;32m'; YLW='\033[0;33m'; CYN='\033[0;36m'; BLD='\033[1m'; RST='\033[0m'
+else
+    RED=''; GRN=''; YLW=''; CYN=''; BLD=''; RST=''
+fi
+info(){ printf "${CYN}[INFO]${RST} %s\n" "$*"; }
+ok(){   printf "${GRN}[OK]${RST}   %s\n" "$*"; }
+warn(){ printf "${YLW}[WARN]${RST} %s\n" "$*"; }
+die(){  printf "${RED}[FATAL]${RST} %s\n" "$*" >&2; exit 1; }
+banner(){ printf "\n${BLD}${CYN}== %s ==${RST}\n" "$*"; }
+
+# ── args ─────────────────────────────────────────────────────────────────────
+BUILD_ONLY=0
+KEEP=0
+JOBS="$( (command -v nproc >/dev/null && nproc) || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build-only) BUILD_ONLY=1; shift;;
+        --keep)       KEEP=1; shift;;
+        --jobs)       JOBS="${2:?}"; shift 2;;
+        -h|--help)    sed -n '2,60p' "${BASH_SOURCE[0]}"; exit 0;;
+        *) die "unknown argument: $1";;
+    esac
+done
+
+# ── config ───────────────────────────────────────────────────────────────────
+OUT_DIR="${FLEXAID_BENCH_OUT:-${REPO_ROOT}/WRK/bench_flexaid_fast}"
+BASELINE_BUILD="${OUT_DIR}/build-baseline"
+FAST_BUILD="${OUT_DIR}/build-fast"
+SEED="${FLEXAID_SEED:-42}"
+CF_TOL="${FLEXAID_BENCH_CF_TOL:-0.50}"
+DOCK_TIMEOUT="${FLEXAID_BENCH_TIMEOUT:-3600}"
+ASTEX_DIR="${ASTEX_DIR:-${HOME}/FlexAIDdS_reviewer_benchmark/astex_diverse}"
+REPORT="${OUT_DIR}/bench_report.txt"
+mkdir -p "${OUT_DIR}"
+: > "${REPORT}"
+
+log(){ printf '%s\n' "$*" | tee -a "${REPORT}"; }
+
+# ── portable wall-clock timer ────────────────────────────────────────────────
+now(){ date +%s.%N; }
+elapsed(){ awk -v a="$1" -v b="$2" 'BEGIN{printf "%.2f", b-a}'; }
+
+# ── build one variant ────────────────────────────────────────────────────────
+# $1 = build dir, $2 = human label, $3.. = extra cmake -D flags
+build_variant(){
+    local dir="$1" label="$2"; shift 2
+    banner "Building FlexAID (${label})"
+    local t0 t1
+    t0="$(now)"
+    cmake -S "${REPO_ROOT}" -B "${dir}" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DFLEXAIDS_BUILD_CORE=ON \
+        "$@" > "${dir}.cmake.log" 2>&1 \
+        || { tail -40 "${dir}.cmake.log"; die "cmake configure failed (${label}) — see ${dir}.cmake.log"; }
+    cmake --build "${dir}" --target FlexAID -j "${JOBS}" > "${dir}.build.log" 2>&1 \
+        || { tail -60 "${dir}.build.log"; die "build failed (${label}) — see ${dir}.build.log"; }
+    t1="$(now)"
+    local secs; secs="$(elapsed "${t0}" "${t1}")"
+    local bin="${dir}/FlexAID"
+    [[ -x "${bin}" ]] || die "FlexAID binary not produced (${label}): ${bin}"
+    printf '%s' "${secs}"
+}
+
+banner "FlexAID-Fast P0 build + parity harness"
+log "repo_root        : ${REPO_ROOT}"
+log "git_head         : $(git -C "${REPO_ROOT}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+log "jobs             : ${JOBS}"
+log "seed             : ${SEED}"
+log "cf_tolerance     : ${CF_TOL}"
+log ""
+
+BASE_SECS="$(build_variant "${BASELINE_BUILD}" "baseline (-O3 -ffast-math, BUILD_FLEXAID_FAST=OFF)" \
+                -DBUILD_FLEXAID_FAST=OFF -DFLEXAID_PGO=off)"
+ok "baseline build: ${BASE_SECS}s"
+FAST_SECS="$(build_variant "${FAST_BUILD}" "fast (LTO/IPO + native + NDEBUG, BUILD_FLEXAID_FAST=ON)" \
+                -DBUILD_FLEXAID_FAST=ON)"
+ok "fast build:     ${FAST_SECS}s"
+
+BASE_BIN="${BASELINE_BUILD}/FlexAID"
+FAST_BIN="${FAST_BUILD}/FlexAID"
+BASE_SZ="$(stat -c%s "${BASE_BIN}" 2>/dev/null || stat -f%z "${BASE_BIN}" 2>/dev/null || echo '?')"
+FAST_SZ="$(stat -c%s "${FAST_BIN}" 2>/dev/null || stat -f%z "${FAST_BIN}" 2>/dev/null || echo '?')"
+
+log ""
+log "─── BUILD RESULTS ────────────────────────────────────────────"
+log "baseline build wall-time : ${BASE_SECS}s   binary=${BASE_SZ} bytes"
+log "fast     build wall-time : ${FAST_SECS}s   binary=${FAST_SZ} bytes"
+log "(fast build is expected to be SLOWER to compile — LTO trades build time for run time)"
+
+if [[ "${BUILD_ONLY}" -eq 1 ]]; then
+    ok "--build-only: skipping dock + parity phase"
+    log ""
+    log "Both FlexAID variants built successfully. Report: ${REPORT}"
+    exit 0
+fi
+
+# ── resolve reference input ──────────────────────────────────────────────────
+RECEPTOR="${FLEXAID_BENCH_RECEPTOR:-}"
+LIGAND="${FLEXAID_BENCH_LIGAND:-}"
+if [[ -z "${RECEPTOR}" || -z "${LIGAND}" ]]; then
+    _apo="${ASTEX_DIR}/1G9V/1G9V_apo.pdb"
+    if [[ -f "${_apo}" ]]; then
+        RECEPTOR="${_apo}"
+        for ext in sdf mol2 mol pdb; do
+            for cand in "${ASTEX_DIR}/1G9V/1G9V_ligand.${ext}" "${ASTEX_DIR}/1G9V/1G9V_lig.${ext}"; do
+                [[ -f "${cand}" ]] && { LIGAND="${cand}"; break 2; }
+            done
+        done
+    fi
+fi
+
+if [[ -z "${RECEPTOR}" || ! -f "${RECEPTOR}" || -z "${LIGAND}" || ! -f "${LIGAND}" ]]; then
+    banner "Reference dock: SKIPPED (no local input set found)"
+    warn "No runnable receptor + ligand pair was found."
+    log ""
+    log "─── DOCK + PARITY: SKIPPED ───────────────────────────────────"
+    log "The classic FlexAID binary needs an on-disk receptor + cognate ligand"
+    log "(it does not support --redock, which is FlexAIDdS-only, and RCSB download"
+    log " is unavailable in this environment)."
+    log ""
+    log "To stage the 1G9V reference set, run the Astex reproducer once:"
+    log "    bash scripts/reproduce_astex85.sh"
+    log "then re-run this script (it auto-detects \$ASTEX_DIR/1G9V/1G9V_apo.pdb +"
+    log "cognate ligand), or pass an explicit pair:"
+    log "    FLEXAID_BENCH_RECEPTOR=path/to/receptor.pdb \\"
+    log "    FLEXAID_BENCH_LIGAND=path/to/ligand.sdf \\"
+    log "    bash scripts/bench_flexaid_fast.sh"
+    ok "Build phase complete; dock/parity deferred. Report: ${REPORT}"
+    exit 0
+fi
+
+log ""
+log "reference receptor : ${RECEPTOR}"
+log "reference ligand   : ${LIGAND}"
+
+# ── run one dock ─────────────────────────────────────────────────────────────
+# echoes wall-seconds to stdout; writes poses under $out_prefix*
+run_dock(){
+    local bin="$1" out_prefix="$2" logf="$3"
+    local t0 t1
+    t0="$(now)"
+    # shellcheck disable=SC2086
+    FLEXAID_SEED="${SEED}" timeout "${DOCK_TIMEOUT}" \
+        "${bin}" "${RECEPTOR}" "${LIGAND}" -o "${out_prefix}" \
+        ${FLEXAID_BENCH_EXTRA_ARGS:-} > "${logf}" 2>&1 || return $?
+    t1="$(now)"
+    elapsed "${t0}" "${t1}"
+}
+
+# ── extract best CF (lowest REMARK CF=) + owning pose file from an output dir ──
+# prints "<best_cf> <top_pose_file>" or "NA NA" if none found. No fabrication.
+extract_best_cf(){
+    local dir="$1"
+    local best_cf="" best_file=""
+    while IFS= read -r f; do
+        # skip the pre-optimisation initial pose
+        [[ "${f}" == *_INI.pdb ]] && continue
+        local cf
+        cf="$(grep -aoE 'REMARK CF=[ ]*-?[0-9]+\.[0-9]+' "${f}" 2>/dev/null | head -1 | grep -oE '\-?[0-9]+\.[0-9]+' || true)"
+        [[ -z "${cf}" ]] && continue
+        if [[ -z "${best_cf}" ]] || awk -v a="${cf}" -v b="${best_cf}" 'BEGIN{exit !(a<b)}'; then
+            best_cf="${cf}"; best_file="${f}"
+        fi
+    done < <(find "${dir}" -maxdepth 1 -name '*.pdb' 2>/dev/null)
+    if [[ -z "${best_cf}" ]]; then printf 'NA NA'; else printf '%s %s' "${best_cf}" "$(basename "${best_file}")"; fi
+}
+
+banner "Reference dock — baseline"
+BASE_OUT="${OUT_DIR}/dock-baseline"; mkdir -p "${BASE_OUT}"
+if BASE_DOCK_SECS="$(run_dock "${BASE_BIN}" "${BASE_OUT}/1G9V" "${BASE_OUT}/dock.log")"; then
+    ok "baseline dock: ${BASE_DOCK_SECS}s"
+else
+    rc=$?; BASE_DOCK_SECS="FAILED(rc=${rc})"; warn "baseline dock did not complete (rc=${rc}); see ${BASE_OUT}/dock.log"
+fi
+
+banner "Reference dock — fast"
+FAST_OUT="${OUT_DIR}/dock-fast"; mkdir -p "${FAST_OUT}"
+if FAST_DOCK_SECS="$(run_dock "${FAST_BIN}" "${FAST_OUT}/1G9V" "${FAST_OUT}/dock.log")"; then
+    ok "fast dock: ${FAST_DOCK_SECS}s"
+else
+    rc=$?; FAST_DOCK_SECS="FAILED(rc=${rc})"; warn "fast dock did not complete (rc=${rc}); see ${FAST_OUT}/dock.log"
+fi
+
+read -r BASE_CF BASE_POSE < <(extract_best_cf "${BASE_OUT}")
+read -r FAST_CF FAST_POSE < <(extract_best_cf "${FAST_OUT}")
+
+log ""
+log "─── DOCK RESULTS ─────────────────────────────────────────────"
+log "baseline dock wall-time : ${BASE_DOCK_SECS}s"
+log "fast     dock wall-time : ${FAST_DOCK_SECS}s"
+if [[ "${BASE_DOCK_SECS}" =~ ^[0-9.]+$ && "${FAST_DOCK_SECS}" =~ ^[0-9.]+$ ]]; then
+    SPEEDUP="$(awk -v a="${BASE_DOCK_SECS}" -v b="${FAST_DOCK_SECS}" 'BEGIN{ if(b>0) printf "%.3f", a/b; else printf "NA"}')"
+    log "dock speedup (baseline/fast) : ${SPEEDUP}x"
+fi
+
+log ""
+log "─── PARITY (rank/pose-equivalence, drift allowed) ────────────"
+log "baseline best-CF : ${BASE_CF}   top-pose : ${BASE_POSE}"
+log "fast     best-CF : ${FAST_CF}   top-pose : ${FAST_POSE}"
+if [[ "${BASE_CF}" == "NA" || "${FAST_CF}" == "NA" ]]; then
+    warn "Could not extract best-CF from one or both runs — parity UNDETERMINED (no fabricated value)."
+    log "parity : UNDETERMINED (missing REMARK CF= in output)"
+else
+    DCF="$(awk -v a="${BASE_CF}" -v b="${FAST_CF}" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.5f", d}')"
+    if awk -v d="${DCF}" -v t="${CF_TOL}" 'BEGIN{exit !(d<=t)}'; then
+        ok "parity PASS  |ΔCF|=${DCF} <= tol ${CF_TOL}"
+        log "parity : PASS  |ΔCF|=${DCF}  (tol=${CF_TOL})"
+    else
+        warn "parity FAIL |ΔCF|=${DCF} > tol ${CF_TOL}"
+        log "parity : FAIL  |ΔCF|=${DCF}  (tol=${CF_TOL})"
+    fi
+fi
+
+log ""
+log "Full report: ${REPORT}"
+if [[ "${KEEP}" -eq 0 ]]; then
+    info "(build dirs kept under ${OUT_DIR}; pass nothing to reuse, or delete manually to reclaim disk)"
+fi
+ok "bench_flexaid_fast.sh complete"

--- a/tests/test_vcontacts_calc_areas_degenerate.cpp
+++ b/tests/test_vcontacts_calc_areas_degenerate.cpp
@@ -1,0 +1,125 @@
+// tests/test_vcontacts_calc_areas_degenerate.cpp
+//
+// Degenerate-face guard for the P2.1/P2.3 float spherical-excess area path
+// added in PR#370 (the FlexAID-Fast recoding).  Vcontacts.cpp:981-1000 moved
+// the l'Huilier tangent formula for the contact-area triangle from double to
+// float:
+//
+//     U,V,W,X   = sqrt( (1±c0)(1±c1)(1±c2)/8 )                 // float
+//     tansqrS   = (1 - U + V + W + X) / (1 + U - V - W - X)    // float ratio
+//     ... (three sibling ratios) ...
+//     area     += 4 r^2 * atan( sqrt( sqrt(tS*tA*tB*tC) ) )    // accum in double
+//
+// The accumulator and the cosine inputs stay double (bounds the error on
+// generic faces), but the RATIO DENOMINATORS `(1 + U - V - W - X)` etc. go
+// toward zero on near-degenerate / near-coplanar faces — precisely the
+// geometry where a Voronoi contact sits on the knife-edge of existing.
+// float32 loses relative precision there that double absorbed, and the
+// downstream atan(sqrt(...)) amplifies it.
+//
+// So the drift is NOT uniform epsilon: measured on this formula it is ~2e-7
+// (relative) on a well-conditioned face and climbs ~4 orders of magnitude,
+// toward ~1e-3, as the vertex cosines approach 1.  On a marginal face that
+// error is what can flip whether a contact (and its area) is counted, which
+// is a pose-RANKING risk — and the Astex-85 A/B can pass on average while
+// individual poses reorder.  This test pins the fragile-face behaviour as a
+// tripwire: it fires if the near-degenerate relative error ever exceeds a
+// documented ceiling, i.e. if the float path is made materially less faithful
+// to the double reference than it is today (or than any future double
+// fallback would be).
+//
+// The two formulas are replicated inline (not linked from Vcontacts.cpp) so
+// the test is a pure numerical-property check with no engine dependency; the
+// float path mirrors Vcontacts.cpp:981-1000 exactly, and the double path
+// mirrors the pre-PR reference it replaced.
+//
+// Origin: PR#370 independent review (Fizz), review ask #3.
+// Apache-2.0 © 2026 Le Bonhomme Pharma
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+// Pre-PR reference: spherical-excess triangle area in double precision.
+double area_double(double c0, double c1, double c2, double rado) {
+    const double U = std::sqrt((1 + c0) * (1 + c1) * (1 + c2) / 8.0);
+    const double V = std::sqrt((1 - c0) * (1 - c1) * (1 + c2) / 8.0);
+    const double W = std::sqrt((1 - c0) * (1 + c1) * (1 - c2) / 8.0);
+    const double X = std::sqrt((1 + c0) * (1 - c1) * (1 - c2) / 8.0);
+    const double tS = (1 - U + V + W + X) / (1 + U - V - W - X);
+    const double tA = (1 - U - V - W + X) / (1 + U + V + W - X);
+    const double tB = (1 - U - V + W - X) / (1 + U + V - W + X);
+    const double tC = (1 - U + V - W - X) / (1 + U - V + W + X);
+    const double tp = tS * tA * tB * tC;
+    if (tp <= 0.0) return 0.0;
+    return 4.0 * rado * rado * std::atan(std::sqrt(std::sqrt(tp)));
+}
+
+// PR#370 float path: mirrors LIB/Vcontacts.cpp:981-1000 exactly.
+double area_float(double c0d, double c1d, double c2d, double rado) {
+    const float c0 = static_cast<float>(c0d);
+    const float c1 = static_cast<float>(c1d);
+    const float c2 = static_cast<float>(c2d);
+    float rad4[4] = {
+        (1.0f + c0) * (1.0f + c1) * (1.0f + c2) * 0.125f,
+        (1.0f - c0) * (1.0f - c1) * (1.0f + c2) * 0.125f,
+        (1.0f - c0) * (1.0f + c1) * (1.0f - c2) * 0.125f,
+        (1.0f + c0) * (1.0f - c1) * (1.0f - c2) * 0.125f,
+    };
+    float root4[4];
+    for (int q = 0; q < 4; ++q) root4[q] = std::sqrt(rad4[q]);
+    const float U = root4[0], V = root4[1], W = root4[2], X = root4[3];
+    const float tS = (1.0f - U + V + W + X) / (1.0f + U - V - W - X);
+    const float tA = (1.0f - U - V - W + X) / (1.0f + U + V + W - X);
+    const float tB = (1.0f - U - V + W - X) / (1.0f + U + V - W + X);
+    const float tC = (1.0f - U + V - W - X) / (1.0f + U - V + W + X);
+    const float tp = std::sqrt(tS * tA * tB * tC);
+    if (tp > 0.0f) return 4.0 * rado * rado * static_cast<double>(std::atan(std::sqrt(tp)));
+    return 0.0;
+}
+
+double rel_err(double ref, double got) {
+    return ref != 0.0 ? std::fabs(ref - got) / std::fabs(ref) : std::fabs(got);
+}
+
+constexpr double kRado = 1.9;  // representative contact radius (Å)
+
+}  // namespace
+
+// A well-conditioned face: the float path must track double to near-epsilon.
+// If this ever loosens, the float move has cost precision on GENERIC faces,
+// not just fragile ones — a different and larger regression.
+TEST(CalcAreasFloat, GenericFaceMatchesDoubleToEpsilon) {
+    const double d = area_double(0.30, 0.20, 0.25, kRado);
+    const double f = area_float(0.30, 0.20, 0.25, kRado);
+    EXPECT_GT(d, 0.0);
+    EXPECT_LT(rel_err(d, f), 1e-5)
+        << "generic-face float area diverged from double by more than 1e-5 relative";
+}
+
+// Near-degenerate faces (vertex cosines -> 1, denominators -> 0).  The float
+// error concentrates here; today it peaks near ~1e-3.  This ceiling is the
+// tripwire: crossing 1e-2 means the fragile-face precision has degraded past
+// the point where "rank/pose-equivalent" can be assumed without an Astex A/B.
+TEST(CalcAreasFloat, DegenerateFaceStaysWithinCeiling) {
+    double worst = 0.0;
+    for (double c = 0.99; c <= 0.99999; c = 1.0 - (1.0 - c) * 0.1) {
+        const double d = area_double(c, c, c, kRado);
+        const double f = area_float(c, c, c, kRado);
+        const double re = rel_err(d, f);
+        worst = std::max(worst, re);
+        EXPECT_LT(re, 1e-2)
+            << "near-degenerate face c=" << c
+            << " float area diverged from double by " << re
+            << " relative (ceiling 1e-2)";
+    }
+    // Document the concentration: the fragile-face error is orders of
+    // magnitude above the generic-face epsilon measured above.  This is not a
+    // pass/fail assertion (a future double fallback would legitimately shrink
+    // it); it records the measured worst case for reviewers.
+    RecordProperty("worst_degenerate_rel_err_x1e6",
+                   static_cast<int>(worst * 1e6));
+}


### PR DESCRIPTION
> **Post-merge correction (body was stale at merge time).**
> This description was written before the review, and its "Release impact" section claimed three defaults flip **ON**. That is **the opposite of what merged.** Following @LeBonhommePharma's review against `METHODOLOGY.md` §1 step 4 — *"Any intended behavior change must be opt-in behind an env flag that defaults OFF, and parity must hold with the flag OFF"* — all three ship **OFF**:
> `BUILD_FLEXAID_FAST=OFF`, `FLEXAIDS_USE_SOA_DISTANCES=OFF`, `FLEXAIDDS_PARALLEL_REPRODUCE=OFF`.
> Every optimization below is present but **opt-in**. The sections below are otherwise left as originally written; where they say a default is ON, this note overrides them.

## Summary

Accelerates the **classic FlexAID** docking core (Voronoi complementarity function + genetic algorithm) to FlexAIDdS-grade performance engineering, keeping behavior "almost as is." Adds `docs/FLEXAID_FAST_DOCKING_PLAN.md` and implements all six of its phases.

**P0 — build-level.** `BUILD_FLEXAID_FAST` gives the classic `FlexAID` target the LTO/IPO + `-march=native` + `-DNDEBUG` + `-flto -s` block that only `FlexAIDdS` had, reusing the existing sanitizer/coverage guard. Adds `FLEXAID_PGO` (off/generate/use) and `scripts/bench_flexaid_fast.sh`. Ships OFF — `-march=native` makes the binary a function of the build host's CPU, which is why it is not merely a perf knob (see #373).

**P1+P2 — scoring core.** Per-call bounding-box `memset` replaced with a per-thread epoch stamp, and `calc_areas` sphere-area invariants hoisted (both bit-identical by construction). `calc_areas` triangle math moved to `float` with four independent roots packed for a 4-wide `sqrt`. The SoA distance path was disabled because it called `simd::distance2_1x4`, **which did not exist in the AVX2/AVX-512 branches** of `simd_distance.h` — a latent hard compile break on x86 production configs. Now fixed at source (4-wide overload added after the ISA branches), with `atom_soa::distance2_1x4` as the ISA-portable call site.

**P3 — GA parallelism.** Deferred offspring eval with the stale-status fix; the per-generation full workspace clone replaced by a shape-keyed resident cache (an O(generations × threads × natoms) copy becomes a one-time O(threads × natoms)); new `FLEXAID_DETERMINISTIC` switch pins serial-equivalent evaluation for CI A/B.

**P4 — GPU CF fidelity.** CUDA/Metal batch kernels extended from com/wal/sas to the full CF channel set: constraints, electrostatics, H-bond, GIST desolvation, PoseBust clash + pocket, VCT distance weighting, with static arrays device-resident. Contact areas use a drift-tolerant C0 linear-switching model rather than porting the branchy analytic Voronoi. Also fixes a latent Metal reduction bug — split out as #374.

**P5 — throughput.** New `flexaid_screen` CLI driving the existing `TwoStageScreener`/`CoarseScreener` as a rigid NRGRank pre-filter, plus best-CF plateau early-stop (opt-in via `FLEXAIDDS_ADAPTIVE_GENERATIONS`).

## Scope

- [x] Core 1.0 supported surface
- [x] Experimental surface only — the GPU (P4) portion

## Release impact

- [x] affects CLI behavior — new `flexaid_screen` binary; new opt-in env flags
- [x] **no change to default behavior** — all three new performance flags ship OFF (corrected; see the note at top)

## Validation

- [x] unit tests
- [x] manual validation

Authoritative build used **Clang 18.1.3** (the container's GCC 13.3 rejects `-std=c++26`, below the repo's gate): `ninja FlexAID flexaid_screen` 309/309 steps 0 errors; full test build 1907 steps exit 0; `ctest` 86/86 passed; re-run after the P4 merge (which edits `gaboom.cpp`) 86/86 passed. Those runs confirm the build and unit tests only.

## Security and safety

- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

## Reproducibility

- [x] benchmark language remains preliminary

**No speedup number is claimed, because none was measured.** No dock was run during development: the repo ships no runnable receptor+cognate-ligand pair and RCSB fetches were proxy-blocked (HTTP 403). All figures in the plan document are labeled unmeasured hypotheses.

## Outstanding before any of this is enabled

1. **METHODOLOGY §1 parity has not been run.** Three things here are ranking-affecting: float32 squared distances under `FLEXAIDS_USE_SOA_DISTANCES=ON`; float `calc_areas`; and P4's linear-switching area model, whose ≈15–20% per-face error is *assumed* to cancel in ranking. Run `FLEXAIDS_SOA_ASSERT=1` first. A degenerate-face tripwire test (`VcontactsCalcAreasDegenerateTests`) was added during review and guards the float path.
2. **P4's GPU kernels were never compiled or run** (no CUDA toolkit; Metal is macOS-only) — self-reviewed only. Known gaps, all guarded so the CPU path is unaffected: Metal multi-complex screening is still com/wal/sas only; GIST host upload isn't wired (`gist_nx=0`); `metal_coord`/`vct_entropy`/tENCoM `h_rep` are zeroed; kernels reuse the translation-only gene decode. `hbond_angle_repr=0.7` is an unvalidated placeholder.
3. **P3 runtime reproducibility is unretested** — compile-checked only; the ≈0.2% multi-thread divergence in `OPTIMIZATION_KNOWN_ISSUES.md` is unresolved, which is why the flag ships OFF.
4. Deliberately deferred: flattening the `ca_rec` linked list (P2.2), full struct-level `double`→`float` of the Voronoi hull, and `rsqrt`+Newton / polynomial-`atan` variants.

## Split out of this PR

- #373 — `-march=native` makes METHODOLOGY §1's md5 comparison uncheckable across machines (pre-existing on `main`).
- #374 — Metal CF kernels reduce with `simd_sum()` over 256-thread threadgroups, discarding 7/8 of contributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZZEznbrXSyU7EnGmiL6uL