### PR TITLE
Fix: Repair Code Coverage CI; flag genuine Tier-1 benchmark regression

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,15 @@ jobs:
     name: Coverage Analysis (Linux/Clang)
     runs-on: ubuntu-latest
 
+    # Least-privilege grant. `pull-requests: write` is what the final
+    # "Comment PR with coverage" step needs to call issues.createComment; without
+    # any permissions block the default GITHUB_TOKEN for pull_request events is
+    # read-only, so that POST returned "403 Resource not accessible by
+    # integration" and (being an unhandled rejection) failed the whole job.
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
@@ -61,10 +70,21 @@ jobs:
             GCOV_TOOL=/tmp/llvm-gcov.sh
           fi
 
-          # Broad ignore set: clang+llvm-gcov routinely emits inconsistent
-          # function-end / line mismatches (e.g. ShannonThermoStack.h dtors).
-          LCOV_IGNORE=mismatch,unused,negative,gcov,version,inconsistent,empty,corrupt,category,format,path,count,parallel,unsupported
+          # Ignore only categories the installed lcov actually knows. lcov 2.x
+          # (ubuntu-latest) hard-errors on an unknown --ignore-errors token —
+          # "lcov: ERROR: unknown argument for --ignore-errors: 'category'",
+          # exit 255 — which is what aborted the `lcov --extract` below, left
+          # core.info uncreated, and made the whole percentage undefined. The
+          # tokens kept here are the ones this lcov accepted in the failing run
+          # (proven from its log) and cover the clang+llvm-gcov noise we see
+          # (inconsistent/mismatch/unused/empty). Bogus tokens dropped:
+          # category, format, path, count, parallel, unsupported.
+          LCOV_IGNORE=mismatch,unused,negative,gcov,version,inconsistent,empty,corrupt
 
+          # Do not let an lcov hiccup abort the job. A genuinely unusable
+          # measurement is reported as "unavailable" (a ::warning::) by the
+          # Calculate step below, never as a hard failure — but a REAL measured
+          # coverage under threshold still fails there.
           lcov --directory . \
                --capture \
                --output-file coverage/coverage.info \
@@ -73,31 +93,72 @@ jobs:
                --exclude '*/_deps/*' \
                --exclude '*/tests/*' \
                --exclude '*/python/*' \
-               --exclude '*/benchmarks/*'
+               --exclude '*/benchmarks/*' \
+            || echo "::warning::lcov --capture reported errors; downstream steps will treat coverage as best-effort."
 
           lcov --extract coverage/coverage.info '*/LIB/*' \
                --output-file coverage/core.info \
-               --ignore-errors "$LCOV_IGNORE"
+               --ignore-errors "$LCOV_IGNORE" \
+            || echo "::warning::lcov --extract reported errors; core.info may be incomplete."
 
           genhtml coverage/core.info \
                   --output-directory coverage/html \
                   --title "FlexAIDdS Code Coverage" \
-                  --ignore-errors source,unmapped,inconsistent,empty
+                  --ignore-errors source,unmapped,inconsistent,empty \
+            || echo "::warning::genhtml reported errors; the HTML report may be partial."
 
       - name: Calculate coverage percentage
+        # always() so a resilient "unavailable" result is still reported even if
+        # an earlier step degraded; a REAL measured value under threshold still
+        # exits non-zero here and fails the job.
+        if: always()
         run: |
-          cd build/coverage
-          COVERAGE=$(lcov --summary core.info 2>&1 | grep "lines" | awk '{print $4}' | sed 's/%//')
-          echo "COVERAGE=${COVERAGE}" >> $GITHUB_ENV
-          echo "### Code Coverage: ${COVERAGE}%" >> $GITHUB_STEP_SUMMARY
-
+          set -uo pipefail
+          INFO=build/coverage/core.info
           THRESHOLD=50
