### PR TITLE
Fix: TEMPER 0 must not fatal -- guard TargetServer construction

### DIFF
--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -2588,12 +2588,29 @@ int main(int argc, char **argv){
 		// P1: create local TargetServer for this GA run (P1 wiring; default 1M conc, later from config)
 		std::unique_ptr<target::TargetServer> local_ts;
 		target::TargetServer* active_ts = nullptr;
-		{
+		// TEMPER 0 is a SUPPORTED legacy configuration, not an error: read_input.cpp
+		// detects it and deliberately forces clustering to CF, printing "does not
+		// allow the consideration of conformational entropy". The grand-canonical
+		// machinery is therefore already excluded by the user's own config.
+		//
+		// TargetServer holds a GrandPartitionFunction by value, whose constructor
+		// throws on temperature <= 0. Constructing it unconditionally turned that
+		// supported config into a hard fatal ("Fatal error: Temperature must be
+		// positive") before the GA could start. Guard the construction instead of
+		// relaxing the positive-temperature invariant in the thermodynamic classes,
+		// which is correct and should stay.
+		//
+		// Leaving active_ts null is safe on this path: cluster() accepts the pointer
+		// but never dereferences it, and the post-run [GRAND] reporting block below
+		// is already wrapped in `if (active_ts)`.
+		if (FA->temperature > 0) {
 			target::TargetConfig tcfg;
 			tcfg.temperature_K = static_cast<double>(FA->temperature);
 			tcfg.default_conc_M = user_conc_M; // P3: from --conc or default
 			local_ts = std::make_unique<target::TargetServer>(tcfg);
 			active_ts = local_ts.get();
+		} else {
+			printf("[GRAND] disabled: TEMPER=0 (legacy CF-only mode)\n");
 		}
 
 		if (use_parallel_dock) {


### PR DESCRIPTION
Ruled by Codex: option **B**, at `TargetServer`, with `TEMPER 0` unchanged. Branch rooted at exact `f2778c973a725a000efe53376545c97f38336831`.

## The regression

`TEMPER 0` is a **supported** configuration — `read_input.cpp` detects it and deliberately forces clustering to CF, printing that the temperature "does not allow the consideration of conformational entropy". The grand-canonical machinery is already excluded by the user's own config.

But `top.cpp` constructed `TargetServer` unconditionally:

```cpp
tcfg.temperature_K = static_cast<double>(FA->temperature);   // 0
local_ts = std::make_unique<target::TargetServer>(tcfg);     // UNCONDITIONAL
```

`TargetServer` holds a `GrandPartitionFunction` by value (`TargetServer.cpp:16`, member initialiser), whose constructor throws on `temperature <= 0` (`GrandPartitionFunction.cpp:19`). A supported config became a hard fatal **before the GA started** — which also meant the `[SEC]` witness line could never print.

Note `MultiSiteGPF` is *not* on this path: it appears only in its own files, CMake wiring, and tests. `grep -n GrandPartitionFunction LIB/top.cpp` returns one hit, a comment.

## Why guard the caller, not the class

The positive-temperature invariant in `GrandPartitionFunction` / `MultiSiteGPF` is correct and stays. Only the unconditional construction was wrong.

## Why `active_ts == nullptr` is safe

It is the declared default (`top.cpp:2590`) and the handled state on **every** path that receives it:

| consumer | status |
|---|---|
| `cluster.cpp` | accepts `ts`, never dereferences it |
| `DensityPeak_Cluster.cpp` | accepts `ts`, never dereferences it |
| `FastOPTICS_cluster.cpp` | guarded — `if (ts && !ligand_name.empty())` |
| `ParallelDock.cpp` | guarded — `if (ts_ && !ligand_name_.empty())` |
| `top.cpp` `[GRAND]` block | entirely inside `if (active_ts)` |

The four-consumer audit is Honey's; the arm-A paths were verified independently.

## Verification — ran the previously-fatal case

arm-A 1GPK legacy `CONFIG.inp` carrying `TEMPER 0`, bounded to 50 chromosomes x 20 generations, one merged stdout+stderr log:

```
EXIT=0                                     (was: exit 1, GA never ran)
[NATIVE_CF] cf=-32.692056  no WARN/SKIP
[GRAND] disabled: TEMPER=0 (legacy CF-only mode)
[SEC] All entropy-convergence early exits DISABLED (FLEXAIDDS_NO_SEC=1)
TIMING SUMMARY: 20 gens timed               full configured budget, no early exit
```

All four of the ratified smoke requirements appear in a single log. `[NATIVE_CF] cf=-32.6920` matches the value Fizz measured independently on the unpatched binary, so the guard did not disturb scoring.

Build: configure needed `-DFLEXAIDS_USE_METAL=OFF` on this macOS host — that is the separate Metal-toolchain configure failure #379 addresses, reproduced locally and unrelated to this change.

Not run locally: `ctest`. Left to CI.
