### PR TITLE
Add: record every early-termination parameter in the benchmark artifact

### DIFF
--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -441,6 +441,10 @@ class TargetResult:
     grand_log_Z: Optional[float] = None  # P3: ensemble log_Z for this ligand (for grand Xi)
     conc_M: float = 1.0  # P3: the conc used for this ligand
     grand_xi: Optional[float] = None  # P3: computed log_Xi if grand_log_Z present
+    # Early-termination evidence. Without this a run that stopped at 14% of its
+    # generation budget is indistinguishable in the artifact from a full one.
+    early_termination: Dict[str, Any] = field(default_factory=dict)
+    early_exit_params: Dict[str, Any] = field(default_factory=dict)
 
     @property
     def success(self) -> bool:
@@ -539,6 +543,15 @@ class DatasetResult:
     # value is a real exit/return code, or None when the engine never executed
     # (exec failure) — mirrors DatasetRunner._entry_exit_codes.
     entry_exit_codes: Dict[str, Optional[int]] = field(default_factory=dict)
+    # "target/state" -> early-termination record for entries whose GA stopped
+    # before its configured budget. Keyed per entry like entry_exit_codes above,
+    # so an MPI merge is a dict update rather than a sum. Empty is the normal
+    # case; a non-empty map means this run's numbers came from less search than
+    # the configuration asked for, and are not comparable run-to-run.
+    early_terminations: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    # The governing knobs, as the engine actually saw them (one entry sampled;
+    # they are process-level and identical across entries of a run).
+    early_exit_params: Dict[str, Any] = field(default_factory=dict)
     inconclusive_metrics: List[str] = field(default_factory=list)
     # Targets actually executed this run (excludes --resume checkpoints, whose
     # poses are not reloaded into all_poses). Gates 2-3 only judge a run that
@@ -631,6 +644,8 @@ class DatasetResult:
             "flexaid_crashes": self.flexaid_crashes,
             "total_poses": self.total_poses,
             "entry_exit_codes": self.entry_exit_codes,
+            "early_terminations": self.early_terminations,
+            "early_exit_params": self.early_exit_params,
             "inconclusive_metrics": self.inconclusive_metrics,
             "newly_executed": self.newly_executed,
             "resumed": self.resumed,
@@ -1194,6 +1209,98 @@ class CostHistory:
         return cls(history_path)
 
 
