### PR TITLE
Fix: Set up MSVC via ilammy/msvc-dev-cmd in Windows bindings smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,16 @@ jobs:
           choco install ninja eigen -y
           python -m pip install --upgrade pip
           python -m pip install "pybind11[global]" pytest numpy
+      # Sets up the MSVC toolchain (cl, link, headers) once and exports it to
+      # PATH for all subsequent steps in this job. Replaces the per-step
+      # hardcoded vcvars64.bat calls, whose Enterprise-edition path no longer
+      # resolves on the windows-latest image (cl was never on PATH -> build
+      # failed with "cl is not a full path and was not found in the PATH").
+      - name: Set up MSVC developer environment (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
+        with:
+          arch: x64
       - name: Configure Python bindings (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -314,7 +324,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cmake -S . -B build-python -G Ninja ^
             -DCMAKE_BUILD_TYPE=Release ^
             -DCMAKE_C_COMPILER=cl ^
@@ -332,7 +341,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cmake --build build-python --parallel --target _core
       - name: Run Python binding tests
         env:


### PR DESCRIPTION
## Summary

The `python_bindings_smoke` job's Windows leg failed with `cl is not a full path and was not found in the PATH`. The "Configure Python bindings (Windows)" and "Build Python extension (Windows)" steps each `call`ed a hardcoded `C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat`, which no longer resolves on the current `windows-latest` runner image (the hosted image is not the Enterprise edition at that path), so `cl` was never placed on `PATH`.

This replaces the per-step `vcvars64.bat` calls with the `ilammy/msvc-dev-cmd` action, added once before the Configure step with `if: runner.os == 'Windows'` and `arch: x64`. The action sets up the MSVC developer environment (cl, link, headers) and exports it to `PATH` for all subsequent steps in the job, so the redundant per-step vcvars calls are removed. The Configure/Build steps otherwise keep their `cmake ... -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl ...` invocations and `shell: cmd`.

The action is SHA-pinned to `0b201ec74fa43914dc39ae48a89fd1d8cb592756` (the `v1` tag) per this repo's pinning convention, with a `# v1` trailing comment.

The Windows matrix entry keeps `allow_failure: true` for now — this change cannot be verified green without an actual CI run. Once a run confirms the Windows build passes, the entry can be promoted to blocking (drop `allow_failure`).

## Scope

- [x] CI / release engineering

## Release impact

- [x] no user-facing release impact

## Validation

- [x] manual validation

`.github/workflows/ci.yml` parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`). No `call "...vcvars64.bat"` lines remain. The MSVC build itself can only be validated by a Windows CI run, which is why the leg stays non-blocking.

## Security and safety

- [x] third-party dependency added and documented

Adds the GitHub Action `ilammy/msvc-dev-cmd`, SHA-pinned to a 40-char commit SHA per repo convention. It is a build-environment setup action (MSVC toolchain on PATH), used only in the Windows CI leg.

## Reproducibility

- [x] no benchmark claim involved

## Notes

Only `.github/workflows/ci.yml` is touched; `scripts/check_licenses.py` and `coverage.yml` are intentionally left to a separate PR. The pinned SHA `0b201ec74fa43914dc39ae48a89fd1d8cb592756` was resolved via `git ls-remote --tags https://github.com/ilammy/msvc-dev-cmd.git v1` (a lightweight tag pointing directly at the commit — no peeled `v1^{}` ref exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ)_