-          if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
+
+          emit_unavailable() {
+            echo "::warning::$1"
+            echo "COVERAGE=unavailable" >> "$GITHUB_ENV"
+            echo "### Code Coverage: unavailable" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
+
+          [ -s "$INFO" ] || emit_unavailable "Coverage tracefile $INFO is missing or empty — coverage measurement unavailable this run."
+
+          # Derive line coverage directly from the tracefile's LH/LF records
+          # (lines-hit / lines-found summed over all files). This is independent
+          # of the installed lcov's --summary output format: lcov 2.x prints
+          # "lines.......: NN.N% (h of f lines)", so the old `awk '{print $4}'`
+          # grabbed the word "of", yielding an empty COVERAGE and the
+          # "undefined%" report plus a `bc` crash. LH/LF is version-proof.
+          COVERAGE=$(awk -F: '
+            /^LF:/ { f += $2 }
+            /^LH:/ { h += $2 }
+            END { if (f > 0) printf "%.1f", (h / f) * 100 }
+          ' "$INFO")
+
+          # Fallback: if for any reason the tracefile carried no LF/LH records,
+          # parse the first percentage lcov --summary prints, robustly.
+          if [ -z "$COVERAGE" ]; then
+            COVERAGE=$(lcov --summary "$INFO" 2>&1 \
+                       | grep -iE 'lines' \
+                       | grep -oE '[0-9]+(\.[0-9]+)?%' \
+                       | head -1 | tr -d '%')
+          fi
+
+          [ -n "$COVERAGE" ] || emit_unavailable "Could not derive a line-coverage percentage from $INFO — reporting unavailable."
+
+          echo "COVERAGE=${COVERAGE}" >> "$GITHUB_ENV"
+          echo "### Code Coverage: ${COVERAGE}%" >> "$GITHUB_STEP_SUMMARY"
+
+          # awk comparison, not bc: bc is not guaranteed present and crashes on
+          # an empty operand. A real measured value below threshold fails.
+          if awk -v c="$COVERAGE" -v t="$THRESHOLD" 'BEGIN { exit !(c < t) }'; then
             echo "Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
             exit 1
-          else
-            echo "Coverage ${COVERAGE}% meets threshold ${THRESHOLD}%"
           fi
+          echo "Coverage ${COVERAGE}% meets threshold ${THRESHOLD}%"
 
       - name: Upload coverage artifacts
         if: always()
@@ -112,20 +173,33 @@ jobs:
         with:
           script: |
             const coverage = process.env.COVERAGE;
+            const available =
+              coverage !== undefined && coverage !== '' && coverage !== 'unavailable';
             const pct = Number(coverage);
-            const pass = Number.isFinite(pct) && pct >= 50;
+            const pass = available && Number.isFinite(pct) && pct >= 50;
+            const coverageText = available
+              ? `${coverage}%`
+              : 'unavailable (measurement could not be produced this run)';
+            const status = !available ? 'UNAVAILABLE' : pass ? 'PASS' : 'FAIL';
             const lines = [
               '## Code Coverage Report',
               '',
-              `Core coverage: ${coverage}%`,
+              `Core coverage: ${coverageText}`,
               'Target: >= 50%',
-              `Status: ${pass ? 'PASS' : 'FAIL'}`,
+              `Status: ${status}`,
               '',
               'Generated by Code Coverage workflow',
             ];
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: lines.join('\n'),
-            });
+            // Posting the comment is informational: wrap it so a post failure
+            // (e.g. a 403 on a fork PR where the token is read-only) can never
+            // fail the job.
+            try {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: lines.join('\n'),
+              });
+            } catch (error) {
+              core.warning(`Could not post coverage comment: ${error.message}`);
+            }


### PR DESCRIPTION
## Summary

Two CI jobs fail on every PR to `main`. This PR **fixes** the Code Coverage job (a real CI/config bug) and, after reading the actual job logs, **flags** the Tier-1 benchmark failure as a *genuine below-threshold docking result* rather than masking it. Only `.github/workflows/coverage.yml` is changed; `benchmark-tier1.yml` is intentionally left untouched.

### Job A — "Coverage Analysis (Linux/Clang)" — FIXED

Two independent root causes, both confirmed from the failing run (run `31052482220`, job `92462598629`):

**1. lcov 2.x rejects an invalid `--ignore-errors` token → the whole measurement collapses.** Quoting the log:

```
Finished .info-file creation
lcov: ERROR: unknown argument for --ignore-errors: 'category'
##[error]Process completed with exit code 255.
```

`LCOV_IGNORE` contained `...,corrupt,category,format,path,count,parallel,unsupported`. The installed lcov (2.x on `ubuntu-latest`) accepts the tokens up to `corrupt` but hard-errors (exit 255) on `category`. That aborted the `lcov --extract` in "Generate coverage report", so `core.info`/HTML were never produced (`No files were found with the provided path: build/coverage/html`), the "Calculate coverage percentage" step was **skipped** (never setting `COVERAGE`), and the comment reported `Core coverage: undefined%`.

Note the old measurement was *also* version-fragile independent of this: lcov 2.x prints `lines.......: NN.N% (h of f lines)`, so `lcov --summary | grep lines | awk '{print $4}'` grabbed the word `of`, not the percentage.

**2. No `permissions:` block → 403 on the PR comment.** Quoting the log:

```
POST /repos/LeBonhommePharma/FlexAIDdS/issues/393/comments - 403 ...
##[error]Unhandled error: HttpError: Resource not accessible by integration
  'x-accepted-github-permissions': 'issues=write; pull_requests=write'
```

The default `pull_request` `GITHUB_TOKEN` is read-only; the unhandled rejection failed the job.

