### PR TITLE
Fix: a missing Metal toolchain no longer blocks configure on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,17 @@ if(POLICY CMP0167)
     cmake_policy(SET CMP0167 NEW)
 endif()
 
+# Did the caller ASK for Metal, or is it only on because FlexAIDOptions.cmake
+# defaults it ON for Apple?  A -D on the command line defines the variable
+# before option() runs, so this distinguishes "the user wants Metal" from "this
+# is a Mac".  Used below to decide whether a missing Metal toolchain is a hard
+# error or a degrade-to-OFF.
+if(DEFINED FLEXAIDS_USE_METAL)
+    set(_FLEXAIDS_METAL_EXPLICIT TRUE)
+else()
+    set(_FLEXAIDS_METAL_EXPLICIT FALSE)
+endif()
+
 # ─── Centralized options + platform + SIMD helpers ─────────────────────────
 # Extracted to cmake/FlexAIDOptions.cmake to fight monolith growth.
 # All FLEXAIDS_* toggles, architecture detection, flexaids_configure_simd(),
@@ -135,12 +146,44 @@ if(APPLE AND FLEXAIDS_USE_METAL)
         )
     endif()
 
+    # A missing Metal toolchain is only a hard error when Metal was ASKED for.
+    #
+    # FlexAIDOptions.cmake:45 defaults FLEXAIDS_USE_METAL to ON for any Apple
+    # host with an Objective-C++ compiler, so before this change a plain
+    # `cmake -S . -B build` on a Mac whose Xcode lacks the (separately
+    # downloaded) Metal toolchain component FAILED TO CONFIGURE -- reproduced on
+    # Xcode-beta 21, which ships clang and objc++ but no `metal`.  Nothing about
+    # that machine wants GPU acceleration; it was opted in by being a Mac and
+    # then failed for a component it never asked for.
+    #
+    # This mirrors the OBJCXX fallback at the top of this file, which already
+    # degrades gracefully rather than demanding a toolchain: same platform, same
+    # class of optional compiler, now the same handling.
+    set(_FLEXAIDS_METAL_MISSING "")
     if(NOT FLEXAIDS_METALC OR NOT EXISTS "${FLEXAIDS_METALC}")
-        message(FATAL_ERROR "FLEXAIDS_USE_METAL=ON but no executable Metal compiler was found. Run: xcodebuild -downloadComponent MetalToolchain")
+        set(_FLEXAIDS_METAL_MISSING "no executable Metal compiler was found")
+    elseif(NOT FLEXAIDS_METALLIB OR NOT EXISTS "${FLEXAIDS_METALLIB}")
+        set(_FLEXAIDS_METAL_MISSING "metallib was not found beside ${FLEXAIDS_METALC}")
     endif()
-    if(NOT FLEXAIDS_METALLIB OR NOT EXISTS "${FLEXAIDS_METALLIB}")
-        message(FATAL_ERROR "FLEXAIDS_USE_METAL=ON but metallib was not found beside ${FLEXAIDS_METALC}. Run: xcodebuild -downloadComponent MetalToolchain")
+
+    if(_FLEXAIDS_METAL_MISSING)
+        if(_FLEXAIDS_METAL_EXPLICIT)
+            # -DFLEXAIDS_USE_METAL=ON was passed: honour it and fail loudly.
+            message(FATAL_ERROR
+                "FLEXAIDS_USE_METAL=ON but ${_FLEXAIDS_METAL_MISSING}. "
+                "Run: xcodebuild -downloadComponent MetalToolchain")
+        endif()
+        message(WARNING
+            "Metal acceleration disabled: ${_FLEXAIDS_METAL_MISSING}. "
+            "FLEXAIDS_USE_METAL defaults ON for Apple hosts; it is being turned "
+            "OFF for this configure because the toolchain is absent. "
+            "To use Metal, run: xcodebuild -downloadComponent MetalToolchain. "
+            "To make this a hard error instead, pass -DFLEXAIDS_USE_METAL=ON.")
+        set(FLEXAIDS_USE_METAL OFF CACHE BOOL "Enable Metal GPU acceleration" FORCE)
     endif()
+endif()
+
+if(APPLE AND FLEXAIDS_USE_METAL)
 
     set(FLEXAIDS_METAL_MODULE_CACHE
         "${CMAKE_BINARY_DIR}/metal_module_cache"


### PR DESCRIPTION
## The failure

A plain `cmake -S . -B build` does not configure on a Mac whose Xcode lacks the separately-downloaded Metal toolchain component:

```
CMake Error at CMakeLists.txt:138 (message):
  FLEXAIDS_USE_METAL=ON but no executable Metal compiler was found.
  Run: xcodebuild -downloadComponent MetalToolchain
```

Reproduced on Xcode-beta 21, which ships clang and an Objective-C++ compiler but no `metal` / `metallib`.

## Why the machine was opted in

`cmake/FlexAIDOptions.cmake:45`

```cmake
if(APPLE AND _HAS_OBJCXX)
    option(FLEXAIDS_USE_METAL "Enable Metal GPU acceleration" ON)
```

Any Apple host with an Objective-C++ compiler gets Metal **ON by default** — and then a hard error for a component it never requested. Someone who only wants to build and run FlexAID on CPU cannot configure at all.

(Note for anyone reading the docs: `CLAUDE.md`'s options table lists `FLEXAIDS_USE_METAL` as `OFF`. That is the non-Apple default; on Apple it is ON. I misread it that way myself before reading the option.)

## The fix

This mirrors the **Graceful OBJCXX Fallback** block already at the top of `CMakeLists.txt`, which detects an optional Apple compiler and continues without it. Same platform, same class of optional toolchain, now the same handling:

| situation | behaviour |
|---|---|
| toolchain missing, `-DFLEXAIDS_USE_METAL=ON` passed explicitly | `FATAL_ERROR`, **unchanged** |
| toolchain missing, Metal on only by platform default | `WARNING` + `FLEXAIDS_USE_METAL=OFF`, configure continues |

"Explicit" is detected by capturing whether `FLEXAIDS_USE_METAL` was defined *before* `FlexAIDOptions.cmake` runs — a `-D` on the command line defines it ahead of `option()`; the platform default does not.

The warning names what is missing, how to install it, and how to make it fatal again.

## Verification — on this host, from `origin/main`

```
cmake -S . -B build                          exit 0   ("Metal acceleration disabled: ...")
cmake --build build --target FlexAID -j10    exit 0   binary produced, runs
cmake -S . -B build3 -DFLEXAIDS_USE_METAL=ON exit 1   original FATAL_ERROR preserved
```

No effect on Linux or on a Mac with the toolchain present — the new branch is reachable only when the Metal compiler is absent, and CI is unchanged (`ubuntu-latest`, Metal off).

## Scope

CMake only. No source, no scoring, no defaults changed on any platform that currently configures successfully. Found while building FlexAID locally at @Bonhomme's request to test the latest implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling when Metal tooling is unavailable.
  * Explicit Metal requests now provide a clear configuration error.
  * Automatic configuration continues with Metal disabled and a warning when required tools are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->