### PR TITLE
Fix: unblock C++ CI — silence orphaned tests/rmsd_crosscheck_engine.h

### DIFF
--- a/build_sources.ignore
+++ b/build_sources.ignore
@@ -162,3 +162,10 @@ LIB/memetic_gate.h
 LIB/new_search_arch.h
 LIB/niche_distance.h
 src/backends/webgpu/webgpu_eval.h
+
+# Orphan silenced 2026-08-05 to unblock C++ CI on main (blocks all C++ jobs at
+# cmake configure via ValidateSources.cmake). tests/rmsd_crosscheck_engine.h is a
+# test helper included transitively by tests/rmsd_crosscheck_engine.cpp, which is
+# already listed in the test_dataset_runner target (CMakeLists.txt). Header-only
+# orphan; no build output changes from listing it. Introduced by #371.
+tests/rmsd_crosscheck_engine.h


### PR DESCRIPTION
## Summary

Unblocks C++ CI on `main`. Every C++ job (`linux-gcc`, `linux-clang`, `linux-gcc-asan`, `linux-gcc-avx512`, `linux-gcc-mpi`, `macOS CPU`) is currently failing at `cmake` **configure** because `cmake/ValidateSources.cmake:112` reports `tests/rmsd_crosscheck_engine.h` as an orphaned source file — present on disk (added by #371) but not referenced in any build file. Since the guard runs before compilation, all C++ jobs abort identically.

The header is a test helper transitively included by `tests/rmsd_crosscheck_engine.cpp`, which is already a source of the `test_dataset_runner` target. Listing it in `build_sources.ignore` — the validator's own sanctioned escape for header-only orphans, matching the existing dated "orphans silenced to unblock CI" blocks — is the correct, zero-build-impact fix.

## Scope

- [x] CI / release engineering

## Release impact

- [x] no user-facing release impact

## Validation

- [x] manual validation

Confirmed the orphan is on `main` (not this branch), absent from `build_sources.ignore`, and that its `.cpp` sibling is already listed at `CMakeLists.txt:2421`. No source or build output changes — only the validator ignore list.

## Security and safety

- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

## Reproducibility

- [x] no benchmark claim involved

## Notes

This is the smaller of two follow-ups from the codebase review. Alternative fix would be to add the header to the `test_dataset_runner` `target_sources` next to its `.cpp`; the ignore-list route was chosen to match the repo's established convention for header-only orphans and to keep the diff to one line + rationale.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ)_