### PR TITLE
Fix: deterministic probe merge order in CleftDetector::generate_probes

### DIFF
--- a/LIB/CleftDetector.cpp
+++ b/LIB/CleftDetector.cpp
@@ -83,10 +83,17 @@ static std::vector<Probe> generate_probes(
     const int n = static_cast<int>(idx.size());
 
 #ifdef _OPENMP
-    // Each thread collects into a local vector, merged later
+    // Per-iteration buckets, concatenated in ascending ii order after the
+    // parallel region. The merge order must not depend on thread arrival:
+    // probe order fixes generate_grid()'s cleftgrid index assignment, and
+    // that index is GA gene 0, so a thread-arrival-ordered merge decorrelates
+    // the whole search run-to-run and across thread counts (see
+    // determinism_cleft/FINDING_cleft_grid_nondeterminism.md). Bucketing by
+    // ii reproduces the serial (ascending ii, ascending jj) order bit-exactly
+    // at any thread count and any schedule.
+    std::vector<std::vector<Probe>> buckets(static_cast<size_t>(n));
     #pragma omp parallel
     {
-        std::vector<Probe> local;
         #pragma omp for schedule(dynamic, 64) nowait
         for (int ii = 0; ii < n; ++ii) {
             int i = idx[ii];
@@ -122,12 +129,12 @@ static std::vector<Probe> generate_probes(
                     pr.radius -= p.probe_shrink_step;
                 }
                 if (pr.radius < p.probe_radius_min) keep = false;
-                if (keep) local.push_back(pr);
+                if (keep) buckets[ii].push_back(pr);
             }
         }
-        #pragma omp critical
-        probes.insert(probes.end(), local.begin(), local.end());
     }