**Changes:**
- Added job-level `permissions: { contents: read, pull-requests: write }`.
- Trimmed `LCOV_IGNORE` to the tokens this lcov accepts (`mismatch,unused,negative,gcov,version,inconsistent,empty,corrupt`) — dropping `category,format,path,count,parallel,unsupported`; the kept set covers the actual clang+llvm-gcov noise (inconsistent/mismatch/unused/empty). The `lcov`/`genhtml` calls are now best-effort (`|| echo "::warning::..."`) so a hiccup can't abort the job.
- Rewrote "Calculate coverage percentage": derive line coverage directly from the tracefile's `LH`/`LF` records (version-proof), fall back to a robust `grep -oE '[0-9]+(\.[0-9]+)?%'` parse of `lcov --summary`, replace `bc` with an `awk` comparison, and emit `::warning::` + "unavailable" (exit 0) when no measurement can be made — **a real measured value below the 50% threshold still fails.**
- Made "Comment PR with coverage" `await` inside `try/catch` (post failure only warns) and handle the "unavailable" case in the message.

Validated locally: `python3 -c "import yaml; yaml.safe_load(...)"` passes; the `LH/LF` awk yields `60.0` for 6/10; the threshold awk fails below-50 and passes at/above-50; the summary-regex fallback extracts `42.3` from the lcov-2.x line that the old parser mis-read.

### Job B — "Tier-1 Benchmark (astex_diverse)" — GENUINE FAILURE, FLAGGED (not a config bug)

Read from run `31052481958`, job `92462597912`. The build succeeded, the binary was verified, and the engine **actually docked** for ~27 min:

```
Entry 1gpk/holo: 10 poses in 1056.7s
Entry 1mq6/holo: 10 poses in 1614.0s
REGRESSION DETECTED — one or more metrics dropped below baseline.

| docking_power_top1 | 0.0000 | Baseline 0.700 | Published 0.452 | ⚠ YES |
| docking_power_top3 | 0.0000 | Baseline 0.850 |                 | ⚠ YES |
| entropy_rescue_rate| 0.0000 | Baseline 0.300 |                 | ⚠ YES |
| mean_rmsd          | 6.9195 | Baseline 2.300 |                 | ⚠ YES |
| median_rmsd        | 6.9195 | Baseline 1.950 |                 | ⚠ YES |
##[error]Process completed with exit code 1.
```

This is **not** a CI/environment/path/binary problem. The engine ran and produced a real result: on both `1gpk` and `1mq6` the top pose lands **~6.9 Å** from the crystal ligand (baseline `mean_rmsd` 2.3 Å), and `docking_power_top1 = 0.0` (no target reproduced within the ~2 Å success cutoff at rank 1). The regression gate in `benchmarks/run.py` against `expected_baselines` (`benchmarks/datasets/astex_diverse.yaml`: `docking_power_top1: 0.70`, `mean_rmsd: 2.30`, `median_rmsd: 1.95`) is behaving **exactly as designed** — it caught a real quality drop and returned non-zero. The failure is identical across branches (e.g. run `31051953794`), confirming a stable, deterministic engine result rather than flakiness or a gate misfire.

Per the reproducibility rules, I did **not** weaken or mask the gate. `benchmark-tier1.yml` is unchanged.

**Recommendation for the maintainer:** investigate this as a docking-quality regression, not a workflow bug. Concretely:
- Pull the uploaded `tier1-results-astex_diverse-31052481958` artifact (poses are kept via `FLEXAIDDS_KEEP_POSES=1`) and inspect the top poses for `1gpk`/`1mq6`. A ~6.9 Å RMSD with 10 valid poses is consistent with the search exploring the wrong region (binding-site/cleft definition or reference-ligand/RMSD-target mismatch in the CI data layout) or a scoring/GA regression.
- Confirm the CI run truly reproduces the intended binding site (both targets at ~identical 6.9195 Å is worth a look — with only 2 targets, mean == median, but verify the site restraint is applied). If the site/reference is mis-wired for these two entries specifically, that would be a data/config fix in `benchmarks/`; if the site is correct, this is a real engine regression to bisect against the last known-good `docking_power_top1`.
- Either way it needs a scientific decision (bisect the engine vs. correct the CI target data), not a green-washing of the gate.

## Scope

- [x] CI / release engineering

## Release impact

- [x] no user-facing release impact

## Validation

- [x] manual validation

`coverage.yml` and `benchmark-tier1.yml` both parse with `yaml.safe_load`. The coverage measurement/threshold/parse logic was exercised locally with representative lcov 2.x inputs (see Summary). The Tier-1 diagnosis is read directly from the failing job logs; no workflow change was made there.

## Security and safety

- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

The added coverage permissions are least-privilege (`contents: read`, `pull-requests: write`).

## Reproducibility

- [x] no benchmark claim involved

No benchmark threshold was changed. The Tier-1 gate is left intact so the genuine regression stays visible.

## Notes

- Files changed: `.github/workflows/coverage.yml` only.
- Deliberately **not** touched: `benchmark-tier1.yml` (the failure it reports is real), and `ci.yml` / `scripts/check_licenses.py` / `license-scan.yml` (owned by other PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ)_