### PR TITLE
Docs: divergence nine — the two harnesses record a failure differently

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -96,6 +96,16 @@ simply different runs, and a number from one does not transfer to the other.
 | `coarse_init.enabled` | **OFF** | ON (hardcoded, `DatasetRunner.cpp:6036`) |
 | `mif_enabled` | **OFF** | ON (hardcoded, `DatasetRunner.cpp:6012`) |
 | retained poses | 10 (`ga_constants.h:16` `GA_DEFAULT_NUM_PRINT`, applied `gaboom.cpp:315`) | 50 per restart (`DatasetRunner.cpp:86` `kBenchmarkPoseLimit`, emitted as `max_results` at `:5959`) |
+| **what a timed-out dock records** | **nothing.** `runner.py:1415` logs and `continue`s without touching the crash count or the exit-code map, so a timeout is indistinguishable **in the artifact** from "ran and found nothing". The only witness is one `logger.error("Docking timed out")` line in the CI job log. | **three places.** `wait_with_timeout` returns `-1` (`DatasetRunner.cpp:335`) → `docking_completed=false` (`:6856`) → every scoring stage skipped and `result.pb_failed_keys = "docking_incomplete"` written (`:7553-7555`), plus `[TIMEOUT]` in the captured `stderr.log`. |
+
+🔴 **The last row is a divergence of a different kind.** The other rows are about what the engine
+*computes*; that one is about what the harness *admits went wrong*. It matters because
+`#326`'s liveness gate exists precisely to distinguish "the engine did not run" from "the engine
+ran and produced nothing" — and on the gate path a timeout is the former reported as the latter.
+The `OSError` handler three lines below (`runner.py:1418`) does record both, with a comment
+explaining that omitting it would make the run "look like 'executed, 0 poses' (productivity)
+rather than 'engine did not run' (liveness)." That reasoning applies verbatim to
+`TimeoutExpired` and was not applied to it. (Found by Honey; campaign side traced by both of us.)
 
 **The consequence that matters:** with `mif_enabled = 0` and `grid_prio_percent = 100.0`, the
 guard at `top.cpp:1836` makes `initialize_direct_mif` return immediately. **The gate docks


### PR DESCRIPTION
`§0.1` catalogued eight ways the gate and the campaign diverge in **what the engine computes**. This adds a ninth of a different kind: **what each harness admits went wrong.**

| | gate | campaign |
|---|---|---|
| a timed-out dock records | **nothing** — `runner.py:1415` logs and `continue`s. No crash count, no exit code, no artifact field. One `logger.error` line in a CI job log. | **three places** — `wait_with_timeout` returns `-1` (`DatasetRunner.cpp:335`) → `docking_completed=false` (`:6856`) → all scoring stages skipped and `result.pb_failed_keys = "docking_incomplete"` (`:7553-7555`), plus `[TIMEOUT]` in the captured `stderr.log`. |

## Why it matters rather than being trivia

`#326`'s liveness gate exists precisely to separate *"the engine did not run"* from *"the engine ran and produced nothing."* On the gate path a timeout is the **former reported as the latter**.

And the rationale is already written down — on the wrong branch. `runner.py:1418` handles `OSError` and *does* record both, with this comment:

> the exception would otherwise be swallowed per-entry by `_process_one_item` and the run would look like "executed, 0 poses" (productivity) rather than "engine did not run" (liveness).

That applies verbatim to `TimeoutExpired` three lines above, and was not applied to it.

## Newly relevant

#372 adds `compute_mif` plus a CDF build to every gate dock. 1mq6 already sits at **46%** of the 3600 s ceiling (1653.4 s observed). If MIF pushes a target over, the gate reports a target that produced zero poses and the liveness gate stays silent.

## Scope

**Documentation only.** The code fix — recording the crash and exit code on the timeout branch — belongs in the witness follow-up PR alongside the `sanitized_env` lift, the `num_chrom` printf, and the `DatasetRunner.cpp:6859` stderr dump that skips the `ret != 0` case. Four instances, one theme: *a determining event that leaves no witness in the artifact.*

## Attribution

Defect found by Honey. The campaign-side trace is joint — I established the `-1` return and its propagation to `ret`, and explicitly scoped out the hop to the artifact; Honey closed that hop to `pb_failed_keys`.

Author: Bumble
