### PR TITLE
Docs: restore the deleted rationale for the tier-1 baselines

### DIFF
--- a/benchmarks/datasets/astex_diverse.yaml
+++ b/benchmarks/datasets/astex_diverse.yaml
@@ -133,6 +133,32 @@ metrics:
   - median_rmsd
   - entropy_rescue_rate
 
+# PROVENANCE of the five values below.  They are not measurements and they are
+# not guesses: every one of them is a re-estimate recorded in this file on
+# 2026-04-19 (50aebaee) in a labelled `claude_reevaluated_baselines:` block,
+# which c414e814 (2026-06-19, "stabilize benchmark thermodynamics and
+# diagnostics") promoted into `expected_baselines` while deleting the label and
+# the reasoning in the same diff.  The numbers survived; their justification did
+# not, and a bare 0.70 has read as an unsourced target ever since.  Restored
+# verbatim from 50aebaee so the threshold carries its own argument:
+#
+#   claude_reevaluated_by: "Claude Opus 4.6 — 2026-04-19"
+#
+#   docking_power_top1: 0.70   # was 0.80 — above all published; 0.70 is still SOTA-tier
+#   docking_power_top3: 0.85   # was 0.90 — follows top-1 adjustment
+#   mean_rmsd:          2.30   # was 2.10 — slight increase for realism
+#   median_rmsd:        1.95   # was 1.80 — follows mean adjustment
+#   entropy_rescue_rate 0.30   # unchanged; conservative and defensible
+#
+#   rationale: "Docking power 0.80→0.70: no published method exceeds 74% top-1
+#   on Astex Diverse (Glide SP).  FlexAIDdS with entropy correction at 70% would
+#   be competitive with Glide XP and above Vina. ... Entropy rescue rate
+#   unchanged at 0.30 — this is the honest conservative estimate for a general
+#   set."
+#
+# Read that alongside `published_baselines` below (0.452, Gaudreault &
+# Najmanovich): these are ASPIRATIONAL targets for FlexAIDdS, not the measured
+# state of the field, and the gate compares against the aspiration.
 expected_baselines:
   docking_power_top1: 0.70
   docking_power_top3: 0.85

--- a/benchmarks/datasets/astex_nonnative.yaml
+++ b/benchmarks/datasets/astex_nonnative.yaml
@@ -57,6 +57,28 @@ metrics:
   - docking_power_top3
   - entropy_rescue_rate
 
+# PROVENANCE of the values below.  Restored verbatim from 50aebaee (2026-04-19),
+# where they lived in a labelled `claude_reevaluated_baselines:` block.
+# c414e814 (2026-06-19) promoted the numbers into `expected_baselines` and
+# deleted the label and the rationale in the same diff -- here, in hap2.yaml and
+# in astex_diverse.yaml.
+#
+#   claude_reevaluated_by: "Claude Opus 4.6 - 2026-04-19"
+#
+#   crossdock_success_rate_2A: 0.32  # was 0.40 - top of published; 0.32 still excellent
+#   crossdock_success_rate_3A: 0.52  # was 0.60 - follows 2A adjustment
+#   crossdock_mean_rmsd:       3.10  # was 2.90 - consistent with 32% under 2A
+#   crossdock_median_rmsd:     2.65  # was 2.40 - follows mean
+#   docking_power_top1:        0.38  # was 0.45 - cross-docking is hard; 0.38 competitive
+#   docking_power_top3:        0.55  # was 0.60 - follows top-1
+#   entropy_rescue_rate:       0.22  # was 0.20 - cross-docking benefits most
+#
+#   rationale: "Cross-docking baselines adjusted down to reflect published
+#   performance.  Original 40% under 2A is at the very top of published range
+#   (Glide: 30-40%).  32% is still excellent and defensible. ... Entropy rescue
+#   rate raised slightly from 0.20->0.22: cross-docking is the scenario where
+#   entropy corrections should matter most (induced-fit conformational
+#   entropy)."
 expected_baselines:
   crossdock_success_rate_2A: 0.32
   crossdock_success_rate_3A: 0.52

