### PR TITLE
Add: seeded-random Tier-1 target selection so gate coverage rotates

### DIFF
--- a/benchmarks/datasets/astex_diverse.yaml
+++ b/benchmarks/datasets/astex_diverse.yaml
@@ -33,12 +33,22 @@ download_url: "https://www.ccdc.cam.ac.uk/community/freeprod/astex-diverse-set/"
 data_format: pdb
 tier: 2
 tier1_subset_size: 2
+# Tier-1 samples a RANDOM subset of `tier1_subset_size` targets rather than always
+# the first N, so coverage rotates instead of leaving 83 of the 85 codes untested.
+# The draw is seeded and logged: re-run with FLEXAIDDS_TIER1_SEED=<logged seed> to
+# reproduce a draw exactly. Seed precedence: FLEXAIDDS_TIER1_SEED > tier1_seed >
+# UTC date (YYYYMMDD), so the set rotates daily but is stable within a run.
+#
+# CONSEQUENCE: metrics below are target-dependent, so two runs with DIFFERENT
+# seeds are not comparable to each other and a regression flag from a fresh draw
+# is not evidence on its own. Compare only runs reporting the same seed.
+tier1_selection: random
 
 structural_states:
   - holo
 
 # Parity with LIB/DatasetRunner.cpp::astex_diverse_codes() (85 PDB IDs).
-# Tier-1 CI uses the first tier1_subset_size entries (confirmed on disk).
+# Tier-1 CI uses tier1_subset_size entries drawn per tier1_selection above.
 targets:
   - 1gpk
   - 1mq6

--- a/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
+++ b/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
@@ -33,12 +33,22 @@ download_url: "https://www.ccdc.cam.ac.uk/community/freeprod/astex-diverse-set/"
 data_format: pdb
 tier: 2
 tier1_subset_size: 2
+# Tier-1 samples a RANDOM subset of `tier1_subset_size` targets rather than always
+# the first N, so coverage rotates instead of leaving 83 of the 85 codes untested.
+# The draw is seeded and logged: re-run with FLEXAIDDS_TIER1_SEED=<logged seed> to
+# reproduce a draw exactly. Seed precedence: FLEXAIDDS_TIER1_SEED > tier1_seed >
+# UTC date (YYYYMMDD), so the set rotates daily but is stable within a run.
+#
+# CONSEQUENCE: metrics below are target-dependent, so two runs with DIFFERENT
+# seeds are not comparable to each other and a regression flag from a fresh draw
+# is not evidence on its own. Compare only runs reporting the same seed.
+tier1_selection: random
 
 structural_states:
   - holo
 
 # Parity with LIB/DatasetRunner.cpp::astex_diverse_codes() (85 PDB IDs).
-# Tier-1 CI uses the first tier1_subset_size entries (confirmed on disk).
+# Tier-1 CI uses tier1_subset_size entries drawn per tier1_selection above.
 targets:
   - 1gpk
   - 1mq6

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -39,6 +39,7 @@ import json
 import csv
 import logging
 import os
+import random
 import re
 import shutil
 import socket
@@ -157,6 +158,10 @@ class DatasetConfig:
         download_url:          Alternative download URL.
         tier:                  Minimum tier required to run the full dataset (1 or 2).
         tier1_subset_size:     Number of targets to use for tier-1 (PR sanity) runs.
+        tier1_selection:       ``fixed`` (first N targets) or ``random`` (seeded
+                               sample of N, so coverage rotates across runs).
+        tier1_seed:            Explicit seed for ``random`` selection. Overridden by
+                               ``FLEXAIDDS_TIER1_SEED``; defaults to the UTC date.
         benchmark_order:       Stable run/display order; lower values run first.
         targets:               Full list of target identifiers.
         structural_states:     Receptor states available (``holo``, ``apo``, ``af2``).
@@ -179,6 +184,8 @@ class DatasetConfig:
     download_url: str = ""
     tier: int = 2
     tier1_subset_size: int = 5
+    tier1_selection: str = "fixed"
+    tier1_seed: Optional[int] = None
     benchmark_order: int = 1000
     targets: List[str] = field(default_factory=list)
     structural_states: List[str] = field(default_factory=lambda: ["holo"])
