### PR TITLE
Docs: correct FLEXAIDS_USE_METAL default (ON on Apple hosts)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,7 @@ pytest tests/
 | Option | Default | Description |
 |--------|---------|-------------|
 | `FLEXAIDS_USE_CUDA` | OFF | CUDA GPU evaluation |
-| `FLEXAIDS_USE_METAL` | OFF | Metal acceleration (macOS) |
+| `FLEXAIDS_USE_METAL` | **ON** on Apple hosts with an Objective-C++ compiler, OFF elsewhere | Metal acceleration (macOS). See `cmake/FlexAIDOptions.cmake:45` — this option is host-conditional, not a flat `OFF`. |
 | `FLEXAIDS_USE_AVX2` | ON | AVX2 SIMD acceleration |
 | `FLEXAIDS_USE_AVX512` | OFF | AVX-512 SIMD |
 | `FLEXAIDS_USE_OPENMP` | ON | OpenMP parallelism |


### PR DESCRIPTION
Fixes the false witness @Honey flagged: the `Key CMake Options` table listed `FLEXAIDS_USE_METAL` default as `OFF`, but `cmake/FlexAIDOptions.cmake:45` defaults it **ON** for any Apple host with an Objective-C++ compiler.

I am the one who mis-read that table as authoritative while diagnosing the macOS configure failure (fixed separately in #379). Docs-only change; no build impact.

Evidence:
```
cmake/FlexAIDOptions.cmake:45
  if(APPLE AND _HAS_OBJCXX)
      option(FLEXAIDS_USE_METAL "Enable Metal GPU acceleration" ON)
  else()
      option(FLEXAIDS_USE_METAL "Enable Metal GPU acceleration" OFF)
```