--- a/benchmarks/datasets/hap2.yaml
+++ b/benchmarks/datasets/hap2.yaml
@@ -104,6 +104,34 @@ metrics:
 
 # Based on FlexAID JCIM 2015 reported performance on HAP2 holo/apo pairs,
 # with entropy correction expected to improve non-native receptor docking.
+# PROVENANCE of the values below.  Restored verbatim from 50aebaee (2026-04-19),
+# where they lived in a labelled `claude_reevaluated_baselines:` block.
+# c414e814 (2026-06-19, "stabilize benchmark thermodynamics and diagnostics")
+# promoted the numbers into `expected_baselines` and deleted the label, the
+# per-value notes and the rationale in the same diff -- in this file and in
+# astex_diverse.yaml and astex_nonnative.yaml.  The numbers survived; their
+# justification did not.
+#
+#   claude_reevaluated_by: "Claude Opus 4.6 - 2026-04-19"
+#
+#   docking_power_top1: 0.60   # was 0.62 - essentially unchanged; FlexAID published ~0.56
+#   docking_power_top3: 0.76   # was 0.78 - follows top-1
+#   mean_rmsd:          2.55   # was 2.50 - consistent with ~60% under 2A
+#   median_rmsd:        2.15   # was 2.10 - follows mean
+#   entropy_rescue_rate 0.30   # was 0.28 - HAP2 has many flexible targets
+#   scoring_power_pearson_r 0.55  # was 0.58 - no published r for FlexAID
+#   scoring_power_rmse  2.30   # was 2.20 - consistent with r~0.55
+#
+#   rationale: "HAP2 is the most credible dataset because it has published
+#   FlexAID baselines from the JCIM 2015 paper.  Original FlexAID achieved ~56%
+#   top-1 on holo; with entropy correction, ~60% is realistic and defensible.
+#   ... This is the only dataset where original baselines are grounded in
+#   published data."
+#
+# That last sentence is the most load-bearing provenance claim in the suite:
+# HAP2 is the one dataset whose targets descend from measured FlexAID numbers
+# rather than from field-wide comparison.  It existed only in git history
+# between 2026-06-19 and this commit.
 expected_baselines:
   docking_power_top1: 0.60
   docking_power_top3: 0.76

--- a/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
+++ b/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
@@ -133,6 +133,32 @@ metrics:
   - median_rmsd
   - entropy_rescue_rate
 
+# PROVENANCE of the five values below.  They are not measurements and they are
+# not guesses: every one of them is a re-estimate recorded in this file on
+# 2026-04-19 (50aebaee) in a labelled `claude_reevaluated_baselines:` block,
+# which c414e814 (2026-06-19, "stabilize benchmark thermodynamics and
+# diagnostics") promoted into `expected_baselines` while deleting the label and
+# the reasoning in the same diff.  The numbers survived; their justification did
+# not, and a bare 0.70 has read as an unsourced target ever since.  Restored
+# verbatim from 50aebaee so the threshold carries its own argument:
+#
+#   claude_reevaluated_by: "Claude Opus 4.6 — 2026-04-19"
+#
+#   docking_power_top1: 0.70   # was 0.80 — above all published; 0.70 is still SOTA-tier
+#   docking_power_top3: 0.85   # was 0.90 — follows top-1 adjustment
+#   mean_rmsd:          2.30   # was 2.10 — slight increase for realism
+#   median_rmsd:        1.95   # was 1.80 — follows mean adjustment
+#   entropy_rescue_rate 0.30   # unchanged; conservative and defensible
+#
+#   rationale: "Docking power 0.80→0.70: no published method exceeds 74% top-1
+#   on Astex Diverse (Glide SP).  FlexAIDdS with entropy correction at 70% would
+#   be competitive with Glide XP and above Vina. ... Entropy rescue rate
+#   unchanged at 0.30 — this is the honest conservative estimate for a general
+#   set."
+#
+# Read that alongside `published_baselines` below (0.452, Gaudreault &
+# Najmanovich): these are ASPIRATIONAL targets for FlexAIDdS, not the measured
+# state of the field, and the gate compares against the aspiration.
 expected_baselines:
   docking_power_top1: 0.70
   docking_power_top3: 0.85