+
+# ---------------------------------------------------------------------------
+# Early-termination tracking
+# ---------------------------------------------------------------------------
+# The GA can stop before its configured generation budget through several
+# independent paths.  The engine announces each on stdout, but the runner used to
+# scan stdout only for "[GRAND]" and discard the rest -- so a run that stopped at
+# 14% of budget was indistinguishable in the artifact from one that ran to 2000
+# generations, while METHODOLOGY §0 pins the budget at 2000 x 1000.
+#
+# Guard status (LIB/gaboom.cpp) -- this is the part that matters:
+#   * stagnation, entropy-convergence, SEC and the H-plateau exits are all
+#     guarded by `!no_sec`, and this runner sets FLEXAIDDS_NO_SEC=1 on every
+#     benchmark subprocess, so they are OFF on the benchmark path.
+#   * the [P5-ADAPTIVE-GEN] best-CF plateau exit is guarded ONLY by
+#     `ag_patience > 0` (gaboom.cpp:927) -- it does NOT check `no_sec`, so
+#     FLEXAIDDS_ADAPTIVE_GENERATIONS still fires on a benchmark run and silently
+#     shortens the budget the NO_SEC switch is there to guarantee.
+# Recording both the event and the governing parameters makes that visible in the
+# artifact instead of only in a discarded log.
+_TERMINATION_PATTERNS: Tuple[Tuple[str, "re.Pattern[str]"], ...] = (
+    ("adaptive_cf_plateau", re.compile(
+        r"\[P5-ADAPTIVE-GEN\] GA converged: best-CF plateau for (?P<plateau>\d+) gens "
+        r"\(best_CF=(?P<best_cf>[-\d.eE+]+)\) at gen (?P<generation>\d+) .*?"
+        r"max_generations=(?P<max_generations>\d+)")),
+    ("h_plateau", re.compile(
+        r"Early exit at gen (?P<generation>\d+): H plateau < (?P<eps>[-\d.eE+]+) "
+        r"\(H_now=(?P<h_now>[-\d.eE+]+) nats, delta=(?P<delta>[-\d.eE+]+) nats\)")),
+    ("cf_stagnant_gene_collapsed", re.compile(
+        r"GA terminated: CF stagnant for (?P<plateau>\d+) gens "
+        r"\(best_CF=(?P<best_cf>[-\d.eE+]+)\)")),
+    ("entropy_convergence", re.compile(r"GA terminated early by entropy convergence")),
+    ("fitness_stagnation", re.compile(r"GA terminated early by fitness stagnation")),
+)
+
+_LAST_GENERATION_RE = re.compile(r"Generation:\s*(\d+)")
+
+
+def parse_early_termination(stdout: str) -> Dict[str, Any]:
+    """Extract early-termination evidence from engine stdout.
+
+    Returns ``{"terminated_early": bool, "reason": str|None, ...}``.  ``reason`` is
+    None when the GA ran its full budget.  ``last_generation`` is reported either
+    way so a silent truncation is visible even if a future exit path forgets to
+    announce itself.
+    """
+    out: Dict[str, Any] = {"terminated_early": False, "reason": None}
+    if not stdout:
+        return out
+    for reason, pat in _TERMINATION_PATTERNS:
+        m = pat.search(stdout)
+        if m:
+            out["terminated_early"] = True
+            out["reason"] = reason
+            for k, v in (m.groupdict() or {}).items():
+                try:
+                    out[k] = float(v) if "." in v or "e" in v.lower() else int(v)
+                except (TypeError, ValueError):
+                    out[k] = v
+            break
+    gens = _LAST_GENERATION_RE.findall(stdout)
+    if gens:
+        out["last_generation"] = int(gens[-1])
+    return out
+
+
+def early_exit_parameters(env: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    """Governing early-termination settings, as actually seen by the engine.
+
+    These are ``getenv``-only knobs; METHODOLOGY §0.2 classes anything read from
+    the environment and written nowhere as LOST after the shell exits.  Recording
+    them beside the result is what makes a completed run distinguishable from one
+    that ran under different termination settings.
+    """
+    e = os.environ if env is None else env
+    adaptive = (e.get("FLEXAIDDS_ADAPTIVE_GENERATIONS") or "").strip()
+    return {
+        # master switch: disables stagnation / entropy / SEC / H-plateau exits
+        "FLEXAIDDS_NO_SEC": e.get("FLEXAIDDS_NO_SEC"),
+        "FLEXAIDDS_BENCHMARK": e.get("FLEXAIDDS_BENCHMARK"),
+        # NOT covered by NO_SEC -- see the note above
+        "FLEXAIDDS_ADAPTIVE_GENERATIONS": adaptive or None,
+        "FLEXAIDDS_ADAPTIVE_EPS": (e.get("FLEXAIDDS_ADAPTIVE_EPS") or "").strip() or None,
+        "adaptive_bypasses_no_sec": bool(adaptive and adaptive not in ("0", "")),
+        # compiled-in thresholds, recorded so the artifact is self-describing
+        "compiled_stagnation_limit": 300,          # gaboom.cpp:548 STAGNATION_LIMIT
+        "compiled_entropy_check_interval": 10,     # ga_constants.h:21
+        "compiled_h_plateau_window": 20,           # gaboom.cpp:589 kHPlateauWindow
+        "compiled_h_plateau_eps_nats": 0.001,      # gaboom.cpp:590 kHPlateauEps
+    }
+
+
 # ---------------------------------------------------------------------------
 # DatasetRunner
 # ---------------------------------------------------------------------------
@@ -1309,6 +1416,14 @@ class DatasetRunner:
         # int = a real process exit/return code; None = the engine never
         # executed (exec failure), which no completed subprocess.run can produce.
         self._entry_exit_codes: Dict[str, Optional[int]] = {}
+        # Early-termination evidence, keyed "target/state", recorded by
+        # _run_flexaid and consumed by run_dataset when it builds the
+        # TargetResult.  Routed through instance state under the same lock as
+        # the crash tally for the same reason: _run_flexaid returns only poses,
+        # and entries dispatch across a thread pool, so there is no other way
+        # for the per-entry evidence to reach the artifact.
+        self._entry_early_termination: Dict[str, Dict[str, Any]] = {}
+        self._entry_early_exit_params: Dict[str, Dict[str, Any]] = {}
         # Poses whose element list disagreed with the reference's.  Per
         # instance and reset per dataset, like the crash tally above it: a
         # process-global would report the previous dataset's refusals as
@@ -1461,6 +1576,13 @@ class DatasetRunner:
                 sub_env["FLEXAIDDS_NO_SEC"] = "1"
                 # Signal to core that this is a benchmark run needing equal search effort
                 sub_env["FLEXAIDDS_BENCHMARK"] = "1"
+                # Record the governing knobs BEFORE the engine runs: a timeout or
+                # exec failure below returns without ever reaching the stdout
+                # parse, and those are exactly the runs whose settings we most
+                # want on record.
+                entry_key = f"{target_id}/{structural_state}"
+                with self._crash_lock:
+                    self._entry_early_exit_params[entry_key] = early_exit_parameters(sub_env)
                 # Wrap ONLY the subprocess call: the exceptions here (timeout,
                 # exec failure) are properties of *running the engine*. Pose
                 # parsing lives below, deliberately outside this try, so an
@@ -1561,6 +1683,18 @@ class DatasetRunner:
                     )
                 # P3: capture grand log_Z from [GRAND] stdout (emitted by C++ cluster hook when --conc used)
                 grand_log_z = None
+                # Early-termination evidence from engine stdout (otherwise discarded).
+                early_term = parse_early_termination(result.stdout or "")
+                with self._crash_lock:
+                    self._record_early_termination(entry_key, ligand_id, early_term)
+                if early_term.get("terminated_early"):
+                    logger.warning(
+                        "%s/%s: GA stopped early (%s) at generation %s -- the "
+                        "configured budget was NOT consumed; see early_termination "
+                        "in the entry artifact",
+                        target_id, ligand_id, early_term.get("reason"),
+                        early_term.get("generation") or early_term.get("last_generation"),
+                    )
                 if result.stdout:
                     for line in result.stdout.splitlines():
                         if '[GRAND]' in line and 'log_Z=' in line:
@@ -1574,6 +1708,46 @@ class DatasetRunner:
                 poses.extend(parsed)
 
         return poses