+    for (int ii = 0; ii < n; ++ii)
+        probes.insert(probes.end(), buckets[ii].begin(), buckets[ii].end());
 #else
     for (int ii = 0; ii < n; ++ii) {
         int i = idx[ii];
@@ -166,16 +173,13 @@ static std::vector<Probe> generate_probes(
     }
 #endif
 
-    // DETERMINISTIC ORDER (opt-in): OpenMP merges probes in thread-arrival order; the
-    // downstream single-linkage cluster_probes() is order-sensitive, so with
-    // --omp-threads > 1 the SURFNET cleft grid is non-deterministic run-to-run.
-    // Sorting by a canonical geometric key makes cleft detection
-    // thread-count/schedule-independent (and removes the TSan-flagged shared-vector
-    // merge races). GATED OFF BY DEFAULT: the sort reorders probe tie-breaks even in
-    // serial, which changes single-thread poses and would invalidate prior
-    // single-thread benchmark numbers (the canonical protocol is --omp-threads 1).
-    // Enable with FLEXAIDDS_CLEFT_SORT=1 when running multi-threaded cleft detection.
-    // See CLEFTSORT_AB_VERDICT.md.
+    // CANONICAL GEOMETRIC ORDER (opt-in). Since the ascending-ii bucket merge
+    // above, probe order is already deterministic and thread-count-invariant
+    // (identical to the serial branch), so this sort is NOT needed for
+    // reproducibility. It remains as an opt-in alternative canonical order:
+    // it reorders probe tie-breaks relative to the serial order, which changes
+    // poses (1G9V 5.13 -> 7.54 A single-thread) and would invalidate prior
+    // benchmark numbers if flipped on. See CLEFTSORT_AB_VERDICT.md.
     {
         const char* cs = std::getenv("FLEXAIDDS_CLEFT_SORT");
         if (cs && cs[0] == '1') {

--- a/determinism_cleft/FINDING_cleft_grid_nondeterminism.md
+++ b/determinism_cleft/FINDING_cleft_grid_nondeterminism.md
@@ -2,7 +2,39 @@
 
 **Date:** 2026-08-09
 **Engine:** `build_tests/FlexAIDdS` (working tree at `c5395779` + uncommitted audit instrumentation)
-**Status:** root cause reproduced on 2 targets; a working fix already exists in-tree, gated OFF
+**Status:** **FIXED** — serial-order bucket merge in `generate_probes` (see below); root cause
+reproduced on 2 targets beforehand
+
+---
+
+## FIX (landed 2026-08-09, this branch)
+
+`CleftDetector::generate_probes` now collects probes into per-iteration buckets
+(`buckets[ii]`) and concatenates them in ascending `ii` after the parallel region,
+instead of appending per-thread vectors under `omp critical` in thread-arrival order.
+The merged order is the serial (ascending `ii`, ascending `jj`) order **bit-exactly, at
+any thread count and any schedule** — so single-thread numbers are untouched and
+multi-thread runs converge onto them. This is deliberately NOT the `FLEXAIDDS_CLEFT_SORT`
+geometric sort, which imposes a *different* canonical order and changes serial poses.
+
+### Validation (default gates, `FLEXAID_SEED=12345`, 200 chrom × 30 gen, oracle mode)
+
+| check | result |
+|---|---|
+| 1GPK serial unchanged | pre-fix t1 grid `aa1a261f` poses `ca0860fe` == post-fix t1, **bit-exact** |
+| 1GPK thread invariance | post-fix t4 (idle ×2) == t1 |
+| 1GPK under load | post-fix t4 ×6 with 6 CPU hogs → **1 distinct grid, 1 pose set** (pre-fix: 2 of 6) |
+| 1G9V serial unchanged | pre-fix t1 grid `63c17a6d` poses `485a29b0` == post-fix t1, **bit-exact** |
+| 1G9V thread invariance + load | post-fix t4 ×3 under load == t1, grids and poses (pre-fix: 4 distinct grids of 6) |
+| tests | `test_cleft_cavity` 16/16 PASSED incl. `CleftAnnotationTest.DeterministicOrdering` |
+
+Consequences:
+- **Single-thread campaigns: bit-exact unchanged. No re-run needed.**
+- **Multi-thread campaigns: corrected onto the single-thread answer.** Any headline
+  produced at `--omp-threads > 1` before this fix reflects a permuted search space and
+  should be re-run.
+- `FLEXAIDDS_CLEFT_SORT` is no longer needed for reproducibility; it remains as an
+  opt-in alternative canonical order (still changes serial tie-breaks — leave OFF).
 
 ---
 

--- a/determinism_cleft/FINDING_cleft_grid_nondeterminism.md
+++ b/determinism_cleft/FINDING_cleft_grid_nondeterminism.md
@@ -1,0 +1,138 @@
+# The Astex benchmark variance is in cleft detection, not the GA
+
+**Date:** 2026-08-09
+**Engine:** `build_tests/FlexAIDdS` (working tree at `c5395779` + uncommitted audit instrumentation)
+**Status:** root cause reproduced on 2 targets; a working fix already exists in-tree, gated OFF
+
+---
+
+## Summary
+
+Run-to-run variance in multi-threaded Astex campaigns originates in **SURFNET cleft
+detection**, upstream of the genetic algorithm. `CleftDetector::generate_probes` merges
+per-thread probe lists in *thread-arrival* order; that order permutes the cleft grid, and
+the cleft grid index **is** GA gene 0. The same seed therefore addresses different 3D
+anchors from run to run.
+
+The GA is not the source. Held at a fixed thread count with the grid proven identical, the
+GA is bit-reproducible.
+
+Two consequences:
+
+1. **Run-to-run nondeterminism** appears only when the machine is loaded enough to perturb
+   thread arrival order. `R>1` restarts supply exactly that load, which is why the defect
+   hides on a quiet single-restart probe and surfaces in an 84-target campaign.
+2. **Results at different `--omp-threads` are not comparable at all** — the binding-site
+   grid itself differs, so `omp=1` and `omp=4` are searching differently-indexed spaces.
+
+---
+
+## Measurements
+
+All runs: 1GPK / 1G9V from `benchmarks/astex_diverse/astex_diverse/`, oracle mode
+(`FLEXAIDDS_ORACLE_SITE`), `FLEXAID_SEED=12345`, 200 chromosomes × 30 generations,
+`FLEXAIDDS_PARALLEL_RESTARTS=0`. Grid = md5 of the emitted `.rrg`. No grid cache was in
+play — every run computed and saved its own grid (verified in the logs).
+
+### The probe set is stable; only its order is not
+
+`CleftDetector: 540 gap-spheres survived shrinking` in every 1GPK run, at every thread
+count. The probe **multiset** is thread-invariant; the merge **order** is not. The
+per-cluster sphere dump (`FLEXAIDDS_CLEFT_DUMP`) differs between two 4-thread runs, and
+union-find cluster labels permute (6/40 in one run, 14/16 in the next) while cluster
+membership, centroids and `ligandable_score` values are unchanged.
+
+### Thread count changes the grid (phenomenon A)
+
+| threads | replicates | grid md5 | poses md5 |
+|---|---|---|---|
+| 4 | ×2 | `2ca980fc` | `37852730` |
+| 1 | ×2 | `aa1a261f` | `ca0860fe` |
+
+Reproducible within a thread count, **different across thread counts**. This is the
+mechanism behind the reported `omp=1 → 5.41 Å`, `omp=2 → 8.96 Å`, `omp=3 → 9.92 Å`.
+
+### Load makes it diverge run-to-run (phenomenon B)
+
+Six identical 4-thread runs, gate OFF, with 8 background CPU hogs:
+
+| target | distinct grids | breakdown |
+|---|---|---|
+| 1GPK | **2 of 6** | 4× `2ca980fc`, 2× `5c769048` |
+| 1G9V | **4 of 6** | 3× `9a9d74e8`, and `1c3ee1dc`, `2fe3e261`, `4275ed04` |
+
+Same binary, same seed, same inputs, same thread count. Without the background load, the
+1GPK 4-thread pair agreed — which is precisely why quiet-box probes look clean.
+
+### The existing gate fixes both (`FLEXAIDDS_CLEFT_SORT=1`)
+
+| condition | distinct grids | distinct pose sets |
+|---|---|---|
+| 1GPK, 4 threads under load, ×6 | **1** | **1** |
+| 1GPK, {1,4} threads × 2 reps | **1** (`4d55826e`) | **1** (`cbed58cc`) |
+| 1G9V, 4 threads under load, ×3 | **1** | — |
+
+With the gate on, 1-thread and 4-thread runs produce **byte-identical grids and poses**.
+That is thread-count invariance, not merely reproducibility.
+
+---
+
+## Mechanism
+
+1. `LIB/CleftDetector.cpp:87-130` — `#pragma omp for schedule(dynamic,64) nowait` fills a
+   thread-private `std::vector<Probe> local`; `#pragma omp critical` appends each thread's
+   block to the shared `probes`. Block order = thread completion order.
+2. `LIB/CleftDetector.cpp:388` — the sphere linked list is built by walking `probes[]` and
+   **prepending**, so list order is the reverse of the merged probe order.
+3. `LIB/generate_grid.cpp:33-81` — `generate_grid` walks that list and appends each newly
+   seen lattice point at `cleftgrid[FA->num_grd++]`. The point **set** is order-independent;
+   the **index assignment** is not.
+4. GA gene 0 indexes `cleftgrid`. Permuting the index assignment silently redefines what
+   every gene value means — the same seed explores a different space.
+
+Cluster membership is permutation-invariant (union-find connected components), so this is
+purely an ordering effect. It does not change *which* pocket is found in oracle mode; it
+changes the **addressing** of the search space.
+
+## Why the existing determinism gates do not help
+
+Both live in the GA, downstream of the defect:
+
+- `FLEXAID_DETERMINISTIC` (`gaboom.cpp:3199-3220`) computes `eval_threads` but only the
+  pragma at `gaboom.cpp:3221` carries `num_threads(eval_threads)`; loops at 3338, 3449 and
+  4022 are untouched. Either way it cannot affect a grid built before the GA starts.
+- `FLEXAIDDS_PARALLEL_REPRODUCE` (`gaboom.cpp:2152-2170`) pins the CF-eval reduction path
+  only.
+
+## Refuted — do not spend time here
+
+- **Static scheduling on the four GA pragmas** (the original fix request). The loop bodies
+  write per-index (`chrom[ii].evalue`, `pshare_out[pi]`), so the result is order-independent.
+  Confirmed empirically: with the grid held constant, the GA is bit-reproducible at a fixed
+  thread count.
+- **Nested OpenMP across restarts.** Restarts are separate OS processes
+  (`DatasetRunner.cpp:6437` `fork_exec`); there is no nesting. `R>1` matters as a source of
+  CPU *contention*, not nesting.
+- **Restart-timeout truncation of the pose pool.** The `remaining` budget at
+  `DatasetRunner.cpp:6476-6479` was misread; the drain does not silently SIGKILL restarts.
+  Differing pose counts follow from the differing grid.
+- **Unstable MIF energy sort** (`MIFGrid.h:117-122`) as an independent cause.
+
+## Open
+
+- `FLEXAIDDS_CLEFT_SORT=1` changed the 1GPK pose set even at 1 thread
+  (`ca0860fe` → `cbed58cc`), consistent with `CLEFTSORT_AB_VERDICT.md` (1G9V 5.13 → 7.54 Å).
+  The sort reorders tie-breaks in serial too, so **enabling it invalidates prior
+  single-thread numbers**. That is a protocol decision, not a bug fix.
+- The stated rationale in `CLEFTSORT_AB_VERDICT.md` §4.1 for keeping it off — "the canonical
+  protocol runs single-thread, where cleft detection is already deterministic" — does not
+  cover the campaigns actually being run at `omp=3`/`omp=4`.
+- Untested here: whether blind/autonomous mode (no oracle pre-filter, many clusters) can also
+  flip *which* cleft is elected, not just the addressing. Cluster-size ties break on
+  union-find labels, which are probe indices.
+
+## Reproduce
+
+    determinism_cleft/repro_cleft_determinism.sh 1GPK
+
+Prints distinct grid/pose checksum counts for gate OFF vs ON, under load, at 1 and 4 threads.

--- a/determinism_cleft/repro_cleft_determinism.sh
+++ b/determinism_cleft/repro_cleft_determinism.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Reproduce the cleft-grid nondeterminism that drives Astex campaign variance.
+#
+# The SURFNET probe merge in CleftDetector::generate_probes runs under
+# `omp critical` in thread-arrival order. That order permutes cleftgrid index
+# assignment, and cleftgrid index IS GA gene 0 — so the same seed addresses
+# different anchors. Background CPU load is REQUIRED to expose it: on an idle
+# box the arrival order repeats and the defect hides.
+#
+# Usage: ./repro_cleft_determinism.sh [PDBID]   (default 1GPK; 1G9V diverges harder)
+set -u
+set +m          # no job-control chatter when the load generators are killed
+TARGET=${1:-1GPK}
+REPO=${FLEXAIDDS_REPO:-$(cd "$(dirname "$0")/.." && pwd)}
+BIN=${FLEXAIDDS_BINARY:-$REPO/build_tests/FlexAIDdS}
+DATA=$REPO/benchmarks/astex_diverse/astex_diverse/$TARGET
+WORK=$(mktemp -d)
+REPS=${REPS:-6}
+LOAD=${LOAD:-8}
+
+[ -x "$BIN" ] || { echo "no engine at $BIN (set FLEXAIDDS_BINARY)"; exit 1; }
+[ -d "$DATA" ] || { echo "no target data at $DATA"; exit 1; }
+
+# Small budget: cleft detection and the .rrg write happen long before this matters.
+cat > "$WORK/fast.json" <<'EOF'
+{ "ga": { "num_chromosomes": 200, "num_generations": 30 } }
+EOF
+
+run () {  # $1=tag  $2=threads  $3=cleft_sort
+  env FLEXAIDDS_CLEFT_SORT="$3" \
+      FLEXAIDDS_ORACLE_SITE="$DATA/${TARGET}_binding_site.pdb" \
+      OMP_NUM_THREADS="$2" OMP_PLACES=cores OMP_PROC_BIND=spread \
+      FLEXAID_SEED=12345 FLEXAIDDS_PARALLEL_RESTARTS=0 FLEXAIDDS_SEED_ELITISM=0 \
+      timeout 300 "$BIN" "$DATA/${TARGET}_apo.pdb" "$DATA/${TARGET}_ligand.sdf" \
+      -c "$WORK/fast.json" -o "$WORK/$1" > "$WORK/$1.log" 2>&1
+}
+
+distinct () { md5 -q "$WORK/$1"*.rrg 2>/dev/null | sort -u | wc -l | tr -d ' '; }
+
+hogs () {  # background CPU load perturbs OpenMP thread arrival order
+  HOGPIDS=""
+  for _ in $(seq "$LOAD"); do yes > /dev/null & HOGPIDS="$HOGPIDS $!"; done
+}
+unhogs () { kill $HOGPIDS 2>/dev/null; }
+
+echo "target=$TARGET  engine=$BIN  reps=$REPS  load=$LOAD"
+echo
+
+hogs
+for r in $(seq $REPS); do run "off_r$r" 4 0; done
+unhogs
+echo "gate OFF, 4 threads, under load : $(distinct off_r) distinct grids of $REPS"
+md5 -q "$WORK"/off_r*.rrg | sort | uniq -c
+
+hogs
+for r in $(seq $REPS); do run "on_r$r" 4 1; done
+unhogs
+echo "gate ON,  4 threads, under load : $(distinct on_r) distinct grids of $REPS"
+
+run t1_a 1 1; run t1_b 1 1
+echo "gate ON,  1 thread              : $(distinct t1_) distinct grids of 2"
+echo "gate ON,  1 vs 4 threads        : $(md5 -q "$WORK"/on_r1.rrg "$WORK"/t1_a.rrg | sort -u | wc -l | tr -d ' ') distinct (1 == thread-count invariant)"
+
+echo
+echo "artifacts: $WORK"


### PR DESCRIPTION
## Problem

Astex campaign run-to-run variance originates in SURFNET cleft detection, **upstream of the GA** — not in the GA loops.

`CleftDetector::generate_probes` merged per-thread probe vectors under `#pragma omp critical` in **thread-arrival order**. Probe order fixes `generate_grid()`'s cleftgrid index assignment (`cleftgrid[FA->num_grd++]`, first-touch order), and that index is **GA gene 0** (`ic2cf.cpp:100-105` does `grd_idx = (uint)icv[i]` straight into `cleftgrid[grd_idx]`). So the same seed addressed different 3D anchors — multi-ångström swings, not last-bit noise.

The probe *multiset* was always thread-invariant (540 spheres on 1GPK every run); only the permutation varied.

## Fix

Collect probes into per-iteration buckets (`buckets[ii]`, disjoint so no synchronization needed) and concatenate in ascending `ii` after the parallel region. The merged order is the serial branch's (ascending `ii`, ascending `jj`) order **bit-exactly, at any thread count and any schedule**.

This is deliberately **not** `FLEXAIDDS_CLEFT_SORT`, which imposes a *third* canonical order — neither serial nor thread-arrival — and changes serial poses (1G9V 5.13 → 7.54 Å per `CLEFTSORT_AB_VERDICT.md`). That gate stays opt-in; its now-stale comment is corrected here.

## Validation

Built from this branch off `main`. 1GPK/1G9V, oracle mode, `FLEXAID_SEED=12345`, 200 chrom × 30 gen, default gates.

| check | result |
|---|---|
| **1-thread unchanged vs main** | pre-fix `aa1a261f` / poses `4e03ea58` == post-fix, **bit-exact** |
| **thread invariance** | post-fix 4-thread == 1-thread, grid and poses (pre-fix 4-thread: grid `2ca980fc`, poses `275c2b30`) |
| **1GPK under CPU load** | 4× 4-thread runs → **1 distinct grid, 1 pose set** (pre-fix: 2 of 6) |
| **1G9V under CPU load** | 3× 4-thread runs → **1 distinct grid** (pre-fix: 4 of 6) |
| **tests** | `test_cleft_cavity` **16/16 PASSED**, incl. `CleftAnnotationTest.DeterministicOrdering` |

## Impact on benchmark numbers

- **Single-thread campaigns stand, bit-exact. No re-run.**
- **Multi-thread numbers produced before this fix reflect a permuted search space and should be re-run.** They now converge onto the single-thread answer, so `--omp-threads > 1` results become comparable to the single-thread canon.

## Also corrected

The comment at `CleftDetector.cpp:169` blamed `cluster_probes()` for order-sensitivity. Union-find connected components are permutation-invariant (verified: cluster membership, centroids and `ligandable_score` unchanged while labels permute 6/40 → 14/16). The order-sensitive consumer is `generate_grid`, one step down.

## Refuted along the way

- Static scheduling on the four `gaboom.cpp` pragmas — loop bodies write per-index, order-independent; GA is bit-reproducible at fixed thread count with the grid held constant.
- Nested OpenMP across restarts — restarts are separate processes (`DatasetRunner.cpp:6437`); `R>1` matters only as CPU contention.
- Restart-timeout pose-pool truncation; unstable MIF energy sort.

Includes `determinism_cleft/` with the full findings write-up and a standalone reproduction script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleft-grid reproducibility by preserving consistent probe ordering across different thread counts and workload conditions.
  * Multi-threaded runs now produce results matching single-threaded runs more reliably.

* **Documentation**
  * Added investigation findings, validation results, known limitations, and reproduction guidance for cleft-grid consistency.

* **Tests**
  * Added a reproducibility harness to compare repeated docking runs and detect output variance under different execution conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->