### PR TITLE
Fix: reconcile emitted CF.app and .mcf head with the recomputed score

### DIFF
--- a/LIB/cluster.cpp
+++ b/LIB/cluster.cpp
@@ -450,6 +450,7 @@ void cluster(FA_Global* FA, GB_Global* GB, VC_Global* VC, chromosome* chrom, gen
 		// substitute a stale search score.
 		cf=ic2cf(FA,VC,atoms,residue,cleftgrid,GB->num_genes,FA->opt_par);
 		const double emitted_cf = get_cf_evalue(&cf, FA);
+		const double emitted_app = get_apparent_cf_evalue(&cf);
 		const double score_delta = std::abs(emitted_cf - chrom[Clus_TOP[j]].evalue);
 		const bool score_pose_consistent = std::isfinite(emitted_cf) &&
 		                                   score_delta <= 1e-4;
@@ -459,6 +460,17 @@ void cluster(FA_Global* FA, GB_Global* GB, VC_Global* VC, chromosome* chrom, gen
 			        "delta=%.8f\n",
 			        j, chrom[Clus_TOP[j]].evalue, emitted_cf, score_delta);
 		}
+		// Bug 5 (1HP0 CF=-1700): a GA-time transient can leave chrom.evalue /
+		// chrom.app_evalue as a spurious large-NEGATIVE phantom that is far more
+		// favorable than any clean re-score of the emitted geometry. REMARK CF=
+		// already reports the recomputed emitted_cf, but REMARK CF.app and the
+		// .mcf sidecar still carried the stored app_evalue — and the DatasetRunner
+		// pooled selector reads the .mcf, so the phantom was elected as best_score
+		// (dragging in a wrong pose). When the stored score is pose-inconsistent,
+		// substitute the recomputed apparent CF everywhere the phantom leaked.
+		const double emit_app_value = score_pose_consistent
+		                              ? chrom[Clus_TOP[j]].app_evalue
+		                              : emitted_app;
 
 		size_t remark_len = 0;
 		remark[0] = '\0';
@@ -475,7 +487,7 @@ void cluster(FA_Global* FA, GB_Global* GB, VC_Global* VC, chromosome* chrom, gen
 		snprintf(tmpremark, MAX_REMARK, "REMARK CF.pose_score_consistent=%s\n",
 		         score_pose_consistent ? "true" : "false");
 		safe_remark_cat(remark, tmpremark, &remark_len);
-		snprintf(tmpremark, MAX_REMARK, "REMARK CF.app=%8.5f\n",chrom[Clus_TOP[j]].app_evalue);
+		snprintf(tmpremark, MAX_REMARK, "REMARK CF.app=%8.5f\n", emit_app_value);
 		safe_remark_cat(remark, tmpremark, &remark_len);
 
 		// P2 provenance — emitted ONLY for non-default modes so the default
@@ -599,8 +611,11 @@ void cluster(FA_Global* FA, GB_Global* GB, VC_Global* VC, chromosome* chrom, gen
 				mcf_path = mcf_path.substr(0, mcf_path.size() - 4) + ".mcf";
 			FILE* mf = fopen(mcf_path.c_str(), "w");
 			if (mf) {
-				// Head chromosome (guaranteed first so member_cfs[0] == head CF)
-				fprintf(mf, "%.6f\n", chrom[Clus_TOP[j]].app_evalue);
+				// Head chromosome (guaranteed first so member_cfs[0] == head CF).
+				// Use the pose-consistent apparent CF (emit_app_value): a phantom
+				// stored app_evalue (Bug 5, 1HP0) must not reach the pooled
+				// selector, which reads member_cfs[0] from this sidecar.
+				fprintf(mf, "%.6f\n", emit_app_value);
 				// Members: scan all chromosomes assigned to this cluster head
 				for (int k = 0; k < num_chrom; ++k) {
 					if (k != Clus_TOP[j] && Clus_GAPOP[k] == Clus_TOP[j])


### PR DESCRIPTION
Cherry-pick of `1cb0cf9a` from `fix/1hp0-cf-divergence` onto main. That branch has four other unrelated commits (pb_clash, vct_norm); this lifts only the reconciliation.

## Problem

A GA-time transient can leave `chrom.evalue` / `chrom.app_evalue` as a spurious large-**negative** phantom, far more favourable than any clean re-score of the emitted geometry (1HP0: stored CF = −1700, re-score = +593).

`REMARK CF=` already reported the recomputed `emitted_cf`, but **`REMARK CF.app` and the `.mcf` sidecar still carried the stored `app_evalue`** — and the DatasetRunner pooled selector reads the `.mcf`. So the phantom was elected as `best_score` and dragged in a wrong pose.

## Why this matters more now than when it was written

The entropy-aware election LP has chosen for the relaunch (`FLEXAIDDS_SOFTBETA_ELECTION=1`) computes `Z = Σ e^(−CF_i/T)`, `P_i`, `H̃ = Σ P_i·CF_i` and `S̃ = −Σ P_i ln P_i` **from `.mcf` member CFs** (`cluster.cpp:590-610`, consumed per `SoftBetaFreeEnergy.h`). An unreconciled phantom would therefore corrupt the **mode ranking itself**, not merely `best_score`. This was the one open caveat blocking clean interpretation of that experiment.

## Verification

Coordinate-inert absent a phantom — ATOM/HETATM hashes unchanged vs main:

| target | main | +reconcile |
|---|---|---|
| 1GPK | `f0bfe158` | `f0bfe158` |
| 1G9V | `b99f51b5` | `b99f51b5` |

(Coordinate-only hashes, excluding REMARK/header — whole-file hashing gives false positives here, as #405 demonstrated.)

## Known limit — deliberately not fixed here

Only `member_cfs[0]` (the head) is reconciled. Member entries below still write `chrom[k].app_evalue`, so a phantom in a **non-head member** would still reach the `.mcf`.

That is sufficient for the pooled selector (which reads `member_cfs[0]`) but **not sufficient in general for `Z` and `S̃`, which sum over all members**. If the ΔG̃ ranking shows anomalies, this is the first place to look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)