### PR TITLE
Add: anchor targets + CI-budget-sized Tier-1/Tier-2 subsets

### DIFF
--- a/benchmarks/datasets/astex_diverse.yaml
+++ b/benchmarks/datasets/astex_diverse.yaml
@@ -32,7 +32,16 @@ zenodo_doi: ""
 download_url: "https://www.ccdc.cam.ac.uk/community/freeprod/astex-diverse-set/"
 data_format: pdb
 tier: 2
-tier1_subset_size: 2
+# CI TIME BUDGET (measured, not guessed). Worst per-target docking wall time on a
+# 4-core ubuntu-latest runner at --omp-threads 1 is 1614 s = 26.9 min (Tier-1 run
+# 31052481958: 1gpk 1056.7 s, 1mq6 1614.0 s). Targets run in batches of `workers`,
+# so wall ~= ceil(n / workers) * 26.9 min.
+#
+# Tier-1 uses workers = min(nproc, 5) = 4 and its docking step is capped at 105 min:
+#   n=2 -> 26.9 min   n=4 -> 26.9 min   n=8 -> 53.8 min   n=16 -> 107.6 min (OVER)
+# n=4 costs the SAME wall as n=2 (both are one batch of 4) while doubling coverage,
+# so 4 is the free-coverage point. Raising it further does cost real minutes.
+tier1_subset_size: 4
 # Tier-1 samples a RANDOM subset of `tier1_subset_size` targets rather than always
 # the first N, so coverage rotates instead of leaving 83 of the 85 codes untested.
 # The draw is seeded and logged: re-run with FLEXAIDDS_TIER1_SEED=<logged seed> to
@@ -43,6 +52,14 @@ tier1_subset_size: 2
 # seeds are not comparable to each other and a regression flag from a fresh draw
 # is not evidence on its own. Compare only runs reporting the same seed.
 tier1_selection: random
+
+# Tier-2 (weekly, job cap 360 min, N_WORKERS=4, and it runs EVERY dataset in one
+# job). The full 85 targets would need ceil(85/4)*26.9 = 592 min -- over the cap on
+# this dataset alone, before the other 13 datasets get any time at all. 12 targets
+# is ceil(12/4)*26.9 = 80.7 min, ~22% of the budget, leaving room for the rest.
+# Random selection means the full 85 are still covered, in ~7 weekly runs.
+tier2_subset_size: 12
+tier2_selection: random
 
 structural_states:
   - holo

--- a/benchmarks/datasets/astex_diverse.yaml
+++ b/benchmarks/datasets/astex_diverse.yaml
@@ -53,6 +53,17 @@ tier1_subset_size: 4
 # is not evidence on its own. Compare only runs reporting the same seed.
 tier1_selection: random
 
+# Anchor targets: pinned into EVERY draw, so a fixed core of each run stays
+# directly comparable run-to-run while the remaining slots rotate for coverage.
+# 1gpk and 1mq6 are the historical pair (every Tier-1 run before #400 used exactly
+# these two), so their numbers are the ones with prior art to compare against.
+# Metrics restricted to the anchors are comparable across runs; metrics over the
+# full draw are NOT -- see the comparability note above.
+anchor_targets:
+  - 1gpk
+  - 1mq6
+
+
 # Tier-2 (weekly, job cap 360 min, N_WORKERS=4, and it runs EVERY dataset in one
 # job). The full 85 targets would need ceil(85/4)*26.9 = 592 min -- over the cap on
 # this dataset alone, before the other 13 datasets get any time at all. 12 targets

--- a/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
+++ b/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
@@ -32,7 +32,16 @@ zenodo_doi: ""
 download_url: "https://www.ccdc.cam.ac.uk/community/freeprod/astex-diverse-set/"
 data_format: pdb
 tier: 2
