### PR TITLE
Fix: align write_report CSV header with its row writer

### DIFF
--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -8208,6 +8208,11 @@ void DatasetRunner::write_report(const BenchmarkReport& report,
                "native_pose_seeded,native_pose_seed_fraction,protocol_claim_eligible,"
                "cf_native,best_cluster_rmsd,conditional_scanned_pool_ceiling,best_cluster_idx,"
                "seed_echo,pose_source,"
+               // The row writer below emits election_mode/consensus_count/rank0_demoted
+               // here. Omitting them left the header 3 fields short of every row, so
+               // pandas promoted the surplus to an index and shifted every named column
+               // from cf_top1_pose_path onward left by 3 -- silently, without an error.
+               "election_mode,consensus_count,rank0_demoted,"
                "cf_top1_pose_path,cf_top1_score,cf_top1_rmsd,cf_top1_pose_sha256,"
                "entropy_top1_pose_path,entropy_top1_score,entropy_top1_rmsd,entropy_top1_pose_sha256,"
                "H_rep_rank0,H_pop,H_rep_mean,D_vib";


### PR DESCRIPTION
## Problem

`write_report()`'s aggregate results CSV header omits `election_mode`, `consensus_count` and `rank0_demoted`, while its row writer emits all three immediately after `pose_source`:

- header: `LIB/DatasetRunner.cpp:8210` — `seed_echo,pose_source,` → `cf_top1_pose_path,...`
- rows:   `LIB/DatasetRunner.cpp:8259` — `... pose_source, election_mode, consensus_count, rank0_demoted, cf_top1_pose_path, ...`

Every row is 3 fields wider than the header. pandas promotes the surplus to an index and **shifts every named column from `cf_top1_pose_path` onward left by three — silently, with no parse error.** Any analysis reading `cf_top1_rmsd`, `cf_top1_score`, the entropy top-1 columns, or `H_rep_rank0`/`H_pop`/`D_vib` from this file has been reading a neighbouring column.

The per-target header (`:7792`) already lists all three correctly. Only the aggregate report — the file campaign analyses actually read — was wrong.

## Fix

Add the three names to the aggregate header so it matches the row writer. Header text only; the row writer is untouched, so no emitted data changes.

## Verification

Both header sites now carry the columns and align with their respective row writers:

```
7793:  "election_mode,consensus_count,rank0_demoted,"   (per-target, was already correct)
8215:  "election_mode,consensus_count,rank0_demoted,"   (aggregate, this fix)
```

`benchmark_datasets` rebuilds and links clean.

## Why this matters now

This gates analysis of any re-run campaign. Worth landing alongside #403 before the Astex-84 relaunch, otherwise the corrected determinism produces a correctly-computed CSV that is still parsed misaligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)