+
+    def _early_termination_for(
+        self, target_id: str, structural_state: str
+    ) -> Dict[str, Dict[str, Any]]:
+        """TargetResult kwargs carrying this entry's early-termination record.
+
+        Empty dicts when nothing was recorded (dry runs, and any path where the
+        engine was never invoked) -- an absent record and a clean full-budget
+        run must not look alike, so nothing is synthesised here.
+        """
+        key = f"{target_id}/{structural_state}"
+        with self._crash_lock:
+            return {
+                "early_termination": dict(self._entry_early_termination.get(key) or {}),
+                "early_exit_params": dict(self._entry_early_exit_params.get(key) or {}),
+            }
+
+    def _record_early_termination(
+        self, entry_key: str, ligand_id: str, early_term: Dict[str, Any]
+    ) -> None:
+        """Merge one ligand's termination evidence into the entry's record.
+
+        Caller must hold ``self._crash_lock``.  An entry is reported as
+        terminated early if ANY of its ligands did: the entry's scores are
+        pooled across ligands, so one truncated ligand is enough to make the
+        entry's numbers incomparable with a full-budget run.  Per-ligand detail
+        is kept alongside so which one it was stays recoverable.
+        """
+        rec = self._entry_early_termination.setdefault(
+            entry_key, {"terminated_early": False, "reason": None, "per_ligand": {}}
+        )
+        rec["per_ligand"][ligand_id] = early_term
+        if early_term.get("terminated_early") and not rec["terminated_early"]:
+            rec["terminated_early"] = True
+            rec["reason"] = early_term.get("reason")
+            if early_term.get("generation") is not None:
+                rec["generation"] = early_term["generation"]
+        last = early_term.get("last_generation")
+        if isinstance(last, int):
+            rec["last_generation"] = max(last, rec.get("last_generation", 0))
 
     def pose_pdb_dir(self, target_id: str, ligand_id: str, structural_state: str) -> Path:
         """Destination for preserved pose PDBs, ALWAYS under ``results_dir``.
@@ -1920,6 +2094,8 @@ class DatasetRunner:
         with self._crash_lock:
             self._flexaid_crashes = 0
             self._entry_exit_codes = {}
+            self._entry_early_termination = {}
+            self._entry_early_exit_params = {}
             self._element_mismatches = []
 
         def _process_one_item(item: Tuple[str, str]) -> Tuple[str, str, List[PoseScore], float, str]:
@@ -1968,6 +2144,7 @@ class DatasetRunner:
                     duration_seconds=elapsed,
                     error=error,
                     conc_M=eff_conc,
+                    **self._early_termination_for(target_id, state),
                 )
                 if poses and getattr(poses[0], 'ensemble_log_Z', None) is not None:
                     tr.grand_log_Z = poses[0].ensemble_log_Z
@@ -2048,6 +2225,13 @@ class DatasetRunner:
         with self._crash_lock:
             crashes = self._flexaid_crashes
             exit_codes = dict(self._entry_exit_codes)
+            early_terms = {
+                k: dict(v) for k, v in self._entry_early_termination.items()
+                if v.get("terminated_early")
+            }
+            early_params = next(
+                (dict(v) for v in self._entry_early_exit_params.values()), {}
+            )
         newly = len(results)
         resumed = len(already_completed)
 
@@ -2063,10 +2247,28 @@ class DatasetRunner:
                 " ..." if len(self._element_mismatches) > 5 else "",
             )
 
+        if early_terms:
+            logger.warning(
+                "%d entr%s stopped before the configured generation budget "
+                "(reasons: %s). These numbers came from less search than "
+                "configured and are NOT comparable with a full-budget run.",
+                len(early_terms), "y" if len(early_terms) == 1 else "ies",
+                ", ".join(sorted({str(v.get("reason")) for v in early_terms.values()})),
+            )
+            if early_params.get("adaptive_bypasses_no_sec"):
+                logger.warning(
+                    "FLEXAIDDS_ADAPTIVE_GENERATIONS=%s is set: the adaptive "
+                    "best-CF plateau exit is NOT covered by FLEXAIDDS_NO_SEC "
+                    "(gaboom.cpp:927), so the no-early-exit guarantee this "
+                    "runner relies on does not hold for this run.",
+                    early_params.get("FLEXAIDDS_ADAPTIVE_GENERATIONS"),
+                )
+
         # MPI gather (still works at target granularity for final aggregation)
         if self._mpi_comm is not None:
             all_results_by_rank = self._mpi_comm.gather(
-                (all_poses, completed, failed, crashes, exit_codes, newly, resumed), root=0
+                (all_poses, completed, failed, crashes, exit_codes, newly, resumed,
+                 early_terms, early_params), root=0
             )
             if self._mpi_root:
                 all_poses = []
@@ -2076,12 +2278,19 @@ class DatasetRunner:
                 exit_codes = {}
                 newly = 0
                 resumed = 0
-                for poses_i, comp_i, fail_i, crash_i, codes_i, newly_i, resumed_i in (all_results_by_rank or []):
+                merged_early_terms: Dict[str, Dict[str, Any]] = {}
+                merged_early_params: Dict[str, Any] = {}
+                for (poses_i, comp_i, fail_i, crash_i, codes_i, newly_i, resumed_i,
+                     early_i, params_i) in (all_results_by_rank or []):
                     all_poses.extend(poses_i)
                     completed.extend(comp_i)
                     failed.extend(fail_i)
                     crashes += crash_i
                     exit_codes.update(codes_i)
+                    # Keyed per entry and partitioned across ranks, like
+                    # exit_codes: a dict update merges without double-counting.
+                    merged_early_terms.update(early_i or {})
+                    merged_early_params = merged_early_params or (params_i or {})
                     newly += newly_i
                     # `resumed` is REPLICATED, not partitioned: every rank runs
                     # _discover_completed_targets over the same shared disk, so
@@ -2092,6 +2301,8 @@ class DatasetRunner:
                     # but a wrong number in the artifact is the exact thing this
                     # whole change exists to prevent.
                     resumed = max(resumed, resumed_i)
+                early_terms = merged_early_terms
+                early_params = early_params or merged_early_params
 
         # Root finalizes
         if self._mpi_root:
@@ -2099,6 +2310,8 @@ class DatasetRunner:
             dr.targets_failed = failed
             dr.flexaid_crashes = crashes
             dr.entry_exit_codes = exit_codes
+            dr.early_terminations = early_terms
+            dr.early_exit_params = early_params
             dr.total_poses = len(all_poses)
             dr.newly_executed = newly
             dr.resumed = resumed
@@ -2299,6 +2512,10 @@ class DatasetRunner:
             "grand_log_Z": getattr(tr, 'grand_log_Z', None),
             "grand_xi": getattr(tr, 'grand_xi', None),
             "conc_M": getattr(tr, 'conc_M', 1.0),
+            # Was the configured generation budget actually consumed? Recorded so a
+            # truncated run cannot be mistaken for a complete one.
+            "early_termination": getattr(tr, 'early_termination', {}) or {},
+            "early_exit_params": getattr(tr, 'early_exit_params', {}) or {},
             "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
         }
         tmp.write_text(json.dumps(payload, indent=2))
@@ -2332,6 +2549,12 @@ class DatasetRunner:
                 grand_log_Z=data.get("grand_log_Z"),
                 conc_M=data.get("conc_M", 1.0),
                 grand_xi=data.get("grand_xi"),
+                # Carried across resume: an entry reloaded from cache that lost
+                # its termination record would read as "no record", which is the
+                # exact conflation with a full-budget run this tracking exists
+                # to prevent.
+                early_termination=data.get("early_termination") or {},
+                early_exit_params=data.get("early_exit_params") or {},
             )
         except Exception as e:
             logger.warning("Corrupt target result %s — will re-run: %s", path, e)

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -1244,6 +1244,12 @@ _TERMINATION_PATTERNS: Tuple[Tuple[str, "re.Pattern[str]"], ...] = (
     ("fitness_stagnation", re.compile(r"GA terminated early by fitness stagnation")),
 )
 
+# The progress line prints `gen_id` 0-based -- a complete 2000-generation run
+# emits "Generation: 0" through "Generation: 1999" (verified on a full 1gpk run).
+# Every exit message above instead prints `i + 1`, i.e. 1-based. Reporting both
+# conventions in one dict would make `last_generation` look one short of
+# `max_generations` on a run that finished, which is precisely the false positive
+# this tracking must not manufacture, so the parser normalises to 1-based.
 _LAST_GENERATION_RE = re.compile(r"Generation:\s*(\d+)")
 
 
@@ -1253,7 +1259,8 @@ def parse_early_termination(stdout: str) -> Dict[str, Any]:
     Returns ``{"terminated_early": bool, "reason": str|None, ...}``.  ``reason`` is
     None when the GA ran its full budget.  ``last_generation`` is reported either
     way so a silent truncation is visible even if a future exit path forgets to
-    announce itself.
+    announce itself, and is 1-based like ``generation``/``max_generations`` so the
+    three are directly comparable.
     """
     out: Dict[str, Any] = {"terminated_early": False, "reason": None}
     if not stdout:
