### PR TITLE
Fix: bound restart fan-out so the host is not oversubscribed by n_restarts

### DIFF
--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -34,6 +34,7 @@
 #include <array>
 #include <cassert>
 #include <cmath>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <cctype>
@@ -387,6 +388,30 @@ void SubprocessGuard::kill_all() {
 size_t SubprocessGuard::active_count() const {
     std::lock_guard<std::mutex> lock(const_cast<std::mutex&>(mtx_));
     return pids_.size();
+}
+
+// =============================================================================
+// Restart launch throttling — SCHEDULING ONLY (contract in DatasetRunner.h)
+// =============================================================================
+
+int fold_restart_return_codes(const std::vector<RestartResult>& results,
+                              int fallback) {
+    int ret = fallback;
+    for (const auto& r : results) {
+        if (r.ri == 0) ret = r.ret;        // canonical restart sets the base
+        else if (r.ret != 0) ret = r.ret;  // any later failure overrides it
+    }
+    return ret;
+}
+
+int restart_concurrency_cap(int cpu_budget, int omp_per_worker,
+                            int num_workers, int env_override) {
+    if (env_override == 0) return 0;             // unlimited (legacy fan-out)
+    if (env_override > 0)  return env_override;  // explicit operator cap
+    if (cpu_budget <= 0)   return 1;             // unknown budget → serialize
+    const int per_child =
+        std::max(1, omp_per_worker) * std::max(1, num_workers);
+    return std::max(1, cpu_budget / per_child);
 }
 
 // =============================================================================
@@ -5838,9 +5863,37 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                 pid_t pid;
                 int   ri;
                 std::chrono::steady_clock::time_point launch_t;
+                int   ret{-1};       ///< exit code, filled in at reap time
+                bool  reaped{false}; ///< guards against double-waiting a pid
             };
             std::vector<RestartPid> par_pids;
             auto par_wall_start = std::chrono::steady_clock::now();
