### PR TITLE
Fix: give three determining events a witness in the artifact

### DIFF
--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -6855,15 +6855,24 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         // The latter is only true once we have a valid pose RMSD under 2 Å.
         const bool docking_completed = (ret == 0 && n_poses > 0 && !result.stuck);
 
-        // If FlexAIDdS ran but produced no output, check stderr for clues
-        if (ret == 0 && n_poses == 0) {
+        // If the dock produced no output, surface stderr for clues.
+        //
+        // This used to be gated on `ret == 0`, which skipped the no-poses case
+        // most in need of explaining: a TIMEOUT returns -1 from
+        // SubprocessGuard::wait_with_timeout and also yields zero poses, so the
+        // one diagnostic written to explain "no poses" declined to run exactly
+        // when the [TIMEOUT] line it would have surfaced was sitting in
+        // stderr.log.  Widened to any zero-pose outcome, with the exit code
+        // named so the two cases stay distinguishable in the console output.
+        if (n_poses == 0) {
             std::string stderr_path = out_dir + "/stderr.log";
             std::ifstream stderr_file(stderr_path);
             if (stderr_file.is_open()) {
                 std::string err_line;
                 int err_lines = 0;
                 std::cerr << "  [WARN] " << entry.pdb_id
-                          << " exited 0 but produced no output poses. stderr:\n";
+                          << " produced no output poses (exit " << ret
+                          << "). stderr:\n";
                 while (std::getline(stderr_file, err_line) && err_lines < 5) {
                     std::cerr << "    " << err_line << "\n";
                     err_lines++;

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -295,6 +295,16 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	}
 
 	printf("num_genes=%d\n",GB->num_genes);
+	// The search budget determines the result and, until this line, left no
+	// witness on a SUCCESSFUL run: num_chrom appeared only in the
+	// chrom_snapshot-overflow fprintf below, which fires solely when the value
+	// is <= 0.  So "what population did this run use?" was answerable from the
+	// source (whichever of config_defaults.h / a gainp NUMCHROM / DatasetRunner's
+	// DoF scaling supplied it) but never from the run's own output — and the two
+	// harnesses supply it differently (gate 1000, campaign 1000 x ceil(n_genes/4)).
+	// One line, stdout, unconditional, so any log answers it directly.
+	printf("num_chrom=%d max_generations=%d\n",
+	       GB->num_chrom, GB->max_generations);
 
 	printf("file in GA is <%s>\n",gainpfile);
 

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -295,16 +295,6 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	}
 
 	printf("num_genes=%d\n",GB->num_genes);
-	// The search budget determines the result and, until this line, left no
-	// witness on a SUCCESSFUL run: num_chrom appeared only in the
-	// chrom_snapshot-overflow fprintf below, which fires solely when the value
-	// is <= 0.  So "what population did this run use?" was answerable from the
-	// source (whichever of config_defaults.h / a gainp NUMCHROM / DatasetRunner's
-	// DoF scaling supplied it) but never from the run's own output — and the two
-	// harnesses supply it differently (gate 1000, campaign 1000 x ceil(n_genes/4)).
-	// One line, stdout, unconditional, so any log answers it directly.
-	printf("num_chrom=%d max_generations=%d\n",
-	       GB->num_chrom, GB->max_generations);
 
 	printf("file in GA is <%s>\n",gainpfile);
 
@@ -332,6 +322,22 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	} else {
 		printf("No GA input file — using pre-configured parameters\n");
 	}
+
+	// The search budget determines the result and, until this line, left no
+	// witness on a SUCCESSFUL run: num_chrom appeared only in the
+	// chrom_snapshot-overflow fprintf below, which fires solely when the value
+	// is <= 0.  So "what population did this run use?" was answerable from the
+	// source but never from the run's own output — and the three suppliers
+	// disagree: the gate takes config_defaults.h's 1000, the campaign multiplies
+	// by ceil(n_genes/4), and the legacy path reads NUMCHROM/NUMGENER from gainp.
+	//
+	// Placed AFTER the gainp block deliberately.  Printed before it, this line
+	// would report the pre-file value on the legacy `./FlexAID cfg.inp ga.inp`
+	// path — right for the two harnesses we benchmark and silently wrong for the
+	// third, which is precisely the stale-witness failure this PR exists to
+	// remove.  Here it reports what the GA actually runs with, on every path.
+	printf("num_chrom=%d max_generations=%d\n",
+	       GB->num_chrom, GB->max_generations);
 
 	// Defensive clamp: a zero (or negative) check interval reaches three
 	// integer division / modulo sites in the generation loop below and would

--- a/python/flexaidds/dataset_runner/cli.py
+++ b/python/flexaidds/dataset_runner/cli.py
@@ -258,8 +258,14 @@ def _benchmark_inconclusive_reasons(datasets) -> list[str]:
             codes = ", ".join(
                 f"{k}={v}" for k, v in list(dr.entry_exit_codes.items())[:5]
             )
+            # "did not complete" rather than "non-zero exit": entry_exit_codes
+            # records None for an invocation that produced no exit code at all —
+            # an exec failure (OSError) or a timeout. Calling that a non-zero
+            # exit sends the reader hunting for a code that was never produced.
             reasons.append(
-                f"{slug}: liveness — {dr.flexaid_crashes} FlexAID non-zero exit(s) [{codes}]"
+                f"{slug}: liveness — {dr.flexaid_crashes} FlexAID invocation(s) "
+                f"did not complete successfully (None = no exit code produced: "
+                f"exec failure or timeout) [{codes}]"
             )
         # 2. Productivity — only a run that executed targets can be faulted for
         #    producing no poses (a resume/no-op executed nothing this session).

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1413,6 +1413,24 @@ class DatasetRunner:
                         env=sub_env,
                     )
                 except subprocess.TimeoutExpired:
