### PR TITLE
Add: classify diffs into engine vs swarm/audit pack vs hygiene

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,23 @@
 
 What changed and why.
 
+## Change class (pick **one** primary)
+
+- [ ] **Fix** — bug; default path unchanged, or fail-closed
+- [ ] **Science enhancement** — opt-in; env-gated **OFF** (`flexaids::env_bool`)
+- [ ] **Engine/code** — LIB/src behavior that is not a science gate
+- [ ] **Docs / audit / swarm pack** — `docs/swarm/`, `docs/audit/` (own PR; do not mix with LIB)
+- [ ] **Benchmark harness / frozen referee**
+- [ ] **CI / hygiene**
+
+Run `python3 scripts/classify_diff.py` on this branch. If it prints `VERDICT: MIXED`, split the PR.
+
+## Science-Impact
+
+- [ ] none (cannot move docked coordinates or CF ranking)
+- [ ] gated OFF — flag name: `FLEXAIDDS_…`
+- [ ] default-path (requires METHODOLOGY.md §1 parity)
+
 ## Scope
 
 - [ ] Core 1.0 supported surface

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,8 +386,8 @@ jobs:
         run: python -m pip install --upgrade pip pytest pyyaml numpy
       - name: Check tracked secrets and hardcoded agent paths
         run: python3 scripts/check_repo_hygiene.py
-      - name: Root run-artifact guard
-        run: python3 -m pytest tests/test_check_root_artifacts.py -q --tb=line
+      - name: Root run-artifact guard and diff classifier
+        run: python3 -m pytest tests/test_check_root_artifacts.py tests/test_classify_diff.py -q --tb=line
       - name: Validate public thermodynamic claims and provenance firewall
         run: |
           python3 scripts/validate_thermo_claims.py

--- a/docs/SCIENCE_CRITICAL_PATHS.txt
+++ b/docs/SCIENCE_CRITICAL_PATHS.txt
@@ -1,8 +1,10 @@
 # Science-critical paths — a change here can move docked coordinates or scores.
 #
-# Consumed by scripts/check_repo_hygiene.py (anti-bundling lint). A PR touching
-# any path below must declare `Science-Impact:` in its body and must not also
-# touch a non-engine stack (typescript/, swift/, site/) in the same commit.
+# Consumed by scripts/check_repo_hygiene.py (anti-bundling lint) and
+# scripts/classify_diff.py. A PR touching any path below must declare
+# `Science-Impact:` in its body, must not also touch a non-engine stack
+# (typescript/, swift/, site/), and must not also touch docs/swarm/ or
+# docs/audit/ (those are a separate pack PR).
 #
 # Format: one glob per line, '#' comments, blank lines ignored. Matched against
 # repo-relative paths with fnmatch.
@@ -23,6 +25,10 @@ LIB/Vcontacts.cpp
 LIB/Vcontacts.h
 LIB/VoronoiCFBatch.h
 LIB/SoftBetaFreeEnergy.h
+
+# ── RNG: stream identity changes sampled poses (F1) ───────────────────────────
+LIB/RngSeed.h
+LIB/EnvFlags.h
 
 # ── search / GA ───────────────────────────────────────────────────────────────
 LIB/gaboom.cpp

--- a/scripts/check_repo_hygiene.py
+++ b/scripts/check_repo_hygiene.py
@@ -4,9 +4,13 @@
 Fails when:
 - tracked files match secret/env patterns (.env, .env.local, etc.)
 - agent/skill instruction files contain machine-specific absolute paths
+- a science-critical engine path is bundled with a swarm/audit pack (or a
+  non-engine product stack)
 
 Run:
   python3 scripts/check_repo_hygiene.py