@@ -1271,7 +1278,7 @@ def parse_early_termination(stdout: str) -> Dict[str, Any]:
             break
     gens = _LAST_GENERATION_RE.findall(stdout)
     if gens:
-        out["last_generation"] = int(gens[-1])
+        out["last_generation"] = int(gens[-1]) + 1  # 0-based print -> 1-based
     return out
 
 

--- a/python/tests/test_early_termination_tracking.py
+++ b/python/tests/test_early_termination_tracking.py
@@ -1,0 +1,333 @@
+"""Early-termination tracking: the GA's exit path must reach the artifact.
+
+The runner captures engine stdout but used to scan it only for ``[GRAND]`` and
+throw the rest away.  Every early-exit path announces itself there, so a run that
+stopped at 14% of its configured generation budget landed in the results JSON
+looking exactly like one that ran the full 2000 generations -- same schema, same
+fields, no trace of the truncation.  Its mean RMSD then gets compared against
+full-budget baselines as though the two came from the same amount of search.
+
+These tests pin three things:
+
+* every exit message the engine can actually print is recognised, with its
+  governing numbers extracted (the regexes are checked against the literal
+  ``printf`` formats in ``LIB/gaboom.cpp``, not against paraphrases);
+* the governing knobs are recorded from the environment the *subprocess* saw,
+  including the one that matters -- ``FLEXAIDDS_ADAPTIVE_GENERATIONS`` is not
+  covered by ``FLEXAIDDS_NO_SEC`` (gaboom.cpp:927), so the runner's
+  "full budget is always consumed" guarantee does not hold when it is set;
+* absence of a record is never synthesised into "ran clean" -- a dry run and a
+  full-budget run must not produce the same evidence.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+from flexaidds.dataset_runner.runner import (
+    DatasetConfig,
+    DatasetResult,
+    DatasetRunner,
+    TargetResult,
+    early_exit_parameters,
+    parse_early_termination,
+)
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+GABOOM = REPO / "LIB" / "gaboom.cpp"
+
+# Verbatim renderings of the five printf() sites in LIB/gaboom.cpp, with the
+# format specifiers filled in. If the engine changes its wording these strings
+# must change with it -- that is the point of testing against them.
+ADAPTIVE = (
+    "[P5-ADAPTIVE-GEN] GA converged: best-CF plateau for 50 gens "
+    "(best_CF=-123.4500) at gen 279 — early stop (max_generations=2000)\n"
+)
+H_PLATEAU = (
+    "Early exit at gen 812: H plateau < 0.0010 "
+    "(H_now=0.863000 nats, delta=0.000400 nats)\n"
+)
+CF_STAGNANT = (
+    "GA terminated: CF stagnant for 300 gens (best_CF=-98.7600) "
+    "with gene-space collapsed\n"
+)
+ENTROPY = "GA terminated early by entropy convergence\n"
+FITNESS = "GA terminated early by fitness stagnation\n"
+
+
+# ---------------------------------------------------------------------------
+# parse_early_termination
+# ---------------------------------------------------------------------------
+
+
+def test_clean_run_is_not_flagged():
+    out = parse_early_termination("Generation:     1\nGeneration:  2000\ndone\n")
+    assert out["terminated_early"] is False
+    assert out["reason"] is None
+    assert out["last_generation"] == 2000
+
+
+def test_empty_stdout_is_not_flagged():
+    assert parse_early_termination("")["terminated_early"] is False
+    assert parse_early_termination(None)["terminated_early"] is False  # type: ignore[arg-type]
+
+
+def test_adaptive_plateau_is_parsed():
+    out = parse_early_termination("Generation:   279\n" + ADAPTIVE)
+    assert out["terminated_early"] is True
+    assert out["reason"] == "adaptive_cf_plateau"
+    # The numbers are the whole reason to record the event: "stopped at 279 of
+    # 2000" is actionable, "stopped early" is not.
+    assert out["generation"] == 279
+    assert out["max_generations"] == 2000
+    assert out["plateau"] == 50
+    assert out["best_cf"] == pytest.approx(-123.45)
+
+
+def test_h_plateau_is_parsed():
+    out = parse_early_termination(H_PLATEAU)
+    assert out["reason"] == "h_plateau"
+    assert out["generation"] == 812
+    assert out["eps"] == pytest.approx(0.001)
+    assert out["h_now"] == pytest.approx(0.863)
+    assert out["delta"] == pytest.approx(0.0004)
+
+
+def test_cf_stagnation_is_parsed():
+    out = parse_early_termination(CF_STAGNANT)
+    assert out["reason"] == "cf_stagnant_gene_collapsed"
+    assert out["plateau"] == 300
+    assert out["best_cf"] == pytest.approx(-98.76)
+
+
+@pytest.mark.parametrize(
+    "text,reason",
+    [(ENTROPY, "entropy_convergence"), (FITNESS, "fitness_stagnation")],
+)
+def test_bare_termination_messages_are_parsed(text, reason):
+    out = parse_early_termination(text)
+    assert out["terminated_early"] is True
+    assert out["reason"] == reason
+
+
+def test_last_generation_takes_the_final_occurrence():
+    """Progress lines repeat; the truncation point is the last one seen."""
+    text = "".join(f"Generation: {i:5d}\n" for i in (1, 2, 3, 154))
+    assert parse_early_termination(text)["last_generation"] == 154
+
+
+def test_termination_is_found_amid_ordinary_engine_chatter():
+    noisy = (
+        "Generation:   279\n"
+        "   7 (   2046.00      10.00 )  cf=-111058.302 fitnes=    2.627\n"
+        + ADAPTIVE
+        + "[GRAND] log_Z=12.5\n"
+    )
+    assert parse_early_termination(noisy)["reason"] == "adaptive_cf_plateau"
+
+
+@pytest.mark.skipif(not GABOOM.is_file(), reason="engine source not present")
+@pytest.mark.parametrize(
+    "needle",
+    [
+        "[P5-ADAPTIVE-GEN] GA converged: best-CF plateau for %d ",
+        "Early exit at gen %d: H plateau < %.4f ",
+        "GA terminated: CF stagnant for %d gens (best_CF=%.4f) ",
+        "GA terminated early by entropy convergence",
+        "GA terminated early by fitness stagnation",
+    ],
+)
+def test_patterns_track_the_real_engine_messages(needle):
+    """Guard against the parser silently going deaf.
+
+    A reworded printf() would make every regex above miss, and a missed exit
+    reads as a clean full-budget run -- failing open, in the one direction that
+    matters. Asserting the literal format strings still exist makes that a test
+    failure instead of a quiet loss of evidence.
+    """
+    assert needle in GABOOM.read_text(errors="replace")
+
+
+# ---------------------------------------------------------------------------
+# early_exit_parameters
+# ---------------------------------------------------------------------------
+
+
+def test_parameters_come_from_the_subprocess_env_not_the_parent():
+    """The engine sees ``sub_env``; recording os.environ would misreport it."""
+    got = early_exit_parameters({"FLEXAIDDS_NO_SEC": "1", "FLEXAIDDS_BENCHMARK": "1"})
+    assert got["FLEXAIDDS_NO_SEC"] == "1"
+    assert got["FLEXAIDDS_BENCHMARK"] == "1"
+    assert got["FLEXAIDDS_ADAPTIVE_GENERATIONS"] is None
+    assert got["adaptive_bypasses_no_sec"] is False
+
+
+def test_adaptive_generations_is_flagged_as_bypassing_no_sec():
+    """The finding this tracking exists for.
+
+    ``FLEXAIDDS_NO_SEC=1`` is what the runner relies on to guarantee the full
+    generation budget, and it does cover the stagnation / entropy / SEC /
+    H-plateau exits. It does NOT cover the adaptive best-CF plateau exit, which
+    is guarded only by ``ag_patience > 0``. So NO_SEC=1 and ADAPTIVE=50 together
+    still produce a truncated run, and the artifact has to say so.
+    """
+    got = early_exit_parameters(
+        {"FLEXAIDDS_NO_SEC": "1", "FLEXAIDDS_ADAPTIVE_GENERATIONS": "50",
+         "FLEXAIDDS_ADAPTIVE_EPS": "1.0"}
+    )
+    assert got["adaptive_bypasses_no_sec"] is True
+    assert got["FLEXAIDDS_ADAPTIVE_GENERATIONS"] == "50"
+    assert got["FLEXAIDDS_ADAPTIVE_EPS"] == "1.0"
+
+
+@pytest.mark.parametrize("value,expected", [("0", False), ("", False), ("  ", False),
+                                            ("1", True), ("50", True)])
+def test_adaptive_disabled_values_do_not_raise_the_flag(value, expected):
+    got = early_exit_parameters({"FLEXAIDDS_ADAPTIVE_GENERATIONS": value})
+    assert got["adaptive_bypasses_no_sec"] is expected
+
+
+@pytest.mark.skipif(not GABOOM.is_file(), reason="engine source not present")
+def test_recorded_compiled_thresholds_match_the_engine():
+    """The compiled-in constants are not configurable, so the artifact carries
+    them as literals. Literals drift; pin them to the source."""
+    src = GABOOM.read_text(errors="replace")
+    params = early_exit_parameters({})
+
+    def _const(pattern: str) -> str:
+        m = re.search(pattern, src)
+        assert m, f"constant not found in gaboom.cpp: {pattern}"
+        return m.group(1)
+
+    assert int(_const(r"STAGNATION_LIMIT\s*=\s*(\d+)")) == params["compiled_stagnation_limit"]
+    assert int(_const(r"kHPlateauWindow\s*=\s*(\d+)")) == params["compiled_h_plateau_window"]
+    assert float(_const(r"kHPlateauEps\s*=\s*([\d.eE+-]+)")) == pytest.approx(
+        params["compiled_h_plateau_eps_nats"]
+    )
+
+    ga_const = REPO / "LIB" / "ga_constants.h"
+    if ga_const.is_file():
+        m = re.search(r"GA_DEFAULT_ENTROPY_CHECK_INTERVAL\s*=?\s*(\d+)", ga_const.read_text())
+        if m:
+            assert int(m.group(1)) == params["compiled_entropy_check_interval"]
+
+
+# ---------------------------------------------------------------------------
+# Runner plumbing: _run_flexaid records, run_dataset consumes
+# ---------------------------------------------------------------------------
+
+
+def _runner(tmp_path) -> DatasetRunner:
+    return DatasetRunner(results_dir=tmp_path / "results", dry_run=True, n_workers=1)
+
+
+def test_no_record_is_not_synthesised_into_a_clean_run(tmp_path):
+    """An entry with no evidence must stay empty.
+
+    Dry runs and exec failures never reach the stdout parse. Filling in a
+    default "terminated_early: False" there would assert something the run never
+    established -- the same conflation, one layer up.
+    """
+    r = _runner(tmp_path)
+    got = r._early_termination_for("1gpk", "holo")
+    assert got == {"early_termination": {}, "early_exit_params": {}}
+
+
+def test_recorded_evidence_reaches_the_target_result_kwargs(tmp_path):
+    r = _runner(tmp_path)
+    key = "1gpk/holo"
+    r._entry_early_exit_params[key] = early_exit_parameters({"FLEXAIDDS_NO_SEC": "1"})
+    r._record_early_termination(key, "lig1", parse_early_termination(ADAPTIVE))
+
+    got = r._early_termination_for("1gpk", "holo")
+    assert got["early_termination"]["terminated_early"] is True
+    assert got["early_termination"]["reason"] == "adaptive_cf_plateau"
+    assert got["early_exit_params"]["FLEXAIDDS_NO_SEC"] == "1"
+    # TargetResult accepts them as-is (the call site splats this dict).
+    tr = TargetResult(target_id="1gpk", structural_state="holo", poses=[], **got)
+    assert tr.early_termination["generation"] == 279
+
+
+def test_one_truncated_ligand_marks_the_whole_entry(tmp_path):
+    """Scores are pooled across an entry's ligands, so one truncated ligand is
+    enough to make the entry's numbers incomparable."""
+    r = _runner(tmp_path)
+    key = "1gpk/holo"
+    r._record_early_termination(key, "ligA", parse_early_termination("Generation:  2000\n"))
+    r._record_early_termination(key, "ligB", parse_early_termination(ADAPTIVE))
+
+    rec = r._entry_early_termination[key]
+    assert rec["terminated_early"] is True
+    assert rec["reason"] == "adaptive_cf_plateau"
+    # ...and which ligand it was stays recoverable.
+    assert rec["per_ligand"]["ligA"]["terminated_early"] is False
+    assert rec["per_ligand"]["ligB"]["reason"] == "adaptive_cf_plateau"
+
+
+def test_entry_record_keeps_the_furthest_generation_seen(tmp_path):
+    r = _runner(tmp_path)
+    key = "t/holo"
+    r._record_early_termination(key, "a", parse_early_termination("Generation:   154\n"))
+    r._record_early_termination(key, "b", parse_early_termination("Generation:  1900\n"))
+    r._record_early_termination(key, "c", parse_early_termination("Generation:   300\n"))
+    assert r._entry_early_termination[key]["last_generation"] == 1900
+
+
+def test_entries_are_tracked_independently(tmp_path):
+    r = _runner(tmp_path)
+    r._record_early_termination("a/holo", "l", parse_early_termination(ADAPTIVE))
+    r._record_early_termination("b/holo", "l", parse_early_termination("Generation: 2000\n"))
+    assert r._early_termination_for("a", "holo")["early_termination"]["terminated_early"]
+    assert not r._early_termination_for("b", "holo")["early_termination"]["terminated_early"]
+
+
+# ---------------------------------------------------------------------------
+# Persistence -- the evidence has to survive the round trip
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_survives_save_and_resume(tmp_path):
+    """--resume reloads entries from JSON. Dropping the record there would put
+    the truncation back out of sight for exactly the runs that were interrupted.
+    """
+    r = _runner(tmp_path)
+    cfg = DatasetConfig(slug="s", name="n", description="d", targets=["1gpk"])
+    tr = TargetResult(
+        target_id="1gpk",
+        structural_state="holo",
+        poses=[],
+        early_termination=parse_early_termination(ADAPTIVE),
+        early_exit_params=early_exit_parameters(
+            {"FLEXAIDDS_NO_SEC": "1", "FLEXAIDDS_ADAPTIVE_GENERATIONS": "50"}
+        ),
+    )
+    r._save_target_result(tr, cfg, tier=1)
+    back = r._load_target_result(cfg, 1, "1gpk", "holo")
+
+    assert back is not None
+    assert back.early_termination["reason"] == "adaptive_cf_plateau"
+    assert back.early_termination["generation"] == 279
+    assert back.early_exit_params["adaptive_bypasses_no_sec"] is True
+
+
+def test_dataset_report_exposes_the_rollup():
+    dr = DatasetResult(
+        config=DatasetConfig(slug="s", name="n", description="d", targets=[]), tier=1
+    )
+    dr.early_terminations = {"1gpk/holo": parse_early_termination(ADAPTIVE)}
+    dr.early_exit_params = early_exit_parameters({"FLEXAIDDS_ADAPTIVE_GENERATIONS": "50"})
+    payload = dr.to_dict()
+    assert payload["early_terminations"]["1gpk/holo"]["reason"] == "adaptive_cf_plateau"
+    assert payload["early_exit_params"]["adaptive_bypasses_no_sec"] is True
+
+
+def test_dataset_report_rollup_defaults_to_empty():
+    dr = DatasetResult(
+        config=DatasetConfig(slug="s", name="n", description="d", targets=[]), tier=1
+    )
+    payload = dr.to_dict()
+    assert payload["early_terminations"] == {}
+    assert payload["early_exit_params"] == {}

