### PR TITLE
Fix: gitignore the benchmark output dirs the documented runs actually use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,12 @@ env/
 # Local benchmark / experiment workspaces (not for commit)
 benchmarks/astex_entropy/
 benchmarks/results/
-results/local/
+# Benchmark output. Was `results/local/`, which missed the paths the repo's own
+# documented runs actually use: benchmark-tier1.yml writes RESULTS_DIR=results/tier1
+# and benchmark-tier2.yml writes results/tier2, so running either locally left an
+# untracked tree. Nothing under results/ is tracked; it is all regenerable engine
+# output (pose PDBs, per-entry JSON, reports).
+results/
 wrk/
 /BIN/
 


### PR DESCRIPTION
## Summary

`.gitignore` covered `results/local/`, but the repo's own documented benchmark runs write elsewhere:

- `benchmark-tier1.yml` → `RESULTS_DIR: results/tier1`
- `benchmark-tier2.yml` → `RESULTS_DIR: results/tier2`

So running either benchmark locally — exactly as CI does — leaves an untracked working tree full of engine output (pose PDBs, per-entry JSON, reports). That is an invitation for benchmark artifacts to be swept into an unrelated commit, which `AGENTS.md` / `CLAUDE.md` explicitly forbid.

Broadens the pattern to `results/`.

## Scope

- [x] Repository hygiene

## Release impact

- [x] no user-facing release impact

## Validation

- [x] manual validation

- `git ls-files results/` returns **0** — this newly ignores nothing that is tracked; all of it is regenerable engine output.
- The 112 tracked files that match ignore patterns all sit under pre-existing `benchmarks/` patterns (`benchmarks/astex_entropy/`, `benchmarks/results/`) and are unaffected by this change.
- With the change applied, `git status --porcelain` is clean after a full local Tier-1 run.

## Security and safety

- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

## Reproducibility

- [x] no benchmark claim involved

No benchmark threshold, metric, or output location changes — only whether git tracks the output.

## Notes

Found while running the Tier-1 gate locally to measure per-entry RMSDs for #398. If retaining benchmark output is ever wanted, the right mechanism is the existing artifact upload in the workflows, not the git tree.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored files configuration to exclude all benchmark results from version control.
  * Added documented rules for tiered benchmark output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->