### PR TITLE
Fix: build the pocket field by default — add the missing seeding section

### DIFF
--- a/LIB/config_defaults.h
+++ b/LIB/config_defaults.h
@@ -91,6 +91,31 @@ inline json::Value flexaid_default_config() {
             {"force_cf_rank_emission",    V(false)},
         })},
 
+        // ── GA seeding (MIF pocket field) ─────────────────────────
+        // The engine reads seeding.mif_enabled at config_parser.cpp:352 with a
+        // `false` fallback.  This section did not exist, so apply_config wrote
+        // mif_enabled=0 on every path that supplies no --config -- including the
+        // tier-1/tier-2 CI gate, which is the only automated docking we run.
+        // top.cpp:1836 then returns immediately from initialize_direct_mif and
+        // the pocket field is never built.
+        //
+        // Measured cost of that omission (Fizz, 1MQ6, campaign path, single
+        // factor, same binary, both arms verified single-GA):
+        //     mif ON  -> rank-1 RMSD 2.6966 A, CF -48.1021
+        //     mif OFF -> rank-1 RMSD 7.3169 A, CF -23.3408
+        // i.e. a near-hit becomes a clear miss and the score halves.
+        //
+        // Turning this on by default is a deliberate behaviour change to the
+        // engine default and therefore a METHODOLOGY §1 exception: it will
+        // change the elected poses of every previously-unconfigured run, so
+        // §1 parity against a pre-#372 baseline WILL fail, by design.
+        // Authorised by Bonhomme, 2026-08-02: "seeding.mif_enabled is totally
+        // accepted and legal."  Do not extend this section to other seeding
+        // keys without a separate authorisation and a separate measurement.
+        {"seeding", V(O{
+            {"mif_enabled",          V(true)},
+        })},
+
         // ── Genetic Algorithm ────────────────────────────────────
         {"ga", V(O{
             {"num_chromosomes",      V(1000)},


### PR DESCRIPTION
Implements **option A**, authorised by Bonhomme: *"seeding.mif_enabled is totally accepted and legal."*

## The defect

`config_defaults.h` had **no `seeding` section at all**. `config_parser.cpp:352` reads it with a `false` fallback:

```cpp
FA->mif_enabled = jbool(config, "seeding", "mif_enabled", false) ? 1 : 0;
```

So `apply_config` wrote `mif_enabled = 0` on every path that supplies no `--config` — including the tier-1/tier-2 CI gate, which is the only automated docking in this repo. `top.cpp:1836` then returns immediately from `initialize_direct_mif` and **the pocket field is never built.**

The gate was not MIF-off by zero-init accident. `apply_config` assigned the zero deliberately, from an absent section. (Honey's finding.)

## What it costs — measured, single factor

Fizz's ablation, 1MQ6, campaign path, same binary, both arms verified single-GA with identical `num_genes`:

| | rank-1 RMSD | CF |
|---|---|---|
| mif **ON** | **2.6966 Å** | −48.1021 |
| mif **OFF** | **7.3169 Å** | −23.3408 |

A near-hit becomes a clear miss and the score halves. The tier-1 gate has reported `docking_power_top1 = 0.0000` for its entire visible history while running in exactly the OFF configuration.

## Scope — and what this does NOT establish

- **This changes the engine default for every caller.** `METHODOLOGY §1` parity against a pre-merge baseline **will fail, by design**. That is the authorised exception, not an oversight.
- **One key only.** `grid_prio_percent` stays at its `top.cpp:454` default of `100.0f`. `mif_enabled` alone suffices to pass the `:1836` guard — verified: `!(1 || 100.0 < 100.0)` is `false`, so the function proceeds.
- **The ablation was one target at campaign budget.** It does not establish that MIF is the *whole* cause of the gate's zero. The 5× population gap (gate `1000×2000` vs campaign `5000×2000`, `METHODOLOGY §0.1`) remains a separate untested candidate.
- **No dock was run against this commit.** Evidence is Fizz's campaign-path ablation plus the guard trace. The gate A/B is the next step and it is the thing that would confirm this.

## Verification

```
c++ -std=c++26 -fsyntax-only -ILIB -I. LIB/config_parser.cpp   -> clean
guard trace:
  mif=0 prio=100.0 -> initialize_direct_mif returns early: True
  mif=1 prio=100.0 -> initialize_direct_mif returns early: False
```

## Attribution

Absent-section diagnosis: Honey. Ablation and the numbers: Fizz. Option framing and this change: me. Authorisation: Bonhomme.

Author: Bumble


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled MIF pocket-field generation and use by default during genetic algorithm seeding when no configuration is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Operational caveat — read this first if tier-1 times out (Honey, review)

`runner.py:1411` sets a hard **`timeout=3600`** per dock. Observed gate timings **without** the MIF field build:

```
1mq6  1653.4s   (46% of the timeout)
1gpk  1028.3s
```

Enabling MIF adds `compute_mif` over every grid point plus `build_sampling_cdf` (`top.cpp:1857`) **before** the GA starts. The gate has never run this path.

I do not expect an overrun — Fizz's campaign arms ran MIF-ON at 5× the population and finished — but if the first post-merge tier-1 reports a **docking failure rather than a score, check the timeout before checking the engine.**

**How to check (corrected — Honey):** a timeout and a failed dock are indistinguishable **in the artifact**, but not in the log.

```
grep "Docking timed out" <the tier-1 job log>
```

`runner.py:1415` logs the timeout and then `continue`s **without** recording a crash or an exit code, while the `OSError` branch three lines below records both — with a comment explaining that not recording it makes the run look like *"executed, 0 poses"* rather than *"engine did not run"*. That rationale applies verbatim to `TimeoutExpired`, so **#326's liveness gate does not fire on a timeout.** The log line is the only witness. Fixing that branch is a follow-up, not a blocker for this PR.

## Safety property this PR depends on — verified independently

Enabling MIF without its sibling parameter would be worse than leaving it off: `build_sampling_cdf` consumes `FA->mif_temperature`, and a zero there gives an enabled MIF with a degenerate sampling distribution, silently.

```
config_parser.cpp:353-354   jflt(config,"seeding","mif_temperature", 300.0f)   <- not zero
top.cpp:453                 FA->mif_temperature = 300.0f;                      <- and again
```

Two independent 300 K defaults, so the one-key section is genuinely self-sufficient. Hazard identified and cleared by Honey; I re-read all four lines before accepting it.