--- a/python/tests/test_early_termination_tracking.py
+++ b/python/tests/test_early_termination_tracking.py
@@ -64,10 +64,25 @@ FITNESS = "GA terminated early by fitness stagnation\n"
 
 
 def test_clean_run_is_not_flagged():
-    out = parse_early_termination("Generation:     1\nGeneration:  2000\ndone\n")
+    out = parse_early_termination("Generation:     0\nGeneration:  1999\ndone\n")
     assert out["terminated_early"] is False
     assert out["reason"] is None
     assert out["last_generation"] == 2000
+
+
+def test_last_generation_is_normalised_to_the_1_based_convention():
+    """The engine prints two conventions; the record must expose only one.
+
+    The progress line prints ``gen_id`` 0-based -- a complete 2000-generation run
+    ends at "Generation:  1999" (verified against a full 1gpk run). Every exit
+    message prints ``i + 1``. Reporting both raw would make a run that finished
+    its budget look one generation short of ``max_generations``: a fabricated
+    truncation, the exact false positive this tracking exists to avoid.
+    """
+    full = "".join(f"Generation: {i:5d}\n" for i in range(2000))
+    out = parse_early_termination(full)
+    assert out["terminated_early"] is False
+    assert out["last_generation"] == 2000, "0-based print leaked into the record"
 
 
 def test_empty_stdout_is_not_flagged():