-tier1_subset_size: 2
+# CI TIME BUDGET (measured, not guessed). Worst per-target docking wall time on a
+# 4-core ubuntu-latest runner at --omp-threads 1 is 1614 s = 26.9 min (Tier-1 run
+# 31052481958: 1gpk 1056.7 s, 1mq6 1614.0 s). Targets run in batches of `workers`,
+# so wall ~= ceil(n / workers) * 26.9 min.
+#
+# Tier-1 uses workers = min(nproc, 5) = 4 and its docking step is capped at 105 min:
+#   n=2 -> 26.9 min   n=4 -> 26.9 min   n=8 -> 53.8 min   n=16 -> 107.6 min (OVER)
+# n=4 costs the SAME wall as n=2 (both are one batch of 4) while doubling coverage,
+# so 4 is the free-coverage point. Raising it further does cost real minutes.
+tier1_subset_size: 4
 # Tier-1 samples a RANDOM subset of `tier1_subset_size` targets rather than always
 # the first N, so coverage rotates instead of leaving 83 of the 85 codes untested.
 # The draw is seeded and logged: re-run with FLEXAIDDS_TIER1_SEED=<logged seed> to
@@ -43,6 +52,14 @@ tier1_subset_size: 2
 # seeds are not comparable to each other and a regression flag from a fresh draw
 # is not evidence on its own. Compare only runs reporting the same seed.
 tier1_selection: random
+
+# Tier-2 (weekly, job cap 360 min, N_WORKERS=4, and it runs EVERY dataset in one
+# job). The full 85 targets would need ceil(85/4)*26.9 = 592 min -- over the cap on
+# this dataset alone, before the other 13 datasets get any time at all. 12 targets
+# is ceil(12/4)*26.9 = 80.7 min, ~22% of the budget, leaving room for the rest.
+# Random selection means the full 85 are still covered, in ~7 weekly runs.
+tier2_subset_size: 12
+tier2_selection: random
 
 structural_states:
   - holo

--- a/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
+++ b/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
@@ -53,6 +53,17 @@ tier1_subset_size: 4
 # is not evidence on its own. Compare only runs reporting the same seed.
 tier1_selection: random
 
+# Anchor targets: pinned into EVERY draw, so a fixed core of each run stays
+# directly comparable run-to-run while the remaining slots rotate for coverage.
+# 1gpk and 1mq6 are the historical pair (every Tier-1 run before #400 used exactly
+# these two), so their numbers are the ones with prior art to compare against.
+# Metrics restricted to the anchors are comparable across runs; metrics over the
+# full draw are NOT -- see the comparability note above.
+anchor_targets:
+  - 1gpk
+  - 1mq6
+
+
 # Tier-2 (weekly, job cap 360 min, N_WORKERS=4, and it runs EVERY dataset in one
 # job). The full 85 targets would need ceil(85/4)*26.9 = 592 min -- over the cap on
 # this dataset alone, before the other 13 datasets get any time at all. 12 targets

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -196,6 +196,9 @@ class DatasetConfig:
     tier2_subset_size: int = 0  # 0 = every target (historical tier-2 behaviour)
     tier2_selection: str = "fixed"
     tier2_seed: Optional[int] = None
+    # Targets pinned into every random draw. They make a fixed core of the run
+    # comparable across runs even while the remaining slots rotate.
+    anchor_targets: List[str] = field(default_factory=list)
     benchmark_order: int = 1000
     targets: List[str] = field(default_factory=list)
     structural_states: List[str] = field(default_factory=lambda: ["holo"])
@@ -269,6 +272,7 @@ class DatasetConfig:
             tier1_subset_size=int(raw.pop("tier1_subset_size", 5)),
             tier1_selection=str(raw.pop("tier1_selection", "fixed")).strip().lower(),
             tier1_seed=(lambda v: None if v is None else int(v))(raw.pop("tier1_seed", None)),
+            anchor_targets=list(raw.pop("anchor_targets", [])),
             tier2_subset_size=int(raw.pop("tier2_subset_size", 0)),
             tier2_selection=str(raw.pop("tier2_selection", "fixed")).strip().lower(),
             tier2_seed=(lambda v: None if v is None else int(v))(raw.pop("tier2_seed", None)),
@@ -379,15 +383,32 @@ class DatasetConfig:
         if k >= len(self.targets):
             return list(self.targets)  # nothing to sample; keep dataset order
         seed = self.resolve_tier_seed(tier)
