### PR TITLE
Docs: correct FLEXAIDDS_NO_SEC comment -- BENCHMARK does not disable the entropy early exit

### DIFF
--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -624,8 +624,26 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	////// Genetic Algorithm ///////
 	////////////////////////////////
 
-	// FLEXAIDDS_NO_SEC=1 (or FLEXAIDDS_BENCHMARK=1) disables early-exit paths
-	// (stagnation + entropy/SEC) so the *full* generation budget is always used.
+	// FLEXAIDDS_NO_SEC (presence) disables early-exit paths (stagnation +
+	// entropy/SEC) so the *full* generation budget is always used.
+	//
+	// FLEXAIDDS_BENCHMARK is NOT equivalent. The two env vars set two distinct
+	// fields (ProtocolConfig.cpp: cfg.no_sec / cfg.benchmark_mode):
+	//
+	//   FLEXAIDDS_NO_SEC     -> disables BOTH entropy/SEC exits AND stagnation
+	//   FLEXAIDDS_BENCHMARK  -> disables the STAGNATION plateau exit only
+	//                           (`benchmark_full`, below); the entropy/SEC
+	//                           guards test `no_sec` alone and ignore it
+	//
+	// This comment previously read "(or FLEXAIDDS_BENCHMARK=1)", generalising
+	// the stagnation behaviour to both exits. That is the half that matters:
+	// all 80 restarts of the Jul-28 arm-A pilot terminated by ENTROPY
+	// convergence (stagnation fired 0/80) at a median of 165 of 2000
+	// generations -- ~8% of the intended budget -- and the results were
+	// recorded as full-budget.
+	//
+	// If you need the full budget, set FLEXAIDDS_NO_SEC and verify the
+	// "[SEC] ... DISABLED" line below appears on STDERR (not stdout).
 	// During benchmarking this ensures equal search effort vs other methods.
 	// "Spare" generations after a plateau are used with boosted mutation/exploration
 	// (see stagnation handling) to search conformational space more effectively.


### PR DESCRIPTION
Comment-only fix to `LIB/gaboom.cpp`. The comment above the `no_sec` read claimed:

```
// FLEXAIDDS_NO_SEC=1 (or FLEXAIDDS_BENCHMARK=1) disables early-exit paths
// (stagnation + entropy/SEC) so the *full* generation budget is always used.
```

The `or` is wrong. The two env vars set two distinct `ProtocolConfig` fields:

| env var | field | what it actually disables |
|---|---|---|
| `FLEXAIDDS_NO_SEC` | `cfg.no_sec` | **both** entropy/SEC exits **and** stagnation (first disjunct of `benchmark_full`) |
| `FLEXAIDDS_BENCHMARK` | `cfg.benchmark_mode` | **stagnation plateau only** |

`benchmark_mode` appears exactly once in the file — in `benchmark_full`. Both entropy/SEC guards test `no_sec` alone.

## Why this is not cosmetic

A 3Dsig benchmark campaign was planned around the documented `or`. Measured from the retained Jul-28 arm-A pilot log (206 MB, 8 targets x 10 restarts):

```
"GA terminated early by entropy convergence"     80 / 80 restarts
"GA terminated early by fitness stagnation"       0 / 80 restarts
generations reached:  min 10   median 165   max 380     (budget 2000)
=> median ~165,000 evaluations vs the intended 2,000,000  (8.25%)
```

The one exit `FLEXAIDDS_BENCHMARK` governs is the one that never fired. Those runs were written out with `protocol_claim_eligible=1` and an empty `evals_actual` column.

The corrected comment also points readers at the existing `[SEC] ... DISABLED` witness line and notes it goes to **stderr**, not stdout — a `tee` that captures only stdout will miss it. (Thanks to Honey for catching that the `or` is half-true via the stagnation path, and for confirming the guards independently on `origin/main`; the comment now states the split explicitly rather than flatly denying it.)

## Verification

`git diff -U0` filtered to non-comment lines is empty — comment-only, no generated code change.

Related: #382 (scorer guard for cases that never started). This one is about cases that started and quit early — a different boundary, still unguarded.