@@ -116,7 +131,7 @@ def test_bare_termination_messages_are_parsed(text, reason):
 def test_last_generation_takes_the_final_occurrence():
     """Progress lines repeat; the truncation point is the last one seen."""
     text = "".join(f"Generation: {i:5d}\n" for i in (1, 2, 3, 154))
-    assert parse_early_termination(text)["last_generation"] == 154
+    assert parse_early_termination(text)["last_generation"] == 155  # 1-based
 
 
 def test_termination_is_found_amid_ordinary_engine_chatter():
@@ -256,7 +271,7 @@ def test_one_truncated_ligand_marks_the_whole_entry(tmp_path):
     enough to make the entry's numbers incomparable."""
     r = _runner(tmp_path)
     key = "1gpk/holo"
-    r._record_early_termination(key, "ligA", parse_early_termination("Generation:  2000\n"))
+    r._record_early_termination(key, "ligA", parse_early_termination("Generation:  1999\n"))
     r._record_early_termination(key, "ligB", parse_early_termination(ADAPTIVE))
 
     rec = r._entry_early_termination[key]
@@ -271,7 +286,7 @@ def test_entry_record_keeps_the_furthest_generation_seen(tmp_path):
     r = _runner(tmp_path)
     key = "t/holo"
     r._record_early_termination(key, "a", parse_early_termination("Generation:   154\n"))
