### PR TITLE
Fix: make `pytest tests/` collect again -- two module-level sys.exit calls

### DIFF
--- a/tests/p0_claim_contract/test_fixed_denominator.py
+++ b/tests/p0_claim_contract/test_fixed_denominator.py
@@ -80,4 +80,14 @@ check("denominator stays 85 with an off-manifest extra row",
       rep3["N_denominator"] == 85)
 
 print(f"\n{'ALL PASS' if not failures else f'{len(failures)} FAILURES: {failures}'}")
-sys.exit(1 if failures else 0)
+
+# Only exit the interpreter when run as a script. Under pytest this module is
+# imported during collection, and a module-level sys.exit() aborts the whole
+# session with INTERNALERROR before any test runs -- see the guard below.
+if __name__ == "__main__":
+    sys.exit(1 if failures else 0)
+
+
+def test_fixed_denominator_invariants():
+    """Expose the script's checks to pytest so a failure is reported, not exited."""
+    assert not failures, f"{len(failures)} failures: {failures}"

--- a/tests/p0_claim_contract/test_posebusters_fixtures.py
+++ b/tests/p0_claim_contract/test_posebusters_fixtures.py
@@ -7,9 +7,22 @@ returns PASS on a valid molecule and FAIL on a physically broken one.
 Run: python tests/p0_claim_contract/test_posebusters_fixtures.py
 """
 import sys
-from rdkit import Chem
-from rdkit.Chem import AllChem
-from posebusters import PoseBusters
+
+# rdkit and posebusters are optional at collection time. Importing them
+# unguarded aborts the ENTIRE pytest session with a collection error, not just
+# this module. As a script this still raises normally; under pytest the module
+# is skipped when the dependency is absent.
+try:
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+    from posebusters import PoseBusters
+except ImportError as _exc:  # pragma: no cover - environment-dependent
+    if __name__ == "__main__":
+        raise
+    import pytest
+    pytest.skip(
+        f"optional dependency unavailable: {_exc.name}", allow_module_level=True
+    )
 
 failures = []
 def check(name, cond):
@@ -52,4 +65,14 @@ if bad_pass < ok_total:
     print(f"  broken pose failed: {failed_checks}")
 
 print(f"\n{'ALL PASS' if not failures else f'{len(failures)} FAILURES: {failures}'}")
-sys.exit(1 if failures else 0)
+
+# Only exit the interpreter when run as a script. Under pytest this module is
+# imported during collection, and a module-level sys.exit() aborts the whole
+# session with INTERNALERROR before any test runs -- see the guard below.
+if __name__ == "__main__":
+    sys.exit(1 if failures else 0)
+
+
+def test_posebusters_fixtures():
+    """Expose the script's checks to pytest so a failure is reported, not exited."""
+    assert not failures, f"{len(failures)} failures: {failures}"


### PR DESCRIPTION
`python3 -m pytest tests/` collected **zero** tests repo-wide and died with `INTERNALERROR SystemExit` before a single test ran. Found by Honey; this is the fix.

## Cause

Two modules under `tests/p0_claim_contract/` are standalone scripts wearing `test_` filenames and call `sys.exit()` at **module level**. Pytest imports them during collection, so the interpreter exits and takes the whole session with it:

```
tests/p0_claim_contract/test_fixed_denominator.py:83
tests/p0_claim_contract/test_posebusters_fixtures.py:55
```

Both are now guarded behind `if __name__ == "__main__":` — they still work as scripts (their documented usage) — and each module's own `failures` list is exposed as a real test, so a regression is *reported* instead of silently exiting.

### A second abort hiding behind the first

`test_posebusters_fixtures.py` also imported `rdkit` / `posebusters` unguarded. With the `sys.exit` fixed, that import became the *next* collection-aborting error on any machine without those optional packages — again taking down the entire session, not just the module. It now skips at module level under pytest and still raises when run as a script.

## Correction to the original report

Three files were named as causes. Only **two** are: `tests/test_posebust_upstream_parity.py` already guards its `sys.exit(main())` with `if __name__ == "__main__":` at line 482. It is not part of the problem and is untouched here.

## Why CI never caught it

No job runs the suite as a suite — `.github/workflows/ci.yml` invokes pytest with explicit file lists only (`:45`, `:364`). The question was never asked.

## Result

```
before   python3 -m pytest tests/ -q   ->  0 collected, INTERNALERROR, exit 3
after    python3 -m pytest tests/ -q   ->  234 passed, 15 skipped, 3 failed
```

The 3 remaining failures are **pre-existing and environmental**, not from this change — `tests/test_benchmark_coord.py` disk-preflight assertions fail on a host under the 20 GiB floor (`free=15.05GiB < floor=20.0GiB`). This diff touches only the two files under `tests/p0_claim_contract/`.