+  python3 scripts/classify_diff.py              # vs origin/main
+  python3 scripts/classify_diff.py A B          # git diff --name-only A B
 """
 from __future__ import annotations
 
@@ -99,6 +103,20 @@ SCIENCE_PATHS_FILE = "docs/SCIENCE_CRITICAL_PATHS.txt"
 # Stacks that cannot affect docked coordinates. Bundling one of these with a
 # science-critical change is what made PR #405 unreviewable.
 NON_ENGINE_STACKS = ("typescript/", "swift/", "site/")
+# Handoff packs / audit write-ups drown engine diffs (PR #420: 16 swarm files
+# vs 3 LIB files). Split: engine PR vs pack PR. Tests next to LIB are fine.
+SCIENCE_PACK_PREFIXES = ("docs/swarm/", "docs/audit/")
+
+CHANGE_CLASSES = (
+    "engine_critical",
+    "engine_other",
+    "tests",
+    "science_pack",
+    "benchmark",
+    "ci_hygiene",
+    "docs_other",
+    "other",
+)
 
 
 def _load_science_globs(repo_root: Path) -> list[str]:
@@ -131,6 +149,38 @@ def _changed_files(base: str = "origin/main") -> tuple[list[str], str | None]:
         return [f for f in out.stdout.splitlines() if f], None
     except Exception as exc:  # noqa: BLE001
         return [], f"git unavailable: {exc}"
+
+
+def classify_path(rel: str, science_globs: list[str]) -> str:
+    """Bucket a repo-relative path. engine_critical uses SCIENCE_CRITICAL_PATHS."""
+    rel = rel.replace("\\", "/")
+    if any(fnmatch.fnmatch(rel, g) for g in science_globs):
+        return "engine_critical"
+    if rel.startswith(SCIENCE_PACK_PREFIXES):
+        return "science_pack"
+    if rel.startswith("benchmarks/"):
+        return "benchmark"
+    if rel.startswith("tests/") or "/tests/" in rel or rel.startswith("python/tests/"):
+        return "tests"
+    if rel.startswith("LIB/") or rel.startswith("src/"):
+        return "engine_other"
+    if rel.startswith((".github/", "cmake/", "scripts/")) or rel in {
+        "CMakeLists.txt",
+        "build_sources.ignore",
+        ".gitignore",
+        ".pre-commit-config.yaml",
+    }:
+        return "ci_hygiene"
+    if rel.startswith("docs/") or rel.endswith(".md"):
+        return "docs_other"
+    return "other"
+
+
+def classify_paths(files: list[str], science_globs: list[str]) -> dict[str, list[str]]:
+    buckets = {k: [] for k in CHANGE_CLASSES}
+    for rel in files:
+        buckets[classify_path(rel, science_globs)].append(rel)
+    return buckets
 
 
 def check_science_bundling(repo_root: Path) -> list[str]:
@@ -172,6 +222,35 @@ def check_science_bundling(repo_root: Path) -> list[str]:
     ]
 
 
+def check_science_pack_bundling(repo_root: Path) -> list[str]:
+    """Engine-critical paths must not share a PR with swarm/audit packs.
+
+    PR #420 mixed gated LIB/RngSeed.h+gaboom.h with docs/swarm/ (frozen CSV).
+    Both were useful; neither is reviewable in the same diff. Split them.
+    """
+    globs = _load_science_globs(repo_root)
+    if not globs:
+        return []
+    changed, skip = _changed_files()
+    if skip or not changed:
+        return []
+    buckets = classify_paths(changed, globs)
+    engine = buckets["engine_critical"]
+    pack = buckets["science_pack"]
+    if not engine or not pack:
+        return []
+    return [
+        "science-critical engine change bundled with a swarm/audit pack; split the PR.\n"
+        f"      engine-critical: {', '.join(sorted(engine)[:5])}"
+        f"{' ...' if len(engine) > 5 else ''}\n"
+        f"      science pack:    {', '.join(sorted(pack)[:5])}"
+        f"{' ...' if len(pack) > 5 else ''}\n"
+        "      engine/bugfix PR stays in LIB/+tests; pack PR stays under "
+        "docs/swarm/ or docs/audit/. "
+        "python3 scripts/classify_diff.py prints the buckets."
+    ]
+
+
 # Regenerable run scratch that must never sit at the repo root — A/B benchmark
 # output, stray worktrees. Belongs under $FLEXAIDDS_LOCAL_ROOT (~/flexaidds_results).
 ROOT_ARTIFACT_GLOBS = ("ab_mac_*", "ab_*", "wt_pre_*", "wt_post_*")
@@ -195,6 +274,7 @@ def main() -> int:
     errors = (check_tracked_env_files(tracked)
               + check_hardcoded_paths(tracked)
               + check_science_bundling(repo_root)
+              + check_science_pack_bundling(repo_root)
               + check_root_artifacts(repo_root))
 
     if errors:

--- a/scripts/classify_diff.py
+++ b/scripts/classify_diff.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Classify a git diff into engine / pack / tests / hygiene buckets.
+
+Use this before reviewing a PR or a `git diff A B` that looks like "mostly
+science docs." It does not decide Fix vs Add (that is the commit prefix);
+it decides *what kind of tree* moved so a mixed PR can be split.
+
+Examples:
+  python3 scripts/classify_diff.py
+  python3 scripts/classify_diff.py origin/main HEAD
+  python3 scripts/classify_diff.py pre-swarm-baseline-20260813 origin/main
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+
+import check_repo_hygiene as hygiene  # noqa: E402
+
+REPO_ROOT = hygiene.REPO_ROOT
+
+
+def _name_only(a: str, b: str) -> list[str]:
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", a, b],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(proc.stderr.strip() or f"git diff failed: {a} {b}")
+    return [ln for ln in proc.stdout.splitlines() if ln]
+
+
+def format_report(buckets: dict[str, list[str]]) -> str:
+    lines = ["=== change class (path buckets) ===", ""]
+    nonempty = [(k, v) for k, v in buckets.items() if v]
+    if not nonempty:
+        return "=== change class (path buckets) ===\n(no files)\n"
+    for key, files in nonempty:
+        lines.append(f"{key} ({len(files)})")
+        for rel in files:
+            lines.append(f"  {rel}")
+        lines.append("")
+    engine = buckets.get("engine_critical") or []
+    pack = buckets.get("science_pack") or []
+    if engine and pack:
+        lines.append("VERDICT: MIXED — split engine/bugfix from swarm/audit pack")
+    elif engine:
+        lines.append("VERDICT: engine-critical (can move coordinates or CF ranking)")
+    elif pack:
+        lines.append("VERDICT: science pack (docs/swarm or docs/audit; not engine)")
+    elif buckets.get("benchmark"):
+        lines.append("VERDICT: benchmark harness")
+    elif buckets.get("ci_hygiene"):
+        lines.append("VERDICT: CI / hygiene")
+    elif buckets.get("docs_other"):
+        lines.append("VERDICT: docs")
+    else:
+        lines.append("VERDICT: non-engine")
+    lines.append("Intent (Fix vs Add vs Docs) is the commit prefix, not this tool.")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "commits",
+        nargs="*",
+        help="git diff A B (default: merge-base origin/main HEAD .. HEAD)",
+    )
+    parser.add_argument(
+        "--strict-split",
+        action="store_true",
+        help="exit 1 if engine_critical and science_pack both nonempty",
+    )
+    args = parser.parse_args(argv)
+
+    if len(args.commits) == 2:
+        files = _name_only(args.commits[0], args.commits[1])
+    elif len(args.commits) == 0:
+        files, skip = hygiene._changed_files("origin/main")
+        if skip:
+            print(f"NOTE: {skip}", file=sys.stderr)
+            files = []
+    else:
+        parser.error("give zero args or exactly two commits")
+
+    globs = hygiene._load_science_globs(REPO_ROOT)
+    buckets = hygiene.classify_paths(files, globs)
+    print(format_report(buckets), end="")
+    if args.strict_split and buckets["engine_critical"] and buckets["science_pack"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_classify_diff.py
+++ b/tests/test_classify_diff.py
@@ -1,0 +1,60 @@
+"""Path buckets: engine-critical vs swarm/audit pack vs hygiene."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import check_repo_hygiene as hygiene  # noqa: E402
+
+
+def test_classify_engine_vs_pack():
+    globs = ["LIB/gaboom.h", "LIB/RngSeed.h", "LIB/statmech.cpp"]
+    buckets = hygiene.classify_paths(
+        [
+            "LIB/gaboom.h",
+            "docs/swarm/2026-08-13/ASTEX84_FROZEN_POSE_BENCHMARK.csv",
+            "tests/test_gaboom.cpp",
+            "scripts/check_repo_hygiene.py",
+        ],
+        globs,
+    )
+    assert buckets["engine_critical"] == ["LIB/gaboom.h"]
+    assert buckets["science_pack"] == [
+        "docs/swarm/2026-08-13/ASTEX84_FROZEN_POSE_BENCHMARK.csv"
+    ]
+    assert buckets["tests"] == ["tests/test_gaboom.cpp"]
+    assert buckets["ci_hygiene"] == ["scripts/check_repo_hygiene.py"]
+
+
+def test_pack_bundling_flags_mix(tmp_path: Path, monkeypatch):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "SCIENCE_CRITICAL_PATHS.txt").write_text(
+        "LIB/gaboom.h\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        hygiene,
+        "_changed_files",
+        lambda base="origin/main": (
+            ["LIB/gaboom.h", "docs/swarm/README.md"],
+            None,
+        ),
+    )
+    errors = hygiene.check_science_pack_bundling(tmp_path)
+    assert errors
+    assert "split the PR" in errors[0]
+
+
+def test_pack_bundling_ok_when_split(tmp_path: Path, monkeypatch):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "SCIENCE_CRITICAL_PATHS.txt").write_text(
+        "LIB/gaboom.h\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        hygiene,
+        "_changed_files",
+        lambda base="origin/main": (["LIB/gaboom.h", "tests/test_gaboom.cpp"], None),
+    )
+    assert hygiene.check_science_pack_bundling(tmp_path) == []