-    r._record_early_termination(key, "b", parse_early_termination("Generation:  1900\n"))
+    r._record_early_termination(key, "b", parse_early_termination("Generation:  1899\n"))
     r._record_early_termination(key, "c", parse_early_termination("Generation:   300\n"))
     assert r._entry_early_termination[key]["last_generation"] == 1900
 
@@ -279,7 +294,7 @@ def test_entry_record_keeps_the_furthest_generation_seen(tmp_path):
 def test_entries_are_tracked_independently(tmp_path):
     r = _runner(tmp_path)
     r._record_early_termination("a/holo", "l", parse_early_termination(ADAPTIVE))
-    r._record_early_termination("b/holo", "l", parse_early_termination("Generation: 2000\n"))
+    r._record_early_termination("b/holo", "l", parse_early_termination("Generation: 1999\n"))
     assert r._early_termination_for("a", "holo")["early_termination"]["terminated_early"]
     assert not r._early_termination_for("b", "holo")["early_termination"]["terminated_early"]
 


### PR DESCRIPTION
## Summary

The runner captures engine stdout but scanned it only for `[GRAND]`, discarding the rest. Every GA early-exit path announces itself there — so a run that stopped at 14% of its generation budget landed in the results JSON **indistinguishable** from one that ran the full 2000 generations: same schema, same fields, no trace of the truncation. Its `mean_rmsd` was then compared against full-budget baselines as though the two came from the same amount of search.

This records, per entry:

- **the exit event** — reason, `generation`, `max_generations`, and the governing numbers (plateau length, `best_CF`, `H_now`/`delta`), parsed from the five `printf` sites in `LIB/gaboom.cpp`;
- **the governing knobs as the subprocess saw them** — `FLEXAIDDS_NO_SEC`, `FLEXAIDDS_BENCHMARK`, `FLEXAIDDS_ADAPTIVE_GENERATIONS`/`_EPS` — plus the compiled-in thresholds (`STAGNATION_LIMIT`, `kHPlateauWindow`, `kHPlateauEps`, entropy check interval), so the artifact is self-describing;
- **a run-level rollup** on `DatasetResult` (`early_terminations`, `early_exit_params`), merged across MPI ranks by entry key — a dict update, like `entry_exit_codes`, so no double counting.