+
+            // Reap one restart child. Each restart keeps its OWN full
+            // per_job_timeout_s budget, measured from ITS OWN fork — identical
+            // to the unthrottled drain loop. Idempotent: safe to call again
+            // from the final drain after the launch window already reaped it.
+            auto reap_restart = [&](RestartPid& rp) {
+                if (rp.reaped) return;
+                int ri_ret = -1;
+                if (rp.pid > 0) {
+                    auto elapsed_s = static_cast<int>(
+                        std::chrono::duration_cast<std::chrono::seconds>(
+                            std::chrono::steady_clock::now() - rp.launch_t).count());
+                    int remaining = std::max(1,
+                        config.per_job_timeout_s - elapsed_s);
+                    ri_ret = proc_guard_->wait_with_timeout(rp.pid, remaining);
+                }
+                rp.ret    = ri_ret;
+                rp.reaped = true;
+            };
+
+            // ── Sliding launch window (CPU-oversubscription fix) ─────────────
+            // par_max_inflight < 0 = not yet resolved (needs omp_per_worker,
+            // which is computed further down inside the loop body).
+            // par_reap_cursor = FIFO index of the next entry to reap for a slot.
+            int    par_max_inflight = -1;
+            size_t par_reap_cursor  = 0;
 
             for (int ri = 0; ri < n_restarts; ri++) {
                 const std::string ri_dir    = (ri == 0) ? out_dir
@@ -6175,13 +6228,19 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             //   2. floor(parent OMP_NUM_THREADS / num_workers)
             //   3. floor(hardware_concurrency()  / num_workers)
             //   minimum 1 in all cases.
+            // `omp_budget_base` is hoisted out of the branch below (pure
+            // computation, identical value) so the restart-concurrency cap can
+            // reuse the very same CPU budget the per-worker split was taken
+            // from.  omp_per_worker itself is UNCHANGED — thread count is
+            // science-affecting in this engine and must never be tuned here.
+            const char* env_omp = std::getenv("OMP_NUM_THREADS");
+            const int omp_budget_base = (env_omp && std::atoi(env_omp) > 0)
+                ? std::atoi(env_omp)
+                : static_cast<int>(std::thread::hardware_concurrency());
             int omp_per_worker = config.omp_threads_per_worker;
             if (omp_per_worker <= 0) {
-                const char* env_omp = std::getenv("OMP_NUM_THREADS");
-                int base = (env_omp && std::atoi(env_omp) > 0)
-                    ? std::atoi(env_omp)
-                    : static_cast<int>(std::thread::hardware_concurrency());
-                omp_per_worker = std::max(1, base / std::max(1, config.num_threads));
+                omp_per_worker = std::max(1,
+                    omp_budget_base / std::max(1, config.num_threads));
             }
 
             // ── Blind the initial placement (Bug #1 fix) ─────────────────
@@ -6417,8 +6476,36 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                 << ">" << shell_quote(ri_dir + "/stdout.log");
 
             if (parallel_restarts) {
-                // ── Parallel mode: fork now, wait after all restarts launched ──
-                // The config/cmd is fully built above; just fork and move on.
+                // ── Parallel mode: fork inside a bounded launch window ────────
+                // Every parent-side artifact for this restart (dock_config.json,
+                // blinded ligand, receptor prep) has already been written above,
+                // in exactly the same order as the unthrottled path. ONLY the
+                // fork is gated, so no child's inputs can change.
+                if (par_max_inflight < 0) {
+                    par_max_inflight = restart_concurrency_cap(
+                        omp_budget_base, omp_per_worker, config.num_threads,
+                        protocol_cfg_.max_concurrent_restarts);
+                    char capbuf[32];
+                    if (par_max_inflight > 0)
+                        std::snprintf(capbuf, sizeof capbuf, "%d", par_max_inflight);
+                    else
+                        std::snprintf(capbuf, sizeof capbuf, "unlimited");
+                    fprintf(stderr,
+                        "[PARALLEL-RESTART] %s: launch window = %s concurrent "
+                        "restart(s) (cpu_budget=%d omp/worker=%d workers=%d)\n",
+                        entry.pdb_id.c_str(), capbuf,
+                        omp_budget_base, omp_per_worker, config.num_threads);
+                }
+                // Free a slot before forking. Reaping is FIFO in launch order,
+                // so par_pids stays ordered by ri and the failure fold below is
+                // bit-for-bit what the unthrottled drain produced.
+                while (par_max_inflight > 0 &&
+                       par_reap_cursor < par_pids.size() &&
+                       static_cast<int>(par_pids.size() - par_reap_cursor)
+                           >= par_max_inflight) {
+                    reap_restart(par_pids[par_reap_cursor]);
+                    ++par_reap_cursor;
+                }
                 pid_t rp = proc_guard_->fork_exec(cmd.str());
                 par_pids.push_back({rp, ri, std::chrono::steady_clock::now()});
                 if (rp < 0) {
@@ -6453,19 +6540,17 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // Remaining timeout = per_job_timeout - elapsed since that restart's
             // fork, ensuring no restart silently outlives the budget.
             if (parallel_restarts && !par_pids.empty()) {
+                // par_pids is in launch order (== ri order); entries already
+                // reaped by the launch window are no-ops here and contribute
+                // their recorded exit code, so the fold sees the identical
+                // sequence of (ri, ret) pairs the unthrottled path produced.
+                std::vector<RestartResult> restart_rets;
+                restart_rets.reserve(par_pids.size());
                 for (auto& rp : par_pids) {
-                    int ri_ret = -1;
-                    if (rp.pid > 0) {
-                        auto elapsed_s = static_cast<int>(
-                            std::chrono::duration_cast<std::chrono::seconds>(
-                                std::chrono::steady_clock::now() - rp.launch_t).count());
-                        int remaining = std::max(1,
-                            config.per_job_timeout_s - elapsed_s);
-                        ri_ret = proc_guard_->wait_with_timeout(rp.pid, remaining);
-                    }
-                    if (rp.ri == 0) ret = ri_ret;
-                    else if (ri_ret != 0) ret = ri_ret;
+                    reap_restart(rp);
+                    restart_rets.push_back({rp.ri, rp.ret});
                 }
+                ret = fold_restart_return_codes(restart_rets, ret);
                 // Wall time = elapsed from first fork to last finish.
                 result.wall_time_s = std::chrono::duration<double>(
                     std::chrono::steady_clock::now() - par_wall_start).count();

--- a/LIB/DatasetRunner.h
+++ b/LIB/DatasetRunner.h
@@ -452,6 +452,47 @@ private:
 };
 
 // =============================================================================
+// Restart launch throttling — SCHEDULING ONLY
+//
+// These helpers decide *when* restart child processes are forked. They never
+// touch a child's config, seed, output prefix, or OMP_NUM_THREADS, so they
+// cannot move a docked coordinate or a score.
+// =============================================================================
+
+/// One restart's exit code, recorded in launch order.
+struct RestartResult {
+    int ri{0};    ///< restart index (0 = the canonical restart)
+    int ret{-1};  ///< exit code; -1 = signal / timeout / fork failure
+};
+
+/// Fold per-restart exit codes into a single target-level return code.
+///
+/// Preserves the historical propagation rule EXACTLY: restart 0's code sets the
+/// base, and ANY non-zero code from restarts 1..n-1 overrides it (so the last
+/// non-zero failure wins). One failed restart therefore still poisons the whole
+/// target, which is what makes `docking_completed` false downstream.
+/// `fallback` is returned unchanged when `results` is empty.
+int fold_restart_return_codes(const std::vector<RestartResult>& results,
+                              int fallback);
+
+/// How many restart children may be alive concurrently.
+///
+/// `omp_per_worker` already divides the CPU budget by the number of concurrent
+/// workers, but the parallel-restart path forks every restart of a target at
+/// once and each child inherits `OMP_NUM_THREADS=omp_per_worker`. Real demand
+/// was therefore `workers * n_restarts * omp_per_worker` — the restart fan-out
+/// was never in the denominator. This bounds it so that
+/// `cap * omp_per_worker * num_workers ~= cpu_budget`.
+///
+/// `env_override` (FLEXAIDDS_MAX_CONCURRENT_RESTARTS):
+///   < 0 → auto-derive from the CPU budget
+///   = 0 → unlimited (legacy pre-fix fan-out)
+///   > 0 → explicit cap
+/// Returns 0 for "unlimited"; otherwise >= 1.
+int restart_concurrency_cap(int cpu_budget, int omp_per_worker,
+                            int num_workers, int env_override);
+
+// =============================================================================
 // Atom structure for ligand extraction
 // =============================================================================
 

--- a/LIB/ProtocolConfig.cpp
+++ b/LIB/ProtocolConfig.cpp
@@ -103,6 +103,12 @@ ProtocolConfig ProtocolConfig::from_env() {
         cfg.parallel_restarts = (cfg.restarts > 1);
     }
 
+    // Scheduling-only knob: bound how many restart children run at once.
+    // Negative values normalize to -1 ("auto"); 0 keeps the legacy fan-out.
+    if (auto n = env_opt_int("FLEXAIDDS_MAX_CONCURRENT_RESTARTS")) {
+        cfg.max_concurrent_restarts = std::max(-1, *n);
+    }
+
     if (auto v = env_opt_double("FLEXAIDDS_VCT_R0")) {
         cfg.vct_r0 = *v;
     }
@@ -332,6 +338,7 @@ std::string ProtocolConfig::to_json() const {
     o << "\"seed_base\":" << seed_base << ',';
     o << "\"restarts\":" << restarts << ',';
     json_bool(o, "parallel_restarts", parallel_restarts);
+    o << "\"max_concurrent_restarts\":" << max_concurrent_restarts << ',';
     o << "\"vct_r0\":" << vct_r0 << ',';
     json_bool(o, "vct_normalize_contacts", vct_normalize_contacts);
     o << "\"vct_entropy_weight\":" << vct_entropy_weight << ',';
@@ -430,6 +437,9 @@ ProtocolConfig ProtocolConfig::from_json(const std::string& json_text) {
         cfg.restarts = std::max(1, root["restarts"].as_int(5));
     if (!root["parallel_restarts"].is_null())
         cfg.parallel_restarts = root["parallel_restarts"].as_bool(true);
+    if (!root["max_concurrent_restarts"].is_null())
+        cfg.max_concurrent_restarts =
+            std::max(-1, root["max_concurrent_restarts"].as_int(-1));
     if (!root["vct_r0"].is_null())
         cfg.vct_r0 = root["vct_r0"].as_double(7.0);
     if (!root["vct_normalize_contacts"].is_null())

--- a/LIB/ProtocolConfig.h
+++ b/LIB/ProtocolConfig.h
@@ -26,6 +26,11 @@ struct ProtocolConfig {
     /// Env FLEXAIDDS_PARALLEL_RESTARTS: if unset, defaults to (restarts > 1).
     bool parallel_restarts{true};
     bool parallel_restarts_explicit{false}; ///< true if env overrode default
+    /// Cap on restart child processes alive at once (scheduling only — never
+    /// changes docked coordinates). FLEXAIDDS_MAX_CONCURRENT_RESTARTS:
+    /// -1 = auto (derive from the CPU budget), 0 = unlimited (legacy fan-out
+    /// that oversubscribed the host by n_restarts x), >0 = explicit cap.
+    int max_concurrent_restarts{-1};
 
     // ── VCT / scoring knobs ──────────────────────────────────────────────
     double vct_r0{7.0};               ///< FLEXAIDDS_VCT_R0

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ FlexAID∆S exposes its scientific innovations as environment-variable flags so 
 | `FLEXAIDDS_EVAL_SCALE_DIHEDRAL` | `1` | GA budget scaling: 1=pop-scale (default), 0=gen-scale, -1=fixed |
 | `FLEXAIDDS_RESTARTS` | `5` | Number of independent GA restarts per target |
 | `FLEXAIDDS_PARALLEL_RESTARTS` | ON | Launch restart workers concurrently |
+| `FLEXAIDDS_MAX_CONCURRENT_RESTARTS` | auto | Cap on restart children alive at once. Auto = `cpu_budget / (omp_per_worker × workers)`, min 1. `0` = unlimited (legacy, oversubscribes by `n_restarts×`). Scheduling only — results are unaffected |
 | `FLEXAIDDS_USE_SHANNON` | OFF | Presence-gated GA monitor that pools ligand ANM mode eigenvalues across cluster representatives and reports an ω-space Shannon diagnostic. The eigenvalues never enter CF, fitness, or election |
 | `FLEXAIDDS_RING_FLEX` | OFF | Enable non-aromatic ring pucker sampling (LigandRingFlex) |
 | `FLEXAIDDS_HBOND_WEIGHT` | `-2.5` | Hydrogen-bond term coefficient |

--- a/docs/implementation/protocol-config.md
+++ b/docs/implementation/protocol-config.md
@@ -63,6 +63,7 @@ start; the C++ path is a superset (adds `protocol_config`, hashes, git, schema).
 | `FLEXAIDDS_SEED_BASE` | `seed_base` | `0` |
 | `FLEXAIDDS_RESTARTS` | `restarts` | `5` |
 | `FLEXAIDDS_PARALLEL_RESTARTS` | `parallel_restarts` | `restarts > 1` |
+| `FLEXAIDDS_MAX_CONCURRENT_RESTARTS` | `max_concurrent_restarts` | `-1` (auto) |
 | `FLEXAIDDS_VCT_R0` | `vct_r0` | `7.0` |
 | `FLEXAIDDS_VCT_NORM` | `vct_normalize_contacts` | off |
 | `FLEXAIDDS_VCT_ENTROPY_WEIGHT` | `vct_entropy_weight` | `0.0` |
@@ -169,12 +170,48 @@ All former FLEXAIDDS_* overrides go through ProtocolConfig.
 6. Document each migrated var and drop it from Residual.
 7. Do not change pose ranking / clustering order without an explicit request + feature flag.
 
+## Restart concurrency throttle (`FLEXAIDDS_MAX_CONCURRENT_RESTARTS`)
+
+`omp_per_worker` divides the CPU budget by the number of concurrent **workers**
+(`config.num_threads`) — but the parallel-restart path forks every restart of a
+target at once, and each child inherits `OMP_NUM_THREADS=omp_per_worker`. Actual
+demand was therefore
+
+```
+workers × n_restarts × (cpu_budget / workers)  =  n_restarts × cpu_budget
+```
+
+i.e. the restart fan-out was never in the budget denominator, so a 10-restart
+target oversubscribed the machine 10×.
+
+`restart_concurrency_cap()` (`LIB/DatasetRunner.h`) bounds how many restart
+children may be alive at once:
+
+| `FLEXAIDDS_MAX_CONCURRENT_RESTARTS` | behaviour |
+|---|---|
+| unset (`-1`) | auto — `cpu_budget / (omp_per_worker × workers)`, floor 1 |
+| `0` | unlimited (legacy pre-fix fan-out) |
+| `N > 0` | explicit cap of `N` |
+
+The launcher uses a **sliding window**: it reaps in FIFO launch order to free a
+slot before forking the next restart. This is a **scheduling-only** change —
+`OMP_NUM_THREADS` is untouched (thread count is science-affecting in this
+engine), each restart keeps its own config, seed, output prefix, and its own
+full `per_job_timeout_s` measured from its own fork. Per-restart exit codes are
+recorded at reap time and folded by `fold_restart_return_codes()`, which
+preserves the historical rule exactly: restart 0's code is the base and any
+non-zero code from restarts 1..n-1 overrides it.
+
 ## Tests
 
 ```bash
 cmake -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build build --target test_protocol_config -j
 ctest --test-dir build -R ProtocolConfigTests --output-on-failure
+
+# Restart throttle: cap arithmetic, failure-fold equivalence, live window bound
+cmake --build build --target test_dataset_runner -j
+ctest --test-dir build -R DatasetRunnerTests --output-on-failure
 ```
 
 

--- a/tests/test_dataset_runner.cpp
+++ b/tests/test_dataset_runner.cpp
@@ -1954,3 +1954,151 @@ TEST(EmittedClusterHeads, RejectsNonDigitSuffixes) {
 
     fs::remove_all(dir);
 }
+
+// =============================================================================
+// Restart launch throttling (CPU-oversubscription fix)
+//
+// These cover the PURE-SCHEDULING contract: the sliding launch window bounds
+// how many restart children run at once, without changing any child's inputs
+// or the failure-propagation semantics the rest of the pipeline depends on.
+// =============================================================================
+
+TEST(RestartThrottle, CapArithmeticMatchesCpuBudget) {
+    // Legacy / opt-out: 0 means "unlimited", regardless of the budget.
+    EXPECT_EQ(restart_concurrency_cap(11, 5, 2, 0), 0);
+
+    // Explicit operator override wins over the derived value.
+    EXPECT_EQ(restart_concurrency_cap(11, 5, 2, 4), 4);
+
+    // Auto (env unset, -1). The observed defect configuration: 11 cores split
+    // across 2 workers => 5 OMP threads each. 2 workers * 5 threads already
+    // saturates the host, so restarts must serialize (cap 1) rather than
+    // multiply demand by n_restarts.
+    EXPECT_EQ(restart_concurrency_cap(11, 5, 2, -1), 1);
+
+    // Under-allocated threads leave genuine headroom for concurrent restarts.
+    EXPECT_EQ(restart_concurrency_cap(11, 2, 2, -1), 2);   // 11 / 4
+    EXPECT_EQ(restart_concurrency_cap(12, 1, 3, -1), 4);   // 12 / 3
+    EXPECT_EQ(restart_concurrency_cap(16, 2, 1, -1), 8);   // 16 / 2
+
+    // Floor of 1: never returns 0 (which would mean "unlimited") from auto.
+    EXPECT_EQ(restart_concurrency_cap(4, 8, 4, -1), 1);
+    EXPECT_EQ(restart_concurrency_cap(1, 64, 64, -1), 1);
+
+    // Degenerate inputs must not divide by zero or go negative.
+    EXPECT_EQ(restart_concurrency_cap(0, 0, 0, -1), 1);
+    EXPECT_EQ(restart_concurrency_cap(-1, 4, 2, -1), 1);
+    EXPECT_GE(restart_concurrency_cap(11, 0, 0, -1), 1);
+}
+
+TEST(RestartThrottle, FoldPreservesAnyFailureWins) {
+    // All restarts succeeded → success.
+    EXPECT_EQ(fold_restart_return_codes(
+        {{0, 0}, {1, 0}, {2, 0}}, 99), 0);
+
+    // Restart 0 sets the base code.
+    EXPECT_EQ(fold_restart_return_codes(
+        {{0, 7}, {1, 0}, {2, 0}}, 99), 7);
+
+    // ONE failed restart poisons the whole target, even when restart 0 was
+    // fine. This is what drives docking_completed=false downstream.
+    EXPECT_EQ(fold_restart_return_codes(
+        {{0, 0}, {1, 0}, {2, 3}}, 99), 3);
+
+    // Timeout (-1 from wait_with_timeout) propagates like any other failure.
+    EXPECT_EQ(fold_restart_return_codes(
+        {{0, 0}, {1, -1}, {2, 0}}, 99), -1);
+
+    // LAST non-zero wins among restarts 1..n-1 — not first-failure-wins.
+    EXPECT_EQ(fold_restart_return_codes(
+        {{0, 0}, {1, 2}, {2, 0}, {3, 5}}, 99), 5);
+
+    // Restart 0 is order-sensitive: it unconditionally overwrites whatever
+    // came before it. par_pids must therefore stay in launch order (ri order),
+    // which is exactly what FIFO reaping in the launch window guarantees.
+    EXPECT_EQ(fold_restart_return_codes(
+        {{1, 4}, {0, 0}}, 99), 0);
+    EXPECT_EQ(fold_restart_return_codes(
+        {{0, 0}, {1, 4}}, 99), 4);
+
+    // Empty (no restarts forked) leaves the caller's value untouched.
+    EXPECT_EQ(fold_restart_return_codes({}, 99), 99);
+}
+
+#ifndef _MSC_VER
+// Drives REAL child processes through the same sliding-window algorithm the
+// runner uses, and proves (a) no more than `cap` children are ever un-reaped,
+// and (b) the window actually serializes — wall time scales with n/cap.
+TEST(RestartThrottle, SlidingWindowBoundsLiveChildren) {
+    SubprocessGuard guard;
+
+    struct Slot {
+        pid_t pid;
+        int   ri;
+        std::chrono::steady_clock::time_point launch_t;
+        int   ret{-1};
+        bool  reaped{false};
+    };
+
+    const int n_restarts = 6;
+    const int cap        = restart_concurrency_cap(/*cpu_budget=*/8,
+                                                   /*omp_per_worker=*/2,
+                                                   /*num_workers=*/2,
+                                                   /*env_override=*/-1);
+    ASSERT_EQ(cap, 2);
+
+    std::vector<Slot> slots;
+    size_t reap_cursor = 0;
+    size_t max_inflight_seen = 0;
+
+    auto reap = [&](Slot& s) {
+        if (s.reaped) return;
+        int r = -1;
+        if (s.pid > 0) r = guard.wait_with_timeout(s.pid, 60);
+        s.ret    = r;
+        s.reaped = true;
+    };
+
+    const auto t0 = std::chrono::steady_clock::now();
+    for (int ri = 0; ri < n_restarts; ri++) {
+        while (cap > 0 && reap_cursor < slots.size() &&
+               static_cast<int>(slots.size() - reap_cursor) >= cap) {
+            reap(slots[reap_cursor]);
+            ++reap_cursor;
+        }
+        pid_t pid = guard.fork_exec("sleep 1");
+        ASSERT_GT(pid, 0) << "fork_exec failed for ri=" << ri;
+        slots.push_back({pid, ri, std::chrono::steady_clock::now()});
+
+        // active_count() = registered-but-unreaped children. A pid is only
+        // forgotten after its child has exited, so this is an UPPER bound on
+        // the number actually alive; bounding it bounds real concurrency.
+        max_inflight_seen = std::max(max_inflight_seen, guard.active_count());
+        EXPECT_LE(static_cast<int>(guard.active_count()), cap)
+            << "launch window exceeded at ri=" << ri;
+    }
+
+    std::vector<RestartResult> rets;
+    for (auto& s : slots) {
+        reap(s);
+        rets.push_back({s.ri, s.ret});
+    }
+    const double elapsed_s =
+        std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+
+    // Every restart ran, in launch order, and all succeeded.
+    ASSERT_EQ(rets.size(), static_cast<size_t>(n_restarts));
+    for (int ri = 0; ri < n_restarts; ri++) {
+        EXPECT_EQ(rets[static_cast<size_t>(ri)].ri, ri);
+        EXPECT_EQ(rets[static_cast<size_t>(ri)].ret, 0);
+    }
+    EXPECT_EQ(fold_restart_return_codes(rets, 42), 0);
+    EXPECT_EQ(static_cast<int>(max_inflight_seen), cap);
+
+    // 6 x `sleep 1` at 2-at-a-time cannot finish faster than ~3 s; the
+    // unthrottled fan-out would land near 1 s. Generous lower bound to stay
+    // robust on a loaded machine (which only ever makes this slower).
+    EXPECT_GE(elapsed_s, 2.5) << "window did not actually serialize";
+    EXPECT_EQ(guard.active_count(), 0u);
+}
+#endif  // !_MSC_VER

--- a/tests/test_protocol_config.cpp
+++ b/tests/test_protocol_config.cpp
@@ -63,6 +63,7 @@ struct ClearProtocolEnv {
         : seed_base("FLEXAIDDS_SEED_BASE", nullptr)
         , restarts("FLEXAIDDS_RESTARTS", nullptr)
         , parallel("FLEXAIDDS_PARALLEL_RESTARTS", nullptr)
+        , max_conc("FLEXAIDDS_MAX_CONCURRENT_RESTARTS", nullptr)
         , vct_r0("FLEXAIDDS_VCT_R0", nullptr)
         , vct_norm("FLEXAIDDS_VCT_NORM", nullptr)
         , vct_ew("FLEXAIDDS_VCT_ENTROPY_WEIGHT", nullptr)
@@ -121,7 +122,7 @@ struct ClearProtocolEnv {
         , elect_tau("FLEXAIDDS_ELECTION_SCORE_TAU", nullptr)
         , elect_sing("FLEXAIDDS_ELECTION_INCLUDE_SINGLETONS", nullptr) {}
 
-    ScopedEnv seed_base, restarts, parallel, vct_r0, vct_norm, vct_ew,
+    ScopedEnv seed_base, restarts, parallel, max_conc, vct_r0, vct_norm, vct_ew,
               sharing, boom, n_elite, shannon, thermo, t_eff, tencom,
               data_dir, oracle_dir, oracle_site, cleft, cf_win, cluster,
               seed_elit, seed_delta, freqsel, freq_a, freq_r, consensus,
@@ -256,6 +257,37 @@ TEST(ProtocolConfig, PresenceFlagsAndParallelRestarts) {
     // Explicit parallel=1 but restarts==1 → parallel stays false.
     EXPECT_FALSE(cfg.parallel_restarts);
     EXPECT_TRUE(cfg.parallel_restarts_explicit);
+}
+
+TEST(ProtocolConfig, MaxConcurrentRestartsFromEnvAndJsonRoundTrip) {
+    {   // Unset → -1 ("auto": derive the cap from the CPU budget).
+        ClearProtocolEnv clear;
+        EXPECT_EQ(flexaids::ProtocolConfig::from_env().max_concurrent_restarts, -1);
+    }
+    {   // 0 → unlimited, i.e. the legacy unbounded restart fan-out.
+        ClearProtocolEnv clear;
+        ScopedEnv mc("FLEXAIDDS_MAX_CONCURRENT_RESTARTS", "0");
+        EXPECT_EQ(flexaids::ProtocolConfig::from_env().max_concurrent_restarts, 0);
+    }
+    {   // Explicit positive cap passes through.
+        ClearProtocolEnv clear;
+        ScopedEnv mc("FLEXAIDDS_MAX_CONCURRENT_RESTARTS", "3");
+        EXPECT_EQ(flexaids::ProtocolConfig::from_env().max_concurrent_restarts, 3);
+    }
+    {   // Junk negatives normalize to -1 rather than becoming a bogus cap.
+        ClearProtocolEnv clear;
+        ScopedEnv mc("FLEXAIDDS_MAX_CONCURRENT_RESTARTS", "-7");
+        EXPECT_EQ(flexaids::ProtocolConfig::from_env().max_concurrent_restarts, -1);
+    }
+    {   // Survives the RUN_RECEIPT JSON round-trip (provenance for the knob).
+        ClearProtocolEnv clear;
+        ScopedEnv mc("FLEXAIDDS_MAX_CONCURRENT_RESTARTS", "2");
+        const auto a = flexaids::ProtocolConfig::from_env();
+        const std::string json = a.to_json();
+        EXPECT_NE(json.find("\"max_concurrent_restarts\":2"), std::string::npos);
+        const auto b = flexaids::ProtocolConfig::from_json(json);
+        EXPECT_EQ(b.max_concurrent_restarts, a.max_concurrent_restarts);
+    }
 }
 
 TEST(ProtocolConfig, Chunk2PoseAndBudgetKnobs) {


### PR DESCRIPTION
## The defect

The per-worker OMP thread budget is divided by the number of **workers**:

```
omp_per_worker = cpu_budget / num_threads
```

but the parallel-restart path then forks **every** restart at once, with no semaphore and no cap. Actual thread demand is therefore

```
num_workers × n_restarts × (cpu_budget / num_workers)  =  n_restarts × cpu_budget
```

The restart fan-out multiplies load by `n_restarts` and never appears in the budget denominator.

**Measured on this host:** 10 restarts × 11 cores predicts ~110 threads. Observed load average peaked at **108.6**, with 18 engine processes collectively achieving only ~3 cores of useful work. The comment above the thread-budget block describes this exact thrash failure mode and fixes it for workers; the restart path then reintroduces it.

## The fix

A sliding launch window: at most N restart children alive at once, and as each exits the next is forked. N derives from the same CPU budget the per-worker split was taken from.

`FLEXAIDDS_MAX_CONCURRENT_RESTARTS`: `-1` auto (default), `0` legacy unlimited, `>0` explicit cap. Serialized into the emitted config for provenance.

**`omp_per_worker` is unchanged.** Thread count is science-affecting in this engine (~2 Å spread), so it is never tuned here — only the number of concurrent *processes* changes.

Failure and timeout semantics are preserved exactly:
- the any-failure-wins fold is extracted **verbatim** into `fold_restart_return_codes()` so it can be unit-tested;
- reaping is FIFO in launch order and **idempotent**, so the final drain observes the identical sequence of `(ri, ret)` pairs the unthrottled path produced;
- each child keeps its own full `per_job_timeout_s`, measured from its own fork.

## Verification

```
test_dataset_runner   92 tests, 92 PASSED   (incl. 3 new RestartThrottle tests)
test_protocol_config  14 tests, 14 PASSED
```
`RestartThrottle.SlidingWindowBoundsLiveChildren` actually spawns children and asserts the live-child count never exceeds the cap. Build clean (Release, `BUILD_TESTING=ON`).

> Note for reviewers: test binaries in this environment link against Anaconda's GoogleTest 1.11.0 dylib with no rpath, so `ctest` discovery aborts for **every** target including pre-existing ones. Run with `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/anaconda3/lib`. Pre-existing environment defect, worth fixing separately.

## Science-Impact: none — scheduling only

Every parent-side artifact (`dock_config.json`, blinded ligand, receptor prep) is written in the same order as before; **only the fork is gated**, so no child's argv, config, seed, or working directory changes. Each restart is an independent deterministic process with its own `ri_dir` and its own deterministic seed. `all_prefixes` is still appended in `ri` index order, so the pooled election sees the same list in the same order.

`wall_time_s` and the `[PARALLEL-RESTART]` banner change; those are not science. Per-target wall time will rise (restarts now queue) while machine-wide throughput improves — that is the intended trade.

Side benefit: fewer concurrent children reduces exposure to the shared `<PDB>_dockin.sdf` restart race (it does not fix it — that needs the write hoisted out of the restart loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)