### PR DESCRIPTION
## Summary

Reviewers were drowning in swarm/audit files when the engine change was three LIB headers. This adds `scripts/classify_diff.py` and a fail-closed hygiene rule: do not bundle `SCIENCE_CRITICAL_PATHS` with `docs/swarm/` or `docs/audit/` in one PR.

## Change class (pick **one** primary)

- [x] **CI / hygiene**

Run `python3 scripts/classify_diff.py` on this branch. If it prints `VERDICT: MIXED`, split the PR.

## Science-Impact

- [x] none (cannot move docked coordinates or CF ranking)

`LIB/RngSeed.h` and `LIB/EnvFlags.h` are added to the *list* of science-critical paths (the list file, not those sources).

## Scope

- [x] CI / release engineering
- [x] Benchmark / reproducibility

## Release impact

- [x] no user-facing release impact

## Validation

```
python3 -m pytest tests/test_classify_diff.py -q
python3 scripts/classify_diff.py origin/main HEAD
python3 scripts/classify_diff.py pre-swarm-baseline-20260813 origin/main
```

This PR classifies as CI/hygiene. Tag..main classifies as MIXED (the #420 bundling).

- [x] unit tests
- [x] manual validation

## Security and safety

- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

## Reproducibility

- [x] no benchmark claim involved

Made with [Cursor](https://cursor.com)