--- a/python/flexaidds/dataset_runner/datasets/astex_nonnative.yaml
+++ b/python/flexaidds/dataset_runner/datasets/astex_nonnative.yaml
@@ -57,6 +57,28 @@ metrics:
   - docking_power_top3
   - entropy_rescue_rate
 
+# PROVENANCE of the values below.  Restored verbatim from 50aebaee (2026-04-19),
+# where they lived in a labelled `claude_reevaluated_baselines:` block.
+# c414e814 (2026-06-19) promoted the numbers into `expected_baselines` and
+# deleted the label and the rationale in the same diff -- here, in hap2.yaml and
+# in astex_diverse.yaml.
+#
+#   claude_reevaluated_by: "Claude Opus 4.6 - 2026-04-19"
+#
+#   crossdock_success_rate_2A: 0.32  # was 0.40 - top of published; 0.32 still excellent
+#   crossdock_success_rate_3A: 0.52  # was 0.60 - follows 2A adjustment
+#   crossdock_mean_rmsd:       3.10  # was 2.90 - consistent with 32% under 2A
+#   crossdock_median_rmsd:     2.65  # was 2.40 - follows mean
+#   docking_power_top1:        0.38  # was 0.45 - cross-docking is hard; 0.38 competitive
+#   docking_power_top3:        0.55  # was 0.60 - follows top-1
+#   entropy_rescue_rate:       0.22  # was 0.20 - cross-docking benefits most
+#
+#   rationale: "Cross-docking baselines adjusted down to reflect published
+#   performance.  Original 40% under 2A is at the very top of published range
+#   (Glide: 30-40%).  32% is still excellent and defensible. ... Entropy rescue
+#   rate raised slightly from 0.20->0.22: cross-docking is the scenario where
+#   entropy corrections should matter most (induced-fit conformational
+#   entropy)."
 expected_baselines:
   crossdock_success_rate_2A: 0.32
   crossdock_success_rate_3A: 0.52

--- a/python/flexaidds/dataset_runner/datasets/hap2.yaml
+++ b/python/flexaidds/dataset_runner/datasets/hap2.yaml
@@ -104,6 +104,34 @@ metrics:
 
 # Based on FlexAID JCIM 2015 reported performance on HAP2 holo/apo pairs,
 # with entropy correction expected to improve non-native receptor docking.
+# PROVENANCE of the values below.  Restored verbatim from 50aebaee (2026-04-19),
+# where they lived in a labelled `claude_reevaluated_baselines:` block.
+# c414e814 (2026-06-19, "stabilize benchmark thermodynamics and diagnostics")
+# promoted the numbers into `expected_baselines` and deleted the label, the
+# per-value notes and the rationale in the same diff -- in this file and in
+# astex_diverse.yaml and astex_nonnative.yaml.  The numbers survived; their
+# justification did not.
+#
+#   claude_reevaluated_by: "Claude Opus 4.6 - 2026-04-19"
+#
+#   docking_power_top1: 0.60   # was 0.62 - essentially unchanged; FlexAID published ~0.56
+#   docking_power_top3: 0.76   # was 0.78 - follows top-1
+#   mean_rmsd:          2.55   # was 2.50 - consistent with ~60% under 2A
+#   median_rmsd:        2.15   # was 2.10 - follows mean
+#   entropy_rescue_rate 0.30   # was 0.28 - HAP2 has many flexible targets
+#   scoring_power_pearson_r 0.55  # was 0.58 - no published r for FlexAID
+#   scoring_power_rmse  2.30   # was 2.20 - consistent with r~0.55
+#
+#   rationale: "HAP2 is the most credible dataset because it has published
+#   FlexAID baselines from the JCIM 2015 paper.  Original FlexAID achieved ~56%
+#   top-1 on holo; with entropy correction, ~60% is realistic and defensible.
+#   ... This is the only dataset where original baselines are grounded in
+#   published data."
+#
+# That last sentence is the most load-bearing provenance claim in the suite:
+# HAP2 is the one dataset whose targets descend from measured FlexAID numbers
+# rather than from field-wide comparison.  It existed only in git history
+# between 2026-06-19 and this commit.
 expected_baselines:
   docking_power_top1: 0.60
   docking_power_top3: 0.76


