### PR TITLE
Fix: contacts epoch rewound every generation, silently corrupting CF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2246,6 +2246,29 @@ flexaids_add_unit_test(test_protocol_config
         add_test(NAME CompareEnergyMatricesTests COMMAND test_compare_energy_matrices)
     endif()
 
+    # test_contacts_epoch — FLEXAIDDS_CONTACTS_EPOCH stamp-buffer invariant.
+    #   Pins the generation-boundary rewind: FA_Global is re-snapshotted from the
+    #   master every generation (gaboom.cpp) while the contacts stamp buffer stays
+    #   resident, so the epoch counter must live inside the buffer, not the struct.
+    #   Header-only under test — no engine sources needed.
+    flexaids_add_unit_test(test_contacts_epoch
+        SOURCES
+            tests/test_contacts_epoch.cpp
+        TEST_NAME ContactsEpochTests
+    )
+
+    # Same source compiled against the PRE-FIX layout (epoch carried by the
+    # per-thread struct instead of by the buffer). Registered WILL_FAIL: it must
+    # detect the corruption. This is what stops the test above from silently
+    # decaying into one that would pass on the broken code too.
+    flexaids_add_unit_test(test_contacts_epoch_prefix_layout
+        SOURCES
+            tests/test_contacts_epoch.cpp
+        DEFINES CONTACTS_EPOCH_PREFIX_LAYOUT=1
+        TEST_NAME ContactsEpochPrefixLayoutDetected
+    )
+    set_tests_properties(ContactsEpochPrefixLayoutDetected PROPERTIES WILL_FAIL TRUE)
+
     # test_ion_handling — assign_radii / assign_types HETATM + ion coverage
     #                     + tENCoM ion contact surface (TmContSct) tests
     flexaids_add_unit_test(test_ion_handling

--- a/LIB/VoronoiCFBatch.h
+++ b/LIB/VoronoiCFBatch.h
@@ -107,7 +107,10 @@ struct ThreadWorkspace {
 
         atoms        .assign(ref_atoms,   ref_atoms   + natm);
         residue      .assign(ref_residue, ref_residue + nres);
-        contacts     .assign(100000, 0);
+        // CONTACTS_BUFFER_SIZE: stamps + the trailing epoch slot (flexaid.h).
+        // Allocated together with `fa` below so the epoch and the stamps it
+        // guards share this workspace's lifetime.
+        contacts     .assign(CONTACTS_BUFFER_SIZE, 0);
         contributions.assign(static_cast<std::size_t>(nctb), 0.0f);
         optres       .assign(FA->optres,  FA->optres  + nopt);
         calc         .resize(static_cast<std::size_t>(natmr));

--- a/LIB/flexaid.h
+++ b/LIB/flexaid.h
@@ -34,6 +34,7 @@
 #include "ThermodynamicEngine.h"
 #include <map>
 #include <cstdint>
+#include <climits>
 
 #include "flexaid_exception.h"
 
@@ -64,6 +65,13 @@ static inline void safe_remark_cat(char* remark, const char* src, size_t* cur_le
 #define MAX_RING_FLEX 16            // max non-aromatic/sugar rings per ligand (LigandRingFlex Phase 2)
 //#define MAX_FLEX_BONDS 20           // max number of flexible bonds for het groups
 #define MAX_ATOM_NUMBER 100000      // Max PDB atom number for contacts/num_atm arrays
+// FA_Global::contacts layout — see the epoch helpers further down in this file:
+//   [0 .. MAX_ATOM_NUMBER-1] : per-atom "already visited this eval" stamps
+//   [CONTACTS_EPOCH_SLOT]    : the epoch counter that stamps them
+// EVERY allocator of a contacts buffer must allocate CONTACTS_BUFFER_SIZE ints,
+// zero-initialized (epoch 0 == "this buffer has never been stamped").
+#define CONTACTS_EPOCH_SLOT  MAX_ATOM_NUMBER
+#define CONTACTS_BUFFER_SIZE (MAX_ATOM_NUMBER + 1)
 #define MAX_GRID_POINTS 1000        // Total number of points to anchor ligand
 #define MAX_NORMAL_GRID 5000        // max number of grid points in normal grid
 #define MAX_SPHERE_POINTS 610       // Total number of points in atom surface sphere 
@@ -73,6 +81,59 @@ static inline void safe_remark_cat(char* remark, const char* src, size_t* cur_le
 #define MBNDS 4                     // max number of cov bonds an atom can have 
 #define MAX_BONDED 20               // max number of bonded atom list
 #define MAX_PAR 100                 // max number of parameters for simplex optimization, not used at the moment
+
+// ── FLEXAIDDS_CONTACTS_EPOCH: epoch / stamp-buffer pairing invariant ─────────
+//
+// FA_Global::contacts holds a per-atom "already visited this eval" flag.  In the
+// default (legacy) path vcfunction() memsets the whole array every evaluation.
+// Under FLEXAIDDS_CONTACTS_EPOCH that O(MAX_ATOM_NUMBER) memset is replaced by
+// an O(1) epoch bump: a slot stamped with the *current* epoch means "visited",
+// any other value means "unset".
+//
+// INVARIANT (mirrors LIB/Vcontacts.cpp:1816 box_stamp/box_epoch):
+//   1. the epoch counter and the buffer it stamps share a lifetime;
+//   2. the counter is strictly monotonic with respect to its OWN buffer;
+//   3. any reset of the counter is accompanied by zeroing that buffer.
+//
+// The counter therefore lives INSIDE the buffer (slot CONTACTS_EPOCH_SLOT) and
+// NOT in FA_Global.  This is load-bearing, not stylistic:
+//
+//   FA_Global is shallow-copied per worker thread, and that copy is REFRESHED
+//   at every generation boundary (LIB/gaboom.cpp `tl_fa[t] = *FA;`) while the
+//   stamp buffer it is re-pointed at (ParEvalWS::tl_contacts) is allocated ONCE
+//   and stays resident across generations.  A counter stored in FA_Global was
+//   rewound by that refresh while the buffer still held the previous
+//   generation's high-water stamps, so stale stamps aliased live epoch values,
+//   contacts were silently treated as already-visited and skipped, and CF came
+//   out wrong with no error and no diagnostic.
+//
+//   Keeping the counter in the buffer makes that entire class of bug
+//   unrepresentable: a struct copy carries the pointer, so the counter can
+//   never be separated from the stamps it guards, and zeroing the buffer
+//   necessarily zeroes the counter.
+//
+// Regression coverage: tests/test_contacts_epoch.cpp.
+
+// Begin a new evaluation on `contacts`; returns the epoch to stamp with.
+inline int contacts_epoch_begin(int* contacts)
+{
+	int& epoch = contacts[CONTACTS_EPOCH_SLOT];
+	// Wraparound guard.  An int epoch could in principle repeat a stale stamp
+	// after ~2^31 evals (never reached in one restart, but this keeps
+	// arbitrarily long campaigns correct).  Per invariant 3 the rewind zeroes
+	// the stamps as well, so no stale stamp can survive it.
+	if(epoch >= INT_MAX - 1){
+		memset(contacts, 0, CONTACTS_BUFFER_SIZE*sizeof(int));
+		epoch = 0;
+	}
+	return ++epoch;
+}
+
+// Epoch currently stamping `contacts` (0 == never stamped).
+inline int contacts_epoch_current(const int* contacts)
+{
+	return contacts[CONTACTS_EPOCH_SLOT];
+}
 #define MAX_ROTLIBSIZE 500
 #define MAXFLXSC 100
 #define MAX_CLOSE_DIST 10
@@ -523,11 +584,13 @@ struct FA_Global_struct{
 	int   translational;                 // flag indicating if translation degrees of freedom are enabled
 	int   refstructure;                  // reference structure for rmsd calculation
   
-	int* contacts;                       // matrix used for not calculating the same interaction twice
-	int  contacts_epoch;                 // FLEXAIDDS_CONTACTS_EPOCH: monotonic per-eval stamp used to
-	                                     // O(1)-clear FA->contacts instead of memset(); see vcfunction.cpp.
-	                                     // Zero-initialized by FA_Global{} value-init; travels with the
-	                                     // contacts pointer on every FA_Global copy (per-thread workspaces).
+	int* contacts;                       // matrix used for not calculating the same interaction twice.
+	                                     // CONTACTS_BUFFER_SIZE ints, zero-initialized. Slot
+	                                     // CONTACTS_EPOCH_SLOT carries the FLEXAIDDS_CONTACTS_EPOCH
+	                                     // counter — do NOT add an epoch field to this struct: it is
+	                                     // shallow-copied per thread and re-snapshotted every
+	                                     // generation, which rewinds any counter stored here while the
+	                                     // stamp buffer stays resident. See contacts_epoch_begin().
 	struct energy_matrix* energy_matrix;        // potential energy parameters
 	int   ntypes;	                     // number of atom types
 	int   tspoints;                      // actual number of sphere points

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -3147,7 +3147,11 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 			ws.tl_atoms.assign(n_thr, std::vector<atom>(atoms, atoms + natm + 1));
 			ws.tl_res.assign(n_thr, std::vector<resid>(residue, residue + nres + 1));
 			ws.tl_fa.assign(n_thr, *FA);
-			ws.tl_contacts.assign(n_thr, std::vector<int>(MAX_ATOM_NUMBER, 0));
+			// CONTACTS_BUFFER_SIZE: stamps + the trailing epoch slot (flexaid.h).
+			// This buffer is RESIDENT across generations while tl_fa[t] below is
+			// re-snapshotted from *FA every generation; the epoch must therefore
+			// live here, in the buffer, and not in the FA_Global copy.
+			ws.tl_contacts.assign(n_thr, std::vector<int>(CONTACTS_BUFFER_SIZE, 0));
 			ws.tl_contrib.assign(n_thr, std::vector<float>(nctb, 0.0f));
 			ws.tl_optres.assign(n_thr, std::vector<OptRes>(FA->optres, FA->optres + nopt));
 			ws.tl_vc.assign(n_thr, *VC);
@@ -3180,6 +3184,11 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 			// change between generations), then redirect FA scratch to the
 			// resident per-thread buffers.
 			tl_fa[t] = *FA;
+			// NOTE: this snapshot rewinds every scalar in tl_fa[t] to the master
+			// FA's value once per generation. Nothing that must stay monotonic
+			// against a RESIDENT buffer may live in FA_Global — the contacts
+			// epoch lives inside tl_contacts[t] itself for exactly this reason
+			// (flexaid.h, tests/test_contacts_epoch.cpp).
 			tl_fa[t].contacts      = tl_contacts[t].data();
 			tl_fa[t].contributions = tl_contrib[t].data();
 			tl_fa[t].optres        = tl_optres[t].data();
@@ -3956,7 +3965,8 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
 		std::vector<std::vector<atom>>   p_atoms(n_thr, std::vector<atom>(atoms, atoms + natm + 1));
 		std::vector<std::vector<resid>>  p_res(n_thr, std::vector<resid>(residue, residue + nres + 1));
 		std::vector<FA_Global>           p_fa(n_thr, *FA);
-		std::vector<std::vector<int>>    p_contacts(n_thr, std::vector<int>(MAX_ATOM_NUMBER, 0));
+		// CONTACTS_BUFFER_SIZE: stamps + the trailing epoch slot (flexaid.h).
+		std::vector<std::vector<int>>    p_contacts(n_thr, std::vector<int>(CONTACTS_BUFFER_SIZE, 0));
 		std::vector<std::vector<float>>  p_contrib(n_thr, std::vector<float>(nctb, 0.0f));
 		std::vector<std::vector<OptRes>> p_optres(n_thr,
 		    std::vector<OptRes>(FA->optres, FA->optres + nopt));

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -463,7 +463,9 @@ int main(int argc, char **argv){
 	// all-zero once here to match the epoch-0-means-"never touched" invariant.
 	// Legacy mode still memsets it every call, so the zero-fill costs nothing
 	// extra there (one-time, at startup, vs. the malloc it replaces).
-	FA->contacts = (int*)calloc(MAX_ATOM_NUMBER,sizeof(int));
+	// CONTACTS_BUFFER_SIZE (not MAX_ATOM_NUMBER): the trailing slot carries the
+	// epoch counter — see flexaid.h.
+	FA->contacts = (int*)calloc(CONTACTS_BUFFER_SIZE,sizeof(int));
 	if(FA->contacts == NULL){
 		fprintf(stderr,"ERROR: Could not allocate memory for contacts\n");
 		Terminate(2);

--- a/LIB/vcfunction.cpp
+++ b/LIB/vcfunction.cpp
@@ -189,20 +189,17 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 	// to before. Under FLEXAIDDS_CONTACTS_EPOCH we instead stamp visited slots
 	// with a monotonically increasing per-eval epoch and treat any slot whose
 	// stamp != current epoch as unset, making the "clear" O(1) instead of an
-	// O(MAX_ATOM_NUMBER) memset. contacts_epoch lives in FA_Global (copied
-	// per-thread alongside the contacts pointer in gaboom.cpp/VoronoiCFBatch.h),
-	// so each thread's counter tracks only its own private contacts buffer.
+	// O(MAX_ATOM_NUMBER) memset. The counter lives INSIDE the buffer it stamps
+	// (slot CONTACTS_EPOCH_SLOT) so that a shallow FA_Global copy — which every
+	// per-thread workspace in gaboom.cpp/VoronoiCFBatch.h performs, and which
+	// gaboom.cpp repeats at every generation boundary — cannot separate the two
+	// and rewind the counter against a resident stamp buffer. See flexaid.h
+	// (contacts_epoch_begin) for the full invariant and tests/test_contacts_epoch.cpp.
 	if(contacts_epoch_mode){
-		// Wraparound guard: an int epoch could in principle repeat a stale
-		// stamp after ~2^31 evals (never reached in one restart, but this
-		// keeps arbitrarily long campaigns correct). Fall back to one real
-		// clear and restart the counter from 1.
-		if(FA->contacts_epoch >= INT_MAX - 1){
-			memset(FA->contacts,0,MAX_ATOM_NUMBER*sizeof(int));
-			FA->contacts_epoch = 0;
-		}
-		++FA->contacts_epoch;
+		contacts_epoch_begin(FA->contacts);
 	} else {
+		// Legacy path: the epoch slot is never read, so it is left untouched
+		// here — this memset is byte-for-byte the pre-epoch behaviour.
 		memset(FA->contacts,0,MAX_ATOM_NUMBER*sizeof(int));
 	}
 	memset(FA->contributions,0,FA->ntypes*FA->ntypes*sizeof(float));
@@ -464,7 +461,7 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 			}
 			
 			if(contacts_epoch_mode
-			   ? (FA->contacts[VC->Calc[VC->ca_rec[currindex].atom].atom->number] == FA->contacts_epoch)
+			   ? (FA->contacts[VC->Calc[VC->ca_rec[currindex].atom].atom->number] == contacts_epoch_current(FA->contacts))
 			   : (FA->contacts[VC->Calc[VC->ca_rec[currindex].atom].atom->number] != 0)){
 				//printf("%d already calculated\n",VC->Calc[VC->ca_rec[currindex].atom].atom->number );
 				currindex = VC->ca_rec[currindex].prev;
@@ -887,7 +884,7 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 		FA->contributions[(FA->ntypes-1)*FA->ntypes + (VC->Calc[i].atom->type-1)] += contribution;
 		
 		FA->contacts[VC->Calc[i].atom->number] =
-			contacts_epoch_mode ? FA->contacts_epoch : 1;
+			contacts_epoch_mode ? contacts_epoch_current(FA->contacts) : 1;
 
 		// GIST desolvation: accumulate grid-based water displacement energy
 		if (FA->use_gist && FA->gist_evaluator != NULL) {

--- a/OPTIMIZATION_KNOWN_ISSUES.md
+++ b/OPTIMIZATION_KNOWN_ISSUES.md
@@ -73,3 +73,20 @@ targets. Keep `FLEXAIDDS_PARALLEL_REPRODUCE` OFF until both are resolved.
 
 All other merged optimizations (contacts memset->epoch, hoist rigid index, precompute
 PoseBust vdW radius) are verified bit-identical to main with default flags (10/10 parity).
+
+> ⚠️ **Read "with default flags" literally.** For `FLEXAIDDS_CONTACTS_EPOCH` the default is OFF,
+> so the 10/10 parity run exercised the legacy memset path and said **nothing** about the epoch
+> path. With the flag ON the optimization was in fact **incorrect**: the epoch counter lived in
+> `FA_Global`, which the threaded GA re-snapshots from the master every generation
+> (`gaboom.cpp`, `tl_fa[t] = *FA;`) while the stamp buffer it points at stays resident across
+> generations. The counter therefore rewound at every generation boundary against stale
+> high-water stamps, contacts were silently skipped, and CF came out wrong.
+>
+> Fixed by moving the counter **inside** the buffer it stamps (`CONTACTS_EPOCH_SLOT`, see
+> `flexaid.h`), so a struct copy can no longer separate the two. Regression coverage:
+> `tests/test_contacts_epoch.cpp` plus the paired `WILL_FAIL` target that re-creates the
+> pre-fix layout. The flag remains **default OFF** pending the ON-vs-OFF parity evidence
+> required by `METHODOLOGY.md` §1.
+>
+> **Lesson for this table: a parity run with a flag OFF is not evidence about the flag ON.**
+> Any future entry here must state which arm was actually exercised.

--- a/tests/test_contacts_epoch.cpp
+++ b/tests/test_contacts_epoch.cpp
@@ -1,0 +1,287 @@
+// tests/test_contacts_epoch.cpp
+// Regression coverage for the FLEXAIDDS_CONTACTS_EPOCH stamp-buffer invariant.
+//
+// THE BUG THIS PINS
+// -----------------
+// vcfunction() clears a per-atom "already visited this eval" flag array
+// (FA_Global::contacts) on every evaluation. Under FLEXAIDDS_CONTACTS_EPOCH the
+// O(MAX_ATOM_NUMBER) memset is replaced by an O(1) epoch bump: a slot stamped
+// with the current epoch means "visited".
+//
+// The epoch counter originally lived in FA_Global. But the threaded GA
+// evaluation path re-snapshots its per-thread FA_Global from the master
+// *every generation* (LIB/gaboom.cpp, `tl_fa[t] = *FA;`) while the stamp buffer
+// it re-points at (ParEvalWS::tl_contacts) is allocated ONCE and stays resident
+// across generations. The counter was therefore rewound at every generation
+// boundary against a buffer that still held the previous generation's
+// high-water stamps. Stale stamps then aliased live epoch values, atoms were
+// wrongly treated as already-visited, contacts were skipped, and CF was
+// silently wrong — no crash, no warning, no diagnostic.
+//
+// The fix moves the counter INSIDE the buffer it stamps (slot
+// CONTACTS_EPOCH_SLOT), so a struct copy cannot separate them.
+//
+// Apache-2.0 (c) 2026 Le Bonhomme Pharma
+
+// PROOF THAT THIS TEST HAS TEETH
+// ------------------------------
+// Compiling this file with -DCONTACTS_EPOCH_PREFIX_LAYOUT=1 re-creates the
+// pre-fix layout (epoch carried by the per-thread struct instead of by the
+// buffer). SurvivesPerGenerationSnapshotRefresh MUST fail in that mode.
+// CMake builds that second binary as `test_contacts_epoch_prefix_layout` and
+// registers it with WILL_FAIL, so ctest continuously proves both directions:
+//   - shipping layout  -> the invariant holds;
+//   - pre-fix layout   -> this test detects the corruption.
+// A "fix" that silently stopped detecting the bug would turn the WILL_FAIL
+// target green-when-it-should-be-red and break the suite.
+//
+// Apache-2.0 (c) 2026 Le Bonhomme Pharma
+
+#include <gtest/gtest.h>
+#include "../LIB/flexaid.h"
+
+#include <vector>
+
+#ifndef CONTACTS_EPOCH_PREFIX_LAYOUT
+#define CONTACTS_EPOCH_PREFIX_LAYOUT 0
+#endif
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// The per-thread snapshot that the GA refreshes at every generation boundary.
+// ---------------------------------------------------------------------------
+// In the shipping layout this is exactly FA_Global: the epoch is not part of it,
+// it lives in the buffer `fa.contacts` points at. In the pre-fix layout the
+// snapshot also carries the counter — and copying the snapshot then rewinds it.
+struct Snapshot {
+	FA_Global fa{};
+#if CONTACTS_EPOCH_PREFIX_LAYOUT
+	int contacts_epoch = 0;
+#endif
+};
+
+// Begin one evaluation; returns the epoch to stamp with.
+inline int begin_eval(Snapshot& s)
+{
+#if CONTACTS_EPOCH_PREFIX_LAYOUT
+	return ++s.contacts_epoch;                    // pre-fix: counter in the struct
+#else
+	return contacts_epoch_begin(s.fa.contacts);   // shipping: counter in the buffer
+#endif
+}
+
+}  // namespace
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Shared workload model
+// ---------------------------------------------------------------------------
+// Deterministic stand-in for a GA run: kGenerations generations, each of
+// kEvalsPerGen evaluations, each evaluation touching a *different* subset of
+// atoms. The varying subset matters — it is what lets a stamp written late in
+// generation N survive untouched into generation N+1 and collide with the
+// re-issued epoch there. A model that stamped every atom on every eval would
+// overwrite the evidence and pass even on the broken implementation.
+//
+// Partition rule: atom `a` is touched by exactly one eval per generation,
+// namely eval (a % kEvalsPerGen).
+
+constexpr int kGenerations  = 4;
+constexpr int kEvalsPerGen  = 32;
+constexpr int kAtoms        = 256;
+
+inline bool touched_by(int atom, int eval) { return (atom % kEvalsPerGen) == eval; }
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// 1. THE REGRESSION TEST — production code path.
+// ---------------------------------------------------------------------------
+// Mirrors LIB/gaboom.cpp: a resident stamp buffer, and an FA_Global snapshot
+// refreshed from the master at every generation boundary. No stale stamp may
+// ever alias the live epoch.
+TEST(ContactsEpoch, SurvivesPerGenerationSnapshotRefresh)
+{
+	// Allocated ONCE and resident across every generation, exactly like
+	// ParEvalWS::tl_contacts.
+	std::vector<int> resident(CONTACTS_BUFFER_SIZE, 0);
+
+	Snapshot master{};   // the master FA; its scalars do not advance during GA
+	Snapshot tl{};       // the per-thread snapshot
+
+	int evals = 0;
+
+	for (int gen = 0; gen < kGenerations; ++gen) {
+		// ── the generation-boundary refresh (LIB/gaboom.cpp) ──
+		tl = master;
+		tl.fa.contacts = resident.data();
+
+		for (int eval = 0; eval < kEvalsPerGen; ++eval) {
+			const int epoch = begin_eval(tl);
+			int* contacts = tl.fa.contacts;
+			++evals;
+
+			// Start of a fresh evaluation: NOTHING may read as visited.
+			for (int a = 0; a < kAtoms; ++a) {
+				ASSERT_NE(contacts[a], epoch)
+					<< "stale stamp aliased the live epoch — a contact would be "
+					   "silently skipped and CF would be wrong. gen=" << gen
+					<< " eval=" << eval << " atom=" << a << " epoch=" << epoch;
+			}
+
+			// Stamp this evaluation's subset and confirm it reads back visited.
+			for (int a = 0; a < kAtoms; ++a) {
+				if (!touched_by(a, eval)) continue;
+				contacts[a] = epoch;
+				ASSERT_EQ(contacts[a], epoch) << "atom=" << a;
+			}
+		}
+	}
+
+	// The counter advanced once per evaluation and was never rewound by the
+	// per-generation struct copy.
+	EXPECT_EQ(contacts_epoch_current(resident.data()), evals);
+	EXPECT_EQ(evals, kGenerations * kEvalsPerGen);
+}
+
+// ---------------------------------------------------------------------------
+// 2. MECHANISM PIN — the pre-fix layout, reproduced.
+// ---------------------------------------------------------------------------
+// Same workload, same resident buffer, but with the epoch stored in the
+// FA-like struct (the pre-fix layout). This MUST still corrupt. If it ever
+// stops corrupting, the workload model no longer exercises the bug and test 1
+// above has become vacuous — which is precisely the failure mode a regression
+// test is supposed to be protected against.
+namespace {
+struct LegacyFA {
+	int* contacts       = nullptr;
+	int  contacts_epoch = 0;   // <-- the defect: rewound by `tl = master`
+};
+}  // namespace
+
+TEST(ContactsEpoch, LegacyEpochInStructRewindsAndAliases)
+{
+	std::vector<int> resident(CONTACTS_BUFFER_SIZE, 0);
+
+	LegacyFA master;   // master epoch stays at 0 for the whole GA
+	LegacyFA tl;
+
+	int aliases = 0;
+	int first_alias_gen = -1;
+
+	for (int gen = 0; gen < kGenerations; ++gen) {
+		tl = master;                    // <-- rewinds contacts_epoch to 0
+		tl.contacts = resident.data();
+
+		for (int eval = 0; eval < kEvalsPerGen; ++eval) {
+			const int epoch = ++tl.contacts_epoch;
+
+			for (int a = 0; a < kAtoms; ++a) {
+				if (tl.contacts[a] == epoch) {   // false "already visited"
+					++aliases;
+					if (first_alias_gen < 0) first_alias_gen = gen;
+				}
+			}
+			for (int a = 0; a < kAtoms; ++a) {
+				if (touched_by(a, eval)) tl.contacts[a] = epoch;
+			}
+		}
+	}
+
+	EXPECT_GT(aliases, 0)
+		<< "the pre-fix layout no longer reproduces the stale-stamp alias; the "
+		   "workload model above has stopped exercising the bug and "
+		   "SurvivesPerGenerationSnapshotRefresh is now vacuous";
+	EXPECT_EQ(first_alias_gen, 1)
+		<< "corruption must appear at the FIRST generation boundary";
+}
+
+// ---------------------------------------------------------------------------
+// 3. A struct copy cannot rewind the epoch.
+// ---------------------------------------------------------------------------
+TEST(ContactsEpoch, EpochTravelsWithBufferNotWithStruct)
+{
+	std::vector<int> buf(CONTACTS_BUFFER_SIZE, 0);
+
+	FA_Global fa{};
+	fa.contacts = buf.data();
+
+	for (int i = 0; i < 100; ++i) contacts_epoch_begin(fa.contacts);
+	ASSERT_EQ(contacts_epoch_current(fa.contacts), 100);
+
+	// A shallow copy of a *stale* FA_Global — the pre-fix rewind vector.
+	FA_Global stale{};
+	FA_Global snapshot = stale;
+	snapshot.contacts  = buf.data();
+
+	// The copy sees the buffer's epoch, not the stale struct's.
+	EXPECT_EQ(contacts_epoch_current(snapshot.contacts), 100);
+	EXPECT_EQ(contacts_epoch_begin(snapshot.contacts), 101);
+	EXPECT_EQ(contacts_epoch_current(fa.contacts), 101);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Wraparound reset zeroes the stamps it invalidates (invariant 3).
+// ---------------------------------------------------------------------------
+TEST(ContactsEpoch, WraparoundResetZeroesTheStamps)
+{
+	std::vector<int> buf(CONTACTS_BUFFER_SIZE, 0);
+
+	// Drive the counter to the edge and leave stamps at the high-water mark.
+	buf[CONTACTS_EPOCH_SLOT] = INT_MAX - 2;
+	const int last = contacts_epoch_begin(buf.data());
+	ASSERT_EQ(last, INT_MAX - 1);
+	for (int a = 0; a < 64; ++a) buf[a] = last;
+
+	// Next eval must wrap. The reset has to take the stamps with it.
+	const int epoch = contacts_epoch_begin(buf.data());
+	EXPECT_EQ(epoch, 1);
+	for (int a = 0; a < 64; ++a) {
+		ASSERT_EQ(buf[a], 0) << "stale stamp survived the wraparound reset, atom=" << a;
+		ASSERT_NE(buf[a], epoch);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. Independent buffers keep independent counters.
+// ---------------------------------------------------------------------------
+// Each worker thread owns its own contacts buffer; one worker's progress must
+// not be visible to another.
+TEST(ContactsEpoch, IndependentBuffersDoNotInterfere)
+{
+	std::vector<int> a(CONTACTS_BUFFER_SIZE, 0);
+	std::vector<int> b(CONTACTS_BUFFER_SIZE, 0);
+
+	for (int i = 0; i < 10; ++i) contacts_epoch_begin(a.data());
+	for (int i = 0; i < 3;  ++i) contacts_epoch_begin(b.data());
+
+	EXPECT_EQ(contacts_epoch_current(a.data()), 10);
+	EXPECT_EQ(contacts_epoch_current(b.data()), 3);
+
+	const int ea = contacts_epoch_current(a.data());
+	a[7] = ea;
+	EXPECT_EQ(b[7], 0);   // not visited in b
+	EXPECT_NE(b[7], contacts_epoch_current(b.data()));
+}
+
+// ---------------------------------------------------------------------------
+// 6. Allocation contract.
+// ---------------------------------------------------------------------------
+// The epoch slot must sit immediately past the addressable atom range, so it
+// can never be clobbered by a legitimate atom stamp. Every allocator of a
+// contacts buffer must size it CONTACTS_BUFFER_SIZE.
+TEST(ContactsEpoch, EpochSlotSitsPastTheAtomRange)
+{
+	EXPECT_EQ(CONTACTS_EPOCH_SLOT, MAX_ATOM_NUMBER);
+	EXPECT_EQ(CONTACTS_BUFFER_SIZE, MAX_ATOM_NUMBER + 1);
+
+	// A freshly allocated buffer has never been stamped.
+	std::vector<int> buf(CONTACTS_BUFFER_SIZE, 0);
+	EXPECT_EQ(contacts_epoch_current(buf.data()), 0);
+
+	// The first epoch is 1, so a zeroed slot can never read as visited.
+	EXPECT_EQ(contacts_epoch_begin(buf.data()), 1);
+	for (int a = 0; a < 32; ++a) EXPECT_NE(buf[a], contacts_epoch_current(buf.data()));
+}


### PR DESCRIPTION
## The defect

`FLEXAIDDS_CONTACTS_EPOCH` replaces `vcfunction()`'s per-eval 400 KB memset of `FA->contacts` with an O(1) epoch stamp. The counter lived in `FA_Global`.

The threaded GA re-snapshots its per-thread `FA_Global` from the master at **every generation boundary** (`gaboom.cpp`, `tl_fa[t] = *FA;`) while the stamp buffer it re-points at (`ParEvalWS::tl_contacts`) is allocated **once** and stays resident across generations. The counter was therefore rewound at each generation boundary against a buffer still holding the previous generation's high-water stamps. Stale stamps aliased live epoch values, atoms were treated as already-visited, contacts were skipped, and **CF came out wrong — no crash, no warning**. Corruption starts at the first generation boundary.

## The fix

Move the counter **inside the buffer it stamps** (`CONTACTS_EPOCH_SLOT`, buffers sized `CONTACTS_BUFFER_SIZE`). A struct copy then carries the pointer, so the counter can never be separated from the stamps it guards, and zeroing the buffer necessarily zeroes the counter.

This is the same invariant `Vcontacts.cpp:1816` (`box_stamp`/`box_epoch`) already implements correctly. It makes the defect **unrepresentable** rather than merely absent — chosen over a save/restore around the snapshot, because save/restore leaves the next `*FA` copy free to reintroduce the bug, and there are four such copy sites.

`FA_Global::contacts_epoch` is removed so it cannot be reintroduced. Allocation sites updated: `top.cpp` (calloc), `gaboom.cpp` ×2, `VoronoiCFBatch.h`.

## Verification

```
ContactsEpoch (fixed layout):        6 tests, 6 PASSED
ContactsEpoch (pre-fix layout):      1 FAILED — SurvivesPerGenerationSnapshotRefresh
```
The same source is compiled a second time with `-DCONTACTS_EPOCH_PREFIX_LAYOUT=1` (pre-fix layout) and registered `WILL_FAIL`, so ctest proves **both** directions: the invariant holds, and the test can still detect the corruption. Without that, the bug is invisible.

Build: clean (Release, `BUILD_TESTING=ON`).

> Note for reviewers: test binaries in this environment link against Anaconda's GoogleTest 1.11.0 dylib with no rpath set, so `ctest` aborts during discovery for **every** test target, including pre-existing ones untouched by this PR (`test_protocol_config` fails identically). Tests above were run with `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/anaconda3/lib`. That is a pre-existing environment defect worth fixing separately.

## Science-Impact: none on default-flag behaviour

`FLEXAIDDS_CONTACTS_EPOCH` remains **default OFF** (METHODOLOGY §1) and the legacy memset path is byte-for-byte unchanged, so docked coordinates and scores are unchanged for every run to date — no shipped campaign set this flag. Under the flag ON this is a correctness fix: CF values were wrong and are now correct. **No campaign results need reinterpretation.**

Measured context: the memset this optimization removes is ~1.35% of single-thread runtime, so the value here is correctness, not speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact tracking reliability across repeated evaluations and state refreshes.
  * Added wraparound handling to prevent stale contact data from being reused.
  * Ensured independent evaluation buffers maintain separate contact state.

* **Tests**
  * Added regression coverage for contact tracking, buffer sizing, epoch persistence, and legacy behavior.

* **Documentation**
  * Documented contact epoch limitations, validation results, and current feature-flag status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->