@@ -250,6 +257,8 @@ class DatasetConfig:
             download_url=raw.pop("download_url", ""),
             tier=int(raw.pop("tier", 2)),
             tier1_subset_size=int(raw.pop("tier1_subset_size", 5)),
+            tier1_selection=str(raw.pop("tier1_selection", "fixed")).strip().lower(),
+            tier1_seed=(lambda v: None if v is None else int(v))(raw.pop("tier1_seed", None)),
             benchmark_order=int(raw.pop("benchmark_order", 1000)),
             targets=list(raw.pop("targets", [])),
             structural_states=list(raw.pop("structural_states", ["holo"])),
@@ -273,9 +282,65 @@ class DatasetConfig:
             config.data_dir = Path(data_dir_raw).expanduser().resolve()
         return config
 
+    def resolve_tier1_seed(self) -> int:
+        """Resolve the RNG seed used by ``tier1_selection: random``.
+
+        Precedence: ``FLEXAIDDS_TIER1_SEED`` env > yaml ``tier1_seed`` > the UTC
+        date as ``YYYYMMDD``.  The date default rotates the sampled targets daily
+        while keeping every run within a day identical; any run is replayable
+        exactly by exporting the seed recorded in its log.
+
+        A non-integer env value is an error rather than a silent fallback: a
+        mistyped seed must not quietly produce a different draw than intended.
+        """
+        env = os.environ.get("FLEXAIDDS_TIER1_SEED", "").strip()
+        if env:
+            try:
+                return int(env)
+            except ValueError as exc:
+                raise ValueError(
+                    f"FLEXAIDDS_TIER1_SEED must be an integer, got {env!r}"
+                ) from exc
+        if self.tier1_seed is not None:
+            return int(self.tier1_seed)
+        return int(datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d"))
+
     def tier1_targets(self) -> List[str]:
-        """Return the subset of targets used for tier-1 (fast) runs."""
-        return self.targets[: self.tier1_subset_size]
+        """Return the subset of targets used for tier-1 (fast) runs.
+
+        ``tier1_selection: fixed`` (default) takes the first N targets.  Stable,
+        but every target after the Nth is then never exercised -- on astex_diverse
+        that left 83 of 85 codes untested by the gate.
+
+        ``tier1_selection: random`` samples N targets without replacement from a
+        seeded RNG, so coverage rotates across runs while a single run stays
+        exactly reproducible.  The seed is logged; re-run with
+        ``FLEXAIDDS_TIER1_SEED=<logged seed>`` to reproduce a draw.
+
+        COMPARABILITY WARNING: under ``random`` the sampled set differs between
+        runs, so target-dependent aggregates (``mean_rmsd``, ``docking_power_*``)
+        are NOT comparable run-to-run and must not be diffed against a baseline
+        calibrated on a different draw.  Only compare runs reporting the same seed.
+        """
+        k = max(0, min(int(self.tier1_subset_size), len(self.targets)))
+        mode = (self.tier1_selection or "fixed").strip().lower()
+        if mode == "fixed":
+            return self.targets[:k]
+        if mode != "random":
+            raise ValueError(
+                "tier1_selection must be 'fixed' or 'random', got "
+                f"{self.tier1_selection!r}"
+            )
+        seed = self.resolve_tier1_seed()
+        picked = random.Random(seed).sample(list(self.targets), k)
+        # Restore dataset order within the draw so run/display order is stable.
+        picked.sort(key=self.targets.index)
+        logger.info(
+            "tier-1 random subset: seed=%d k=%d targets=%s "
+            "(replay this exact draw with FLEXAIDDS_TIER1_SEED=%d)",
+            seed, k, ",".join(picked), seed,
+        )
+        return picked
 
     def _uses_crossdock_catalog(self, tier: int) -> bool:
         """Full-N crossdock catalog applies only when YAML requests crossdock state."""

--- a/python/tests/test_tier1_random_subset.py
+++ b/python/tests/test_tier1_random_subset.py
@@ -1,0 +1,112 @@
+"""Tier-1 target selection: fixed vs seeded-random.
+
+The gate used to take ``targets[:N]`` unconditionally, so on astex_diverse only
+1gpk/1mq6 were ever exercised and the other 83 codes were never docked.
+``tier1_selection: random`` rotates the draw while keeping any single run exactly
+reproducible from its logged seed.
+
+These tests pin both halves of that contract: the rotation (different seeds give
+different draws) and, more importantly, the reproducibility (same seed always
+gives the same draw) -- a random gate that cannot be replayed would make every
+failure un-investigable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from flexaidds.dataset_runner.runner import DatasetConfig
+
+CODES = [f"t{i:03d}" for i in range(85)]
+
+
+def _cfg(**kw) -> DatasetConfig:
+    base = dict(slug="s", name="n", description="d", targets=list(CODES),
+                tier1_subset_size=2)
+    base.update(kw)
+    return DatasetConfig(**base)
+
+
+def test_fixed_selection_is_unchanged_default():
+    """Default stays first-N so existing datasets keep their behaviour."""
+    cfg = _cfg()
+    assert cfg.tier1_selection == "fixed"
+    assert cfg.tier1_targets() == CODES[:2]
+
+
+def test_random_selection_is_reproducible_for_a_seed(monkeypatch):
+    monkeypatch.delenv("FLEXAIDDS_TIER1_SEED", raising=False)
+    cfg = _cfg(tier1_selection="random", tier1_seed=12345)
+    first = cfg.tier1_targets()
+    # Repeated calls inside one run must not redraw -- callers invoke this more
+    # than once (runner.py and benchmarks/nextgen/runner.py both do).
+    assert cfg.tier1_targets() == first
+    assert _cfg(tier1_selection="random", tier1_seed=12345).tier1_targets() == first
+
+
+def test_random_selection_rotates_across_seeds(monkeypatch):
+    """The whole point: the draw must not be constant across seeds."""
+    monkeypatch.delenv("FLEXAIDDS_TIER1_SEED", raising=False)
+    draws = {
+        tuple(_cfg(tier1_selection="random", tier1_seed=s).tier1_targets())
+        for s in range(40)
+    }
+    assert len(draws) > 1, "seeded sampling produced a constant subset"
+
+
+def test_random_draw_is_valid_subset(monkeypatch):
+    monkeypatch.delenv("FLEXAIDDS_TIER1_SEED", raising=False)
+    for s in range(25):
+        got = _cfg(tier1_selection="random", tier1_seed=s, tier1_subset_size=5).tier1_targets()
+        assert len(got) == 5
+        assert len(set(got)) == 5, "sampled with replacement"
+        assert set(got) <= set(CODES)
+        # dataset order preserved within the draw, so run order is stable
+        assert got == sorted(got, key=CODES.index)
+
+
+def test_env_seed_overrides_yaml_seed(monkeypatch):
+    monkeypatch.setenv("FLEXAIDDS_TIER1_SEED", "999")
+    from_env = _cfg(tier1_selection="random", tier1_seed=1).tier1_targets()
+    monkeypatch.delenv("FLEXAIDDS_TIER1_SEED")
+    assert from_env == _cfg(tier1_selection="random", tier1_seed=999).tier1_targets()
+
+
+def test_bad_env_seed_fails_loudly(monkeypatch):
+    """A mistyped seed must not silently fall back to a different draw."""
+    monkeypatch.setenv("FLEXAIDDS_TIER1_SEED", "not-a-number")
+    with pytest.raises(ValueError, match="FLEXAIDDS_TIER1_SEED"):
+        _cfg(tier1_selection="random").tier1_targets()
+
+
+def test_unknown_selection_mode_rejected(monkeypatch):
+    monkeypatch.delenv("FLEXAIDDS_TIER1_SEED", raising=False)
+    with pytest.raises(ValueError, match="tier1_selection"):
+        _cfg(tier1_selection="shuffle").tier1_targets()
+
+
+def test_subset_larger_than_target_list_is_clamped(monkeypatch):
+    monkeypatch.delenv("FLEXAIDDS_TIER1_SEED", raising=False)
+    cfg = _cfg(tier1_selection="random", tier1_seed=7, tier1_subset_size=500)
+    assert len(cfg.tier1_targets()) == len(CODES)
+
+
+def test_astex_diverse_yaml_uses_random_selection():
+    """Both on-disk copies of the dataset must agree (they have drifted before)."""
+    import pathlib
+
+    import yaml
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    copies = [
+        root / "benchmarks/datasets/astex_diverse.yaml",
+        root / "python/flexaidds/dataset_runner/datasets/astex_diverse.yaml",
+    ]
+    seen = []
+    for p in copies:
+        if not p.exists():
+            pytest.skip(f"{p} not present")
+        d = yaml.safe_load(p.read_text())
+        seen.append((d.get("tier1_selection"), d.get("tier1_subset_size")))
+    assert seen[0] == ("random", 2)
+    assert seen[0] == seen[1], f"astex_diverse copies disagree: {seen}"


### PR DESCRIPTION
## Summary

`DatasetConfig.tier1_targets()` returned `targets[:N]` unconditionally, so the astex_diverse Tier-1 gate always docked **1gpk** and **1mq6** — the other **83 of 85** codes were never exercised. A gate that only ever sees the same two targets cannot detect a change that affects the rest of the set.

Adds `tier1_selection: fixed|random`:

- **`fixed`** (default) — first N, i.e. current behaviour. Every other dataset is unchanged.
- **`random`** — seeded sample without replacement, enabled for `astex_diverse`. The draw rotates across runs while any single run stays exactly reproducible.

**Seed precedence:** `FLEXAIDDS_TIER1_SEED` > yaml `tier1_seed` > UTC date (`YYYYMMDD`). The date default rotates the set daily and keeps a run stable within the day. The resolved seed and drawn codes are logged:

```
tier-1 random subset: seed=20260806 k=2 targets=1q1g,1sq5 (replay this exact draw with FLEXAIDDS_TIER1_SEED=20260806)
```

A non-integer env seed **raises** rather than silently falling back to a different draw — a mistyped seed must not quietly change what was tested.

Verified on the real dataset:

| seed | drawn |
|---|---|
| 20260806 | `1q1g`, `1sq5` |
| 20260807 | `1t9b`, `1s19` |
| 20260808 | `1yv3`, `2gbp` |
| 20260806 (replay) | `1q1g`, `1sq5` ✓ |

## ⚠️ Comparability consequence (documented in the docstring and both YAMLs)

Under `random` the sampled set differs between runs, so `mean_rmsd` and `docking_power_*` are **target-dependent and NOT comparable run-to-run**. A regression flag from a fresh draw is not evidence on its own — **only runs reporting the same seed may be compared**.

This is a deliberate trade: the gate gains coverage and loses cross-run aggregate comparability. Given #398 established that these baselines were never validated on this path and the gate fails at `docking_power_top1 = 0.0` on every draw regardless, the comparability that is lost was not currently load-bearing. Flagging it explicitly so the trade is a decision, not a side effect.

## Scope

- [x] Core 1.0 supported surface
- [x] CI / release engineering

## Release impact

- [x] affects benchmark or metric reporting

Changes which targets the Tier-1 gate docks. Default `fixed` keeps every other dataset byte-identical; only `astex_diverse` opts in.

## Validation

- [x] unit tests

**9 new cases** in `python/tests/test_tier1_random_subset.py`: reproducibility for a seed (including repeated calls within one run — both `runner.py` and `benchmarks/nextgen/runner.py` invoke it more than once), rotation across seeds, valid subset / no replacement, dataset-order stability, env-overrides-yaml, fail-loud on a bad seed, unknown-mode rejection, and clamping when `N > len(targets)`.

Locally: `9 passed` for the new file; **340 passed, 1 skipped** across the dataset-runner and CI pure-Python suites; `validate-dataset-semantics` → `VALIDATION PASSED`.

## Security and safety

- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

## Reproducibility

- [x] benchmark language remains preliminary

Randomised **but replayable** — this does not make runs unreproducible; it makes them reproducible *from a recorded seed* instead of implicitly. The seed is emitted on every run.

## Notes

Both on-disk copies of `astex_diverse.yaml` (`benchmarks/datasets/` and `python/flexaidds/dataset_runner/datasets/`) are updated together — they have drifted before — and a test asserts they agree.

Follow-up worth considering separately: persist the resolved seed into the results artifact / PR comment as well as the log, so a draw is recoverable from the artifact alone rather than from CI log retention.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tier-1 benchmark targets can now be selected using a seeded random subset.
  * Selection is reproducible and records the seed and chosen targets for comparison.
  * Seeds can be provided through the environment, configuration, or an automatic UTC-date fallback.

* **Bug Fixes**
  * Prevented duplicate selections and safely limits subsets when fewer targets are available.
  * Invalid selection modes and malformed seeds now produce clear errors.

* **Configuration**
  * Astex Diverse now uses randomized Tier-1 selection by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->