### The finding this exists for

`FLEXAIDDS_NO_SEC=1` is set on **every** benchmark subprocess (`runner.py:1565`) precisely so the full generation budget is consumed. It guards the stagnation, entropy-convergence, SEC and H-plateau exits. It does **not** guard the adaptive best-CF plateau exit, which checks only `ag_patience > 0` (`LIB/gaboom.cpp:927`):

```c
if (ag_patience > 0 && i > 0) {          // <-- no !no_sec check
    if ((ag_prev_best - ag_cur) < ag_eps) {
        if (++ag_plateau >= ag_patience) { printf("[P5-ADAPTIVE-GEN] ..."); break; }
```

So `FLEXAIDDS_ADAPTIVE_GENERATIONS` still shortens a benchmark run, silently, and the no-early-exit guarantee the runner relies on does not hold. The artifact now says so via `adaptive_bypasses_no_sec`, and the runner logs a warning naming `gaboom.cpp:927`.

Two deliberate non-behaviours:

- **Absence of a record is never synthesised into "ran clean."** Dry runs and exec failures leave the fields empty rather than asserting a full budget — that would be the same conflation, one layer up.
- **Records survive `--resume`.** The loader carries them, otherwise an interrupted run would lose exactly the evidence it needs.

## Scope

- [x] Benchmark / reproducibility

## Release impact

- [x] affects Python package behavior
- [x] affects benchmark or metric reporting

Additive only: two new `TargetResult` fields, two new `DatasetResult` fields, two new keys in the entry JSON and the dataset report. No existing key changes meaning; no metric is recomputed.

## Validation

- [x] unit tests
- [x] integration tests
- [x] manual validation

**31 tests** in `python/tests/test_early_termination_tracking.py`. Two of them close the failure mode that matters: the parser is pinned against the **literal `gaboom.cpp` format strings**, and the recorded thresholds against the **source constants** — so a reworded `printf` fails the suite instead of silently failing open (a missed exit reads as a clean full-budget run).

Both controls were run against the built engine on 1GPK:

**Positive — the truncation is caught.** With `FLEXAIDDS_NO_SEC=1` set by the runner, `FLEXAIDDS_ADAPTIVE_GENERATIONS=3` stopped the GA at **generation 6 of 2000**, and it reached the entry JSON:

```json
"early_termination": {"terminated_early": true, "reason": "adaptive_cf_plateau",
                      "generation": 6, "max_generations": 2000, "best_cf": -42979.6107},
"early_exit_params":  {"FLEXAIDDS_NO_SEC": "1", "adaptive_bypasses_no_sec": true}
```

**Negative — a complete run is not flagged.** A default-config run (no `NO_SEC`, adaptive OFF) consumed all 2000 generations with **no exit message at all**; the parser reports `terminated_early: False, last_generation: 2000`. Worth noting on its own: none of the `NO_SEC`-guarded exits fired unprompted on this target, so the adaptive path — the one `NO_SEC` does not cover — is the only one observed to truncate a run.

Full suite: **1154 passed, 70 skipped**. One pre-existing failure, `test_runner_absolute_paths.py::test_bare_name_on_PATH_still_resolves` — reproduced on a clean `git stash` of this branch, so it is not from this diff; this container's `/bin/sh` is `dash` and the test asserts `sh`.

## Security and safety

- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

The stdout parse is read-only over output the runner already captured; nothing new is executed and no new input is trusted.

## Reproducibility

- [x] benchmark claim updated with reproducibility artifact

This is squarely a reproducibility fix: it makes "how much search produced this number" a recorded property of the run rather than something inferred from a discarded log.

## Notes

For reviewers:

- `_run_flexaid` returns only poses and entries dispatch across a thread pool, so the evidence is routed to `run_dataset` through locked instance state, mirroring the existing `_entry_exit_codes` pattern rather than inventing a second mechanism.
- An entry is flagged if **any** of its ligands truncated — scores are pooled across ligands, so one truncated ligand is enough to make the entry's numbers incomparable. Per-ligand detail is kept under `per_ligand`.
- `early_exit_params` is captured **before** the subprocess runs, so a timeout or exec failure — the runs whose settings matter most — still records them.
- **Generation numbering.** The engine prints two conventions: the progress line prints `gen_id` 0-based (a complete 2000-generation run ends at `Generation:  1999`), while every exit message prints `i + 1`. Recorded raw, a run that consumed its full budget would read as one generation short of `max_generations` — a fabricated truncation. `parse_early_termination` normalises `last_generation` to 1-based so it is directly comparable to `generation` and `max_generations`; commit bd08b2d, with the full-budget run above as its regression fixture. Those progress lines reach stdout because `get_update_file_ptr` returns `stdout` when NRGsuite is not in use (`gaboom.cpp:3466`), which is the benchmark path.
- Follow-up worth deciding separately: whether `FLEXAIDDS_ADAPTIVE_GENERATIONS` should simply be ignored when `FLEXAIDDS_NO_SEC=1`. This PR only makes the conflict visible; it does not change engine behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added early-termination tracking for benchmark runs, including termination reasons, generation counts, and effective settings.
  * Included termination evidence in entry and dataset reports, with support for parallel processing and resumed runs.
  * Added warnings when configured generation budgets are not fully consumed, including adaptive-generation scenarios.

* **Bug Fixes**
  * Improved reporting accuracy for truncated entries and missing termination records.

* **Tests**
  * Added comprehensive coverage for parsing, aggregation, persistence, resume behavior, and adaptive-generation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->