### PR TITLE
Fix: S_top10 scorer must not count never-executed runs as misses

### DIFF
--- a/scripts/bootstrap_3dsig_s_top10.py
+++ b/scripts/bootstrap_3dsig_s_top10.py
@@ -14,6 +14,12 @@ Input formats (auto-detected):
 **Fail-closed:** arm-dir result.csv without mode_rmsd_* (or equivalent rank
 columns) is rejected. Do **not** silently treat rmsd_top1 / rmsd_bcr as S_top10.
 
+**Also fail-closed:** a case that never executed (``n_poses`` /
+``restarts_finished`` present and zero, with no mode RMSDs) is a FAILED RUN,
+not a miss. Scoring it as a miss fabricates a success rate — an arm that never
+started would otherwise report a clean ``0.0000`` indistinguishable from a zero
+the engine earned. Pass ``--allow-unrun-cases`` to drop them from N instead.
+
 Usage:
   python3 scripts/bootstrap_3dsig_s_top10.py --cases cases.json --bootstraps 10000
   python3 scripts/bootstrap_3dsig_s_top10.py --arm-dir path/to/3dsig_r10
@@ -50,6 +56,45 @@ MODE_RMSD_KEYS = (
 
 class MissingModeRmsdError(ValueError):
     """Raised when result.csv lacks mode_rmsd_* (fail-closed for S_top10)."""
+
+
+class UnrunCaseError(ValueError):
+    """Raised when a case never executed (fail-closed for S_top10).
+
+    A row with no poses and no finished restarts is a FAILED RUN, not a miss.
+    Counting it as a miss silently deflates the success rate — a zero from an
+    arm that never started is indistinguishable from a zero the engine earned.
+    """
+
+
+# Columns that witness whether the run actually executed. Absent columns are
+# not evidence of anything, so an unrun verdict requires a present zero.
+_EXECUTION_WITNESS_KEYS = ("n_poses", "restarts_finished")
+
+
+def row_never_ran(row: dict, rmsds: Sequence[Optional[float]]) -> bool:
+    """True when the row has no usable RMSD and a witness proves it never ran.
+
+    Requires BOTH: every mode slot empty, and at least one execution witness
+    column present and equal to zero. A row whose modes are merely empty is
+    left alone — only a positive witness of non-execution disqualifies it.
+    """
+    if any(r is not None for r in rmsds):
+        return False
+    keys_lower = {k.lower(): k for k in row}
+    for key in _EXECUTION_WITNESS_KEYS:
+        col = keys_lower.get(key)
+        if col is None:
+            continue
+        raw = (row.get(col) or "").strip()
+        if not raw:
+            continue
+        try:
+            if float(raw) == 0.0:
+                return True
+        except ValueError:
+            continue
+    return False
 
 
 def _finite_rmsd(value: object) -> Optional[float]:
@@ -168,14 +213,24 @@ def load_rank_table(path: Path) -> Dict[str, List[Optional[float]]]:
 
 
 def load_arm_dir(
-    arm_dir: Path, *, strict: bool = True
+    arm_dir: Path,
+    *,
+    strict: bool = True,
+    allow_unrun: bool = False,
 ) -> Dict[str, List[Optional[float]]]:
     """Scan result.csv under arm_dir for mode_rmsd_0..9.
 
     Fail-closed when *strict* (default): missing mode columns → error, not
     silent rmsd_top1 / rmsd_bcr substitution.
+
+    Also fail-closed on cases that never executed (``n_poses``/
+    ``restarts_finished`` present and zero, all mode slots empty). Pass
+    *allow_unrun* to drop them with a warning instead — they are never
+    scored as misses either way.
     """
     out: Dict[str, List[Optional[float]]] = {}
+    unrun: List[str] = []
+    unrun_detail: List[str] = []
     csv_paths = sorted(arm_dir.rglob("result.csv"))
     if not csv_paths:
         raise FileNotFoundError(f"no result.csv under {arm_dir}")
@@ -199,8 +254,28 @@ def load_arm_dir(
         except MissingModeRmsdError as e:
             errors.append(f"{csv_path}: {e}")
             continue
+        if row_never_ran(row, rmsds):
+            # NOT a miss: the run never executed. Never score it as failure.
+            unrun.append(pdb)
+            unrun_detail.append(f"{pdb} ({csv_path})")
+            continue
         # Keep case even if all mode slots empty (counts as S_top10 fail)
         out[pdb] = rmsds
+
+    if unrun and not allow_unrun:
+        raise UnrunCaseError(
+            f"S_top10 fail-closed: {len(unrun)} case(s) never executed "
+            "(n_poses/restarts_finished = 0 with no mode RMSDs). Scoring them "
+            "as misses would fabricate a success rate. Re-run those targets, "
+            "or pass --allow-unrun-cases to exclude them from N. "
+            f"First: {unrun_detail[0]}"
+        )
+    if unrun:
+        print(
+            f"warning: excluded {len(unrun)} never-executed case(s) from N: "
+            + ", ".join(sorted(unrun)),
+            file=sys.stderr,
+        )
 
     if errors and strict:
         msg = (
@@ -308,6 +383,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         action="store_true",
         help="Do not fail when mode_rmsd_* missing (still never uses BCR as S_top10)",
     )
+    ap.add_argument(
+        "--allow-unrun-cases",
+        action="store_true",
+        help=(
+            "Exclude never-executed cases (n_poses/restarts_finished = 0) from N "
+            "with a warning, instead of failing. They are never scored as misses."
+        ),
+    )
     ap.add_argument("--json-out", type=Path, default=None)
     args = ap.parse_args(argv)
 
@@ -318,9 +401,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             cases = load_rank_table(args.rank_table)
         else:
             cases = load_arm_dir(
-                args.arm_dir, strict=not args.allow_missing_modes
+                args.arm_dir,
+                strict=not args.allow_missing_modes,
+                allow_unrun=args.allow_unrun_cases,
             )
-    except (MissingModeRmsdError, FileNotFoundError, OSError, json.JSONDecodeError) as e:
+    except (
+        MissingModeRmsdError,
+        UnrunCaseError,
+        FileNotFoundError,
+        OSError,
+        json.JSONDecodeError,
+    ) as e:
         print(f"error: {e}", file=sys.stderr)
         return 2
 

--- a/tests/test_bootstrap_3dsig_s_top10.py
+++ b/tests/test_bootstrap_3dsig_s_top10.py
@@ -144,6 +144,81 @@ def test_load_arm_dir_reads_mode_rmsd(tmp_path: Path):
     assert cases["1ABC"][0] == pytest.approx(3.0)
 
 
+def _write_case(
+    arm: Path, pdb: str, rmsds, *, n_poses: str = "500", restarts: str = "10"
+) -> None:
+    """Write one per-target result.csv. ``rmsds`` entries may be None → empty."""
+    d = arm / pdb
+    d.mkdir(parents=True)
+    fields = (
+        ["pdb_id"]
+        + [f"mode_rmsd_{i}" for i in range(10)]
+        + ["n_poses", "restarts_finished"]
+    )
+    row = {"pdb_id": pdb, "n_poses": n_poses, "restarts_finished": restarts}
+    for i, v in enumerate(rmsds):
+        row[f"mode_rmsd_{i}"] = "" if v is None else f"{v:.4f}"
+    with (d / "result.csv").open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        w.writerow(row)
+
+
+def test_load_arm_dir_fail_closed_on_never_executed_case(tmp_path: Path):
+    """A row that never ran must not be scored as an S_top10 miss."""
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    arm = tmp_path / "arm"
+    _write_case(arm, "1ABC", [3.0] * 10)
+    _write_case(arm, "1XYZ", [None] * 10, n_poses="0", restarts="0")
+    with pytest.raises(mod.UnrunCaseError):
+        mod.load_arm_dir(arm, strict=True)
+
+
+def test_load_arm_dir_allow_unrun_excludes_rather_than_fails(tmp_path: Path):
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    arm = tmp_path / "arm"
+    _write_case(arm, "1ABC", [1.5] + [9.0] * 9)
+    _write_case(arm, "1XYZ", [None] * 10, n_poses="0", restarts="0")
+    cases = mod.load_arm_dir(arm, strict=True, allow_unrun=True)
+    # Excluded from N entirely — not counted as a failure.
+    assert set(cases) == {"1ABC"}
+    stats = mod.compute_s_top10_stats(cases, n_boot=64)
+    assert stats["n_cases"] == 1
+    assert stats["point"] == pytest.approx(1.0)
+
+
+def test_empty_modes_without_execution_witness_still_counts_as_miss(tmp_path: Path):
+    """Absent witness columns are not evidence the run failed to start."""
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    arm = tmp_path / "arm" / "1ABC"
+    arm.mkdir(parents=True)
+    fields = ["pdb_id"] + [f"mode_rmsd_{i}" for i in range(10)]
+    row = {"pdb_id": "1ABC"}
+    for i in range(10):
+        row[f"mode_rmsd_{i}"] = ""
+    with (arm / "result.csv").open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        w.writerow(row)
+    cases = mod.load_arm_dir(tmp_path / "arm", strict=True)
+    assert cases["1ABC"] == [None] * 10
+    assert mod.s_top10(cases["1ABC"]) is False
+
+
+def test_cli_arm_dir_fail_closed_on_unrun(tmp_path: Path):
+    """The CLI must refuse to print 0.0000 for an arm that never executed."""
+    arm = tmp_path / "arm"
+    _write_case(arm, "1ABC", [None] * 10, n_poses="0", restarts="0")
+    proc = subprocess.run(
+        [sys.executable, str(BOOT), "--arm-dir", str(arm), "--bootstraps", "10"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert "never executed" in proc.stderr
+    assert "0.0000" not in proc.stdout
+
+
 def test_bootstrap_median_deterministic():
     mod = _load("bootstrap_3dsig_s_top10", BOOT)
     # 2/4 success → point 0.5


### PR DESCRIPTION
## The defect

`scripts/bootstrap_3dsig_s_top10.py` is the designated arbiter of "did we reproduce the 3Dsig deck." It is fail-closed on **missing** `mode_rmsd_*` columns — but it counted **present-but-empty** ones as legitimate S_top10 failures, by explicit design:

```python
# Keep case even if all mode slots empty (counts as S_top10 fail)
out[pdb] = rmsds
```

So an arm where the engine never started reports a clean, confident zero. Measured on real campaign data before this change:

```
A/3dsig_r10 (pilot8)   S_top10=0.0000  bootstrap_median=0.0000
                       p05-p95=[0.0000,0.0000]  n=8
```

All eight of those targets have `n_poses=0`, `restarts_finished=0`, empty `wall_s` and empty `evals_actual`. Nothing in that output distinguishes *the engine missed* from *the engine never ran*.

## The fix

`row_never_ran()` disqualifies a case only when **both** hold:

1. every mode slot is empty, **and**
2. an execution witness column (`n_poses` / `restarts_finished`) is **present and zero**.

Absent witness columns are not evidence of anything, so a row with merely empty modes is still scored as a miss — unchanged behaviour, pinned by `test_empty_modes_without_execution_witness_still_counts_as_miss`.

Disqualified cases raise `UnrunCaseError` (exit 2). `--allow-unrun-cases` drops them from N with a warning naming the PDB ids. They are never counted as failures either way.

## Scope

This guards only against runs that never **started**. It says nothing about whether a run that did start spent its protocol budget — that is a separate witness (`evals_actual`) and a separate problem, being tracked in the originating channel.

## Verification

```
pytest tests/test_bootstrap_3dsig_s_top10.py     19 passed
A/3dsig_r10 (pilot8)                             exit 2, no rate printed
A/3dsig_full85_r10_cf_fix                        exit 2 by default
  same, --allow-unrun-cases                      excludes 23, reports n=62
```

Four new tests: loader fail-closed, `--allow-unrun-cases` excludes rather than fails, empty-modes-without-witness still a miss, and CLI exit-2 with no `0.0000` on stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)