### PR TITLE
Fix: don't skip 6 "rigid-body" modes in internal-coordinate tENCoM entropy

### DIFF
--- a/LIB/ShannonThermoStack/ShannonThermoStack.cpp
+++ b/LIB/ShannonThermoStack/ShannonThermoStack.cpp
@@ -288,10 +288,17 @@ double compute_torsional_vibrational_entropy(
 {
     if (modes.empty()) return 0.0;
 
-    // Collect valid eigenvalues into Eigen array, then vectorise
+    // Collect valid eigenvalues into Eigen array, then vectorise.
+    // These modes come from the INTERNAL-coordinate torsional Hessian
+    // (TorsionalENM::build/build_from_ca), which has no rigid-body zero-mode
+    // manifold — so do NOT positionally skip the first 6 (that discarded the 6
+    // softest real torsions, which carry the largest per-mode entropy). The
+    // eigenvalue > 1e-6 guard drops numerically singular modes, consistent with
+    // how the Cartesian ANM consumers (ic2cf.cpp, ligand_tencom_pose.cpp) filter
+    // their own rigid-body modes by cutoff rather than by position.
     std::vector<double> ev_buf;
     ev_buf.reserve(modes.size());
-    for (size_t m = 6; m < modes.size(); ++m)
+    for (size_t m = 0; m < modes.size(); ++m)
         if (modes[m].eigenvalue > 1e-6) ev_buf.push_back(modes[m].eigenvalue);
     if (ev_buf.empty()) return 0.0;
 

--- a/LIB/tENCoM/tencm.cpp
+++ b/LIB/tENCoM/tencm.cpp
@@ -18,7 +18,11 @@
 //    → Jacobi fallback otherwise
 //
 //  Boltzmann sampling at temperature T:
-//    σ_m² = kB T / λ_m  (equipartition per mode, skip m=0..5 ≈ rigid-body)
+//    σ_m² = kB T / λ_m  (equipartition per mode). NOTE: the torsional Hessian is
+//    built in INTERNAL (dihedral) coordinates, which carry no rigid-body
+//    translation/rotation, so there is NO 6-fold zero-mode manifold to skip here
+//    (unlike a Cartesian 3N ANM). Only the near-zero-λ guard drops numerically
+//    singular modes; the 6 softest torsions are real and must be kept.
 //    δθ   = Σ_{m≥6} σ_m * z_m * v_m,   z_m ~ N(0,1)
 //
 //  Perturbed Cα: r_i' = r_i + Σ_k J_k(i) δθ_k
@@ -842,8 +846,10 @@ Conformer TorsionalENM::sample(float temperature, std::mt19937& rng) const
     Conformer conf;
     conf.delta_theta.assign(static_cast<std::size_t>(M), 0.0f);
 
-    // Skip first 6 modes (rigid-body; eigenvalue ≈ 0)
-    const int SKIP = std::min(6, M);
+    // Internal (torsional) coordinates have no rigid-body zero modes, so do NOT
+    // positionally skip 6 (that dropped the 6 softest real torsions). Genuinely
+    // near-zero numerical modes are handled by the λ < 1e-8 guard in the loop.
+    const int SKIP = 0;
     const double kBT = static_cast<double>(kB_kcal) * temperature;
 
     // Eigen path: accumulate Σ σ_m * z_m * v_m as vector operation
@@ -940,7 +946,10 @@ std::vector<float> TorsionalENM::bfactors(float temperature) const
     const int Np = n_protein_ca_;                  // protein nodes only (output)
     const int M  = static_cast<int>(bonds_.size());
     const double kBT = static_cast<double>(kB_kcal) * temperature;
-    const int SKIP = std::min(6, M);
+    // Internal (torsional) coordinates have no rigid-body zero modes: keep all
+    // modes and let the λ >= 1e-8 guard drop numerically singular ones. (Skipping
+    // 6 here dropped the 6 softest real backbone torsions.)
+    const int SKIP = 0;
     const int M_end = std::min(M, SKIP + N_MODES);
     const double BF_SCALE = 8.0 * std::numbers::pi * std::numbers::pi / 3.0;
 

--- a/LIB/tENCoM/tencom_entropy_diff.cpp
+++ b/LIB/tENCoM/tencom_entropy_diff.cpp
@@ -81,9 +81,12 @@ static encom::VibrationalEntropy tencom_vibrational_entropy(
     const std::vector<tencm::NormalMode>& modes,
     double temperature_K,
     const encom::FrequencyCalibration& calibration,
-    int skip_rigid = 6)
+    int skip_rigid = 0)
 {
-    // Convert tencm::NormalMode → encom::NormalMode for entropy computation
+    // Convert tencm::NormalMode → encom::NormalMode for entropy computation.
+    // TENCoM modes are in INTERNAL (torsional) coordinates, which have no
+    // rigid-body zero-mode manifold, so skip_rigid defaults to 0. The λ < 1e-8
+    // guard drops numerically singular modes.
     std::vector<encom::NormalMode> encom_modes;
     for (int m = skip_rigid; m < static_cast<int>(modes.size()); ++m) {
         if (modes[m].eigenvalue < 1e-8) continue;
@@ -145,8 +148,9 @@ static FlexibilityMode compute_flexibility_mode(
     fm.n_matched = std::min(static_cast<int>(ref_modes.size()),
                             static_cast<int>(tgt_modes.size()));
 
-    // Eigenvalue differentials and eigenvector overlaps
-    const int SKIP = 6; // skip rigid-body modes
+    // Eigenvalue differentials and eigenvector overlaps.
+    // Internal (torsional) coordinates have no rigid-body modes to skip.
+    const int SKIP = 0;
     for (int m = SKIP; m < fm.n_matched; ++m) {
         fm.ref_eigenvalues.push_back(ref_modes[m].eigenvalue);
         fm.tgt_eigenvalues.push_back(tgt_modes[m].eigenvalue);
@@ -201,7 +205,7 @@ static void output_flexibility_mode(const FlexibilityMode& fm,
     os << "  Reference : " << ref_label << "\n"
        << "  Target    : " << fm.label  << "\n"
        << "  Residues  : " << fm.n_residues << "\n"
-       << "  Modes cmp : " << fm.n_matched << " (excl. 6 rigid-body)\n"
+       << "  Modes cmp : " << fm.n_matched << " (internal torsional DOFs; no rigid-body modes)\n"
        << "  Temperature: " << std::fixed << std::setprecision(1) << fm.temperature << " K\n"
        << "  Frequency calibration: " << fm.frequency_calibration.status()
        << " (" << fm.frequency_calibration.label
@@ -237,7 +241,7 @@ static void output_flexibility_mode(const FlexibilityMode& fm,
     // ── Top eigenvalue differentials ──
     int n_show = std::min(static_cast<int>(fm.delta_eigenvalues.size()), 20);
     if (n_show > 0) {
-        os << "  Eigenvalue Differentials (lowest " << n_show << " non-rigid modes):\n"
+        os << "  Eigenvalue Differentials (lowest " << n_show << " torsional modes):\n"
            << "  " << std::left
            << std::setw(8)  << "Mode"
            << std::setw(16) << "λ_ref"
@@ -248,7 +252,7 @@ static void output_flexibility_mode(const FlexibilityMode& fm,
            << "  " << std::string(68, '-') << "\n";
 
         for (int i = 0; i < n_show; ++i) {
-            os << "  " << std::left << std::setw(8) << (i + 7) // mode 7+ (after 6 rigid)
+            os << "  " << std::left << std::setw(8) << (i + 1) // 1-based mode index (no rigid-body skip)
                << std::right << std::scientific << std::setprecision(4)
                << std::setw(14) << fm.ref_eigenvalues[i] << "  "
                << std::setw(14) << fm.tgt_eigenvalues[i] << "  "

--- a/tests/test_hardware_dispatch.cpp
+++ b/tests/test_hardware_dispatch.cpp
@@ -774,7 +774,9 @@ TEST(ShannonThermoStackEdge, WideEnergySpread) {
 // --- Torsional vibrational entropy: single valid mode ---
 
 TEST(TorsionalVibEntropyEdge, SingleValidMode) {
-    // 7 modes: first 6 skipped, only mode[6] counted
+    // Internal-coordinate torsional modes are NOT positionally skipped: every
+    // mode above the eigenvalue threshold contributes (no rigid-body zero-mode
+    // manifold in dihedral space).
     std::vector<tencm::NormalMode> modes(7);
     for (int i = 0; i < 7; ++i)
         modes[i].eigenvalue = 1.0;
@@ -782,6 +784,17 @@ TEST(TorsionalVibEntropyEdge, SingleValidMode) {
     double S = compute_torsional_vibrational_entropy(modes, 298.15);
     EXPECT_GT(S, 0.0);
     EXPECT_TRUE(std::isfinite(S));
+
+    // Regression pin for the internal-coordinate fix: with exactly 6 equal modes
+    // the old "skip first 6" logic left the eigenvalue buffer empty and returned
+    // 0. All 6 must now count, and (all equal) S must be exactly 6x a single mode.
+    std::vector<tencm::NormalMode> six(6);
+    for (auto& m : six) m.eigenvalue = 1.0;
+    std::vector<tencm::NormalMode> one(1, tencm::NormalMode{1.0, {}});
+    double S6 = compute_torsional_vibrational_entropy(six, 298.15);
+    double S1 = compute_torsional_vibrational_entropy(one, 298.15);
+    EXPECT_GT(S6, 0.0);
+    EXPECT_NEAR(S6, 6.0 * S1, 1e-9);
 }
 
 // --- Torsional vibrational entropy: mixed valid/invalid modes ---
@@ -794,8 +807,13 @@ TEST(TorsionalVibEntropyEdge, MixedValidInvalidModes) {
 
     double S = compute_torsional_vibrational_entropy(modes, 298.15);
     EXPECT_TRUE(std::isfinite(S));
-    // Only 3 valid modes (indices 7, 9, 11) should contribute
+    // No positional skip: all 6 odd-index modes (1,3,5,7,9,11) contribute; the 6
+    // sub-threshold even-index modes are dropped by the eigenvalue guard. (Under
+    // the old skip-first-6 logic only indices 7,9,11 counted.)
     EXPECT_GT(S, 0.0);
+    std::vector<tencm::NormalMode> one(1, tencm::NormalMode{1.0, {}});
+    double S1 = compute_torsional_vibrational_entropy(one, 298.15);
+    EXPECT_NEAR(S, 6.0 * S1, 1e-9);
 }
 
 // ===========================================================================

--- a/tests/test_hardware_dispatch.cpp
+++ b/tests/test_hardware_dispatch.cpp
@@ -262,14 +262,17 @@ TEST(TorsionalVibEntropy, EmptyModesReturnsZero) {
     EXPECT_DOUBLE_EQ(compute_torsional_vibrational_entropy(empty), 0.0);
 }
 
-TEST(TorsionalVibEntropy, SkipsFirstSixModes) {
-    // First 6 modes (translation+rotation) should be skipped
-    // If we provide exactly 6 modes, result is 0
+TEST(TorsionalVibEntropy, InternalModesAreNotSkipped) {
+    // Internal (torsional) coordinates carry no rigid-body translation/rotation,
+    // so there is no 6-fold zero-mode manifold to skip. With 6 modes above the
+    // eigenvalue threshold, entropy is POSITIVE — previously this incorrectly
+    // returned 0 because the first 6 modes (the softest real torsions) were
+    // positionally skipped.
     std::vector<tencm::NormalMode> modes(6);
     for (int i = 0; i < 6; ++i)
         modes[i].eigenvalue = 1.0;  // non-trivial eigenvalues
 
-    EXPECT_DOUBLE_EQ(compute_torsional_vibrational_entropy(modes), 0.0);
+    EXPECT_GT(compute_torsional_vibrational_entropy(modes, 298.15), 0.0);
 }
 
 TEST(TorsionalVibEntropy, SkipsNearZeroEigenvalues) {
@@ -282,7 +285,7 @@ TEST(TorsionalVibEntropy, SkipsNearZeroEigenvalues) {
 }
 
 TEST(TorsionalVibEntropy, ValidModesProducePositiveEntropy) {
-    // Modes 6+ with reasonable eigenvalues should give S > 0
+    // All modes above the eigenvalue threshold contribute (no positional skip)
     std::vector<tencm::NormalMode> modes(12);
     for (int i = 0; i < 12; ++i)
         modes[i].eigenvalue = 0.5 + 0.1 * i;

--- a/tests/test_tencom_entropy_diff.cpp
+++ b/tests/test_tencom_entropy_diff.cpp
@@ -64,7 +64,7 @@ static encom::VibrationalEntropy tencom_svib(
     double T,
     const encom::FrequencyCalibration& calibration =
         encom::FrequencyCalibration::model_scale(),
-    int skip = 6)
+    int skip = 0)  // internal (torsional) coords have no rigid-body modes to skip
 {
     std::vector<encom::NormalMode> em;
     for (int m = skip; m < static_cast<int>(modes.size()); ++m) {


### PR DESCRIPTION
## Summary

The torsional (tENCoM) Hessian is assembled in **internal (dihedral) coordinates** (`TorsionalENM::build`/`build_from_ca`), which carry no rigid-body translation/rotation and therefore have **no 6-fold zero-mode manifold**. The vibrational-entropy, backbone-sampling, and B-factor paths were nonetheless positionally skipping the first 6 modes as "rigid-body" — discarding the **6 softest real torsions**, which carry the largest per-mode entropy weight and fluctuation amplitude. That systematically under-counts torsional entropy.

The positional skip is correct only for a Cartesian 3N ANM (`build_from_ligand`), and the Cartesian consumers (`ic2cf.cpp`, `ligand_tencom_pose.cpp`) already drop their 6 rigid-body modes by **eigenvalue cutoff**, not by position. This PR makes the internal paths consistent with that convention: keep every mode and let the existing near-zero eigenvalue guard (`λ < ~1e-8`) drop numerically singular modes.

Sites corrected (all internal-coordinate):
- `ShannonThermoStack::compute_torsional_vibrational_entropy` (`m=6` → `m=0`)
- `TorsionalENM::sample` and `::bfactors` (`SKIP=min(6,M)` → `0`)
- standalone `tENCoM` tool `tencom_entropy_diff.cpp` (`skip_rigid`/`SKIP` `6` → `0`, plus output labels and 1-based mode numbering)

> **Stacked on #393.** Based on `fix/orphan-rmsd-crosscheck-header` so C++ CI can configure and run. Retarget to `main` once #393 merges.

## Scope

- [x] Core 1.0 supported surface

## Release impact

- [x] affects benchmark or metric reporting

Changes tENCoM vibrational entropy, B-factor, and backbone-sampling outputs by design (a METHODOLOGY §1 behavior change — parity against a pre-fix baseline will differ intentionally). It does **not** touch core GA docking geometry: `TorsionalENM::sample`'s only caller is the tENCoM benchmark, not the production GA fitness path, so redocked poses on the default path are unaffected.

## Validation

- [x] unit tests

`tests/test_hardware_dispatch.cpp` updated to pin the corrected behavior: with 6 equal modes the old skip returned 0; entropy must now equal exactly 6× a single-mode result, and 6 (not 3) above-threshold modes contribute in the mixed test. Test helper default skip aligned to 0. Local build not possible (container toolchain is g++ 13.3; engine needs GCC ≥ 14) — relying on CI (`test_hardware_dispatch`, `test_tencom_diff`, `test_tencom_entropy_diff`) to validate.

## Security and safety

- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

## Reproducibility

- [x] benchmark language remains preliminary

The absolute tENCoM entropy is already documented as a model-scale heuristic (unchanged); this fix affects which modes enter that heuristic and the ΔS_vib differential.

## Notes

This came out of the codebase review (finding M2). The `encom.cpp` Cartesian ANM path was checked and is already correct (cutoff-based rigid-body removal at `encom.cpp:140`), so it's intentionally not touched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ)_