### PR TITLE
Add: emit compile_commands.json for clangd/IDEs

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,12 @@
+# clangd configuration for FlexAIDdS.
+#
+# CompilationDatabase points clangd at the compile_commands.json that CMake
+# emits into build/ (CMAKE_EXPORT_COMPILE_COMMANDS, set in CMakeLists.txt).
+#
+# The -std fallback matters for a fresh clone that has not been configured yet:
+# without it clangd assumes an older standard and reports every use of
+# std::optional / std::span / std::filesystem across LIB/ as an error.
+CompileFlags:
+  CompilationDatabase: build
+  Add:
+    - -std=c++23

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,16 @@ endif()
 
 project(FlexAID VERSION 2.0.0 LANGUAGES ${_ENABLED_LANGUAGES})
 
+# ── Editor/tooling support: emit compile_commands.json ────────────────────
+# Emits a JSON description of the compile line for each translation unit.
+# It affects no compiler invocation and produces no object code, so builds
+# and results are byte-identical with it on or off.
+#
+# Without it, clangd/IDEs fall back to a default C++ standard and report the
+# engine's C++23 usage (std::optional, std::span, std::filesystem) as errors
+# across LIB/ — hundreds of phantom diagnostics that mask real ones.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "Emit compile_commands.json for clangd/IDEs" FORCE)
+
 # ── Embed git provenance in binary ────────────────────────────────────────
 execute_process(
     COMMAND git -C "${CMAKE_SOURCE_DIR}" status --porcelain


### PR DESCRIPTION
## Problem

There is no compilation database in the tree (`CMAKE_EXPORT_COMPILE_COMMANDS` was unset, no `compile_commands.json`, no `.clangd`). clangd therefore falls back to a default C++ standard and reports the engine's C++23 usage as errors — `std::optional`, `std::span`, `std::filesystem` are all "missing" across `LIB/`.

Observed phantom diagnostics in `vcfunction.cpp`, `top.cpp`, `DatasetRunner.cpp/.h`, `ProtocolConfig.cpp/.h` and `VoronoiCFBatch.h`, several of them "too many errors emitted, stopping now". Real diagnostics are buried underneath.

## Change

- `CMAKE_EXPORT_COMPILE_COMMANDS ON` in `CMakeLists.txt`.
- `.clangd` pointing at `build/` with a `-std=c++23` fallback, so a freshly cloned, not-yet-configured tree is also diagnosable.

## Verification

```
cmake -S . -B /tmp/cc_verify -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF   # exit 0
```
Produces `compile_commands.json` with **228 entries**; `LIB/vcfunction.cpp` carries `-std=c++23`.

`python3 scripts/check_repo_hygiene.py` — clean.

## Science-Impact: none

`CMAKE_EXPORT_COMPILE_COMMANDS` only writes a JSON description of each compile line. It changes no compiler invocation, no flag, no source file, and no default, and emits no object code. Builds and docked coordinates are byte-identical with it on or off.

`CMakeLists.txt` is listed in `docs/SCIENCE_CRITICAL_PATHS.txt` (because it carries `-march=native` / `-ffast-math`), hence this declaration. No non-engine stack is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Developer Experience**
  * Added improved C++ editor and language-server configuration.
  * Enabled generation of compilation metadata for better IDE support.
  * Configured C++23 as the fallback language standard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->