+                    # #326 liveness: a timeout is the same class as the OSError
+                    # below — the engine produced no result — and the rationale
+                    # written there applies verbatim: without recording it, "the
+                    # run would look like 'executed, 0 poses' (productivity)
+                    # rather than 'engine did not run' (liveness)."  That fix was
+                    # applied to the OSError sibling and not to this one, so a
+                    # timed-out dock left NOTHING in the artifact: no crash count,
+                    # no exit code, only this log line.  Record it the same way.
+                    #
+                    # None, not a numeric sentinel, for the same reason the
+                    # OSError branch gives: subprocess encodes signal death as a
+                    # negative returncode, so -1 already means "ran, killed by
+                    # signal 1".  None is a value no completed subprocess.run can
+                    # yield, so in entry_exit_codes it means "did not complete"
+                    # and only that.
+                    with self._crash_lock:
+                        self._flexaid_crashes += 1
+                        self._entry_exit_codes[f"{target_id}/{ligand_id}"] = None
                     logger.error("Docking timed out: %s/%s", target_id, ligand_id)
                     continue
                 except OSError as exc:


### PR DESCRIPTION
Three places where something that determines a benchmark result left no trace in the run's own output. Each was found while verifying an unrelated claim; they are one defect in three files.

**Item 1 is live risk right now** — tier-1 is running on `main` with `mif_enabled` newly true (#372), which adds a MIF field build before every GA. The worst tier-1 target already sat at **1653s of a 3600s cap** without it. If a target crosses the cap today, the current code records nothing and the run reads as "docked, zero poses."

---

### 1. `TimeoutExpired` records nothing — `python/flexaidds/dataset_runner/runner.py`

A timed-out dock incremented no crash counter and recorded no exit code. It logged one line and `continue`d, so the entry was indistinguishable from "ran and found nothing."

The `OSError` branch **three lines below** already records both, and its comment justifies itself in words that apply to this branch verbatim:

> *"the run would look like 'executed, 0 poses' (productivity) rather than 'engine did not run' (liveness)"*

So #326's liveness gate — which exists to catch exactly that — did not fire on a timeout. The author reasoned the case through for one sibling and left the other. Now both record.

Uses `None` rather than a numeric sentinel, for the reason the sibling gives: `subprocess` encodes signal death as a negative returncode, so `-1` already means "ran, killed by signal 1."

### 2. The GA search budget had no witness on success — `LIB/gaboom.cpp`

`num_chrom` appeared in exactly one live print: the `chrom_snapshot` overflow `fprintf`, which fires only when the value is `<= 0`. On a **successful** run the population was never emitted anywhere.

That matters because the two harnesses supply it differently — the gate takes `config_defaults.h`'s 1000, the campaign multiplies by `ceil(n_genes/4)`. "What budget did this run use?" was answerable from the source but never from the run. One unconditional line to stdout fixes it.

### 3. The no-poses diagnostic skipped the case it was written for — `LIB/DatasetRunner.cpp`

The stderr dump that exists to explain *"produced no output poses"* was gated on `ret == 0`, so it declined to run on a timeout — which returns `-1` and also yields zero poses. The `[TIMEOUT]` line it would have surfaced was sitting in `stderr.log` unread.

Widened to any zero-pose outcome, with the exit code printed so the two cases stay distinguishable in the console.

---

### No scoring behaviour changes

(1) adds bookkeeping on a path that already aborted the entry; (2) is a `printf`; (3) widens a diagnostic condition.

### Verification on this commit

| Check | Result |
|---|---|
| `cmake` configure | exit 0 |
| build `FlexAID` | exit 0 |
| full build | **448/448**, exit 0 |
| `ctest --output-on-failure` | **87/87 passed** |
| `python -m pytest -q` | **1126 passed**, 68 skipped |

Both test counts are **unchanged from `main`**, so nothing was disabled. Metal was off for the configure because this host lacks the toolchain — unrelated to these three files, and it means this run says nothing about the Metal kernels.

### Deliberately not included

Lifting `run_multicleft_astex.py`'s `sanitized_env` denylist into `DatasetRunner`. It is the fourth item of the same class — seven env vars that change scoring and leave no trace — but stripping them changes what the campaign **runs** rather than what it **records**. Strip vs. record is a decision, not a drive-by.

### Credit

The timeout defect surfaced from a review exchange on #372: a claim in that PR's body ("indistinguishable in the current output") turned out to be true of the artifact and false of the log, and checking which is what opened these two handlers. The campaign-side contrast is documented in #375.