### PR DESCRIPTION
`expected_baselines: docking_power_top1: 0.70` has been read all night as an unsourced target that our gate fails 0-for-30 against. It is not unsourced. `git log -S` places it exactly:

| commit | date | what happened |
|---|---|---|
| `50aebaee` | 2026-04-19 | file created with `expected_baselines: 0.80`, **plus** a labelled `claude_reevaluated_baselines:` block giving `0.70`, per-value reasoning, a cited rationale, and `claude_reevaluated_by` |
| `c414e814` | 2026-06-19 | promotes `0.70` into `expected_baselines` **and deletes** `claude_reevaluated_baselines` / `_rationale` / `_by` in the same diff |

The number survived; its justification did not. All five live baselines are that block's values, so the whole set lost its provenance at once.

The deleted rationale is the part that matters: *"no published method exceeds 74% top-1 on Astex Diverse (Glide SP). FlexAIDdS with entropy correction at 70% would be competitive with Glide XP and above Vina."* That is a reasoned, field-aware target — and it is currently unfindable in the file it governs.

## What this changes

Nothing executable. The rationale is restored **verbatim from `50aebaee`** as a comment above the values, with the promotion history named so the next reader does not have to run `git log -S`, and a pointer to read it against `published_baselines` (0.452, Gaudreault & Najmanovich) directly below — these are aspirational targets, not the measured state of the field.

## Verification

```
yaml.safe_load(benchmarks/datasets/astex_diverse.yaml)['expected_baselines']
  -> {'docking_power_top1': 0.7, 'docking_power_top3': 0.85, 'mean_rmsd': 2.3,
      'median_rmsd': 1.95, 'entropy_rescue_rate': 0.3}
same dict from python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
```

Both mirrored copies changed so the pair stays byte-identical — the workflow loads `benchmarks/datasets/` (`--datasets-dir`), the package ships the other, and #337 exists because these drift.

## Attribution

The chase started from @Honey's five-orphan-benchmark finding and @Fizz's manifest divergence. Its result **refutes** the hypothesis it was testing: `0.70` did not leak from the orphan manifest into the gate — the gate config carried it first (2026-04-19) and the manifest inherited it 17 days later (`d5dd31df`, 2026-05-06).

Method note: my first pass at this dated both files to one 2026-07-31 commit. That was a shallow-clone artifact (`git rev-parse --is-shallow-repository` → `true`; 69 commits visible of 2278). Every finding above is from the unshallowed history.

---

## Update — the deletion hit three files, not one

@Honey checked whether `astex_diverse` was the instance or the class while verifying the chain above. It is the class: `c414e814` removed a `claude_reevaluated` block from **three** dataset configs. Both others are now restored here on the same terms — comment only, values untouched, both mirrored copies.

**`hap2.yaml` is the one that mattered most.** Its deleted rationale:

> "HAP2 is the most credible dataset because it has published FlexAID baselines from the JCIM 2015 paper. Original FlexAID achieved ~56% top-1 on holo; with entropy correction, ~60% is realistic and defensible. ... **This is the only dataset where original baselines are grounded in published data.**"

That is the most load-bearing provenance claim in the benchmark suite — the one dataset whose targets descend from measured FlexAID numbers rather than field-wide comparison — and it has existed only in git history since 2026-06-19.

`astex_nonnative.yaml`'s cites the published cross-docking range it was set against (Glide 30–40%, revised 0.40 → 0.32).

Also noted by @Honey and confirmed: the same `c414e814` diff that deleted the rationale **added** `published_baselines: 0.452`. The juxtaposition of an unsourced 0.70 above a sourced 0.452 was manufactured in one commit.

### Verification

`yaml.safe_load` on all six touched files returns dicts identical to `origin/main`'s. Comments only.

### Reported, not fixed here

`benchmarks/datasets/astex_nonnative.yaml` and its python-package mirror have genuinely **drifted**: `data_format: mmcif` vs `pdb`, plus a 13-line `structure_recovery_policy` block present in only one. That is a behaviour difference needing a decision about which copy is authoritative — a live instance of #337, and out of scope for a comment-only PR.
