### PR TITLE
Fix: launcher must fail closed when engine runtime data files are missing

### DIFF
--- a/handoff_swe/launch_astex84_relaunch.sh
+++ b/handoff_swe/launch_astex84_relaunch.sh
@@ -45,7 +45,13 @@ grep -q "omp critical" "$REPO/LIB/CleftDetector.cpp" \
 
 cp "$REPO/build_tests/FlexAIDdS" "$REPO/build_tests/benchmark_datasets" "$OUT/bin/"
 # stage the runtime data files the engine resolves relative to its binary
-cp "$REPO"/build_tests/*.dat "$OUT/bin/" 2>/dev/null || true
+cp "$REPO"/build_tests/*.dat "$REPO"/build_tests/*.def "$OUT/bin/" 2>/dev/null || true
+# fail closed: the engine resolves AMINO.def / NUCLEOTIDES.def next to its binary and
+# aborts with exit code 8 before docking if they are absent — which yields a 13-second
+# "rc=0" campaign with 84 result rows, 0 poses and a 0.0% rate that looks like a result.
+for f in AMINO.def NUCLEOTIDES.def MC_st0r5.2_6.dat; do
+  [ -s "$OUT/bin/$f" ] || fail "runtime data file $f missing from $OUT/bin — engine would abort (exit 8)"
+done
 
 # ── Campaign environment ─────────────────────────────────────────────────────
 export FLEXAID_SEED=12345


### PR DESCRIPTION
## The failure this prevents

The engine resolves `AMINO.def` and `NUCLEOTIDES.def` **relative to its own binary** (`direct_input.cpp:62-68`) and calls `Terminate(8)` via `read_input.cpp:159` when they are absent.

`launch_astex84_relaunch.sh` staged only `*.dat` into `$OUT/bin`. So a campaign could start, abort **every target before docking**, and still finish `rc=0` — 84 result rows, zero poses, and a **0.0% success rate that looks like a measurement** rather than a misconfiguration. A 13-second campaign that reports a number is worse than one that crashes.

## Fix

Stage `*.def` alongside `*.dat`, then assert all three files are present and non-empty in `$OUT/bin` before launching. Consistent with the launcher's other preconditions (#403 bucket merge present, racy merge absent, CSV headers aligned, `CLEFT_SORT` unset): **refuse to start rather than produce a plausible-looking null.**

## Verification

- `build_tests/` carries `AMINO.def`, `NUCLEOTIDES.def`, `MC_st0r5.2_6.dat` — confirmed present.
- The exit-8 path is **not hypothetical**: it fired during this session's #405 bisect, when a relocated binary could not find `MC_st0r5.2_6.dat` and printed `ERROR: Could not open file … / FlexAID terminated with exit code 8`. Passing `--data-dir` fixed it. A campaign has no such second chance.
- `bash -n` clean.

Credit: this guard was drafted by someone else into the working tree; I verified the mechanism against source and landed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)