### PR TITLE
Fix: budget witness validation must fail closed

### DIFF
--- a/scripts/bootstrap_3dsig_s_top10.py
+++ b/scripts/bootstrap_3dsig_s_top10.py
@@ -86,7 +86,7 @@ DEFAULT_MIN_BUDGET_FRACTION = 0.9
 
 
 def has_budget_witness(row: dict) -> bool:
-    """True when ``evals_actual`` is populated with a finite non-negative number.
+    """True when ``evals_actual`` is populated with a finite positive number.
 
     Exact, not proportional: the column is either a witness or it is not.
     ``protocol_claim_eligible`` asserts compliance without establishing it and
@@ -103,7 +103,7 @@ def has_budget_witness(row: dict) -> bool:
         evals = float(raw)
     except ValueError:
         return False
-    return math.isfinite(evals) and evals >= 0.0
+    return math.isfinite(evals) and evals > 0.0
 
 
 def budget_shortfall(row: dict, intended_evals: float) -> Optional[float]:
@@ -127,6 +127,26 @@ def budget_shortfall(row: dict, intended_evals: float) -> Optional[float]:
     if not math.isfinite(evals) or evals < 0.0 or intended_evals <= 0.0:
         return None
     return evals / intended_evals
+
+
+def validate_budget_gate(
+    intended_evals: Optional[float], min_budget_fraction: float
+) -> None:
+    """Reject nonsensical proportional-gate parameters before reading rows."""
+    if intended_evals is None:
+        return
+    if not math.isfinite(intended_evals) or intended_evals <= 0.0:
+        raise BudgetWitnessError(
+            "--intended-evals must be a finite positive number"
+        )
+    if (
+        not math.isfinite(min_budget_fraction)
+        or min_budget_fraction <= 0.0
+        or min_budget_fraction > 1.0
+    ):
+        raise BudgetWitnessError(
+            "--min-budget-fraction must be finite and in the interval (0, 1]"
+        )
 
 
 def row_never_ran(row: dict, rmsds: Sequence[Optional[float]]) -> bool:
@@ -288,6 +308,8 @@ def load_arm_dir(
     *allow_unrun* to drop them with a warning instead — they are never
     scored as misses either way.
     """
+    validate_budget_gate(intended_evals, min_budget_fraction)
+
     out: Dict[str, List[Optional[float]]] = {}
     unrun: List[str] = []
     unrun_detail: List[str] = []
@@ -323,15 +345,24 @@ def load_arm_dir(
             continue
         # Budget spend must be WITNESSED. This is exact — the column is either
         # populated or it is not — and refuses by default.
-        if not allow_unwitnessed_budget and not has_budget_witness(row):
-            unwitnessed.append(pdb)
-            continue
+        witnessed = has_budget_witness(row)
+        if not witnessed:
+            # An explicitly requested proportional gate always fails closed on
+            # an unknown numerator.  The escape hatch only applies when no
+            # intended budget was supplied.
+            if intended_evals is not None or not allow_unwitnessed_budget:
+                unwitnessed.append(pdb)
+                continue
         # The proportional gate is separate and OPT-IN: the expected
         # evals_actual denominator has not had its semantics established, so no
         # percentage threshold is applied unless a caller supplies one.
         if intended_evals is not None:
             frac = budget_shortfall(row, intended_evals)
-            if frac is not None and frac < min_budget_fraction:
+            # Reaching here guarantees a positive, finite witness.
+            if frac is None:
+                unwitnessed.append(pdb)
+                continue
+            if frac < min_budget_fraction:
                 short.append(f"{pdb} ({frac:.1%} of intended)")
                 continue
         # Keep case even if all mode slots empty (counts as S_top10 fail)
@@ -370,7 +401,8 @@ def load_arm_dir(
             f"spent >= {min_budget_fraction:.0%} of the intended "
             f"{intended_evals:,.0f} evaluations. S_top10 is a rate at a FIXED "
             "search effort; scoring a truncated case redefines the statistic. "
-            "Re-run them, or drop --intended-evals to score without the check. "
+            "Re-run or re-parse them with a same-unit budget witness; do not "
+            "report S_top10 from the truncated rows. "
             f"First: {short[0]}"
         )
 
@@ -501,9 +533,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         type=float,
         default=None,
         help=(
-            "Intended energy evaluations per case (deck protocol: 2000000). "
-            "When set, a case must witness >= --min-budget-fraction of it via "
-            "evals_actual or scoring fails closed. Off by default."
+            "Expected evals_actual for each result.csv row, expressed in the "
+            "same counting unit and restart aggregation as evals_actual. When "
+            "set, a case must witness >= --min-budget-fraction of it or scoring "
+            "fails closed. No protocol-specific value is assumed. Off by default."
         ),
     )
     ap.add_argument(

--- a/tests/test_bootstrap_3dsig_s_top10.py
+++ b/tests/test_bootstrap_3dsig_s_top10.py
@@ -261,6 +261,15 @@ def test_budget_witness_required_by_default(tmp_path: Path):
         mod.load_arm_dir(arm, strict=True)
 
 
+@pytest.mark.parametrize("raw", ["0", "-1", "nan", "inf", "not-a-number"])
+def test_budget_witness_must_be_finite_and_positive(tmp_path: Path, raw: str):
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    arm = tmp_path / "arm"
+    _write_case_with_budget(arm, "1ABC", [5.0] * 10, evals_actual=raw)
+    with pytest.raises(mod.BudgetWitnessError):
+        mod.load_arm_dir(arm, strict=True)
+
+
 def test_protocol_claim_eligible_is_not_accepted_as_a_witness(tmp_path: Path):
     """The fixture sets protocol_claim_eligible=1; it must not rescue the row."""
     mod = _load("bootstrap_3dsig_s_top10", BOOT)
@@ -300,6 +309,49 @@ def test_proportional_gate_is_opt_in_and_tunable(tmp_path: Path):
         arm, strict=True, intended_evals=2_000_000, min_budget_fraction=0.05
     )
     assert set(cases) == {"1ABC"}
+
+
+def test_proportional_gate_refuses_unwitnessed_even_with_escape_hatch(
+    tmp_path: Path,
+):
+    """An explicit denominator cannot be checked against an unknown numerator."""
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    arm = tmp_path / "arm"
+    _write_case_with_budget(arm, "1ABC", [5.0] * 10, evals_actual="")
+    with pytest.raises(mod.BudgetWitnessError):
+        mod.load_arm_dir(
+            arm,
+            strict=True,
+            allow_unwitnessed_budget=True,
+            intended_evals=2_000_000,
+        )
+
+
+@pytest.mark.parametrize("intended", [0.0, -1.0, float("nan"), float("inf")])
+def test_proportional_gate_rejects_invalid_intended_budget(
+    tmp_path: Path, intended: float
+):
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    arm = tmp_path / "arm"
+    _write_case_with_budget(arm, "1ABC", [5.0] * 10, evals_actual="100")
+    with pytest.raises(mod.BudgetWitnessError):
+        mod.load_arm_dir(arm, strict=True, intended_evals=intended)
+
+
+@pytest.mark.parametrize("fraction", [0.0, -0.1, 1.1, float("nan"), float("inf")])
+def test_proportional_gate_rejects_invalid_fraction(
+    tmp_path: Path, fraction: float
+):
+    mod = _load("bootstrap_3dsig_s_top10", BOOT)
+    arm = tmp_path / "arm"
+    _write_case_with_budget(arm, "1ABC", [5.0] * 10, evals_actual="100")
+    with pytest.raises(mod.BudgetWitnessError):
+        mod.load_arm_dir(
+            arm,
+            strict=True,
+            intended_evals=100.0,
+            min_budget_fraction=fraction,
+        )
 
 
 def test_cli_budget_witness_fail_closed(tmp_path: Path):


### PR DESCRIPTION
Follow-up to #384. This closes three fail-open seams in the new budget witness guard without activating the unratified proportional threshold by default.

## Fixes

- Require `evals_actual` to be finite and strictly positive; zero evaluations are evidence that no search budget was spent.
- Reject non-positive or non-finite `--intended-evals` and require `--min-budget-fraction` to be finite and in `(0, 1]`.
- When `--intended-evals` is explicitly supplied, refuse an unknown numerator even if `--allow-unwitnessed-budget` is also present.
- Clarify that `--intended-evals` must use the same counting unit and restart aggregation as the row's `evals_actual`; the CLI assumes no protocol-specific value.
- Remove error guidance that suggested disabling the explicit proportional guard to obtain a score.

## Verification

```text
HEAD 5a61c6858da24721df2eb6716a16171fa723d517
python3 -m pytest tests/test_bootstrap_3dsig_s_top10.py -q
40 passed in 0.44s
python3 -m py_compile scripts/bootstrap_3dsig_s_top10.py
git diff --check origin/main...HEAD
```

The repository-wide `python3 -m pytest -q` is currently not a usable gate: collection aborts with `SystemExit: 0` from module-level script code in `tests/p0_claim_contract/test_fixed_denominator.py` before the suite runs. The complete touched test module passes; repairing repo-wide collection is separate scope.