-        picked = random.Random(seed).sample(list(self.targets), k)
+        # Anchors are pinned into every draw so a fixed core of the run stays
+        # directly comparable across runs; only the remaining slots rotate.
+        anchors = [t for t in self.targets if t in set(self.anchor_targets)][:k]
+        pool = [t for t in self.targets if t not in set(anchors)]
+        n_draw = max(0, k - len(anchors))
+        drawn = random.Random(seed).sample(pool, min(n_draw, len(pool)))
+        picked = anchors + drawn
         # Restore dataset order within the draw so run/display order is stable.
         picked.sort(key=self.targets.index)
         logger.info(
-            "tier-%d random subset: seed=%d k=%d of %d targets=%s "
+            "tier-%d subset: seed=%d k=%d of %d | anchors=%s | drawn=%s "
             "(replay this exact draw with FLEXAIDDS_TIER%d_SEED=%d)",
-            tier, seed, k, len(self.targets), ",".join(picked), tier, seed,
+            tier, seed, k, len(self.targets),
+            ",".join(anchors) or "-", ",".join(sorted(drawn, key=self.targets.index)) or "-",
+            tier, seed,
         )
         return picked
+
+    def tier_anchor_targets(self, tier: int) -> List[str]:
+        """Anchors actually scheduled for ``tier`` (dataset order).
+
+        Metrics restricted to these are comparable run-to-run even when the rest
+        of the subset rotates; metrics over the full draw are not.
+        """
+        scheduled = set(self.tier_targets(tier))
+        return [t for t in self.targets if t in set(self.anchor_targets) and t in scheduled]
 
     def tier1_targets(self) -> List[str]:
         """Back-compat alias for :meth:`tier_targets` at tier 1."""

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -38,6 +38,7 @@ import datetime
 import json
 import csv
 import logging
+import math
 import os
 import random
 import re
@@ -78,6 +79,12 @@ from .metrics import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Worst per-target docking wall time measured on a 4-core ubuntu-latest runner at
+# --omp-threads 1 (Tier-1 CI run 31052481958: 1gpk 1056.7s, 1mq6 1614.0s). Used
+# only to size a subset against a CI cap; override per call when the real cost
+# history says otherwise.
+DEFAULT_TARGET_MINUTES = 1614.0 / 60.0
 
 # Tier-2 full-N datasets use committed entry catalogs (C++ parity).
 KNOWN_LARGE_DATASETS: Dict[str, int] = {
@@ -186,6 +193,9 @@ class DatasetConfig:
     tier1_subset_size: int = 5
     tier1_selection: str = "fixed"
     tier1_seed: Optional[int] = None
+    tier2_subset_size: int = 0  # 0 = every target (historical tier-2 behaviour)
+    tier2_selection: str = "fixed"
+    tier2_seed: Optional[int] = None
     benchmark_order: int = 1000
     targets: List[str] = field(default_factory=list)
     structural_states: List[str] = field(default_factory=lambda: ["holo"])
@@ -259,6 +269,9 @@ class DatasetConfig:
             tier1_subset_size=int(raw.pop("tier1_subset_size", 5)),
             tier1_selection=str(raw.pop("tier1_selection", "fixed")).strip().lower(),
             tier1_seed=(lambda v: None if v is None else int(v))(raw.pop("tier1_seed", None)),
+            tier2_subset_size=int(raw.pop("tier2_subset_size", 0)),
+            tier2_selection=str(raw.pop("tier2_selection", "fixed")).strip().lower(),
+            tier2_seed=(lambda v: None if v is None else int(v))(raw.pop("tier2_seed", None)),
             benchmark_order=int(raw.pop("benchmark_order", 1000)),
             targets=list(raw.pop("targets", [])),
             structural_states=list(raw.pop("structural_states", ["holo"])),
@@ -282,10 +295,16 @@ class DatasetConfig:
             config.data_dir = Path(data_dir_raw).expanduser().resolve()
         return config
 
-    def resolve_tier1_seed(self) -> int:
-        """Resolve the RNG seed used by ``tier1_selection: random``.
+    def _tier_selection_params(self, tier: int) -> Tuple[int, str, Optional[int]]:
+        """(subset_size, selection_mode, yaml_seed) for a tier. size 0/negative = all."""
+        if tier == 1:
+            return int(self.tier1_subset_size), self.tier1_selection, self.tier1_seed
+        return int(self.tier2_subset_size), self.tier2_selection, self.tier2_seed
 
-        Precedence: ``FLEXAIDDS_TIER1_SEED`` env > yaml ``tier1_seed`` > the UTC
+    def resolve_tier_seed(self, tier: int) -> int:
+        """Resolve the RNG seed used by ``tier{N}_selection: random``.
+
+        Precedence: ``FLEXAIDDS_TIER{N}_SEED`` env > yaml ``tier{N}_seed`` > the UTC
         date as ``YYYYMMDD``.  The date default rotates the sampled targets daily
         while keeping every run within a day identical; any run is replayable
         exactly by exporting the seed recorded in its log.
@@ -293,54 +312,86 @@ class DatasetConfig:
         A non-integer env value is an error rather than a silent fallback: a
         mistyped seed must not quietly produce a different draw than intended.
         """
-        env = os.environ.get("FLEXAIDDS_TIER1_SEED", "").strip()
+        var = f"FLEXAIDDS_TIER{int(tier)}_SEED"
+        env = os.environ.get(var, "").strip()
         if env:
             try:
                 return int(env)
             except ValueError as exc:
-                raise ValueError(
-                    f"FLEXAIDDS_TIER1_SEED must be an integer, got {env!r}"
-                ) from exc
-        if self.tier1_seed is not None:
-            return int(self.tier1_seed)
+                raise ValueError(f"{var} must be an integer, got {env!r}") from exc
+        _, _, yaml_seed = self._tier_selection_params(tier)
+        if yaml_seed is not None:
+            return int(yaml_seed)
         return int(datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d"))
 
-    def tier1_targets(self) -> List[str]:
-        """Return the subset of targets used for tier-1 (fast) runs.
+    def resolve_tier1_seed(self) -> int:
+        """Back-compat alias for :meth:`resolve_tier_seed` at tier 1."""
+        return self.resolve_tier_seed(1)
 
-        ``tier1_selection: fixed`` (default) takes the first N targets.  Stable,
-        but every target after the Nth is then never exercised -- on astex_diverse
-        that left 83 of 85 codes untested by the gate.
+    def estimate_tier_wall_minutes(
+        self,
+        tier: int,
+        n_workers: int,
+        per_target_minutes: float = DEFAULT_TARGET_MINUTES,
+    ) -> float:
+        """Estimate wall-clock minutes for a tier at a given worker count.
 
-        ``tier1_selection: random`` samples N targets without replacement from a
-        seeded RNG, so coverage rotates across runs while a single run stays
-        exactly reproducible.  The seed is logged; re-run with
-        ``FLEXAIDDS_TIER1_SEED=<logged seed>`` to reproduce a draw.
+        ``ceil(n / workers) * per_target`` -- targets run in batches of ``workers``,
+        so wall time is floored by the slowest single target no matter how small the
+        subset is.  That is why dropping tier-1 from 4 targets to 2 saves nothing:
+        both fit one batch.  Use it to size a subset against a CI cap rather than
+        guessing.
+        """
+        n = len(self.scheduled_targets(tier))
+        w = max(1, int(n_workers))
+        return math.ceil(n / w) * float(per_target_minutes)
+
+    def tier_targets(self, tier: int) -> List[str]:
+        """Return the subset of targets scheduled for ``tier``.
+
+        ``tier{N}_selection: fixed`` takes the first N targets.  Stable, but every
+        target after the Nth is then never exercised -- on astex_diverse that left
+        83 of 85 codes untested by the tier-1 gate.
+
+        ``tier{N}_selection: random`` samples without replacement from a seeded
+        RNG, so coverage rotates across runs while a single run stays exactly
+        reproducible.  The seed is logged; re-run with
+        ``FLEXAIDDS_TIER{N}_SEED=<logged seed>`` to reproduce a draw.
+
+        A subset size of 0 (or negative) means *every* target, which is the
+        historical tier-2 behaviour and remains the tier-2 default.
 
         COMPARABILITY WARNING: under ``random`` the sampled set differs between
         runs, so target-dependent aggregates (``mean_rmsd``, ``docking_power_*``)
         are NOT comparable run-to-run and must not be diffed against a baseline
         calibrated on a different draw.  Only compare runs reporting the same seed.
         """
-        k = max(0, min(int(self.tier1_subset_size), len(self.targets)))
-        mode = (self.tier1_selection or "fixed").strip().lower()
+        size, selection, _ = self._tier_selection_params(tier)
+        mode = (selection or "fixed").strip().lower()
+        # size <= 0 means "all targets" -- subsetting is opt-in per tier.
+        k = len(self.targets) if size <= 0 else min(size, len(self.targets))
         if mode == "fixed":
             return self.targets[:k]
         if mode != "random":
             raise ValueError(
-                "tier1_selection must be 'fixed' or 'random', got "
-                f"{self.tier1_selection!r}"
+                f"tier{tier}_selection must be 'fixed' or 'random', got {selection!r}"
             )
-        seed = self.resolve_tier1_seed()
+        if k >= len(self.targets):
+            return list(self.targets)  # nothing to sample; keep dataset order
+        seed = self.resolve_tier_seed(tier)
         picked = random.Random(seed).sample(list(self.targets), k)
         # Restore dataset order within the draw so run/display order is stable.
         picked.sort(key=self.targets.index)
         logger.info(
-            "tier-1 random subset: seed=%d k=%d targets=%s "
-            "(replay this exact draw with FLEXAIDDS_TIER1_SEED=%d)",
-            seed, k, ",".join(picked), seed,
+            "tier-%d random subset: seed=%d k=%d of %d targets=%s "
+            "(replay this exact draw with FLEXAIDDS_TIER%d_SEED=%d)",
+            tier, seed, k, len(self.targets), ",".join(picked), tier, seed,
         )
         return picked
+
+    def tier1_targets(self) -> List[str]:
+        """Back-compat alias for :meth:`tier_targets` at tier 1."""
+        return self.tier_targets(1)
 
     def _uses_crossdock_catalog(self, tier: int) -> bool:
         """Full-N crossdock catalog applies only when YAML requests crossdock state."""
@@ -354,7 +405,7 @@ class DatasetConfig:
         """Targets actually scheduled for this tier."""
         if self._uses_crossdock_catalog(tier):
             return [e["entry_id"] for e in load_large_dataset_catalog(self.slug)]
-        return self.tier1_targets() if tier == 1 else self.targets
+        return self.tier_targets(tier)
 
     def scheduled_work_items(self, tier: int) -> List[Tuple[str, str]]:
         """(entry_id, state) pairs scheduled for this tier."""

--- a/python/tests/test_tier1_random_subset.py
+++ b/python/tests/test_tier1_random_subset.py
@@ -186,3 +186,78 @@ def test_astex_yaml_tier_sizes_fit_their_ci_budgets():
         # tier-1 docking step cap is 105 min; tier-2 job cap is 360 min.
         assert cfg.estimate_tier_wall_minutes(1, 4) <= 105
         assert cfg.estimate_tier_wall_minutes(2, 4) <= 360
+
+
+# --------------------------------------------------------------------------
+# Anchor targets: a fixed, comparable core inside a rotating draw
+# --------------------------------------------------------------------------
+
+def test_anchors_appear_in_every_draw(monkeypatch):
+    monkeypatch.delenv("FLEXAIDDS_TIER1_SEED", raising=False)
+    anchors = [CODES[0], CODES[1]]
+    for s in range(30):
+        cfg = _cfg(tier1_selection="random", tier1_subset_size=4,
+                   tier1_seed=s, anchor_targets=list(anchors))
+        got = cfg.tier_targets(1)
+        assert set(anchors) <= set(got), f"anchors dropped at seed {s}: {got}"
+        assert len(got) == 4
+        assert len(set(got)) == 4
+
+
+def test_anchors_do_not_freeze_the_rotation(monkeypatch):
+    """The non-anchor slots must still rotate, or anchoring defeats coverage."""
+    monkeypatch.delenv("FLEXAIDDS_TIER1_SEED", raising=False)
+    anchors = [CODES[0], CODES[1]]
+    tails = {
+        tuple(t for t in _cfg(tier1_selection="random", tier1_subset_size=4,
+                              tier1_seed=s, anchor_targets=list(anchors)).tier_targets(1)
+              if t not in anchors)
+        for s in range(30)
+    }
+    assert len(tails) > 1
+
+
+def test_anchors_are_never_duplicated_by_the_draw(monkeypatch):
+    """An anchor must not also be sampled from the pool."""
+    monkeypatch.delenv("FLEXAIDDS_TIER2_SEED", raising=False)
+    anchors = [CODES[0], CODES[1], CODES[2]]
+    cfg = _cfg(tier2_selection="random", tier2_subset_size=6,
+               tier2_seed=3, anchor_targets=list(anchors))
+    got = cfg.tier_targets(2)
+    assert len(got) == len(set(got)) == 6
+    assert set(anchors) <= set(got)
+
+
+def test_tier_anchor_targets_reports_scheduled_anchors(monkeypatch):
+    monkeypatch.delenv("FLEXAIDDS_TIER1_SEED", raising=False)
+    anchors = [CODES[0], CODES[1]]
+    cfg = _cfg(tier1_selection="random", tier1_subset_size=4,
+               tier1_seed=11, anchor_targets=list(anchors))
+    assert cfg.tier_anchor_targets(1) == anchors
+
+
+def test_more_anchors_than_slots_is_truncated_not_overflowed(monkeypatch):
+    monkeypatch.delenv("FLEXAIDDS_TIER1_SEED", raising=False)
+    cfg = _cfg(tier1_selection="random", tier1_subset_size=2,
+               tier1_seed=1, anchor_targets=CODES[:5])
+    got = cfg.tier_targets(1)
+    assert len(got) == 2
+    assert set(got) <= set(CODES[:5])
+
+
+def test_astex_anchors_are_the_historical_pair():
+    """1gpk/1mq6 are the codes every pre-#400 run used -- the comparable baseline."""
+    import pathlib
+
+    from flexaidds.dataset_runner.runner import DatasetConfig
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    for rel in ("benchmarks/datasets/astex_diverse.yaml",
+                "python/flexaidds/dataset_runner/datasets/astex_diverse.yaml"):
+        p = root / rel
+        if not p.exists():
+            pytest.skip(f"{rel} not present")
+        cfg = DatasetConfig.from_yaml(p)
+        assert cfg.anchor_targets == ["1gpk", "1mq6"], rel
+        for tier in (1, 2):
+            assert set(cfg.anchor_targets) <= set(cfg.tier_targets(tier)), (rel, tier)

--- a/python/tests/test_tier1_random_subset.py
+++ b/python/tests/test_tier1_random_subset.py
@@ -108,5 +108,81 @@ def test_astex_diverse_yaml_uses_random_selection():
             pytest.skip(f"{p} not present")
         d = yaml.safe_load(p.read_text())
         seen.append((d.get("tier1_selection"), d.get("tier1_subset_size")))
-    assert seen[0] == ("random", 2)
+    # 4 = the free-coverage point: one batch of 4 workers, same wall as 2.
+    assert seen[0] == ("random", 4)
     assert seen[0] == seen[1], f"astex_diverse copies disagree: {seen}"
+
+
+# --------------------------------------------------------------------------
+# Tier-2 subsetting + CI time-budget sizing
+# --------------------------------------------------------------------------
+
+def test_tier2_defaults_to_every_target():
+    """size 0 means all -- tier-2's historical behaviour must be the default."""
+    cfg = _cfg()
+    assert cfg.tier2_subset_size == 0
+    assert cfg.tier_targets(2) == CODES
+
+
+def test_tier2_random_subset_is_seeded_and_reproducible(monkeypatch):
+    monkeypatch.delenv("FLEXAIDDS_TIER2_SEED", raising=False)
+    a = _cfg(tier2_selection="random", tier2_subset_size=12, tier2_seed=5)
+    b = _cfg(tier2_selection="random", tier2_subset_size=12, tier2_seed=5)
+    assert len(a.tier_targets(2)) == 12
+    assert a.tier_targets(2) == b.tier_targets(2)
+    assert a.tier_targets(2) != _cfg(
+        tier2_selection="random", tier2_subset_size=12, tier2_seed=6
+    ).tier_targets(2)
+
+
+def test_tier_seeds_are_independent(monkeypatch):
+    """TIER1 env must not silently steer the tier-2 draw."""
+    monkeypatch.setenv("FLEXAIDDS_TIER1_SEED", "111")
+    monkeypatch.delenv("FLEXAIDDS_TIER2_SEED", raising=False)
+    cfg = _cfg(tier2_selection="random", tier2_subset_size=6, tier2_seed=222)
+    assert cfg.resolve_tier_seed(1) == 111
+    assert cfg.resolve_tier_seed(2) == 222
+
+
+def test_random_with_size_at_or_above_total_returns_all(monkeypatch):
+    monkeypatch.delenv("FLEXAIDDS_TIER2_SEED", raising=False)
+    cfg = _cfg(tier2_selection="random", tier2_subset_size=len(CODES) + 10)
+    assert cfg.tier_targets(2) == CODES
+
+
+def test_wall_estimate_matches_batch_model(monkeypatch):
+    """ceil(n/workers)*per_target -- the model used to size against the CI cap."""
+    monkeypatch.delenv("FLEXAIDDS_TIER1_SEED", raising=False)
+    cfg = _cfg(tier1_subset_size=4, tier1_selection="fixed")
+    # 4 targets on 4 workers is one batch: same wall as 2 targets would be.
+    assert cfg.estimate_tier_wall_minutes(1, 4, per_target_minutes=26.9) == pytest.approx(26.9)
+    assert cfg.estimate_tier_wall_minutes(1, 2, per_target_minutes=26.9) == pytest.approx(53.8)
+
+
+def test_full_tier2_would_exceed_the_ci_cap(monkeypatch):
+    """Pins the reason tier-2 is subset: the full set does not fit in 360 min."""
+    monkeypatch.delenv("FLEXAIDDS_TIER2_SEED", raising=False)
+    full = _cfg()  # tier2_subset_size=0 -> all 85
+    assert full.estimate_tier_wall_minutes(2, 4, per_target_minutes=26.9) > 360
+    sized = _cfg(tier2_selection="random", tier2_subset_size=12, tier2_seed=1)
+    assert sized.estimate_tier_wall_minutes(2, 4, per_target_minutes=26.9) <= 360
+
+
+def test_astex_yaml_tier_sizes_fit_their_ci_budgets():
+    """The shipped sizes must actually fit the caps in the workflows."""
+    import pathlib
+
+    import yaml
+    from flexaidds.dataset_runner.runner import DatasetConfig
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    for rel in ("benchmarks/datasets/astex_diverse.yaml",
+                "python/flexaidds/dataset_runner/datasets/astex_diverse.yaml"):
+        p = root / rel
+        if not p.exists():
+            pytest.skip(f"{rel} not present")
+        cfg = DatasetConfig.from_yaml(p)
+        assert cfg.tier1_selection == "random" and cfg.tier2_selection == "random"
+        # tier-1 docking step cap is 105 min; tier-2 job cap is 360 min.
+        assert cfg.estimate_tier_wall_minutes(1, 4) <= 105
+        assert cfg.estimate_tier_wall_minutes(2, 4) <= 360


### PR DESCRIPTION
## Summary

Follows #400 (seeded-random Tier-1 draw). Three things, all driven by measurement rather than opinion.

**Measured cost.** Worst per-target docking wall time on a 4-core `ubuntu-latest` runner at `--omp-threads 1` is **1614 s = 26.9 min** (Tier-1 run `31052481958`: 1gpk 1056.7 s, 1mq6 1614.0 s). Targets run in batches of `workers`, so `wall ≈ ceil(n / workers) × 26.9 min`.

### 1. Anchor targets — restores the comparability #400 traded away

#400 bought coverage at a real cost: with a different target set each run, `mean_rmsd` and `docking_power_*` are target-dependent and cannot be diffed run-to-run.

`anchor_targets` pins codes into **every** draw; only the remaining slots rotate. astex_diverse anchors **1gpk** and **1mq6** — the exact pair every Tier-1 run used before #400, so they are the codes with prior art to compare against.

```
seed 20260806 → 1gpk, 1mq6, 1q4g, 1tt1
seed 20260807 → 1gpk, 1mq6, 1gm8, 1sg0
seed 20260812 → 1gpk, 1mq6, 1hp0, 1ia1
```

Anchors give a stable series; the rotation gives coverage; the cost is unchanged (still one batch of 4). `tier_anchor_targets(tier)` lets a consumer restrict metrics to the comparable core. Anchors are de-duplicated against the sample pool, truncated if they exceed the subset size, and reported separately from the drawn codes in the run log.

### 2. Tier-1 was under-using its runner

It dispatches `workers = min(nproc, 5) = 4` but scheduled only **2** targets — two workers idle.

| n | wall | vs 105 min cap |
|---|---|---|
| 2 | 26.9 min | previous |
| **4** | **26.9 min** | **same wall, 2× coverage** |
| 8 | 53.8 min | fits |
| 16 | 107.6 min | over |

`tier1_subset_size: 2 → 4` is **free**: same batch, same wall, twice the targets.

> **On runtime:** wall time is floored by the *slowest single target*, so shrinking the subset below the worker count saves nothing — n=2 and n=4 both cost ~27 min. Going meaningfully faster requires cutting the GA budget or enabling plateau early-stop, both of which change what is measured. Deliberately **not** done here; current runtime is kept as-is.

### 3. Tier-2 could not complete at all

Tier-2 runs every target of every dataset in one job under a **360 min** cap. astex alone needs `ceil(85/4) × 26.9 = 592 min` — over budget before the other 13 datasets get any time.

Adds `tier2_subset_size` / `tier2_selection` / `tier2_seed`, defaulting to **0 = all targets** so every other dataset is byte-identical. astex is set to **12 targets = 80.7 min (~22% of the cap)**, anchors included, rotation covering all 85 in ~7 weekly runs.

## Implementation

- `tier1_targets()` → generalised `tier_targets(tier)`; `tier1_targets()` / `resolve_tier1_seed()` kept as aliases (`benchmarks/nextgen/runner.py` calls the former).
- `scheduled_targets()` now honours tier-2 subsetting (previously `tier == 1 ? subset : all`).
- Seeds are **per tier** (`FLEXAIDDS_TIER1_SEED` / `FLEXAIDDS_TIER2_SEED`) so one cannot silently steer the other.
- `estimate_tier_wall_minutes()` exposes the batch model used for sizing, so the numbers stay checkable rather than becoming folklore.

## Scope

- [x] Core 1.0 supported surface
- [x] CI / release engineering

## Release impact

- [x] affects benchmark or metric reporting

Changes which targets each tier docks for `astex_diverse`. Tier-2 default (`0` = all) keeps every other dataset unchanged. Metrics restricted to the anchors are comparable run-to-run; metrics over the full draw are **not**, and that caveat is documented in both YAMLs.

## Validation

- [x] unit tests

**13 new cases** on top of #400's 9 (22 in the file): anchors present across 30 seeds, the non-anchor slots still rotate (anchoring must not defeat coverage), no anchor/pool duplication, the reporting accessor, over-supplied anchors truncate rather than overflow, tier-2 defaults to all targets, tier-2 seeded reproducibility, per-tier seed independence, size ≥ total returns all, the wall model matches `ceil(n/w)·t`, full tier-2 exceeds 360 min while the sized one does not, and both shipped YAMLs agree and fit their workflow caps.

`22 passed` in the file; **347 passed, 1 skipped** across runner + CI pure-Python suites; `validate-dataset-semantics` → `VALIDATION PASSED`.

## Security and safety

- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

## Reproducibility

- [x] benchmark language remains preliminary

Sizes derive from a measured per-target cost with the source run cited inline in both YAMLs. The estimator is unit-tested against the same model.

## Notes

The 26.9 min figure is the worst of two observed targets; a slower drawn target makes the estimate under-predict. The runner already persists real per-target costs in `.cost_history.json`, so a natural follow-up is to drive `estimate_tier_wall_minutes()` off that history and warn when a plan exceeds the cap.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2cvFhk4EPPSRD3H6i9xQ