### PR TITLE
Add: rigid-receptor fast path + flag overlay (experimental, gated OFF)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1607,6 +1607,27 @@ flexaids_add_unit_test(test_protocol_config
     flexaids_configure_msvc_test(test_vcontacts)
     add_test(NAME VcontactsTests COMMAND test_vcontacts)
 
+    # test_rigid_fastpath — FLEXAIDDS_RIGID_FASTPATH bit-identity
+    # (index_protein + Vcontacts + calc_region; same isolated link as test_vcontacts)
+    add_executable(test_rigid_fastpath
+        tests/test_rigid_fastpath.cpp
+        tests/stubs.cpp
+        LIB/Vcontacts.cpp
+        LIB/geometry.cpp
+    )
+    target_include_directories(test_rigid_fastpath PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/LIB)
+    target_link_libraries(test_rigid_fastpath PRIVATE GTest::gtest_main)
+    if(MSVC)
+        target_compile_options(test_rigid_fastpath PRIVATE /O2)
+    else()
+        target_compile_options(test_rigid_fastpath PRIVATE -O2)
+    endif()
+    if(FLEXAIDS_USE_OPENMP AND OpenMP_CXX_FOUND)
+        target_link_libraries(test_rigid_fastpath PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+    flexaids_configure_msvc_test(test_rigid_fastpath)
+    add_test(NAME RigidFastpathBitIdentity COMMAND test_rigid_fastpath)
+
     # test_vcontacts_geometry — convex-hull geometry functions (test_point, add_vedge, etc.)
     add_executable(test_vcontacts_geometry
         tests/test_vcontacts_geometry.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2279,6 +2279,16 @@ flexaids_add_unit_test(test_protocol_config
     )
     set_tests_properties(ContactsEpochPrefixLayoutDetected PROPERTIES WILL_FAIL TRUE)
 
+    # test_flexaidds_flags — unified FLEXAIDDS_* / FLEXAID_* / FLEXAIDS_* gate
+    #   overlay (resolve / exclusion / FLEXAIDDS_FLAGS / dump). Isolated from
+    #   engine sources; does not remove any existing option.
+    flexaids_add_unit_test(test_flexaidds_flags
+        SOURCES
+            tests/test_flexaidds_flags.cpp
+            LIB/flexaidds_flags.cpp
+        TEST_NAME FlexaiddsFlagsTests
+    )
+
     # test_ion_handling — assign_radii / assign_types HETATM + ion coverage
     #                     + tENCoM ion contact surface (TmContSct) tests
     flexaids_add_unit_test(test_ion_handling

--- a/LIB/CMakeLists.txt
+++ b/LIB/CMakeLists.txt
@@ -11,6 +11,7 @@ set(FLEXAID_CORE_SOURCES
     assign_shift.cpp
     buildic.cpp
     Vcontacts.cpp
+    flexaidds_flags.cpp
     ic2cf.cpp
     vcfunction.cpp
     create_rebuild_list.cpp

--- a/LIB/CoarseScreen.h
+++ b/LIB/CoarseScreen.h
@@ -1,9 +1,10 @@
-// CoarseScreen.h — NRGRank coarse-grained screening for FlexAIDdS
+// CoarseScreen.h — coarse-grained cube screening for FlexAIDdS
 //
-// C++20 translation of NRGRank's process_target.py + rank_molecules.py.
-//   DesCôteaux T, Mailhot O, Najmanovich RJ. "NRGRank: Coarse-grained
-//   structurally-informed ultra-massive virtual screening."
-//   bioRxiv 2025.02.17.638675.
+// Reimplemented from the published method (DesCôteaux, Mailhot, Najmanovich,
+// bioRxiv 2025.02.17.638675v2, doi 10.1101/2025.02.17.638675;
+// supplementary data Zenodo 10.5281/zenodo.16861024), clean-room per
+// docs/licensing/clean-room-policy.md. Apache-2.0. Not a translation of
+// NRGlab/NRGRank source (that tree is GPL-3.0 and is not a dependency).
 //
 // Pipeline:
 //   1. Build index-cube grid (cell_width=6.56 Å) from target atoms
@@ -163,7 +164,7 @@ public:
     void set_config(const CoarseScreenConfig& cfg) { config_ = cfg; }
     const CoarseScreenConfig& config() const { return config_; }
 
-    // ── Target preparation (process_target.py equivalent) ──
+    // ── Target preparation (paper §2 cube/anchor construction) ──
 
     /// Load target from MOL2 file
     bool load_target_mol2(const std::string& path);

--- a/LIB/ParallelCampaign.cpp
+++ b/LIB/ParallelCampaign.cpp
@@ -25,9 +25,12 @@
 #include "hardware_detect.h"
 #include "ProcessLigand/ProcessLigand.h"
 #include "ProcessLigand/CoordBuilder.h"
+#include "CoarseScreen.h"
+#include "TwoStageScreen.h"
 
 #include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <chrono>
 #include <cstdio>
 #include <cstring>
@@ -212,6 +215,85 @@ CampaignSummary run_campaign(
 
     // Split ligand library
     auto lig_lib = library::split_library(config.ligand_path);
+
+    if (config.coarse_prefilter) {
+        std::string mol2 = config.coarse_target_mol2;
+        std::string cleft = config.coarse_cleft_pdb;
+        if (mol2.empty()) {
+            const std::string rp = config.receptor_path;
+            auto dot = rp.rfind('.');
+            std::string ext = dot == std::string::npos ? std::string{} : rp.substr(dot);
+            for (char& c : ext) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+            if (ext == ".mol2") mol2 = rp;
+        }
+        if (mol2.empty() || cleft.empty()) {
+            std::fprintf(stderr,
+                "[CAMPAIGN] ERROR: --coarse-prefilter requires a MOL2 target "
+                "(--screen-target-mol2 or a .mol2 receptor) and a cleft/site PDB "
+                "(FLEXAIDDS_ORACLE_SITE / FLEXAIDDS_CLEFT_SPHERE_FILE).\n");
+            summary.failed = lig_lib.total;
+            summary.total_ligands = lig_lib.total;
+            return summary;
+        }
+
+        auto atoms = nrgrank::parse_target_mol2(mol2);
+        auto spheres = nrgrank::parse_binding_site_pdb(cleft);
+        std::vector<nrgrank::ScreenLigand> screen_ligs;
+        {
+            const std::string lp = config.ligand_path;
+            auto dot = lp.rfind('.');
+            std::string ext = dot == std::string::npos ? std::string{} : lp.substr(dot);
+            for (char& c : ext) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+            if (ext == ".sdf" || ext == ".mol")
+                screen_ligs = nrgrank::CoarseScreener::load_ligands_sdf(lp);
+            else
+                screen_ligs = nrgrank::CoarseScreener::load_ligands_mol2(lp);
+        }
+
+        nrgrank::TwoStageScreener ts;
+        nrgrank::TwoStageConfig tcfg;
+        tcfg.top_n = std::max(1, config.coarse_prefilter_top_n);
+        tcfg.coarse.top_n = tcfg.top_n;
+        tcfg.write_coarse_csv = true;
+        tcfg.output_dir = config.output_prefix + "_screen";
+        tcfg.verbose = true;
+        ts.set_config(tcfg);
+        ts.prepare_target(atoms, spheres);
+        auto staged = ts.run(screen_ligs);
+        auto keep = nrgrank::TwoStageScreener::top_names(staged, tcfg.top_n);
+        nrgrank::TwoStageScreener::write_unified_csv(
+            tcfg.output_dir + "/unified.csv", staged);
+        nrgrank::TwoStageScreener::write_screen_receipt(
+            tcfg.output_dir, static_cast<int>(screen_ligs.size()), tcfg.top_n,
+            false, "campaign-coarse-prefilter");
+
+        std::vector<library::LigandEntry> filtered;
+        filtered.reserve(keep.size());
+        for (const auto& name : keep) {
+            for (const auto& e : lig_lib.ligands) {
+                if (e.name == name) {
+                    filtered.push_back(e);
+                    break;
+                }
+            }
+        }
+        if (filtered.empty()) {
+            // Name schemes can differ (MOL2 title vs file stem). Fall back to
+            // first top_n library entries in Stage-1 order when possible.
+            std::fprintf(stderr,
+                "[CAMPAIGN] WARNING: coarse names did not match library stems; "
+                "keeping first %d split-library entries.\n", tcfg.top_n);
+            const int nkeep = std::min(tcfg.top_n, lig_lib.total);
+            filtered.assign(lig_lib.ligands.begin(),
+                            lig_lib.ligands.begin() + nkeep);
+        }
+        lig_lib.ligands.swap(filtered);
+        lig_lib.total = static_cast<int>(lig_lib.ligands.size());
+        summary.total_ligands = lig_lib.total;
+        summary.total_docks = lig_lib.total * std::max(1, config.receptor_models);
+        std::printf("[CAMPAIGN] coarse-prefilter kept %d / %zu ligands\n",
+                    lig_lib.total, screen_ligs.size());
+    }
 
     // Split receptor if multi-model
     library::LibraryInfo rec_lib;

--- a/LIB/ParallelCampaign.h
+++ b/LIB/ParallelCampaign.h
@@ -67,6 +67,14 @@ struct CampaignConfig {
 
     // P3 grand canonical: default concentration forwarded for TargetServer/GPF when multi-ligand campaign uses grand paths
     double default_conc_M     = 1.0;
+
+    // Optional Stage-1 cube prefilter (default OFF). When true, the ligand
+    // library is coarse-screened and only top_n names are docked. Requires a
+    // MOL2 target + cleft/site PDB. Does not change scoring of kept ligands.
+    bool coarse_prefilter = false;
+    int  coarse_prefilter_top_n = 100;
+    std::string coarse_target_mol2;
+    std::string coarse_cleft_pdb;
 };
 
 // ─── Per-ligand result ──────────────────────────────────────────────────────

--- a/LIB/TwoStageScreen.cpp
+++ b/LIB/TwoStageScreen.cpp
@@ -14,6 +14,7 @@
 #include <filesystem>
 #include <fstream>
 #include <numeric>
+#include <unordered_map>
 
 namespace nrgrank {
 
@@ -105,6 +106,8 @@ std::vector<TwoStageResult> TwoStageScreener::run(
 
             const auto& lig = ligands[it->second];
             results[i].full_dock_score = dock_cb_(lig, results[i].coarse_result);
+            results[i].stage2_kind = config_.stage2_kind_label.empty()
+                ? "callback" : config_.stage2_kind_label;
         }
 
         // Re-sort top-N by full dock score
@@ -141,6 +144,68 @@ void TwoStageScreener::write_csv(const std::string& path,
              << r.best_position.y << ","
              << r.best_position.z << "\n";
     }
+}
+
+void TwoStageScreener::write_unified_csv(const std::string& path,
+                                         const std::vector<TwoStageResult>& results) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::create_directories(fs::path(path).parent_path(), ec);
+    std::ofstream fout(path);
+    if (!fout.is_open()) return;
+
+    fout << "coarse_rank,name,coarse_score,stage2_score,stage2_rmsd,stage2_rank,stage2_kind\n";
+    for (const auto& r : results) {
+        fout << r.coarse_rank << ","
+             << "\"" << r.coarse_result.name << "\","
+             << r.coarse_result.score << ",";
+        if (std::isfinite(r.full_dock_score)) fout << r.full_dock_score;
+        fout << ",";
+        if (std::isfinite(r.rmsd)) fout << r.rmsd;
+        fout << ","
+             << r.full_rank << ","
+             << r.stage2_kind << "\n";
+    }
+}
+
+bool TwoStageScreener::write_screen_receipt(const std::string& output_dir,
+                                            int n_ligands,
+                                            int top_n,
+                                            bool stage2_callback,
+                                            const std::string& extra_mode) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::create_directories(output_dir, ec);
+    const std::string path = output_dir + "/RUN_RECEIPT.json";
+    std::ofstream fout(path);
+    if (!fout.is_open()) return false;
+    const char* mode = extra_mode.empty()
+        ? (stage2_callback ? "two-stage-screen" : "coarse-screen")
+        : extra_mode.c_str();
+    fout << "{\n"
+         << "  \"schema\": \"flexaidds_screen_receipt/1\",\n"
+         << "  \"mode\": \"" << mode << "\",\n"
+         << "  \"n_ligands\": " << n_ligands << ",\n"
+         << "  \"top_n\": " << top_n << ",\n"
+         << "  \"stage2_callback\": " << (stage2_callback ? "true" : "false") << ",\n"
+         << "  \"score_claim\": \"CF/contact-function scoring proxy (coarse); "
+            "stage2 is callback/surrogate unless a real GA dock is wired\",\n"
+         << "  \"method_doi\": \"10.1101/2025.02.17.638675\",\n"
+         << "  \"zenodo_doi\": \"10.5281/zenodo.16861024\",\n"
+         << "  \"matrix\": \"MC_5p_norm_P10_M2_2 (constexpr LIB/nrgrank_matrix.h)\",\n"
+         << "  \"license_note\": \"clean-room Apache-2.0; NRGlab/NRGRank GPL source is not a dependency\"\n"
+         << "}\n";
+    return true;
+}
+
+std::vector<std::string> TwoStageScreener::top_names(
+        const std::vector<TwoStageResult>& results, int top_n) {
+    std::vector<std::string> names;
+    const int n = std::min(std::max(top_n, 0), static_cast<int>(results.size()));
+    names.reserve(static_cast<size_t>(n));
+    for (int i = 0; i < n; ++i)
+        names.push_back(results[static_cast<size_t>(i)].coarse_result.name);
+    return names;
 }
 
 } // namespace nrgrank

--- a/LIB/TwoStageScreen.h
+++ b/LIB/TwoStageScreen.h
@@ -1,16 +1,15 @@
 // TwoStageScreen.h — Two-stage virtual screening pipeline
 //
-// Stage 1: NRGRank coarse-grained screening (CoarseScreen)
+// Stage 1: coarse-grained cube screening (CoarseScreen)
 //          Fast rigid-body CF scoring with 729 rotations × anchor grid.
 //          Filters millions of compounds down to top-N.
 //
-// Stage 2: FlexAIDdS full GA docking
-//          Flexible docking with thermodynamic scoring on top-N hits.
+// Stage 2: optional callback (campaign per-ligand dock, or a test mock).
+//          Default: unset → Stage 1 only. Never implied by --screen alone.
 //
-// Reference:
-//   DesCôteaux T, Mailhot O, Najmanovich RJ. "NRGRank: Coarse-grained
-//   structurally-informed ultra-massive virtual screening."
-//   bioRxiv 2025.02.17.638675.
+// Method: DesCôteaux, Mailhot, Najmanovich, bioRxiv 2025.02.17.638675v2
+// (doi 10.1101/2025.02.17.638675; Zenodo 10.5281/zenodo.16861024).
+// Clean-room per docs/licensing/clean-room-policy.md. Not GPL source.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,6 +18,7 @@
 #include "CoarseScreen.h"
 
 #include <functional>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -43,6 +43,10 @@ struct TwoStageConfig {
 
     /// Verbose progress output
     bool verbose = false;
+
+    /// Written into TwoStageResult::stage2_kind when the callback runs.
+    /// Default "callback". Use "surrogate" when the hook is not a real GA CF.
+    std::string stage2_kind_label = "callback";
 };
 
 /// Result from the full two-stage pipeline
@@ -61,6 +65,10 @@ struct TwoStageResult {
 
     /// Rank after Stage 2 (1-based, 0 if not docked)
     int full_rank = 0;
+
+    /// How Stage 2 was filled: empty (unset), "callback", or "surrogate".
+    /// Never claim this field is a thermodynamic ΔG.
+    std::string stage2_kind;
 };
 
 /// Callback for Stage 2 docking. Receives the ligand and coarse result,
@@ -102,6 +110,21 @@ public:
     /// Write coarse screening results to CSV
     static void write_csv(const std::string& path,
                           const std::vector<ScreenResult>& results);
+
+    /// Unified Stage-1 + Stage-2 CSV (coarse rank/score + dock CF/RMSD).
+    static void write_unified_csv(const std::string& path,
+                                  const std::vector<TwoStageResult>& results);
+
+    /// Thin screen receipt (method DOI / Zenodo / counts). Not a claim package.
+    static bool write_screen_receipt(const std::string& output_dir,
+                                     int n_ligands,
+                                     int top_n,
+                                     bool stage2_callback,
+                                     const std::string& extra_mode = "");
+
+    /// Names of the first min(top_n, size) results (Stage-1 order if undocked).
+    static std::vector<std::string> top_names(const std::vector<TwoStageResult>& results,
+                                              int top_n);
 
     /// Access the internal coarse screener (for advanced use)
     const CoarseScreener& coarse_screener() const { return screener_; }

--- a/LIB/Vcontacts.cpp
+++ b/LIB/Vcontacts.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstdint>
+#include <cstring>
 #include <cmath>
 #include <vector>
 #include <random>
@@ -13,6 +14,381 @@
 #include "AtomSoA.h"  // atom_soa::distance2_1x4 (ISA-portable 4-wide kernel)
 #include <cmath>     // fabs
 #endif
+
+// ── FLEXAIDDS_RIGID_FASTPATH (default OFF) ─────────────────────────────────
+// Incremental spatial index for a rigid receptor. When OFF, index_protein /
+// Vcontacts / calc_region take the legacy bodies unchanged. When ON, hoist
+// is implied; subsequent evals with a stable grid rebuild Calclist from a
+// rigid per-box snapshot + current scorable atoms (atmi-sorted per box).
+namespace {
+
+static bool rigid_fastpath_requested() {
+	const char* e = std::getenv("FLEXAIDDS_RIGID_FASTPATH");
+	return e && e[0] && e[0] != '0';
+}
+
+const bool kHoistReceptorIndexEnv =
+	(std::getenv("FLEXAIDDS_HOIST_RECEPTOR_INDEX") != nullptr);
+
+struct ScoSlot {
+	int calc_idx;
+	int resi;
+	int offset;
+	int natoms;
+};
+
+struct OptresId {
+	int rnum;
+	int type;
+	int tot;
+};
+
+struct FastpathCache {
+	bool valid = false;
+	std::string sig;
+	int dim = 0;
+	int dim3 = 0;
+	int calc_cnt = 0;
+	int atmcnt = 0;
+	float rigid_raw_min[3] = {0.f, 0.f, 0.f};
+	float rigid_raw_max[3] = {0.f, 0.f, 0.f};
+	bool has_rigid = false;
+	std::vector<int> rigid_list;
+	std::vector<int> rigid_first;
+	std::vector<int> rigid_nument;
+	std::vector<ScoSlot> slots;
+	std::vector<OptresId> optres;
+	atomindex* box_ptr = nullptr;
+};
+
+thread_local FastpathCache g_fp;
+thread_local std::vector<int> g_scorable;
+thread_local bool g_fastpath_on = false;
+thread_local bool g_fastpath_used = false;
+thread_local std::string g_prev_sig;
+thread_local std::vector<uint32_t> g_box_stamp;
+thread_local uint32_t g_box_epoch = 0;
+
+bool fa_must_invalidate(const FA_Global* FA)
+{
+	if(!FA) return true;
+	if(FA->multi_model || FA->n_models > 1) return true;
+	if(FA->map_par){
+		for(int p = 0; p < FA->npar; ++p){
+			if(FA->map_par[p].typ == 3) return true;
+		}
+	}
+	return false;
+}
+
+bool optres_identity_changed(const FA_Global* FA)
+{
+	if(!FA) return true;
+	if(FA->num_optres != (int)g_fp.optres.size()) return true;
+	if(FA->num_optres > 0 && !FA->optres) return true;
+	for(int j = 0; j < FA->num_optres; ++j){
+		if(FA->optres[j].rnum != g_fp.optres[j].rnum) return true;
+		if(FA->optres[j].type != g_fp.optres[j].type) return true;
+		if(FA->optres[j].tot  != g_fp.optres[j].tot)  return true;
+	}
+	return false;
+}
+
+void capture_optres_identity(const FA_Global* FA)
+{
+	g_fp.optres.clear();
+	if(!FA || !FA->optres || FA->num_optres <= 0) return;
+	g_fp.optres.reserve((size_t)FA->num_optres);
+	for(int j = 0; j < FA->num_optres; ++j){
+		g_fp.optres.push_back({FA->optres[j].rnum, FA->optres[j].type, FA->optres[j].tot});
+	}
+}
+
+bool rebind_scorable_slots(FA_Global* FA, atom* atoms, resid* residue,
+                           atomsas* Calc, int atmcnt)
+{
+	for(const ScoSlot& s : g_fp.slots){
+		if(s.calc_idx < 0 || s.calc_idx >= g_fp.calc_cnt) return false;
+		if(s.resi < 1 || s.resi > FA->res_cnt) return false;
+		if(!residue[s.resi].fatm || !residue[s.resi].latm) return false;
+		const int rot = residue[s.resi].rot;
+		const int fatm = residue[s.resi].fatm[rot];
+		const int latm = residue[s.resi].latm[rot];
+		if(latm - fatm + 1 != s.natoms) return false;
+		const int atmi = fatm + s.offset;
+		if(atmi < 0 || atmi >= atmcnt || atmi > latm) return false;
+		atomsas& C = Calc[s.calc_idx];
+		C.atom = &atoms[atmi];
+		C.residue = &residue[s.resi];
+		C.ca_index = -1;
+		C.done = 'N';
+		C.exposed = true;
+		C.SAS = 0.0;
+		C.vol = 0.0;
+		C.source = '\0';
+		C.score = atoms[atmi].optres != NULL;
+		if(!C.score) return false;
+	}
+	return true;
+}
+
+void expand_bbox_atom(const float* coor, float* global_min, float* global_max, int* alter)
+{
+	for(int j = 0; j < 3; ++j){
+		if(coor[j] < global_min[j]){
+			global_min[j] = coor[j];
+			*alter = 1;
+		}else if(coor[j] > global_max[j]){
+			global_max[j] = coor[j];
+			*alter = 1;
+		}
+	}
+}
+
+int clamp_box_index(const atomsas& C, const float* global_min, int dim, int dim2)
+{
+	int cx = (int)((C.atom->coor[0] - global_min[0]) / CELLSIZE);
+	int cy = (int)((C.atom->coor[1] - global_min[1]) / CELLSIZE);
+	int cz = (int)((C.atom->coor[2] - global_min[2]) / CELLSIZE);
+	if(cx < 0) cx = 0; else if(cx >= dim) cx = dim - 1;
+	if(cy < 0) cy = 0; else if(cy >= dim) cy = dim - 1;
+	if(cz < 0) cz = 0; else if(cz >= dim) cz = dim - 1;
+	return cx * dim2 + cy * dim + cz;
+}
+
+void capture_rigid_snapshot(FA_Global* FA, atom* atoms, resid* residue,
+                            atomsas* Calc, const int* Calclist, const atomindex* box,
+                            int calc_cnt, int dim, int dim3, const std::string& sig,
+                            int atmcnt)
+{
+	g_fp.valid = true;
+	g_fp.sig = sig;
+	g_fp.dim = dim;
+	g_fp.dim3 = dim3;
+	g_fp.calc_cnt = calc_cnt;
+	g_fp.atmcnt = atmcnt;
+	g_fp.box_ptr = const_cast<atomindex*>(box);
+	capture_optres_identity(FA);
+
+	g_fp.has_rigid = false;
+	g_fp.slots.clear();
+	g_fp.slots.reserve((size_t)calc_cnt);
+	for(int i = 0; i < calc_cnt; ++i){
+		if(!Calc[i].atom || !Calc[i].residue) continue;
+		if(Calc[i].score){
+			const int resi = (int)(Calc[i].residue - residue);
+			const int atmi = (int)(Calc[i].atom - atoms);
+			if(resi < 1 || resi > FA->res_cnt) continue;
+			if(!residue[resi].fatm || !residue[resi].latm) continue;
+			const int rot = residue[resi].rot;
+			const int fatm = residue[resi].fatm[rot];
+			const int latm = residue[resi].latm[rot];
+			g_fp.slots.push_back({i, resi, atmi - fatm, latm - fatm + 1});
+		}else{
+			const float* c = Calc[i].atom->coor;
+			if(!g_fp.has_rigid){
+				g_fp.has_rigid = true;
+				g_fp.rigid_raw_min[0] = c[0];
+				g_fp.rigid_raw_min[1] = c[1];
+				g_fp.rigid_raw_min[2] = c[2];
+				g_fp.rigid_raw_max[0] = c[0];
+				g_fp.rigid_raw_max[1] = c[1];
+				g_fp.rigid_raw_max[2] = c[2];
+			}else{
+				for(int j = 0; j < 3; ++j){
+					if(c[j] < g_fp.rigid_raw_min[j]) g_fp.rigid_raw_min[j] = c[j];
+					if(c[j] > g_fp.rigid_raw_max[j]) g_fp.rigid_raw_max[j] = c[j];
+				}
+			}
+		}
+	}
+
+	g_fp.rigid_list.clear();
+	g_fp.rigid_first.assign((size_t)dim3, 0);
+	g_fp.rigid_nument.assign((size_t)dim3, 0);
+	g_fp.rigid_list.reserve((size_t)calc_cnt);
+	g_scorable.clear();
+	g_scorable.reserve(g_fp.slots.size());
+	for(int boxi = 0; boxi < dim3; ++boxi){
+		g_fp.rigid_first[boxi] = (int)g_fp.rigid_list.size();
+		const int first = box[boxi].first;
+		const int n = box[boxi].nument;
+		for(int k = 0; k < n; ++k){
+			const int atmi = Calclist[first + k];
+			if(atmi < 0 || atmi >= calc_cnt) continue;
+			if(Calc[atmi].score) g_scorable.push_back(atmi);
+			else g_fp.rigid_list.push_back(atmi);
+		}
+		g_fp.rigid_nument[boxi] = (int)g_fp.rigid_list.size() - g_fp.rigid_first[boxi];
+	}
+}
+
+bool try_rigid_fastpath(FA_Global* FA, atom* atoms, resid* residue, atomsas* Calc,
+                        int* Calclist, int* dim, int atmcnt, atomindex* prev_box,
+                        std::map<std::string, atomindex*>& indexed,
+                        int* calc_count_out, atomindex** box_out)
+{
+	if(!g_fp.valid || !FA || !atoms || !residue || !Calc || !Calclist || !dim || !box_out)
+		return false;
+	if(atmcnt != g_fp.atmcnt) return false;
+	if(fa_must_invalidate(FA)) return false;
+	if(optres_identity_changed(FA)) return false;
+	if(!rebind_scorable_slots(FA, atoms, residue, Calc, atmcnt)) return false;
+
+	int alter = 0;
+	float global_min[3], global_max[3];
+	for(int j = 0; j < 3; ++j){
+		global_min[j] = (int)FA->globalmin[j] + 1.0f;
+		global_max[j] = (int)FA->globalmax[j] + 1.0f;
+	}
+	if(g_fp.has_rigid){
+		expand_bbox_atom(g_fp.rigid_raw_min, global_min, global_max, &alter);
+		expand_bbox_atom(g_fp.rigid_raw_max, global_min, global_max, &alter);
+	}
+	for(const ScoSlot& s : g_fp.slots){
+		if(!Calc[s.calc_idx].atom) return false;
+		expand_bbox_atom(Calc[s.calc_idx].atom->coor, global_min, global_max, &alter);
+	}
+
+	float max_width = FA->maxwidth;
+	if(alter){
+		for(int j = 0; j < 3; ++j){
+			global_min[j] = global_min[j] < 0.0f ? (int)global_min[j] - 1.0f : (int)global_min[j] + 1.0f;
+			global_max[j] = global_max[j] < 0.0f ? (int)global_max[j] - 1.0f : (int)global_max[j] + 1.0f;
+			const float diff = global_max[j] - global_min[j];
+			if(diff > max_width) max_width = diff;
+		}
+	}
+	if(max_width > 1000.0f) return false;
+
+	*dim = (int)(max_width / CELLSIZE) + 1;
+	const int dim2 = (*dim) * (*dim);
+	const int dim3 = (*dim) * (*dim) * (*dim);
+	const std::string sig = generate_dim_sig(global_min, *dim);
+	if(sig != g_prev_sig || dim3 != g_fp.dim3 || *dim != g_fp.dim) return false;
+
+	atomindex* box = nullptr;
+	if(!FA->vindex){
+		box = (atomindex*)malloc((size_t)dim3 * sizeof(atomindex));
+		if(!box){
+			fprintf(stderr,"ERROR: memory allocation error for box\n");
+			Terminate(2);
+		}
+	}else{
+		auto it = indexed.find(sig);
+		if(it == indexed.end()) return false;
+		if(it->second != prev_box) return false;
+		box = it->second;
+	}
+
+	const int calc_cnt = g_fp.calc_cnt;
+	if(calc_count_out) *calc_count_out = calc_cnt;
+
+	// get_contlist4 skips neighbors with done=='Y'; leftover rigid stamps
+	// from the previous eval would drop contacts. Reset everyone.
+	for(int i = 0; i < calc_cnt; ++i) Calc[i].done = 'N';
+
+	if((int)g_box_stamp.size() < dim3) g_box_stamp.assign((size_t)dim3, 0u);
+	if(++g_box_epoch == 0u){
+		std::fill(g_box_stamp.begin(), g_box_stamp.end(), 0u);
+		g_box_epoch = 1u;
+	}
+	const uint32_t ep = g_box_epoch;
+
+	std::vector<int> sco;
+	sco.reserve(g_fp.slots.size());
+	for(const ScoSlot& s : g_fp.slots){
+		atomsas& C = Calc[s.calc_idx];
+		C.boxnum = clamp_box_index(C, global_min, *dim, dim2);
+		sco.push_back(s.calc_idx);
+	}
+	std::stable_sort(sco.begin(), sco.end(),
+		[&](int a, int b){ return Calc[a].boxnum < Calc[b].boxnum; });
+
+	for(int boxi = 0; boxi < dim3; ++boxi){
+		if(g_fp.rigid_nument[boxi] > 0){
+			box[boxi].nument = g_fp.rigid_nument[boxi];
+			g_box_stamp[boxi] = ep;
+		}
+	}
+	for(int idx : sco){
+		const int boxi = Calc[idx].boxnum;
+		if(boxi < 0 || boxi >= dim3) continue;
+		if(g_box_stamp[boxi] != ep){
+			box[boxi].nument = 0;
+			g_box_stamp[boxi] = ep;
+		}
+		++box[boxi].nument;
+	}
+
+	int startind = 0;
+	for(int boxi = 0; boxi < dim3; ++boxi){
+		box[boxi].first = startind;
+		startind += (g_box_stamp[boxi] == ep) ? box[boxi].nument : 0;
+	}
+	for(int boxi = 0; boxi < dim3; ++boxi){
+		box[boxi].nument = 0;
+	}
+
+	g_scorable.clear();
+	g_scorable.reserve(sco.size());
+	int si = 0;
+	const int ns = (int)sco.size();
+	for(int boxi = 0; boxi < dim3; ++boxi){
+		int ri = 0;
+		const int rn = g_fp.rigid_nument[boxi];
+		const int rbase = g_fp.rigid_first[boxi];
+		while(ri < rn || (si < ns && Calc[sco[si]].boxnum == boxi)){
+			int pick;
+			if(ri >= rn){
+				pick = sco[si++];
+			}else if(si >= ns || Calc[sco[si]].boxnum != boxi){
+				pick = g_fp.rigid_list[rbase + ri++];
+			}else if(g_fp.rigid_list[rbase + ri] < sco[si]){
+				pick = g_fp.rigid_list[rbase + ri++];
+			}else{
+				pick = sco[si++];
+			}
+			Calclist[box[boxi].first + box[boxi].nument] = pick;
+			++box[boxi].nument;
+			if(Calc[pick].score) g_scorable.push_back(pick);
+		}
+	}
+
+	g_fp.box_ptr = box;
+	g_prev_sig = sig;
+	g_fastpath_used = true;
+	*box_out = box;
+	return true;
+}
+
+} // namespace
+
+void vc_publish_scorable(VC_Global* VC)
+{
+	if(!VC) return;
+	VC->fastpath_used = g_fastpath_used ? 1 : 0;
+	const int n = (int)g_scorable.size();
+	if(VC->scorable_list && VC->scorable_cap >= n){
+		if(n > 0){
+			std::memcpy(VC->scorable_list, g_scorable.data(), (size_t)n * sizeof(int));
+		}
+		VC->n_scorable = n;
+	}else{
+		VC->n_scorable = 0;
+	}
+}
+
+const int* vc_scorable_indices(int* n)
+{
+	if(n) *n = (int)g_scorable.size();
+	return g_scorable.empty() ? nullptr : g_scorable.data();
+}
+
+bool vc_fastpath_active()
+{
+	return g_fastpath_on && !g_scorable.empty();
+}
 
 // Vcontacts calculates the SAS only for the residue sent in argument
 int Vcontacts(FA_Global* FA,atom* atoms,resid* residue,VC_Global* VC,
@@ -32,18 +408,45 @@ int Vcontacts(FA_Global* FA,atom* atoms,resid* residue,VC_Global* VC,
 				&VC->dim,FA->atm_cnt_real,prev_box,indexed,&VC->calc_count);
 	
 	prev_box = VC->box;
+	vc_publish_scorable(VC);
 	
 	const int calc_count = VC->calc_count > 0 ? VC->calc_count : FA->atm_cnt_real;
-	for(int i=0; i<calc_count; ++i) {
-		VC->ca_index[i] = -1;   //initialize pointer array
-		VC->seed[i*3] = -1;
+	int n_sco = 0;
+	const int* sco = vc_scorable_indices(&n_sco);
+	// Scorable-only reset is safe once the incremental index has run
+	// (rigid ca_index/seed already written to -1 on the first full path).
+	// First eval and non_scorable (omit_buried) keep the 0..N loops.
+	const bool use_sco = (VC->fastpath_used && !non_scorable &&
+	                      sco != nullptr && n_sco > 0);
 
-		if(VC->Calc[i].score){
-			if(non_scorable){
-				// make scorable as buried to omit them
-				VC->Calc[i].exposed = false;
-			}else{
-				VC->Calc[i].exposed = true;
+	if(use_sco){
+		for(int k=0; k<n_sco; ++k){
+			const int i = sco[k];
+			if(i < 0 || i >= calc_count) continue;
+			VC->ca_index[i] = -1;   //initialize pointer array
+			VC->seed[i*3] = -1;
+
+			if(VC->Calc[i].score){
+				if(non_scorable){
+					// make scorable as buried to omit them
+					VC->Calc[i].exposed = false;
+				}else{
+					VC->Calc[i].exposed = true;
+				}
+			}
+		}
+	}else{
+		for(int i=0; i<calc_count; ++i) {
+			VC->ca_index[i] = -1;   //initialize pointer array
+			VC->seed[i*3] = -1;
+
+			if(VC->Calc[i].score){
+				if(non_scorable){
+					// make scorable as buried to omit them
+					VC->Calc[i].exposed = false;
+				}else{
+					VC->Calc[i].exposed = true;
+				}
 			}
 		}
 	}
@@ -71,11 +474,21 @@ int Vcontacts(FA_Global* FA,atom* atoms,resid* residue,VC_Global* VC,
 		}
 		if(*clash_value >= CLASH_THRESHOLD){ return(-2); }
 
-		for(int i=0; i<calc_count; ++i) {
-			VC->Calc[i].done = 'N';
+		if(use_sco){
+			for(int k=0; k<n_sco; ++k){
+				const int i = sco[k];
+				if(i < 0 || i >= calc_count) continue;
+				VC->Calc[i].done = 'N';
+				VC->ca_index[i] = -1;   //initialize pointer array
+				VC->seed[i*3] = -1;
+			}
+		}else{
+			for(int i=0; i<calc_count; ++i) {
+				VC->Calc[i].done = 'N';
 			
-			VC->ca_index[i] = -1;   //initialize pointer array
-			VC->seed[i*3] = -1;
+				VC->ca_index[i] = -1;   //initialize pointer array
+				VC->seed[i*3] = -1;
+			}
 		}
 	}
 	
@@ -106,6 +519,59 @@ int calc_region(FA_Global* FA,VC_Global* VC,atom* atoms,int atmcnt,bool non_scor
 	  printf("================================\n");
 	  printf("Calculating SAS for residue [%d]\n", resnum);
 	*/
+
+	auto process_atomzero = [&](int az) -> int {
+		boxi = VC->Calc[az].boxnum;
+		(void)boxi;
+		(void)surfatom;
+
+		//printf("Get_contacts for %d\n",VC->Calc[az].atom->number);
+		rado = VC->Calc[az].atom->radius + Rw;
+
+		NC = get_contlist4(atoms,az, VC->contlist, atmcnt, rado, VC->dim,
+				   VC->Calc, VC->Calclist, VC->box,VC->ca_rec, VC->ca_index,
+				   NULL, 0.0, 0.0f, 0.0f, NULL, NULL);
+
+		// invalid write/read when NC = 0
+		// because planeA is negative subscript
+		if(NC == 0){
+			VC->Calc[az].SAS = -1.0;
+			return 0;
+		}
+
+		NV = voronoi_poly2(VC,az, VC->cont, rado, NC, VC->contlist);
+
+		// could not generate polyhedron
+		// because of clashing atom
+		if(NV == -1){
+			return(-1);
+		}
+
+		surfatom = order_faces(az, VC->poly, VC->centerpt, rado, NC, NV, VC->cont, VC->ptorder);
+
+		calc_areas(VC->poly, VC->centerpt, rado, NC, NV, VC->cont, VC->ptorder, &VC->Calc[az]);
+
+		save_areas(VC->cont, VC->contlist, NC, az, VC->Calc,&VC->ca_recsize, &VC->numcarec, &VC->ca_rec, VC->ca_index);
+
+		//min_areas(VC->ca_rec, VC->Calc, &VC->Calc[az], FA->vcontacts_self_consistency);
+		return 0;
+	};
+
+	// Fastpath: walk the scorable list (Calclist order) instead of
+	// Calclist[0..atmcnt) + skip !score. non_scorable (omit_buried) keeps
+	// the full walk so rigid SAS is still computed.
+	if(!non_scorable && vc_fastpath_active()){
+		int n_sco = 0;
+		const int* sco = vc_scorable_indices(&n_sco);
+		if(sco && n_sco > 0){
+			for(int k=0; k<n_sco; ++k){
+				atomzero = sco[k];
+				if(atomzero < 0 || atomzero >= atmcnt){continue;}
+				if(process_atomzero(atomzero) == -1) return(-1);
+			}
+			return(0);
+		}
+	}
     
 	for(i=0;i<atmcnt;++i) {
 		// ============= atom contact calculations =============
@@ -115,10 +581,6 @@ int calc_region(FA_Global* FA,VC_Global* VC,atom* atoms,int atmcnt,bool non_scor
 		// Vcontacts()): an out-of-range atom index here would read past the
 		// Calc array. Skip rather than dereference garbage.
 		if(atomzero < 0 || atomzero >= atmcnt){continue;}
-
-		boxi = VC->Calc[atomzero].boxnum;
-		(void)boxi;
-		(void)surfatom;
 
 		if(non_scorable){
 			if(VC->Calc[atomzero].score){
@@ -131,37 +593,8 @@ int calc_region(FA_Global* FA,VC_Global* VC,atom* atoms,int atmcnt,bool non_scor
 				continue;
 			}
 		}
-		
-		//printf("Get_contacts for %d\n",VC->Calc[atomzero].atom->number);
-		rado = VC->Calc[atomzero].atom->radius + Rw;
-		
-		NC = get_contlist4(atoms,atomzero, VC->contlist, atmcnt, rado, VC->dim,
-				   VC->Calc, VC->Calclist, VC->box,VC->ca_rec, VC->ca_index,
-				   NULL, 0.0, 0.0f, 0.0f, NULL, NULL);
-		
-		// invalid write/read when NC = 0
-		// because planeA is negative subscript
-		if(NC == 0){
-			VC->Calc[atomzero].SAS = -1.0;
-			continue;
-		}
-		
-		NV = voronoi_poly2(VC,atomzero, VC->cont, rado, NC, VC->contlist);
-		
-		// could not generate polyhedron
-		// because of clashing atom
-		if(NV == -1){
-			return(-1);
-		}
-		
-		surfatom = order_faces(atomzero, VC->poly, VC->centerpt, rado, NC, NV, VC->cont, VC->ptorder);    
-        
-		calc_areas(VC->poly, VC->centerpt, rado, NC, NV, VC->cont, VC->ptorder, &VC->Calc[atomzero]);                
-        
-		save_areas(VC->cont, VC->contlist, NC, atomzero, VC->Calc,&VC->ca_recsize, &VC->numcarec, &VC->ca_rec, VC->ca_index);
-        
-		//min_areas(VC->ca_rec, VC->Calc, &VC->Calc[atomzero], FA->vcontacts_self_consistency);
-		
+
+		if(process_atomzero(atomzero) == -1) return(-1);
 	}
 	
 	return(0);
@@ -1656,9 +2089,22 @@ atomindex* index_protein(FA_Global* FA,atom* atoms,resid* residue,atomsas* Calc,
 	// we skip the per-eval reset+recompute of boxnum for rigid atoms whenever the
 	// grid signature matches the previous eval. Gated OFF by default so main
 	// reproduces today's results bit-for-bit unless the flag is set.
-	static const bool hoist_receptor_index =
-		(std::getenv("FLEXAIDDS_HOIST_RECEPTOR_INDEX") != nullptr);
-	static thread_local std::string prev_sig;
+	// FLEXAIDDS_RIGID_FASTPATH implies hoist; HOIST still works alone when
+	// FASTPATH is off.
+	const bool fastpath_on = rigid_fastpath_requested();
+	const bool hoist_receptor_index = kHoistReceptorIndexEnv || fastpath_on;
+	g_fastpath_on = fastpath_on;
+	g_fastpath_used = false;
+	if(!fastpath_on){
+		g_fp.valid = false;
+		g_scorable.clear();
+	}else{
+		atomindex* fp_box = nullptr;
+		if(try_rigid_fastpath(FA, atoms, residue, Calc, Calclist, dim, atmcnt,
+		                      prev_box, indexed, calc_count_out, &fp_box)){
+			return fp_box;
+		}
+	}
 
 	rot=0;
 	i=0;
@@ -1760,7 +2206,7 @@ atomindex* index_protein(FA_Global* FA,atom* atoms,resid* residue,atomsas* Calc,
 	// `sig` encodes (int)global_min[0..2] and dim; after the bounding-box
 	// normalization above global_min is integer-valued, so an unchanged sig means
 	// an identical grid origin and extent -> identical cell for any fixed atom.
-	const bool grid_changed = (sig != prev_sig);
+	const bool grid_changed = (sig != g_prev_sig);
 	std::map<std::string, atomindex*>::iterator it;
 	if(!FA->vindex){
 		box = (atomindex*)malloc(dim3*sizeof(atomindex));
@@ -1813,11 +2259,9 @@ atomindex* index_protein(FA_Global* FA,atom* atoms,resid* residue,atomsas* Calc,
 	// This removes the 8*dim3-byte memset in exchange for ~calc_cnt stamp
 	// writes — a win on the typical sparse grid, neutral when dense, and
 	// bit-identical box assignment (no numeric change).
-	static thread_local std::vector<uint32_t> box_stamp;
-	static thread_local uint32_t box_epoch = 0;
-	if((int)box_stamp.size() < dim3){ box_stamp.assign(dim3, 0u); }
-	if(++box_epoch == 0u){ std::fill(box_stamp.begin(), box_stamp.end(), 0u); box_epoch = 1u; }
-	const uint32_t _ep = box_epoch;
+	if((int)g_box_stamp.size() < dim3){ g_box_stamp.assign(dim3, 0u); }
+	if(++g_box_epoch == 0u){ std::fill(g_box_stamp.begin(), g_box_stamp.end(), 0u); g_box_epoch = 1u; }
+	const uint32_t _ep = g_box_epoch;
 
 	int calc_cnt = i;  // Use actual count of initialized atoms, not total atmcnt
 	if(calc_count_out != NULL){
@@ -1857,7 +2301,7 @@ atomindex* index_protein(FA_Global* FA,atom* atoms,resid* residue,atomsas* Calc,
 		if (_boxnum >= 0 && _boxnum < dim3) {
 			// Lazy zero: first touch of this box this epoch resets its (stale)
 			// count before we start accumulating into it.
-			if(box_stamp[_boxnum] != _ep){ box[_boxnum].nument = 0; box_stamp[_boxnum] = _ep; }
+			if(g_box_stamp[_boxnum] != _ep){ box[_boxnum].nument = 0; g_box_stamp[_boxnum] = _ep; }
 			++box[_boxnum].nument;
 		}
 	}
@@ -1868,7 +2312,7 @@ atomindex* index_protein(FA_Global* FA,atom* atoms,resid* residue,atomsas* Calc,
 		box[boxi].first = startind;
 		// Unstamped boxes were never touched this epoch, so their `nument` is
 		// stale (no memset) — treat it as 0 for the prefix sum.
-		startind += (box_stamp[boxi] == _ep) ? box[boxi].nument : 0;
+		startind += (g_box_stamp[boxi] == _ep) ? box[boxi].nument : 0;
 	}
     
 	// clear array (needed for recounting index)
@@ -1887,7 +2331,11 @@ atomindex* index_protein(FA_Global* FA,atom* atoms,resid* residue,atomsas* Calc,
 
 	// Remember this eval's grid signature so the next call can decide whether a
 	// cached rigid-atom box is still valid (see grid_changed above).
-	prev_sig = sig;
+	g_prev_sig = sig;
+	if(fastpath_on){
+		capture_rigid_snapshot(FA, atoms, residue, Calc, Calclist, box,
+		                       calc_cnt, *dim, dim3, sig, atmcnt);
+	}
 
 	return box;
 }

--- a/LIB/Vcontacts.h
+++ b/LIB/Vcontacts.h
@@ -162,6 +162,10 @@ struct VC_Global_struct{
 	char       showbonded;            // = Y or N.
 	char       normalize;             // = Y or N. normalize areas to area of sphere.
 	char       radfilename[MAX_PATH__];  // custom name for radii.dat file including path ADDED RJN 28.04.2008
+	int        *scorable_list;   // Calc[] indices with score==true; owned by caller or thread workspace
+	int         n_scorable;
+	int         scorable_cap;
+	int         fastpath_used;   // 1 if this eval took the incremental path
 	// --------------------- function prototypes ----------------------
 };
 typedef struct VC_Global_struct VC_Global;
@@ -193,6 +197,13 @@ int     get_contlist4(atom*,int, contactlist *, int, float, int, atomsas*, const
 void    save_seeds(int*,const plane *, const vertex *, int, int);
 void    get_firstvert(const int*,const plane *, int *, int *, int *, int, int);
 std::string  generate_dim_sig(float* global_min, int dim);
+
+// FLEXAIDDS_RIGID_FASTPATH bookkeeping (default OFF). Thread-local list is
+// always populated when the flag is on; vc_publish_scorable copies it into
+// VC->scorable_list when the caller provided a buffer (gaboom workspace).
+void        vc_publish_scorable(VC_Global* VC);
+const int*  vc_scorable_indices(int* n);
+bool        vc_fastpath_active();
 // ========================================================================
 
 /*

--- a/LIB/flexaidds_flags.cpp
+++ b/LIB/flexaidds_flags.cpp
@@ -1,0 +1,576 @@
+// flexaidds_flags.cpp — resolve + dump for the unified gate registry
+//
+// Copyright 2026 Le Bonhomme Pharma
+// SPDX-License-Identifier: Apache-2.0
+
+#include "flexaidds_flags.h"
+
+#include <cctype>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace flexaidds {
+namespace flags {
+namespace {
+
+enum class Kind : unsigned char { Bool, Enum, Value, Compile };
+
+struct Gate {
+    const char* name = nullptr;
+    Kind kind = Kind::Bool;
+    bool requested = false;
+    bool active = false;
+    std::string value;
+    std::string reason;
+};
+
+struct Registry {
+    std::vector<Gate> gates;
+    std::unordered_map<std::string, std::size_t> index;  // normalized name → idx
+    std::unordered_map<std::string, std::size_t> alias;  // normalized alias → idx
+};
+
+Registry g_reg;
+std::mutex g_mu;
+bool g_resolved = false;
+
+std::string norm_key(const char* s) {
+    std::string o;
+    if (!s) return o;
+    o.reserve(std::strlen(s));
+    for (const char* p = s; *p; ++p) {
+        unsigned char c = static_cast<unsigned char>(*p);
+        if (c == '-') c = '_';
+        o.push_back(static_cast<char>(std::toupper(c)));
+    }
+    return o;
+}
+
+// Truthiness: unset / empty / leading '0' → off; any other non-empty → on.
+// Matches existing gates that test `e && e[0] != '\0' && e[0] != '0'`.
+bool env_truthy(const char* e) {
+    return e && e[0] != '\0' && e[0] != '0';
+}
+
+const char* env_raw(const char* name) {
+    return std::getenv(name);
+}
+
+void add_gate(const char* name, Kind kind) {
+    Gate g;
+    g.name = name;
+    g.kind = kind;
+    const std::size_t idx = g_reg.gates.size();
+    g_reg.gates.push_back(std::move(g));
+    g_reg.index.emplace(norm_key(name), idx);
+}
+
+void add_alias(const char* alias, const char* canonical) {
+    const auto it = g_reg.index.find(norm_key(canonical));
+    if (it == g_reg.index.end()) return;
+    g_reg.alias.emplace(norm_key(alias), it->second);
+}
+
+Gate* find_gate(const char* name) {
+    if (!name || !*name) return nullptr;
+    const std::string k = norm_key(name);
+    if (auto it = g_reg.index.find(k); it != g_reg.index.end())
+        return &g_reg.gates[it->second];
+    if (auto it = g_reg.alias.find(k); it != g_reg.alias.end())
+        return &g_reg.gates[it->second];
+    static const char* kPrefix[] = {"FLEXAIDDS_", "FLEXAID_", "FLEXAIDS_"};
+    for (const char* pre : kPrefix) {
+        if (auto it = g_reg.index.find(std::string(pre) + k); it != g_reg.index.end())
+            return &g_reg.gates[it->second];
+    }
+    return nullptr;
+}
+
+void seed_runtime_gates() {
+    // Required / high-traffic gates first so dump() leads with them.
+    static const char* kBool[] = {
+        "FLEXAIDDS_RIGID_FASTPATH",
+        "FLEXAIDDS_HOIST_RECEPTOR_INDEX",
+        "FLEXAIDDS_CONTACTS_EPOCH",
+        "FLEXAIDDS_PARALLEL_REPRODUCE",
+        "FLEXAIDDS_RNG_STREAM_FIX",
+        "FLEXAID_DETERMINISTIC",
+        "FLEXAIDDS_FORCE_CPU",
+        "FLEXAIDDS_FORCE_RIGID",
+        "FLEXAIDDS_MEDOID_REFINE",
+        "FLEXAIDDS_CLEFT_SORT",
+        "FLEXAIDDS_WAL_COERCIVE",
+        "FLEXAIDDS_SOFTCORE_WAL",
+        "FLEXAIDDS_NO_SAS",
+        "FLEXAIDDS_POSEBUST",
+        "FLEXAIDS_SOA_ASSERT",
+        "FLEXAIDDS_FLAGS_DUMP",
+        // remaining LIB/ getenv + ProtocolConfig switches
+        "FLEXAIDS_VH_DEBUG",
+        "FLEXAIDDS_ADAPTIVE_GENERATIONS",
+        "FLEXAIDDS_BASIN_REINJECT",
+        "FLEXAIDDS_BENCHMARK",
+        "FLEXAIDDS_BUDGET_SCALE",
+        "FLEXAIDDS_CF_WINDOW_SELECTOR",
+        "FLEXAIDDS_CHAIN_NORM",
+        "FLEXAIDDS_CLASSIC_ENTROPY_RANKING",
+        "FLEXAIDDS_CLUSTER_MEMBER_EMIT",
+        "FLEXAIDDS_COGNATE_SITE",
+        "FLEXAIDDS_CONSENSUS_SCORER",
+        "FLEXAIDDS_DEBUG_TYPES",
+        "FLEXAIDDS_DIST_WEIGHT_CON",
+        "FLEXAIDDS_DIVERSITY_MONITORING",
+        "FLEXAIDDS_DUMP_POP",
+        "FLEXAIDDS_ELECT_LEGACY_ACF",
+        "FLEXAIDDS_ELECTION_INCLUDE_SINGLETONS",
+        "FLEXAIDDS_ELECTION_LEGACY_ZH",
+        "FLEXAIDDS_ELECTION_SHANNON_F",
+        "FLEXAIDDS_ELECTION_V135",
+        "FLEXAIDDS_FINE_GRID",
+        "FLEXAIDDS_FORCE_CF_RANK_EMISSION",
+        "FLEXAIDDS_FRAME_CHART_STRICT",
+        "FLEXAIDDS_FREQSEL",
+        "FLEXAIDDS_GENTRACE",
+        "FLEXAIDDS_HBOND_RANK",
+        "FLEXAIDDS_HVIB",
+        "FLEXAIDDS_IGNORE_CACHE",
+        "FLEXAIDDS_MEMETIC",
+        "FLEXAIDDS_MUTATION_GRANULAR",
+        "FLEXAIDDS_NAN_RANK_GUARD",
+        "FLEXAIDDS_NATIVE_ONLY",
+        "FLEXAIDDS_NICHE_CARTESIAN",
+        "FLEXAIDDS_NO_SEC",
+        "FLEXAIDDS_NO_TENCOM",
+        "FLEXAIDDS_PARALLEL_RESTARTS",
+        "FLEXAIDDS_PB_AWARE_PROMOTION",
+        "FLEXAIDDS_PB_CLASH_DEBUG",
+        "FLEXAIDDS_PB_CLASH_PHASE2_PASS",
+        "FLEXAIDDS_PB_METAL_CARVEOUT",
+        "FLEXAIDDS_PB_POCKET_DEBUG",
+        "FLEXAIDDS_PB_VDW_CACHED",
+        "FLEXAIDDS_PHENOTYPE_UNIQUE",
+        "FLEXAIDDS_POSEBUSTERS_REQUIRE_CLI",
+        "FLEXAIDDS_RECEPTOR_ROTAMER_PREP",
+        "FLEXAIDDS_RING_FLEX",
+        "FLEXAIDDS_SCORE_NATIVE",
+        "FLEXAIDDS_SEED_ELITISM",
+        "FLEXAIDDS_SHANNON_ROBUST",
+        "FLEXAIDDS_SMFREE_REQUIRE_T",
+        "FLEXAIDDS_SOFTBETA_ELECTION",
+        "FLEXAIDDS_THERMO",
+        "FLEXAIDDS_THERMO_CSV",
+        "FLEXAIDDS_THERMO_SCORE",
+        "FLEXAIDDS_USE_DP",
+        "FLEXAIDDS_USE_ELEC",
+        "FLEXAIDDS_USE_SHANNON",
+        "FLEXAIDDS_VCT_NORM",
+        "FLEXAIDDS_WALL_PILOT_PASS",
+    };
+    static const char* kEnum[] = {
+        "FLEXAIDDS_CLUSTER_REP",
+        "FLEXAIDDS_SEARCH",
+        "FLEXAIDDS_POSEBUST_BACKEND",
+        "FLEXAIDDS_NEW_SEARCH_ARCH",
+        "FLEXAIDDS_FLAGS",
+    };
+    static const char* kValue[] = {
+        "FLEXAID_SEED",
+        "FLEXAIDDS_WAL_STIFF",
+        "FLEXAIDDS_SOFTCORE_FLOOR",
+        "FLEXAIDDS_CON_R0",
+        "FLEXAIDDS_COM_FLOOR",
+        "FLEXAIDDS_POLAR_DESOLV_WEIGHT",
+        "FLEXAIDDS_PB_CLASH_WEIGHT",
+        "FLEXAIDDS_PB_CLASH_EXP",
+        "FLEXAIDDS_PB_CLASH_RATIO",
+        "FLEXAIDDS_PB_POCKET_WEIGHT",
+        "FLEXAIDDS_PB_POCKET_RADIUS",
+        "FLEXAIDDS_PB_CLASH_ELECT_WEIGHT",
+        "FLEXAIDDS_CMAES_MAX_EVALS",
+        "FLEXAIDDS_ADAPTIVE_EPS",
+        "FLEXAIDDS_BASIN_SIGMA_ANG",
+        "FLEXAIDDS_BINARY",
+        "FLEXAIDDS_BOOM_FRAC",
+        "FLEXAIDDS_BOOM_INTERVAL",
+        "FLEXAIDDS_BUILD",
+        "FLEXAIDDS_CLEFT_SPHERE_FILE",
+        "FLEXAIDDS_CLUSTER_CONSENSUS_K",
+        "FLEXAIDDS_CLUSTER_CONSENSUS_TAU",
+        "FLEXAIDDS_CLUSTER_POCKET_RADIUS",
+        "FLEXAIDDS_CLUSTER_POP_MIN_FRACTION",
+        "FLEXAIDDS_CLUSTER_SPREAD_MAX",
+        "FLEXAIDDS_COARSE_GRID_STEP",
+        "FLEXAIDDS_COARSE_ORIENTATIONS",
+        "FLEXAIDDS_DATA_DIR",
+        "FLEXAIDDS_ELECTION_SCORE_TAU",
+        "FLEXAIDDS_ELECTION_SOFT_T",
+        "FLEXAIDDS_ENTROPY_WEIGHT",
+        "FLEXAIDDS_EVAL_SCALE_DIHEDRAL",
+        "FLEXAIDDS_FREQSEL_ALPHA",
+        "FLEXAIDDS_FREQSEL_RMSD",
+        "FLEXAIDDS_GENTRACE_EVERY",
+        "FLEXAIDDS_GRID_CACHE_DIR",
+        "FLEXAIDDS_HBOND_WEIGHT",
+        "FLEXAIDDS_HTTP_RETRIES",
+        "FLEXAIDDS_INCHI_BIN",
+        "FLEXAIDDS_INSTREAM_INTERVAL",
+        "FLEXAIDDS_LIGAND_BATCH",
+        "FLEXAIDDS_MAX_CONCURRENT_RESTARTS",
+        "FLEXAIDDS_MULTI_CLEFT",
+        "FLEXAIDDS_N_ELITE",
+        "FLEXAIDDS_NICHE_SIGMA_ANG",
+        "FLEXAIDDS_ORACLE_SITE",
+        "FLEXAIDDS_ORACLE_SITE_DIR",
+        "FLEXAIDDS_POSEBUSTERS_BIN",
+        "FLEXAIDDS_PRIORITY_TARGETS",
+        "FLEXAIDDS_REDOCK_CACHE",
+        "FLEXAIDDS_REPO",
+        "FLEXAIDDS_REPORT_T",
+        "FLEXAIDDS_RESTARTS",
+        "FLEXAIDDS_RMSDST",
+        "FLEXAIDDS_ROOT",
+        "FLEXAIDDS_SAS_WEIGHT",
+        "FLEXAIDDS_SEED_BASE",
+        "FLEXAIDDS_SEED_ELITISM_DELTA_CF",
+        "FLEXAIDDS_SHARING_ALPHA",
+        "FLEXAIDDS_SIGMA_SCALE",
+        "FLEXAIDDS_T_EFF",
+        "FLEXAIDDS_T_HOT",
+        "FLEXAIDDS_TENCOM_SCALE",
+        "FLEXAIDDS_VCT_ENTROPY_WEIGHT",
+        "FLEXAIDDS_VCT_R0",
+        "FLEXAIDDS_VIB_ENTROPY_BINS",
+    };
+
+    g_reg.gates.clear();
+    g_reg.index.clear();
+    g_reg.alias.clear();
+    g_reg.gates.reserve(200);
+
+    for (const char* n : kBool) add_gate(n, Kind::Bool);
+    for (const char* n : kEnum) add_gate(n, Kind::Enum);
+    for (const char* n : kValue) add_gate(n, Kind::Value);
+
+    add_alias("hoist", "FLEXAIDDS_HOIST_RECEPTOR_INDEX");
+    add_alias("epoch", "FLEXAIDDS_CONTACTS_EPOCH");
+    add_alias("fastpath", "FLEXAIDDS_RIGID_FASTPATH");
+    add_alias("rng-stream-fix", "FLEXAIDDS_RNG_STREAM_FIX");
+    add_alias("rng_stream_fix", "FLEXAIDDS_RNG_STREAM_FIX");
+}
+
+void add_compile(const char* name, bool on, const char* note) {
+    add_gate(name, Kind::Compile);
+    Gate* g = find_gate(name);
+    if (!g) return;
+    g->requested = on;
+    g->active = on;
+    g->value = on ? "1" : "0";
+    if (note && *note) g->reason = note;  // documentation; cleared if active
+    if (on) g->reason.clear();
+    else if (note && *note) g->reason = note;
+}
+
+void seed_compile_gates() {
+#ifdef FLEXAIDS_USE_AVX2
+    add_compile("FLEXAIDS_USE_AVX2", true, "cmake -DFLEXAIDS_USE_AVX2");
+#else
+    add_compile("FLEXAIDS_USE_AVX2", false, "cmake -DFLEXAIDS_USE_AVX2 (read-only)");
+#endif
+#ifdef FLEXAIDS_USE_AVX512
+    add_compile("FLEXAIDS_USE_AVX512", true, "cmake -DFLEXAIDS_USE_AVX512");
+#else
+    add_compile("FLEXAIDS_USE_AVX512", false, "cmake -DFLEXAIDS_USE_AVX512 (read-only)");
+#endif
+#ifdef FLEXAIDS_USE_CUDA
+    add_compile("FLEXAIDS_USE_CUDA", true, "cmake -DFLEXAIDS_USE_CUDA");
+#else
+    add_compile("FLEXAIDS_USE_CUDA", false, "cmake -DFLEXAIDS_USE_CUDA (read-only)");
+#endif
+#ifdef FLEXAIDS_USE_METAL
+    add_compile("FLEXAIDS_USE_METAL", true, "cmake -DFLEXAIDS_USE_METAL");
+#else
+    add_compile("FLEXAIDS_USE_METAL", false, "cmake -DFLEXAIDS_USE_METAL (read-only)");
+#endif
+#ifdef FLEXAIDS_USE_ROCM
+    add_compile("FLEXAIDS_USE_ROCM", true, "cmake -DFLEXAIDS_USE_ROCM");
+#else
+    add_compile("FLEXAIDS_USE_ROCM", false, "cmake -DFLEXAIDS_USE_ROCM (read-only)");
+#endif
+#ifdef FLEXAIDS_USE_WEBGPU
+    add_compile("FLEXAIDS_USE_WEBGPU", true, "cmake -DFLEXAIDS_USE_WEBGPU");
+#else
+    add_compile("FLEXAIDS_USE_WEBGPU", false, "cmake -DFLEXAIDS_USE_WEBGPU (read-only)");
+#endif
+#ifdef FLEXAIDS_USE_OPENMP
+    add_compile("FLEXAIDS_USE_OPENMP", true, "cmake -DFLEXAIDS_USE_OPENMP");
+#else
+    add_compile("FLEXAIDS_USE_OPENMP", false, "cmake -DFLEXAIDS_USE_OPENMP (read-only)");
+#endif
+#ifdef FLEXAIDS_USE_EIGEN
+    add_compile("FLEXAIDS_USE_EIGEN", true, "cmake -DFLEXAIDS_USE_EIGEN");
+#else
+    add_compile("FLEXAIDS_USE_EIGEN", false, "cmake -DFLEXAIDS_USE_EIGEN (read-only)");
+#endif
+#ifdef FLEXAIDS_USE_MPI
+    add_compile("FLEXAIDS_USE_MPI", true, "cmake -DFLEXAIDS_USE_MPI");
+#else
+    add_compile("FLEXAIDS_USE_MPI", false, "cmake -DFLEXAIDS_USE_MPI (read-only)");
+#endif
+#ifdef FLEXAIDS_USE_NEON
+    add_compile("FLEXAIDS_USE_NEON", true, "cmake -DFLEXAIDS_USE_NEON");
+#else
+    add_compile("FLEXAIDS_USE_NEON", false, "cmake -DFLEXAIDS_USE_NEON (read-only)");
+#endif
+#ifdef FLEXAIDS_USE_256_MATRIX
+    add_compile("FLEXAIDS_USE_256_MATRIX", true, "cmake -DFLEXAIDS_USE_256_MATRIX");
+#else
+    add_compile("FLEXAIDS_USE_256_MATRIX", false, "cmake -DFLEXAIDS_USE_256_MATRIX (read-only)");
+#endif
+#ifdef FLEXAIDS_USE_SOA_DISTANCES
+    add_compile("FLEXAIDS_USE_SOA_DISTANCES", true, "cmake -DFLEXAIDS_USE_SOA_DISTANCES");
+#else
+    add_compile("FLEXAIDS_USE_SOA_DISTANCES", false,
+                "cmake -DFLEXAIDS_USE_SOA_DISTANCES (read-only)");
+#endif
+#ifdef BUILD_FLEXAIDDS_FAST
+    add_compile("BUILD_FLEXAIDDS_FAST", true, "cmake -DBUILD_FLEXAIDDS_FAST (read-only)");
+#else
+    add_compile("BUILD_FLEXAIDDS_FAST", false, "cmake -DBUILD_FLEXAIDDS_FAST (read-only)");
+#endif
+#ifdef FLEXAID_PGO
+    add_compile("FLEXAID_PGO", true, "cmake -DFLEXAID_PGO (read-only)");
+#else
+    add_compile("FLEXAID_PGO", false, "cmake -DFLEXAID_PGO=off|generate|use (read-only)");
+#endif
+}
+
+void warn_once_line(const char* msg) {
+    std::fprintf(stderr, "WARNING: %s\n", msg);
+}
+
+void apply_overlay_token(const char* token, std::size_t n) {
+    if (!token || n == 0) return;
+    std::string t(token, n);
+    Gate* g = find_gate(t.c_str());
+    if (!g) {
+        std::fprintf(stderr,
+                     "WARNING: FLEXAIDDS_FLAGS token '%s' is not a known gate; ignored.\n",
+                     t.c_str());
+        return;
+    }
+    if (g->kind == Kind::Compile) return;  // overlay does not flip compile defs
+    g->requested = true;
+    if (g->value.empty()) g->value = "1";
+}
+
+void apply_flags_overlay(const char* list) {
+    if (!list || !*list) return;
+    // A lone "0" is off (no tokens). Any other non-empty list is a token list.
+    if (list[0] == '0' && list[1] == '\0') return;
+    const char* p = list;
+    while (*p) {
+        while (*p == ' ' || *p == ',' || *p == ';' || *p == '|' || *p == '\t') ++p;
+        if (!*p) break;
+        const char* start = p;
+        while (*p && *p != ' ' && *p != ',' && *p != ';' && *p != '|' && *p != '\t') ++p;
+        apply_overlay_token(start, static_cast<std::size_t>(p - start));
+    }
+}
+
+void read_env_into_gates() {
+    for (Gate& g : g_reg.gates) {
+        if (g.kind == Kind::Compile) continue;
+        const char* e = env_raw(g.name);
+        if (!e) continue;
+        g.value = e;
+        switch (g.kind) {
+            case Kind::Bool:
+                g.requested = env_truthy(e);
+                break;
+            case Kind::Enum:
+            case Kind::Value:
+                g.requested = (e[0] != '\0');
+                break;
+            case Kind::Compile:
+                break;
+        }
+    }
+
+#ifdef FLEXAID_DETERMINISTIC
+    if (Gate* d = find_gate("FLEXAID_DETERMINISTIC")) {
+        d->requested = true;
+        if (d->value.empty()) d->value = "1";
+    }
+#endif
+}
+
+void disable_loser(Gate* loser, const char* why) {
+    if (!loser) return;
+    loser->active = false;
+    loser->reason = why;
+    if (loser->requested) warn_once_line(why);
+}
+
+void apply_implications_and_exclusions() {
+    for (Gate& g : g_reg.gates) {
+        if (g.kind == Kind::Compile) continue;
+        g.active = g.requested;
+        if (g.active) g.reason.clear();
+    }
+
+    // FLEXAIDDS_RIGID_FASTPATH implies hoist; both stay active (superset).
+    Gate* fast = find_gate("FLEXAIDDS_RIGID_FASTPATH");
+    Gate* hoist = find_gate("FLEXAIDDS_HOIST_RECEPTOR_INDEX");
+    if (fast && hoist && fast->requested) {
+        fast->active = true;
+        hoist->active = true;
+        if (!hoist->requested && hoist->reason.empty())
+            hoist->reason = "implied by FLEXAIDDS_RIGID_FASTPATH";
+    }
+
+    // CLUSTER_REP (any explicit value) wins over MEDOID_REFINE.
+    Gate* crep = find_gate("FLEXAIDDS_CLUSTER_REP");
+    Gate* med = find_gate("FLEXAIDDS_MEDOID_REFINE");
+    if (crep && med && crep->requested && med->requested) {
+        disable_loser(med,
+                      "FLEXAIDDS_MEDOID_REFINE disabled by FLEXAIDDS_CLUSTER_REP "
+                      "(ClusterRepMode.h policy)");
+    }
+
+    // CLEFT_SORT is superseded: stay in the registry, become inactive.
+    Gate* cleft = find_gate("FLEXAIDDS_CLEFT_SORT");
+    if (cleft && cleft->requested) {
+        disable_loser(cleft, "FLEXAIDDS_CLEFT_SORT superseded, ignored");
+    }
+
+    // Two WAL models: coercive is more specific and wins if both are set.
+    Gate* wal_c = find_gate("FLEXAIDDS_WAL_COERCIVE");
+    Gate* wal_s = find_gate("FLEXAIDDS_SOFTCORE_WAL");
+    if (wal_c && wal_s && wal_c->requested && wal_s->requested) {
+        wal_c->active = true;
+        disable_loser(wal_s,
+                      "FLEXAIDDS_SOFTCORE_WAL disabled by FLEXAIDDS_WAL_COERCIVE "
+                      "(two WAL models; coercive is more specific)");
+    }
+
+    // FLEXAIDDS_SEARCH=cmaes is one backend; other SEARCH values stay requested
+    // but are not the cmaes backend. The SEARCH gate itself remains active so
+    // the chosen backend can be read via value().
+    Gate* search = find_gate("FLEXAIDDS_SEARCH");
+    if (search && search->requested) {
+        search->active = true;
+        // Document non-cmaes / non-ga leftovers as "not a recognised backend"
+        // without dropping the flag from the registry.
+        const std::string& v = search->value;
+        const bool cmaes = (v == "cmaes" || v == "CMAES" || v == "Cmaes");
+        const bool ga = (v.empty() || v == "ga" || v == "GA" || v == "Ga");
+        if (!cmaes && !ga) {
+            search->reason = "FLEXAIDDS_SEARCH: unrecognised backend (engine keeps GA); "
+                             "cmaes is the only opt-in backend";
+        }
+    }
+
+    // FORCE_CPU: runtime ablation of GPU dispatch (compile flags stay requested).
+    Gate* cpu = find_gate("FLEXAIDDS_FORCE_CPU");
+    if (cpu && cpu->requested) {
+        static const char* kGpu[] = {
+            "FLEXAIDS_USE_CUDA",
+            "FLEXAIDS_USE_METAL",
+            "FLEXAIDS_USE_ROCM",
+            "FLEXAIDS_USE_WEBGPU",
+        };
+        for (const char* n : kGpu) {
+            Gate* gpu = find_gate(n);
+            if (gpu && gpu->requested) {
+                disable_loser(gpu,
+                              "GPU dispatch disabled by FLEXAIDDS_FORCE_CPU "
+                              "(runtime force; compile -D flag retained)");
+            }
+        }
+    }
+
+    // FLEXAID_DETERMINISTIC does NOT disable PARALLEL_REPRODUCE (different axes).
+}
+
+void dump_locked(FILE* out) {
+    if (!out) out = stderr;
+    std::fprintf(out, "# FlexAIDdS flag registry\n");
+    std::fprintf(out, "# name  requested  active  value  reason\n");
+    for (const Gate& g : g_reg.gates) {
+        std::fprintf(out, "%-36s  requested=%d  active=%d  value=%s  %s\n",
+                     g.name, g.requested ? 1 : 0, g.active ? 1 : 0,
+                     g.value.empty() ? "-" : g.value.c_str(),
+                     g.reason.empty() ? "-" : g.reason.c_str());
+    }
+    std::fprintf(out,
+                 "# note: compile AVX512 vs AVX2 is resolved by cmake "
+                 "(AVX512 wins when both requested); both stay in the registry.\n");
+}
+
+void do_resolve_locked() {
+    seed_runtime_gates();
+    seed_compile_gates();
+    read_env_into_gates();
+    apply_flags_overlay(env_raw("FLEXAIDDS_FLAGS"));
+    apply_implications_and_exclusions();
+
+    Gate* dump_flag = find_gate("FLEXAIDDS_FLAGS_DUMP");
+    if (dump_flag && dump_flag->requested) dump_locked(stderr);
+}
+
+}  // namespace
+
+void resolve_once() {
+    std::lock_guard<std::mutex> lock(g_mu);
+    if (g_resolved) return;
+    do_resolve_locked();
+    g_resolved = true;
+}
+
+void reset_for_tests() {
+    std::lock_guard<std::mutex> lock(g_mu);
+    g_resolved = false;
+    g_reg.gates.clear();
+    g_reg.index.clear();
+    g_reg.alias.clear();
+}
+
+bool requested(const char* name) {
+    resolve_once();
+    std::lock_guard<std::mutex> lock(g_mu);
+    if (const Gate* g = find_gate(name)) return g->requested;
+    return env_truthy(env_raw(name));
+}
+
+bool active(const char* name) {
+    resolve_once();
+    std::lock_guard<std::mutex> lock(g_mu);
+    if (const Gate* g = find_gate(name)) return g->active;
+    return env_truthy(env_raw(name));
+}
+
+const char* value(const char* name) {
+    resolve_once();
+    std::lock_guard<std::mutex> lock(g_mu);
+    if (const Gate* g = find_gate(name)) return g->value.c_str();
+    return "";
+}
+
+const char* reason(const char* name) {
+    resolve_once();
+    std::lock_guard<std::mutex> lock(g_mu);
+    if (const Gate* g = find_gate(name)) return g->reason.c_str();
+    return "";
+}
+
+void dump(FILE* out) {
+    resolve_once();
+    std::lock_guard<std::mutex> lock(g_mu);
+    dump_locked(out);
+}
+
+}  // namespace flags
+}  // namespace flexaidds

--- a/LIB/flexaidds_flags.cpp
+++ b/LIB/flexaidds_flags.cpp
@@ -6,6 +6,7 @@
 #include "flexaidds_flags.h"
 
 #include <cctype>
+#include <cstdlib>
 #include <cstring>
 #include <mutex>
 #include <string>
@@ -570,6 +571,31 @@ void dump(FILE* out) {
     resolve_once();
     std::lock_guard<std::mutex> lock(g_mu);
     dump_locked(out);
+}
+
+void apply_to_environ() {
+    resolve_once();
+    std::lock_guard<std::mutex> lock(g_mu);
+    for (const Gate& g : g_reg.gates) {
+        if (g.kind == Kind::Compile) continue;
+        if (std::strcmp(g.name, "FLEXAIDDS_FLAGS") == 0) continue;
+        if (std::strcmp(g.name, "FLEXAIDDS_FLAGS_DUMP") == 0) continue;
+        if (g.active) {
+            if (!env_raw(g.name) || g.kind == Kind::Bool) {
+                // Overlay / implication: publish a value existing getenv() sites see.
+                // Do not overwrite a caller-supplied non-empty value.
+                if (!env_raw(g.name) || env_raw(g.name)[0] == '\0') {
+                    const char* v = g.value.empty() ? "1" : g.value.c_str();
+                    setenv(g.name, v, 0);
+                }
+            }
+        } else if (g.requested && (g.kind == Kind::Bool || g.kind == Kind::Enum)) {
+            // Mutual-exclusion loser or superseded gate: hide from getenv()
+            // so legacy call sites follow the winner. The flag stays in the
+            // registry (requested() remains true).
+            unsetenv(g.name);
+        }
+    }
 }
 
 }  // namespace flags

--- a/LIB/flexaidds_flags.h
+++ b/LIB/flexaidds_flags.h
@@ -1,0 +1,62 @@
+// flexaidds_flags.h — unified runtime/compile gate registry + convenience overlay
+//
+// Streamlines *usage* of FLEXAIDDS_* / FLEXAID_* / FLEXAIDS_* knobs without
+// removing any option, env var, or -D flag. Individual getenv / compile
+// defines keep working. Mutually exclusive pairs keep both names in the
+// registry; resolve_once() auto-disables the loser and emits a one-time
+// stderr warning.
+//
+// Convenience overlay (UNION with individual env vars, not a replacement):
+//   FLEXAIDDS_FLAGS=hoist,epoch,fastpath,rng-stream-fix
+// Tokens are case-insensitive; '-' and '_' are equivalent.
+//   FLEXAIDDS_FLAGS_DUMP=1  → dump the full registry once at resolve.
+//
+// Query RIGID_FASTPATH from C++:
+//   flexaidds::flags::active("FLEXAIDDS_RIGID_FASTPATH")
+//   flexaidds::flags::rigid_fastpath()
+//
+// Copyright 2026 Le Bonhomme Pharma
+// SPDX-License-Identifier: Apache-2.0
+#ifndef FLEXAIDDS_FLAGS_H
+#define FLEXAIDDS_FLAGS_H
+
+#include <cstdio>
+
+namespace flexaidds {
+namespace flags {
+
+/// Idempotent, thread-safe resolve of env + compile defs + overlay + exclusions.
+void resolve_once();
+
+/// Drop the resolved snapshot so the next resolve_once() re-reads the environment.
+/// Tests that setenv/unsetenv must call this (or rely on requested/active after it).
+void reset_for_tests();
+
+/// Raw env / compile / FLEXAIDDS_FLAGS request, before mutual-exclusion.
+bool requested(const char* name);
+
+/// After implication + exclusion (what should actually be treated as on).
+bool active(const char* name);
+
+/// Env/overlay value string for a known gate, or "" if unset / unknown.
+const char* value(const char* name);
+
+/// Disable reason when requested && !active; otherwise "".
+const char* reason(const char* name);
+
+/// Print every known gate: name, requested, active, value, reason-if-disabled.
+void dump(FILE* out);
+
+/// Convenience: same as active("FLEXAIDDS_RIGID_FASTPATH"). Default OFF.
+inline bool rigid_fastpath() { return active("FLEXAIDDS_RIGID_FASTPATH"); }
+
+inline bool hoist_receptor_index() {
+    return active("FLEXAIDDS_HOIST_RECEPTOR_INDEX");
+}
+
+inline bool contacts_epoch() { return active("FLEXAIDDS_CONTACTS_EPOCH"); }
+
+}  // namespace flags
+}  // namespace flexaidds
+
+#endif  // FLEXAIDDS_FLAGS_H

--- a/LIB/flexaidds_flags.h
+++ b/LIB/flexaidds_flags.h
@@ -47,6 +47,15 @@ const char* reason(const char* name);
 /// Print every known gate: name, requested, active, value, reason-if-disabled.
 void dump(FILE* out);
 
+/// Push the resolved registry into the process environment so existing
+/// `getenv("FLEXAIDDS_*")` call sites honour the overlay and exclusions
+/// without being rewritten. Does not delete any flag from the API:
+///   * active but unset  → setenv(name, "1") (overlay / implications)
+///   * requested but inactive → unsetenv(name) (mutual-exclusion loser)
+/// Compile-time -D gates are never written. Individual env vars that are
+/// already set and still active are left untouched.
+void apply_to_environ();
+
 /// Convenience: same as active("FLEXAIDDS_RIGID_FASTPATH"). Default OFF.
 inline bool rigid_fastpath() { return active("FLEXAIDDS_RIGID_FASTPATH"); }
 

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -4004,6 +4004,7 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
 		std::vector<std::vector<vertex>>     p_poly(n_thr, std::vector<vertex>(MAX_POLY));
 		std::vector<std::vector<plane>>      p_cont(n_thr, std::vector<plane>(MAX_PT));
 		std::vector<std::vector<edgevector>> p_vedge(n_thr, std::vector<edgevector>(MAX_POLY));
+		std::vector<std::vector<int>>        p_scorable(n_thr, std::vector<int>(natmr, 0));
 
 		for (int t = 0; t < n_thr; ++t) {
 			p_fa[t].contacts      = p_contacts[t].data();
@@ -4012,6 +4013,10 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
 			p_vc[t].Calc      = p_calc[t].data();
 			p_vc[t].Calclist  = p_calclist[t].data();
 			p_vc[t].ca_index  = p_caidx[t].data();
+			p_vc[t].scorable_list = p_scorable[t].data();
+			p_vc[t].n_scorable = 0;
+			p_vc[t].scorable_cap = natmr;
+			p_vc[t].fastpath_used = 0;
 			p_vc[t].ca_rec    = p_carec[t].data();
 			p_vc[t].seed      = p_seed[t].data();
 			p_vc[t].contlist  = p_contlist[t].data();

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -3125,6 +3125,9 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 			std::vector<std::vector<vertex>>      tl_poly;
 			std::vector<std::vector<plane>>       tl_cont;
 			std::vector<std::vector<edgevector>>  tl_vedge;
+			// Per-thread Calc[] indices with score==true (sibling VC_Global
+			// fields: scorable_list, n_scorable, scorable_cap, fastpath_used).
+			std::vector<std::vector<int>>         tl_scorable;
 		};
 		static ParEvalWS ws;   // resident across generations (serial init: GA
 		                       // parallelism lives strictly inside this loop).
@@ -3166,6 +3169,7 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 			ws.tl_poly.assign(n_thr, std::vector<vertex>(MAX_POLY));
 			ws.tl_cont.assign(n_thr, std::vector<plane>(MAX_PT));
 			ws.tl_vedge.assign(n_thr, std::vector<edgevector>(MAX_POLY));
+			ws.tl_scorable.assign(n_thr, std::vector<int>(natmr, 0));
 		}
 
 		// Aliases keep the eval loop below identical to the previous per-call form.
@@ -3178,6 +3182,22 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 		auto& tl_contlist= ws.tl_contlist; auto& tl_ptorder  = ws.tl_ptorder;
 		auto& tl_centerpt= ws.tl_centerpt; auto& tl_poly     = ws.tl_poly;
 		auto& tl_cont    = ws.tl_cont;     auto& tl_vedge    = ws.tl_vedge;
+		auto& tl_scorable= ws.tl_scorable;
+
+		// Wire per-thread scorable-list scratch. Sibling adds these four
+		// fields at the end of VC_Global; the generic lambda keeps this
+		// block compiling if the header has not landed yet.
+		auto wire_scorable = [](auto& vc, int* buf, int cap) {
+			if constexpr (requires {
+				vc.scorable_list; vc.n_scorable;
+				vc.scorable_cap; vc.fastpath_used;
+			}) {
+				vc.scorable_list = buf;
+				vc.n_scorable = 0;
+				vc.scorable_cap = cap;
+				vc.fastpath_used = 0;
+			}
+		};
 
 		for (int t = 0; t < n_thr; ++t) {
 			// Refresh the cheap live FA snapshot each generation (scalar state may
@@ -3208,6 +3228,7 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 			tl_vc[t].poly      = tl_poly[t].data();
 			tl_vc[t].cont      = tl_cont[t].data();
 			tl_vc[t].vedge     = tl_vedge[t].data();
+			wire_scorable(tl_vc[t], tl_scorable[t].data(), natmr);
 			// Keep the reference-calculation retry path enabled in GA workers.
 			// The direct native probe uses recalc=1; forcing 0 here caused the
 			// same pose to fall into the non-convergence penalty path.

--- a/LIB/nrgrank_matrix.h
+++ b/LIB/nrgrank_matrix.h
@@ -1,9 +1,12 @@
-// nrgrank_matrix.h — NRGRank 41×41 SYBYL pairwise energy matrix (constexpr)
+// nrgrank_matrix.h — 41×41 SYBYL pairwise energy matrix (constexpr)
 //
-// Matrix: MC_5p_norm_P10_M2_2_multiplied_2
-// From: NRGRank (DesCôteaux T, Mailhot O, Najmanovich RJ.
-//       NRGRank: Coarse-grained structurally-informed ultra-massive
-//       virtual screening. bioRxiv 2025.02.17.638675.)
+// Published matrix name: MC_5p_norm_P10_M2_2 (in-repo spelling
+// MC_5p_norm_P10_M2_2_multiplied_2). Values are a clean-room constexpr
+// table for the published method (DesCôteaux, Mailhot, Najmanovich,
+// bioRxiv 2025.02.17.638675v2, doi 10.1101/2025.02.17.638675;
+// Zenodo 10.5281/zenodo.16861024 is CC-BY-4.0 supplementary scores/sites,
+// not this matrix). Do not import NRGlab/NRGRank (GPL-3.0) to "verify"
+// bytes — see docs/licensing/clean-room-policy.md.
 //
 // 41×41 matrix indexed [0..40][0..40].
 // Row/column 0 is unused (padding).  Types 1–39 are SYBYL atom types:

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -369,11 +369,16 @@ static void print_usage(const char* progname) {
 	printf("                             default <PDBid>_redock with --redock)\n");
 	printf("  --backend <cpu|metal|webgpu>  GPU compute backend for CF scoring (default: cpu)\n");
 	printf("  --rigid                    Fast rigid-body screening\n");
-	printf("  --screen                   NRGRank coarse-grained screening mode\n");
+	printf("  --screen                   Coarse-grained cube screening (Stage 1)\n");
 	printf("  --screen-top-n <N>         Return top N from coarse screen (default: 100)\n");
+	printf("  --screen-dock              Stage 2 hook on top-N (default OFF; surrogate\n");
+	printf("                             unless a real GA callback is registered)\n");
+	printf("  --screen-target-mol2 <f>   MOL2 target for cube screen / prefilter\n");
 	printf("  --parallel-dock            Grid-decomposed parallel docking (ParallelDock)\n");
 	printf("  --parallel-dock-regions <N> Number of spatial regions (default: 128)\n");
 	printf("  --campaign                 Parallel virtual screening campaign mode\n");
+	printf("  --coarse-prefilter         Campaign: cube-screen library, dock top-N only\n");
+	printf("  --coarse-prefilter-top-n N Top-N for --coarse-prefilter (default: 100)\n");
 	printf("  --folded                   Skip NATURaL chain growth\n");
 	printf("  --legacy                   Legacy 3-file input mode\n");
 	printf("  --redock <PDBid>           Cognate redock from RCSB PDB ID\n");
@@ -757,12 +762,16 @@ int main(int argc, char **argv){
 	bool use_rigid = false;
 	bool use_folded = false;
 	bool use_screen = false;
+	bool use_screen_dock = false;
 	int  screen_top_n = 100;
 	std::string screen_receptor_path;  // populated in auto-detect path for --screen
 	std::string screen_ligand_path;
+	std::string screen_target_mol2;
 	bool use_parallel_dock = false;
 	int  parallel_dock_regions = 128;
 	bool use_campaign = false;
+	bool use_coarse_prefilter = false;
+	int  coarse_prefilter_top_n = 100;
 	std::string config_path;
 	std::string output_prefix = "flexaid_out";
 	std::string cached_grid_path;  // Strategy A: .rrg grid cache path from "grid_file" JSON key
@@ -899,8 +908,13 @@ int main(int argc, char **argv){
 			}
 			if (arg == "--rigid")  { use_rigid = true;  continue; }
 			if (arg == "--screen") { use_screen = true; continue; }
+			if (arg == "--screen-dock") { use_screen_dock = true; continue; }
 			if (arg == "--screen-top-n") {
 				if (a + 1 < argc) screen_top_n = std::atoi(argv[++a]);
+				continue;
+			}
+			if (arg == "--screen-target-mol2") {
+				if (a + 1 < argc) screen_target_mol2 = argv[++a];
 				continue;
 			}
 			if (arg == "--parallel-dock") { use_parallel_dock = true; continue; }
@@ -909,6 +923,11 @@ int main(int argc, char **argv){
 				continue;
 			}
 			if (arg == "--campaign") { use_campaign = true; continue; }
+			if (arg == "--coarse-prefilter") { use_coarse_prefilter = true; continue; }
+			if (arg == "--coarse-prefilter-top-n") {
+				if (a + 1 < argc) coarse_prefilter_top_n = std::atoi(argv[++a]);
+				continue;
+			}
 			if (arg == "--folded") { use_folded = true; continue; }
 			if (arg == "--conc" || arg == "--concentration") {
 				if (a + 1 < argc) user_conc_M = std::atof(argv[++a]);
@@ -2730,6 +2749,14 @@ int main(int argc, char **argv){
 				use_rigid, use_folded
 			);
 			ccfg.default_conc_M = user_conc_M;  // P3: forward --conc for grand canonical in campaign path
+			ccfg.coarse_prefilter = use_coarse_prefilter;
+			ccfg.coarse_prefilter_top_n = coarse_prefilter_top_n;
+			ccfg.coarse_target_mol2 = screen_target_mol2;
+			{
+				const flexaids::ProtocolConfig camp_proto = flexaids::ProtocolConfig::from_env();
+				ccfg.coarse_cleft_pdb = camp_proto.oracle_site.empty()
+					? camp_proto.cleft_sphere_file : camp_proto.oracle_site;
+			}
 			auto summary = campaign::run_campaign(ccfg,
 				[](int done, int total, const campaign::LigandResult& lr) {
 					printf("\r  [%d/%d] %s: score_proxy=%.2f (%.1fs)",
@@ -2741,25 +2768,21 @@ int main(int argc, char **argv){
 			       summary.successful, summary.total_ligands, summary.throughput_per_hour);
 			n_chrom_snapshot = summary.successful;
 		} else if (use_screen) {
-			// ── CoarseScreen: NRGRank coarse-grained screening ──
-			printf("=== CoarseScreen mode: NRGRank ultra-fast screening (top %d) ===\n", screen_top_n);
+			// ── CoarseScreen / optional Stage-2 hook (default: Stage 1 only) ──
+			printf("=== CoarseScreen mode: cube screening (top %d)%s ===\n",
+			       screen_top_n, use_screen_dock ? " + Stage-2 hook" : "");
 
-			nrgrank::CoarseScreenConfig scfg;
-			scfg.top_n = screen_top_n;
-
-			nrgrank::CoarseScreener screener;
-			screener.set_config(scfg);
-
-			// Load target atoms from receptor MOL2
-			auto screen_target = nrgrank::parse_target_mol2(screen_receptor_path);
+			const std::string target_mol2 = !screen_target_mol2.empty()
+				? screen_target_mol2 : screen_receptor_path;
+			auto screen_target = nrgrank::parse_target_mol2(target_mol2);
 			if (screen_target.empty()) {
 				fprintf(stderr, "[SCREEN] ERROR: could not parse target atoms from %s\n",
-				        screen_receptor_path.c_str());
-				fprintf(stderr, "[SCREEN]   --screen requires a receptor in MOL2 format.\n");
+				        target_mol2.c_str());
+				fprintf(stderr, "[SCREEN]   --screen requires a receptor in MOL2 format "
+				        "(or --screen-target-mol2).\n");
 				Terminate(1);
 			}
 
-			// Locate binding site PDB: prefer FLEXAIDDS_ORACLE_SITE, then FLEXAIDDS_CLEFT_SPHERE_FILE
 			const flexaids::ProtocolConfig screen_proto = flexaids::ProtocolConfig::from_env();
 			std::string site_pdb_path = screen_proto.oracle_site;
 			if (site_pdb_path.empty()) site_pdb_path = screen_proto.cleft_sphere_file;
@@ -2771,15 +2794,6 @@ int main(int argc, char **argv){
 				        "set FLEXAIDDS_ORACLE_SITE or FLEXAIDDS_CLEFT_SPHERE_FILE.\n");
 			}
 
-			screener.prepare_target(screen_target, screen_spheres);
-			if (!screener.is_prepared()) {
-				fprintf(stderr, "[SCREEN] ERROR: target preparation failed.\n");
-				Terminate(1);
-			}
-			printf("[SCREEN] Target prepared: %d anchors\n",
-			       static_cast<int>(screener.num_anchors()));
-
-			// Load ligands from screen_ligand_path (SDF or MOL2)
 			std::vector<nrgrank::ScreenLigand> screen_ligands;
 			{
 				const std::string ext = [&]() {
@@ -2798,22 +2812,54 @@ int main(int argc, char **argv){
 				        screen_ligand_path.c_str());
 				Terminate(1);
 			}
-			printf("[SCREEN] Screening %d ligands...\n",
+
+			nrgrank::TwoStageScreener ts;
+			nrgrank::TwoStageConfig tcfg;
+			tcfg.top_n = screen_top_n;
+			tcfg.coarse.top_n = screen_top_n;
+			tcfg.write_coarse_csv = true;
+			tcfg.output_dir = output_prefix + "_screen";
+			tcfg.verbose = true;
+			tcfg.stage2_kind_label = "surrogate";
+			ts.set_config(tcfg);
+			ts.prepare_target(screen_target, screen_spheres);
+			if (!ts.coarse_screener().is_prepared()) {
+				fprintf(stderr, "[SCREEN] ERROR: target preparation failed.\n");
+				Terminate(1);
+			}
+			printf("[SCREEN] Target prepared: %d anchors; screening %d ligands...\n",
+			       static_cast<int>(ts.coarse_screener().num_anchors()),
 			       static_cast<int>(screen_ligands.size()));
 
-			// Run coarse screen — returns top_n sorted by score (best first)
-			auto screen_results = screener.screen(screen_ligands);
-
-			// Print ranked results
-			printf("\n%-6s  %-10s  %s\n", "Rank", "Score", "Name");
-			printf("------  ----------  ----\n");
-			for (int i = 0; i < static_cast<int>(screen_results.size()); ++i) {
-				printf("%-6d  %-10.3f  %s\n", i + 1,
-				       screen_results[i].score,
-				       screen_results[i].name.c_str());
+			if (use_screen_dock) {
+				// Composition placeholder — same honesty as ParallelCampaign's
+				// surrogate_model_dock_score. Not a Voronoi CF and not ΔG.
+				ts.set_full_dock_callback(
+					[](const nrgrank::ScreenLigand& lig,
+					   const nrgrank::ScreenResult&) {
+						return static_cast<float>(
+							-0.04 * static_cast<double>(lig.atoms.size()));
+					});
 			}
 
-			n_chrom_snapshot = static_cast<int>(screen_results.size());
+			auto staged = ts.run(screen_ligands);
+			nrgrank::TwoStageScreener::write_unified_csv(
+				tcfg.output_dir + "/unified.csv", staged);
+			nrgrank::TwoStageScreener::write_screen_receipt(
+				tcfg.output_dir,
+				static_cast<int>(screen_ligands.size()),
+				screen_top_n,
+				use_screen_dock);
+
+			printf("\n%-6s  %-10s  %s\n", "Rank", "Score", "Name");
+			printf("------  ----------  ----\n");
+			for (int i = 0; i < static_cast<int>(staged.size()); ++i) {
+				printf("%-6d  %-10.3f  %s\n", i + 1,
+				       staged[static_cast<size_t>(i)].coarse_result.score,
+				       staged[static_cast<size_t>(i)].coarse_result.name.c_str());
+			}
+
+			n_chrom_snapshot = static_cast<int>(staged.size());
 		} else {
 			// ── Standard single search run (GA default; CMA-ES opt-in) ──
 			// FLEXAIDDS_CMAES_BEGIN

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -36,6 +36,7 @@
 #include "ProtocolConfig.h"
 #include "shell_exec.h"
 #include "UnifiedHardwareDispatch.h"
+#include "flexaidds_flags.h"
 #if defined(FLEXAIDDS_ENABLE_REDOCK)
 #include "DatasetRunner.h"
 #endif
@@ -454,6 +455,10 @@ int main(int argc, char **argv){
 		fprintf(stderr,"ERROR: Could not allocate memory for FA || GB || VC\n");
 		Terminate(2);
 	}
+	// Honour FLEXAIDDS_FLAGS=… overlay + mutual-exclusion losers before any
+	// later getenv() in scoring/search. Does not remove knobs — losers are
+	// unset in the environment so legacy call sites follow the winner.
+	flexaidds::flags::apply_to_environ();
 	GB->metal_batch_n = 2;  // N=2: safe batch size verified
 	// MIF/RefLig/GridPrio non-zero defaults (pointers already NULL via value-init)
 	FA->mif_temperature = 300.0f;

--- a/LIB/two_stage_screen_main.cpp
+++ b/LIB/two_stage_screen_main.cpp
@@ -190,10 +190,19 @@ int main(int argc, char** argv) {
         }
     }
 
+    TwoStageScreener::write_unified_csv(o.out_dir + "/unified.csv", results);
+    TwoStageScreener::write_screen_receipt(
+        o.out_dir, static_cast<int>(ligands.size()), o.top_n,
+        /*stage2_callback=*/false,
+        o.two_stage ? "flexaid_screen-two-stage" : "flexaid_screen");
+
     std::printf("Screening complete: %zu ligands scored, top %d kept for GA.\n"
                 "  coarse CSV : %s/coarse_screen.csv\n"
+                "  unified CSV: %s/unified.csv\n"
+                "  receipt    : %s/RUN_RECEIPT.json\n"
                 "  top-N list : %s\n",
-                results.size(), n_keep, o.out_dir.c_str(), top_path.c_str());
+                results.size(), n_keep, o.out_dir.c_str(), o.out_dir.c_str(),
+                o.out_dir.c_str(), top_path.c_str());
     std::printf("Best candidate: %s (coarse CF = %.4f)\n",
                 results[0].coarse_result.name.c_str(),
                 results[0].coarse_result.score);

--- a/LIB/vcfunction.cpp
+++ b/LIB/vcfunction.cpp
@@ -12,6 +12,7 @@
 #include <climits>
 #include <vector>
 #include <unordered_map>
+#include <type_traits>
 
 #define DEBUG_LEVEL 0
 
@@ -177,6 +178,88 @@ static const double wal_stiff = [](){
 static const bool contacts_epoch_mode =
     (std::getenv("FLEXAIDDS_CONTACTS_EPOCH") != nullptr);
 
+// FLEXAIDDS_RIGID_FASTPATH (truthy, default OFF): walk only Calc[] indices
+// with score==true. List comes from VC->scorable_list / n_scorable when the
+// sibling fields exist, else vc_scorable_indices(). OFF or a missing list
+// keeps the original O(N) atom walk bit-identical.
+static const bool rigid_fastpath = [](){
+    const char* s = std::getenv("FLEXAIDDS_RIGID_FASTPATH");
+    return s && s[0] != '\0' && s[0] != '0';
+}();
+
+// provided by Vcontacts.cpp (sibling). Weak stubs keep this TU linkable
+// until those helpers land; a strong definition in Vcontacts.cpp wins.
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((weak))
+#endif
+const int* vc_scorable_indices(int* n)
+{
+    if (n) *n = 0;
+    return nullptr;
+}
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((weak))
+#endif
+bool vc_fastpath_active()
+{
+    return false;
+}
+
+namespace {
+template<typename T, typename = void>
+struct vc_has_scorable_fields : std::false_type {};
+
+template<typename T>
+struct vc_has_scorable_fields<T, std::void_t<
+    decltype(std::declval<T&>().scorable_list),
+    decltype(std::declval<T&>().n_scorable)>> : std::true_type {};
+
+template<typename VC_T>
+const int* vcfunction_scorable_list_impl(VC_T* VC, int* n)
+{
+    *n = 0;
+    if constexpr (vc_has_scorable_fields<VC_T>::value) {
+        if (VC->n_scorable > 0 && VC->scorable_list) {
+            *n = VC->n_scorable;
+            return VC->scorable_list;
+        }
+    }
+    int hn = 0;
+    const int* h = vc_scorable_indices(&hn);
+    if (h && hn > 0) {
+        *n = hn;
+        return h;
+    }
+    return nullptr;
+}
+
+inline const int* vcfunction_scorable_list(VC_Global* VC, int* n)
+{
+    return vcfunction_scorable_list_impl(VC, n);
+}
+
+// Null Calc[i].atom for score==true. Fastpath walks the scorable list when
+// the flag is on and a list is available; otherwise the original O(N) loop.
+inline void vc_null_scorable_atoms(VC_Global* VC, int atm_cnt_real, bool use_list)
+{
+    int n = 0;
+    const int* idx = use_list ? vcfunction_scorable_list(VC, &n) : nullptr;
+    if (idx && n > 0) {
+        for (int k = 0; k < n; ++k) {
+            const int i = idx[k];
+            if (i >= 0 && i < atm_cnt_real)
+                VC->Calc[i].atom = NULL;
+        }
+        return;
+    }
+    for(int i=0;i<atm_cnt_real;i++){
+        if(VC->Calc[i].score){
+            VC->Calc[i].atom = NULL;
+        }
+    }
+}
+} // namespace
+
 double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::vector<std::pair<int,int> > & intraclashes, bool* error)
 {
 	int    rnum=0;
@@ -248,11 +331,7 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 	if(rv < 0){
 		*error = true;
 		
-		for(int i=0;i<FA->atm_cnt_real;i++){
-			if(VC->Calc[i].score){
-				VC->Calc[i].atom = NULL;
-			}
-		}
+		vc_null_scorable_atoms(VC, FA->atm_cnt_real, rigid_fastpath);
 		
 		if(!FA->vindex){ free(VC->box); }
 		
@@ -265,7 +344,14 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 		}
 	}
 	
-	for(int i=0; i<FA->atm_cnt_real; ++i) {
+	int fp_n = 0;
+	const int* fp_idx = nullptr;
+	if (rigid_fastpath)
+		fp_idx = vcfunction_scorable_list(VC, &fp_n);
+	const bool use_fp = (fp_idx != nullptr && fp_n > 0);
+
+	for(int k=0; k<(use_fp ? fp_n : FA->atm_cnt_real); ++k) {
+		const int i = use_fp ? fp_idx[k] : k;
 		if(VC->Calc[i].atom == NULL) continue;
 		
 		cfstr* cfs = NULL;
@@ -1345,11 +1431,7 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 		}
 	}
 
-	for(int i=0;i<FA->atm_cnt_real;i++){
-		if(VC->Calc[i].score){
-			VC->Calc[i].atom = NULL;
-		}
-	}
+	vc_null_scorable_atoms(VC, FA->atm_cnt_real, rigid_fastpath);
 
 	if(!FA->vindex){ free(VC->box); }
 	

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -144,22 +144,17 @@ Python Software Foundation License Version 2
 **Project:** NRGlab/NRGRank  
 **License:** GNU General Public License v3.0  
 **Source:** https://github.com/NRGlab/NRGRank (NOT INCLUDED AS DEPENDENCY)  
-**Paper:** Gaudreault et al. (bioRxiv preprint, 2024 - citation pending publication)
+**Paper:** DesCôteaux T, Mailhot O, Najmanovich RJ. *NRGRank: Coarse-grained structurally-informed ultra-massive virtual screening.* bioRxiv 2025.02.17.638675v2. doi:[10.1101/2025.02.17.638675](https://doi.org/10.1101/2025.02.17.638675)  
+**Supplementary data:** Zenodo [10.5281/zenodo.16861024](https://doi.org/10.5281/zenodo.16861024) (CC-BY-4.0 dataset: DUD-E sites/scores — not GPL source, not the energy matrix)
 
 **Relationship to FlexAID∆S:**
-- **Scientific inspiration:** NRGRank's cube screening algorithm informed FreeNRG design
-- **No code dependency:** FlexAID∆S and FreeNRG do NOT import, link to, or incorporate NRGRank code
-- **Clean-room implementation:** Methods reimplemented from published equations under Apache-2.0
-- **License isolation:** GPL-3.0 does not propagate to FlexAID∆S (see clean-room policy)
-
-**Why NRGRank is not a dependency:**
-- Copyright protects *expression* (code), not *ideas* (algorithms)
-- Published scientific methods are not copyrightable
-- Independent implementation from mathematical descriptions avoids GPL contamination
-- FlexAID∆S maintains full Apache-2.0 permissiveness
+- **Published method only:** cube/anchor screening described in the paper is reimplemented in `LIB/CoarseScreen.*` / `LIB/TwoStageScreen.*` under Apache-2.0
+- **No code dependency:** this tree does not import, link, vendor, or translate NRGlab/NRGRank source (`process_target.py` / `rank_molecules.py` are not inputs)
+- **Clean-room:** `docs/licensing/clean_room_policy.md`
+- **License isolation:** GPL-3.0 does not propagate
 
 **Citation in Scientific Work:**
-> "The ultra-HTS cube screening method was inspired by NRGRank (Gaudreault et al., bioRxiv 2024). FlexAID∆S reimplements this approach from first principles with Shannon entropy extensions."
+> "Coarse cube screening follows the published NRGRank method (DesCôteaux, Mailhot, Najmanovich, bioRxiv 2025.02.17.638675v2) and was reimplemented from the paper under Apache-2.0; the GPL NRGRank codebase is not a dependency."
 
 ---
 

--- a/python/THIRD_PARTY_LICENSES.md
+++ b/python/THIRD_PARTY_LICENSES.md
@@ -144,22 +144,16 @@ Python Software Foundation License Version 2
 **Project:** NRGlab/NRGRank  
 **License:** GNU General Public License v3.0  
 **Source:** https://github.com/NRGlab/NRGRank (NOT INCLUDED AS DEPENDENCY)  
-**Paper:** Gaudreault et al. (bioRxiv preprint, 2024 - citation pending publication)
+**Paper:** DesCôteaux T, Mailhot O, Najmanovich RJ. *NRGRank: Coarse-grained structurally-informed ultra-massive virtual screening.* bioRxiv 2025.02.17.638675v2. doi:[10.1101/2025.02.17.638675](https://doi.org/10.1101/2025.02.17.638675)  
+**Supplementary data:** Zenodo [10.5281/zenodo.16861024](https://doi.org/10.5281/zenodo.16861024) (CC-BY-4.0)
 
 **Relationship to FlexAID∆S:**
-- **Scientific inspiration:** NRGRank's cube screening algorithm informed FreeNRG design
-- **No code dependency:** FlexAID∆S and FreeNRG do NOT import, link to, or incorporate NRGRank code
-- **Clean-room implementation:** Methods reimplemented from published equations under Apache-2.0
-- **License isolation:** GPL-3.0 does not propagate to FlexAID∆S (see clean-room policy)
-
-**Why NRGRank is not a dependency:**
-- Copyright protects *expression* (code), not *ideas* (algorithms)
-- Published scientific methods are not copyrightable
-- Independent implementation from mathematical descriptions avoids GPL contamination
-- FlexAID∆S maintains full Apache-2.0 permissiveness
+- **Published method only:** reimplemented in `LIB/CoarseScreen.*` under Apache-2.0
+- **No code dependency:** NRGlab/NRGRank source is not imported, linked, vendored, or translated
+- **Clean-room:** `docs/licensing/clean_room_policy.md`
 
 **Citation in Scientific Work:**
-> "The ultra-HTS cube screening method was inspired by NRGRank (Gaudreault et al., bioRxiv 2024). FlexAID∆S reimplements this approach from first principles with Shannon entropy extensions."
+> "Coarse cube screening follows the published NRGRank method (DesCôteaux, Mailhot, Najmanovich, bioRxiv 2025.02.17.638675v2) and was reimplemented from the paper under Apache-2.0; the GPL NRGRank codebase is not a dependency."
 
 ---
 

--- a/tests/test_coarse_screen.cpp
+++ b/tests/test_coarse_screen.cpp
@@ -12,10 +12,8 @@
 //   9. TwoStageScreener pipeline
 //  10. MOL2/SDF file parsing round-trip
 //
-// Reference:
-//   DesCôteaux T, Mailhot O, Najmanovich RJ. "NRGRank: Coarse-grained
-//   structurally-informed ultra-massive virtual screening."
-//   bioRxiv 2025.02.17.638675.
+// Method (clean-room): DesCôteaux, Mailhot, Najmanovich,
+// bioRxiv 2025.02.17.638675v2; Zenodo 10.5281/zenodo.16861024.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -616,4 +614,95 @@ TEST(TwoStageScreener, CSVOutput) {
 
     // Clean up
     std::filesystem::remove_all(cfg.output_dir);
+}
+
+TEST(TwoStageScreener, UnifiedCsvAndReceipt) {
+    auto atoms   = make_test_target();
+    auto spheres = make_test_spheres();
+
+    TwoStageScreener ts;
+    TwoStageConfig cfg;
+    cfg.coarse.use_clash = false;
+    cfg.coarse.rotations_per_axis = 4;
+    cfg.top_n = 2;
+    cfg.output_dir = "/tmp/test_screen_unified";
+    cfg.write_coarse_csv = false;
+    cfg.stage2_kind_label = "surrogate";
+    ts.set_config(cfg);
+    ts.prepare_target(atoms, spheres);
+    ts.set_full_dock_callback([](const ScreenLigand&, const ScreenResult& cr) {
+        return cr.score - 1.0f;
+    });
+
+    std::vector<ScreenLigand> ligs;
+    ligs.push_back(make_test_ligand("act_A"));
+    ligs.push_back(make_test_ligand("act_B"));
+    ligs.push_back(make_test_ligand("dec_C"));
+
+    auto results = ts.run(ligs);
+    ASSERT_EQ(results.size(), 3u);
+    TwoStageScreener::write_unified_csv(cfg.output_dir + "/unified.csv", results);
+    ASSERT_TRUE(TwoStageScreener::write_screen_receipt(
+        cfg.output_dir, static_cast<int>(ligs.size()), cfg.top_n, true));
+
+    std::ifstream csv(cfg.output_dir + "/unified.csv");
+    ASSERT_TRUE(csv.is_open());
+    std::string header;
+    std::getline(csv, header);
+    EXPECT_NE(header.find("coarse_rank"), std::string::npos);
+    EXPECT_NE(header.find("stage2_score"), std::string::npos);
+    EXPECT_NE(header.find("stage2_kind"), std::string::npos);
+
+    std::ifstream rec(cfg.output_dir + "/RUN_RECEIPT.json");
+    ASSERT_TRUE(rec.is_open());
+    std::string body((std::istreambuf_iterator<char>(rec)),
+                     std::istreambuf_iterator<char>());
+    EXPECT_NE(body.find("10.1101/2025.02.17.638675"), std::string::npos);
+    EXPECT_NE(body.find("10.5281/zenodo.16861024"), std::string::npos);
+    EXPECT_NE(body.find("stage2_callback"), std::string::npos);
+
+    auto names = TwoStageScreener::top_names(results, 2);
+    EXPECT_EQ(names.size(), 2u);
+    std::filesystem::remove_all(cfg.output_dir);
+}
+
+TEST(TwoStageScreener, MiniEnrichmentRecoversActives) {
+    auto atoms   = make_test_target();
+    auto spheres = make_test_spheres();
+
+    CoarseScreener cs;
+    CoarseScreenConfig cfg;
+    cfg.use_clash = false;
+    cfg.rotations_per_axis = 4;
+    cfg.top_n = 2;
+    cs.set_config(cfg);
+    cs.prepare_target(atoms, spheres);
+
+    std::vector<ScreenLigand> ligs;
+    ligs.push_back(make_test_ligand("ACT_1"));
+    ligs.push_back(make_test_ligand("ACT_2"));
+    for (int i = 0; i < 8; ++i) {
+        ScreenLigand dec;
+        dec.name = "DEC_" + std::to_string(i);
+        // Far dummy atom: should be out of the pocket / sentinel-ish
+        dec.atoms.push_back({{400.f + float(i), 400.f, 400.f}, 39});
+        ligs.push_back(dec);
+    }
+
+    auto results = cs.screen(ligs);
+    ASSERT_GE(results.size(), 2u);
+    std::string n0 = results[0].name;
+    std::string n1 = results[1].name;
+    EXPECT_TRUE(n0.rfind("ACT_", 0) == 0) << "top1=" << n0;
+    EXPECT_TRUE(n1.rfind("ACT_", 0) == 0) << "top2=" << n1;
+}
+
+TEST(NRGRankMatrix, ProvenancePinsPublishedName) {
+    // Self-consistency pin. Do not fetch GPL upstream bytes to "verify".
+    double sum = 0.0;
+    for (int i = 0; i < MATRIX_DIM; ++i)
+        for (int j = 0; j < MATRIX_DIM; ++j)
+            sum += kEnergyMatrix[i][j];
+    EXPECT_NEAR(kEnergyMatrix[1][2], -170.52, 0.01);
+    EXPECT_LT(sum, 0.0);  // net attractive table
 }

--- a/tests/test_flexaidds_flags.cpp
+++ b/tests/test_flexaidds_flags.cpp
@@ -169,3 +169,24 @@ TEST_F(FlexaiddsFlagsEnv, OverlayAliasesAreCaseInsensitive) {
     EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_RIGID_FASTPATH"));
     EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_RNG_STREAM_FIX"));
 }
+
+TEST_F(FlexaiddsFlagsEnv, ApplyToEnvironPublishesOverlayAndHidesLoser) {
+    set_env("FLEXAIDDS_FLAGS", "fastpath");
+    set_env("FLEXAIDDS_WAL_COERCIVE", "1");
+    set_env("FLEXAIDDS_SOFTCORE_WAL", "1");
+    set_env("FLEXAIDDS_CLEFT_SORT", "1");
+    resolve_env();
+    flexaidds::flags::apply_to_environ();
+
+    const char* fp = std::getenv("FLEXAIDDS_RIGID_FASTPATH");
+    ASSERT_NE(fp, nullptr);
+    EXPECT_STREQ(fp, "1");
+    const char* hoist = std::getenv("FLEXAIDDS_HOIST_RECEPTOR_INDEX");
+    ASSERT_NE(hoist, nullptr);
+    EXPECT_STREQ(hoist, "1");
+    EXPECT_EQ(std::getenv("FLEXAIDDS_SOFTCORE_WAL"), nullptr);
+    EXPECT_EQ(std::getenv("FLEXAIDDS_CLEFT_SORT"), nullptr);
+    EXPECT_STREQ(std::getenv("FLEXAIDDS_WAL_COERCIVE"), "1");
+    EXPECT_TRUE(flexaidds::flags::requested("FLEXAIDDS_SOFTCORE_WAL"));
+    EXPECT_FALSE(flexaidds::flags::active("FLEXAIDDS_SOFTCORE_WAL"));
+}

--- a/tests/test_flexaidds_flags.cpp
+++ b/tests/test_flexaidds_flags.cpp
@@ -1,0 +1,171 @@
+// tests/test_flexaidds_flags.cpp
+// Unified FLEXAIDDS_* / FLEXAID_* / FLEXAIDS_* gate overlay.
+//
+// Copyright 2026 Le Bonhomme Pharma
+// SPDX-License-Identifier: Apache-2.0
+
+#include "flexaidds_flags.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+void clear_env(const char* key) {
+#if defined(_WIN32)
+    _putenv_s(key, "");
+#else
+    unsetenv(key);
+#endif
+}
+
+void set_env(const char* key, const char* val) {
+#if defined(_WIN32)
+    _putenv_s(key, val);
+#else
+    setenv(key, val, 1);
+#endif
+}
+
+void resolve_env() {
+    flexaidds::flags::reset_for_tests();
+    flexaidds::flags::resolve_once();
+}
+
+class FlexaiddsFlagsEnv : public ::testing::Test {
+protected:
+    void SetUp() override { clear_all(); }
+    void TearDown() override { clear_all(); }
+
+    static void clear_all() {
+        static const char* kKeys[] = {
+            "FLEXAIDDS_RIGID_FASTPATH",
+            "FLEXAIDDS_HOIST_RECEPTOR_INDEX",
+            "FLEXAIDDS_CONTACTS_EPOCH",
+            "FLEXAIDDS_PARALLEL_REPRODUCE",
+            "FLEXAIDDS_RNG_STREAM_FIX",
+            "FLEXAID_DETERMINISTIC",
+            "FLEXAID_SEED",
+            "FLEXAIDDS_FORCE_CPU",
+            "FLEXAIDDS_FORCE_RIGID",
+            "FLEXAIDDS_SEARCH",
+            "FLEXAIDDS_CLUSTER_REP",
+            "FLEXAIDDS_MEDOID_REFINE",
+            "FLEXAIDDS_CLEFT_SORT",
+            "FLEXAIDDS_WAL_COERCIVE",
+            "FLEXAIDDS_SOFTCORE_WAL",
+            "FLEXAIDDS_WAL_STIFF",
+            "FLEXAIDDS_NO_SAS",
+            "FLEXAIDDS_POSEBUST",
+            "FLEXAIDDS_POSEBUST_BACKEND",
+            "FLEXAIDS_SOA_ASSERT",
+            "FLEXAIDDS_FLAGS",
+            "FLEXAIDDS_FLAGS_DUMP",
+        };
+        for (const char* k : kKeys) clear_env(k);
+        flexaidds::flags::reset_for_tests();
+    }
+};
+
+std::string dump_to_string() {
+    FILE* f = std::tmpfile();
+    EXPECT_NE(f, nullptr);
+    if (!f) return {};
+    flexaidds::flags::dump(f);
+    std::rewind(f);
+    std::string out;
+    char buf[512];
+    while (std::fgets(buf, sizeof(buf), f)) out += buf;
+    std::fclose(f);
+    return out;
+}
+
+}  // namespace
+
+TEST_F(FlexaiddsFlagsEnv, DefaultRigidFastpathInactive) {
+    resolve_env();
+    EXPECT_FALSE(flexaidds::flags::requested("FLEXAIDDS_RIGID_FASTPATH"));
+    EXPECT_FALSE(flexaidds::flags::active("FLEXAIDDS_RIGID_FASTPATH"));
+    EXPECT_FALSE(flexaidds::flags::rigid_fastpath());
+    EXPECT_FALSE(flexaidds::flags::active("FLEXAIDDS_HOIST_RECEPTOR_INDEX"));
+}
+
+TEST_F(FlexaiddsFlagsEnv, RigidFastpathImpliesHoist) {
+    set_env("FLEXAIDDS_RIGID_FASTPATH", "1");
+    resolve_env();
+    EXPECT_TRUE(flexaidds::flags::requested("FLEXAIDDS_RIGID_FASTPATH"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_RIGID_FASTPATH"));
+    EXPECT_TRUE(flexaidds::flags::rigid_fastpath());
+    EXPECT_FALSE(flexaidds::flags::requested("FLEXAIDDS_HOIST_RECEPTOR_INDEX"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_HOIST_RECEPTOR_INDEX"));
+    EXPECT_TRUE(flexaidds::flags::hoist_receptor_index());
+}
+
+TEST_F(FlexaiddsFlagsEnv, WalCoerciveWinsOverSoftcore) {
+    set_env("FLEXAIDDS_WAL_COERCIVE", "1");
+    set_env("FLEXAIDDS_SOFTCORE_WAL", "1");
+    resolve_env();
+    EXPECT_TRUE(flexaidds::flags::requested("FLEXAIDDS_WAL_COERCIVE"));
+    EXPECT_TRUE(flexaidds::flags::requested("FLEXAIDDS_SOFTCORE_WAL"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_WAL_COERCIVE"));
+    EXPECT_FALSE(flexaidds::flags::active("FLEXAIDDS_SOFTCORE_WAL"));
+    EXPECT_NE(std::strstr(flexaidds::flags::reason("FLEXAIDDS_SOFTCORE_WAL"),
+                          "WAL_COERCIVE"),
+              nullptr);
+}
+
+TEST_F(FlexaiddsFlagsEnv, ClusterRepWinsOverMedoidRefine) {
+    set_env("FLEXAIDDS_CLUSTER_REP", "lowcf");
+    set_env("FLEXAIDDS_MEDOID_REFINE", "1");
+    resolve_env();
+    EXPECT_TRUE(flexaidds::flags::requested("FLEXAIDDS_CLUSTER_REP"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_CLUSTER_REP"));
+    EXPECT_TRUE(flexaidds::flags::requested("FLEXAIDDS_MEDOID_REFINE"));
+    EXPECT_FALSE(flexaidds::flags::active("FLEXAIDDS_MEDOID_REFINE"));
+}
+
+TEST_F(FlexaiddsFlagsEnv, CleftSortSuperseded) {
+    set_env("FLEXAIDDS_CLEFT_SORT", "1");
+    resolve_env();
+    EXPECT_TRUE(flexaidds::flags::requested("FLEXAIDDS_CLEFT_SORT"));
+    EXPECT_FALSE(flexaidds::flags::active("FLEXAIDDS_CLEFT_SORT"));
+    EXPECT_NE(std::strstr(flexaidds::flags::reason("FLEXAIDDS_CLEFT_SORT"),
+                          "superseded"),
+              nullptr);
+}
+
+TEST_F(FlexaiddsFlagsEnv, FlagsOverlayEnablesEpochAndFastpathWithoutClearingOthers) {
+    set_env("FLEXAIDDS_RNG_STREAM_FIX", "1");
+    set_env("FLEXAIDDS_CONTACTS_EPOCH", "1");
+    set_env("FLEXAIDDS_FLAGS", "epoch,fastpath");
+    resolve_env();
+    EXPECT_TRUE(flexaidds::flags::requested("FLEXAIDDS_CONTACTS_EPOCH"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_CONTACTS_EPOCH"));
+    EXPECT_TRUE(flexaidds::flags::active("epoch"));
+    EXPECT_TRUE(flexaidds::flags::requested("FLEXAIDDS_RIGID_FASTPATH"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_RIGID_FASTPATH"));
+    EXPECT_TRUE(flexaidds::flags::active("fastpath"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_HOIST_RECEPTOR_INDEX"));
+    EXPECT_TRUE(flexaidds::flags::requested("FLEXAIDDS_RNG_STREAM_FIX"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_RNG_STREAM_FIX"));
+}
+
+TEST_F(FlexaiddsFlagsEnv, DumpIncludesRigidFastpath) {
+    resolve_env();
+    const std::string text = dump_to_string();
+    EXPECT_NE(text.find("RIGID_FASTPATH"), std::string::npos);
+    EXPECT_NE(text.find("FLEXAIDDS_RIGID_FASTPATH"), std::string::npos);
+}
+
+TEST_F(FlexaiddsFlagsEnv, OverlayAliasesAreCaseInsensitive) {
+    set_env("FLEXAIDDS_FLAGS", "Hoist, EPOCH, FastPath, rng-stream-fix");
+    resolve_env();
+    EXPECT_TRUE(flexaidds::flags::requested("hoist"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_HOIST_RECEPTOR_INDEX"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_CONTACTS_EPOCH"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_RIGID_FASTPATH"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_RNG_STREAM_FIX"));
+}

--- a/tests/test_rigid_fastpath.cpp
+++ b/tests/test_rigid_fastpath.cpp
@@ -1,0 +1,666 @@
+// tests/test_rigid_fastpath.cpp
+// Bit-identity of FLEXAIDDS_RIGID_FASTPATH (default OFF) vs the legacy
+// index_protein + Vcontacts + calc_region path on a tiny synthetic complex.
+// Isolated target: Vcontacts.cpp + stubs.cpp + geometry.cpp (no gaboom,
+// no vcfunction energy matrix).
+// Apache-2.0 © 2026 Le Bonhomme Pharma
+
+#include <gtest/gtest.h>
+#include "../LIB/Vcontacts.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+constexpr const char* kFlag = "FLEXAIDDS_RIGID_FASTPATH";
+
+// VC_Global may later grow scorable_list / n_scorable / scorable_cap /
+// fastpath_used. These stay compiling if the header has not landed yet.
+template <typename VC_T>
+void wire_scorable_fields(VC_T& vc, int* buf, int cap)
+{
+    if constexpr (requires {
+                      vc.scorable_list;
+                      vc.n_scorable;
+                      vc.scorable_cap;
+                      vc.fastpath_used;
+                  }) {
+        vc.scorable_list = buf;
+        vc.n_scorable = 0;
+        vc.scorable_cap = cap;
+        vc.fastpath_used = 0;
+    }
+}
+
+template <typename VC_T>
+int read_fastpath_used(const VC_T& vc)
+{
+    if constexpr (requires { vc.fastpath_used; }) {
+        return vc.fastpath_used;
+    }
+    return -1;
+}
+
+void clear_fastpath_env()
+{
+    unsetenv(kFlag);
+    unsetenv("FLEXAIDDS_HOIST_RECEPTOR_INDEX");
+}
+
+void set_rigid_fastpath(bool on)
+{
+    if (on) {
+        ASSERT_EQ(setenv(kFlag, "1", 1), 0);
+    } else {
+        unsetenv(kFlag);
+    }
+}
+
+bool bits_eq(double a, double b)
+{
+    return std::memcmp(&a, &b, sizeof(double)) == 0;
+}
+
+std::string double_bits(double v)
+{
+    std::uint64_t u = 0;
+    std::memcpy(&u, &v, sizeof(u));
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "0x%016llx", static_cast<unsigned long long>(u));
+    return buf;
+}
+
+struct ContactTriple {
+    int atom = -1;
+    double area = 0.0;
+    double dist = 0.0;
+
+    bool operator==(const ContactTriple& o) const
+    {
+        return atom == o.atom && bits_eq(area, o.area) && bits_eq(dist, o.dist);
+    }
+};
+
+struct AtomRecord {
+    int boxnum = -1;
+    double sas_field = 0.0;
+    double sas_from_chain = 0.0;
+    std::vector<ContactTriple> chain;
+
+    bool operator==(const AtomRecord& o) const
+    {
+        return boxnum == o.boxnum && bits_eq(sas_field, o.sas_field) &&
+               bits_eq(sas_from_chain, o.sas_from_chain) && chain == o.chain;
+    }
+};
+
+struct PoseRecord {
+    int vcontacts_rc = 0;
+    int calc_count = 0;
+    int dim = 0;
+    int fastpath_used = -1;
+    bool fastpath_fn = false;
+    std::vector<int> boxnum;
+    std::vector<int> calclist;
+    std::vector<std::vector<int>> box_slices;  // sorted Calclist per box
+    std::vector<AtomRecord> scorable;
+};
+
+struct IndexRecord {
+    int dim = 0;
+    int calc_count = 0;
+    int fastpath_used = -1;
+    bool fastpath_fn = false;
+    std::vector<int> boxnum;
+    std::vector<int> calclist;
+    std::vector<std::vector<int>> box_slices;
+};
+
+void expect_pose_eq(const PoseRecord& a, const PoseRecord& b, const char* ctx)
+{
+    EXPECT_EQ(a.vcontacts_rc, b.vcontacts_rc) << ctx;
+    EXPECT_EQ(a.calc_count, b.calc_count) << ctx;
+    EXPECT_EQ(a.dim, b.dim) << ctx;
+    ASSERT_EQ(a.boxnum.size(), b.boxnum.size()) << ctx;
+    for (size_t i = 0; i < a.boxnum.size(); ++i) {
+        EXPECT_EQ(a.boxnum[i], b.boxnum[i]) << ctx << " boxnum[" << i << "]";
+    }
+    ASSERT_EQ(a.calclist.size(), b.calclist.size()) << ctx;
+    for (size_t i = 0; i < a.calclist.size(); ++i) {
+        EXPECT_EQ(a.calclist[i], b.calclist[i]) << ctx << " Calclist[" << i << "]";
+    }
+    ASSERT_EQ(a.box_slices.size(), b.box_slices.size()) << ctx;
+    for (size_t i = 0; i < a.box_slices.size(); ++i) {
+        EXPECT_EQ(a.box_slices[i], b.box_slices[i]) << ctx << " box_slice[" << i << "]";
+    }
+    ASSERT_EQ(a.scorable.size(), b.scorable.size()) << ctx;
+    for (size_t i = 0; i < a.scorable.size(); ++i) {
+        EXPECT_EQ(a.scorable[i].boxnum, b.scorable[i].boxnum)
+            << ctx << " scorable[" << i << "].boxnum";
+        EXPECT_TRUE(bits_eq(a.scorable[i].sas_field, b.scorable[i].sas_field))
+            << ctx << " scorable[" << i << "].SAS "
+            << double_bits(a.scorable[i].sas_field) << " vs "
+            << double_bits(b.scorable[i].sas_field);
+        EXPECT_TRUE(bits_eq(a.scorable[i].sas_from_chain, b.scorable[i].sas_from_chain))
+            << ctx << " scorable[" << i << "].sas_from_chain "
+            << double_bits(a.scorable[i].sas_from_chain) << " vs "
+            << double_bits(b.scorable[i].sas_from_chain);
+        ASSERT_EQ(a.scorable[i].chain.size(), b.scorable[i].chain.size())
+            << ctx << " scorable[" << i << "] ca_rec chain length";
+        for (size_t k = 0; k < a.scorable[i].chain.size(); ++k) {
+            EXPECT_EQ(a.scorable[i].chain[k].atom, b.scorable[i].chain[k].atom)
+                << ctx << " scorable[" << i << "].chain[" << k << "].atom";
+            EXPECT_TRUE(bits_eq(a.scorable[i].chain[k].area, b.scorable[i].chain[k].area))
+                << ctx << " scorable[" << i << "].chain[" << k << "].area "
+                << double_bits(a.scorable[i].chain[k].area) << " vs "
+                << double_bits(b.scorable[i].chain[k].area);
+            EXPECT_TRUE(bits_eq(a.scorable[i].chain[k].dist, b.scorable[i].chain[k].dist))
+                << ctx << " scorable[" << i << "].chain[" << k << "].dist "
+                << double_bits(a.scorable[i].chain[k].dist) << " vs "
+                << double_bits(b.scorable[i].chain[k].dist);
+        }
+    }
+}
+
+void expect_index_eq(const IndexRecord& a, const IndexRecord& b, const char* ctx)
+{
+    EXPECT_EQ(a.dim, b.dim) << ctx;
+    EXPECT_EQ(a.calc_count, b.calc_count) << ctx;
+    ASSERT_EQ(a.boxnum.size(), b.boxnum.size()) << ctx;
+    for (size_t i = 0; i < a.boxnum.size(); ++i) {
+        EXPECT_EQ(a.boxnum[i], b.boxnum[i]) << ctx << " boxnum[" << i << "]";
+    }
+    ASSERT_EQ(a.calclist.size(), b.calclist.size()) << ctx;
+    for (size_t i = 0; i < a.calclist.size(); ++i) {
+        EXPECT_EQ(a.calclist[i], b.calclist[i]) << ctx << " Calclist[" << i << "]";
+    }
+    ASSERT_EQ(a.box_slices.size(), b.box_slices.size()) << ctx;
+    for (size_t i = 0; i < a.box_slices.size(); ++i) {
+        EXPECT_EQ(a.box_slices[i], b.box_slices[i]) << ctx << " box_slice[" << i << "]";
+    }
+}
+
+std::vector<std::vector<int>> sorted_box_slices(const atomindex* box, int dim3,
+                                                const int* calclist, int calc_count)
+{
+    std::vector<std::vector<int>> slices;
+    if (!box || dim3 <= 0) return slices;
+    slices.resize(static_cast<size_t>(dim3));
+    for (int b = 0; b < dim3; ++b) {
+        const int n = box[b].nument;
+        const int first = box[b].first;
+        if (n <= 0 || first < 0) continue;
+        std::vector<int> sl;
+        sl.reserve(static_cast<size_t>(n));
+        for (int k = 0; k < n; ++k) {
+            const int idx = first + k;
+            if (idx >= 0 && idx < calc_count) sl.push_back(calclist[idx]);
+        }
+        std::sort(sl.begin(), sl.end());
+        slices[static_cast<size_t>(b)] = std::move(sl);
+    }
+    return slices;
+}
+
+std::vector<ContactTriple> walk_ca_chain(const VC_Global& vc, int atom_i)
+{
+    std::vector<ContactTriple> out;
+    if (!vc.ca_index || !vc.ca_rec || atom_i < 0) return out;
+    int idx = vc.ca_index[atom_i];
+    const int cap = vc.ca_recsize > 0 ? vc.ca_recsize : 0;
+    int guard = 0;
+    while (idx != -1 && guard++ < cap) {
+        if (idx < 0 || idx >= cap) break;
+        const ca_struct& c = vc.ca_rec[idx];
+        out.push_back({c.atom, c.area, c.dist});
+        idx = c.prev;
+    }
+    return out;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Fixture: 40 rigid receptor atoms on a 5×4×2 lattice + 6 scorable ligand
+// atoms (optres != NULL). 0-based atom indices so index_protein's
+// `atmi >= atmcnt` skip does not drop the last atom.
+// ---------------------------------------------------------------------------
+class RigidFastpathBitIdentity : public ::testing::Test {
+protected:
+    static constexpr int kNRec = 40;
+    static constexpr int kNLig = 6;
+    static constexpr int kNAtoms = kNRec + kNLig;
+    static constexpr float kSpace = 5.0f;
+    static constexpr float kRadius = 1.7f;
+
+    // Pose 4 is an out-of-box / clashy translation (grid signature changes).
+    static constexpr int kNPoses = 5;
+    static constexpr float kPoseDx[kNPoses] = {0.0f, 2.0f, 0.0f, 4.0f, 80.0f};
+    static constexpr float kPoseDy[kNPoses] = {0.0f, 0.0f, -1.5f, 1.0f, 0.0f};
+    static constexpr float kPoseDz[kNPoses] = {0.0f, 0.0f, 0.8f, -0.5f, 0.0f};
+
+    FA_Global fa_{};
+    VC_Global vc_{};
+    OptRes lig_opt_{};
+    std::vector<atom> atoms_;
+    std::vector<resid> residues_;
+    std::vector<int> rec_fatm_{0};
+    std::vector<int> rec_latm_{kNRec - 1};
+    std::vector<int> lig_fatm_{kNRec};
+    std::vector<int> lig_latm_{kNAtoms - 1};
+    std::vector<atomsas> calc_;
+    std::vector<int> calclist_;
+    std::vector<int> ca_index_;
+    std::vector<int> seed_;
+    std::vector<contactlist> contlist_;
+    std::vector<ca_struct> ca_rec_;
+    std::vector<ptindex> ptorder_;
+    std::vector<vertex> centerpt_;
+    std::vector<vertex> poly_;
+    std::vector<plane> cont_;
+    std::vector<edgevector> vedge_;
+    std::vector<int> scorable_buf_;
+    float lig_rest_[kNLig][3]{};
+
+    void SetUp() override
+    {
+        clear_fastpath_env();
+        build_complex();
+        alloc_vc();
+    }
+
+    void TearDown() override
+    {
+        free_vc_box();
+        clear_fastpath_env();
+    }
+
+    void build_complex()
+    {
+        atoms_.assign(static_cast<size_t>(kNAtoms), atom{});
+        residues_.assign(3, resid{});
+
+        int ai = 0;
+        for (int z = 0; z < 2; ++z) {
+            for (int y = 0; y < 4; ++y) {
+                for (int x = 0; x < 5; ++x, ++ai) {
+                    atom& a = atoms_[static_cast<size_t>(ai)];
+                    a.coor[0] = static_cast<float>(x) * kSpace;
+                    a.coor[1] = static_cast<float>(y) * kSpace;
+                    a.coor[2] = static_cast<float>(z) * kSpace;
+                    a.radius = kRadius;
+                    a.pb_vdw_radius = 1.70;
+                    a.number = ai + 1;
+                    a.ofres = 1;
+                    a.optres = nullptr;
+                    a.type = 1;
+                    std::strncpy(a.name, "C", 4);
+                    std::strncpy(a.element, "C", 2);
+                }
+            }
+        }
+        ASSERT_EQ(ai, kNRec);
+
+        // 2×3 ligand grid at z=20 (far enough from the z=5 lattice that
+        // voronoi_poly2 finishes) with 4 Å spacing so neighbour contacts exist.
+        lig_opt_ = OptRes{};
+        lig_opt_.rnum = 2;
+        lig_opt_.type = 1;
+        lig_opt_.tot = kNLig;
+
+        for (int i = 0; i < kNLig; ++i) {
+            atom& a = atoms_[static_cast<size_t>(kNRec + i)];
+            a.coor[0] = 8.0f + static_cast<float>(i % 3) * 4.0f;
+            a.coor[1] = 6.0f + static_cast<float>(i / 3) * 4.0f;
+            a.coor[2] = 20.0f;
+            lig_rest_[i][0] = a.coor[0];
+            lig_rest_[i][1] = a.coor[1];
+            lig_rest_[i][2] = a.coor[2];
+            a.radius = kRadius;
+            a.pb_vdw_radius = 1.70;
+            a.number = kNRec + i + 1;
+            a.ofres = 2;
+            a.optres = &lig_opt_;
+            a.type = 1;
+            std::strncpy(a.name, "C", 4);
+            std::strncpy(a.element, "C", 2);
+        }
+
+        residues_[1].type = 0;
+        residues_[1].number = 1;
+        residues_[1].rot = 0;
+        residues_[1].trot = 1;
+        residues_[1].fatm = rec_fatm_.data();
+        residues_[1].latm = rec_latm_.data();
+        residues_[1].bonded = nullptr;
+        std::strncpy(residues_[1].name, "ALA", 3);
+        residues_[1].chn = 'A';
+
+        residues_[2].type = 1;
+        residues_[2].number = 2;
+        residues_[2].rot = 0;
+        residues_[2].trot = 1;
+        residues_[2].fatm = lig_fatm_.data();
+        residues_[2].latm = lig_latm_.data();
+        residues_[2].bonded = nullptr;
+        std::strncpy(residues_[2].name, "LIG", 3);
+        residues_[2].chn = 'L';
+
+        fa_.atm_cnt = kNAtoms;
+        fa_.atm_cnt_real = kNAtoms;
+        fa_.res_cnt = 2;
+        fa_.vindex = 0;
+        fa_.num_optres = 1;
+        fa_.optres = &lig_opt_;
+        fa_.permeability = 1.0f;
+        fa_.soft_wall_cutoff = 0.0f;
+        fa_.intermolecular_clash_ratio = 0.0f;
+        fa_.omit_buried = 0;
+        fa_.vcontacts_planedef = 'X';
+        // Envelope the in-box poses so only the +80 Å translation expands the grid.
+        // Lattice [0,20]×[0,15]×[0,5]; ligand [8,16]×[6,10]×{20} at rest.
+        fa_.globalmin[0] = -6.0f;
+        fa_.globalmin[1] = -6.0f;
+        fa_.globalmin[2] = -6.0f;
+        fa_.globalmax[0] = 28.0f;
+        fa_.globalmax[1] = 22.0f;
+        fa_.globalmax[2] = 28.0f;
+        fa_.maxwidth = 36.0f;
+    }
+
+    void alloc_vc()
+    {
+        calc_.assign(static_cast<size_t>(kNAtoms), atomsas{});
+        calclist_.assign(static_cast<size_t>(kNAtoms), -1);
+        ca_index_.assign(static_cast<size_t>(kNAtoms), -1);
+        seed_.assign(static_cast<size_t>(3 * kNAtoms), -1);
+        contlist_.assign(10000, contactlist{});
+        ca_rec_.assign(4096, ca_struct{});
+        ptorder_.assign(MAX_PT, ptindex{});
+        centerpt_.assign(MAX_PT, vertex{});
+        poly_.assign(MAX_POLY, vertex{});
+        cont_.assign(MAX_PT, plane{});
+        vedge_.assign(MAX_POLY, edgevector{});
+        scorable_buf_.assign(static_cast<size_t>(kNAtoms), 0);
+
+        vc_ = VC_Global{};
+        vc_.Calc = calc_.data();
+        vc_.Calclist = calclist_.data();
+        vc_.ca_index = ca_index_.data();
+        vc_.seed = seed_.data();
+        vc_.contlist = contlist_.data();
+        vc_.ca_rec = ca_rec_.data();
+        vc_.ca_recsize = static_cast<int>(ca_rec_.size());
+        vc_.numcarec = 0;
+        vc_.ptorder = ptorder_.data();
+        vc_.centerpt = centerpt_.data();
+        vc_.poly = poly_.data();
+        vc_.cont = cont_.data();
+        vc_.vedge = vedge_.data();
+        vc_.planedef = 'X';
+        vc_.recalc = 0;  // do not jitter coordinates on hull failure
+        vc_.box = nullptr;
+        wire_scorable_fields(vc_, scorable_buf_.data(), kNAtoms);
+    }
+
+    void free_vc_box()
+    {
+        if (vc_.box) {
+            std::free(vc_.box);
+            vc_.box = nullptr;
+        }
+    }
+
+    void apply_pose(int pose)
+    {
+        ASSERT_GE(pose, 0);
+        ASSERT_LT(pose, kNPoses);
+        for (int i = 0; i < kNLig; ++i) {
+            atom& a = atoms_[static_cast<size_t>(kNRec + i)];
+            a.coor[0] = lig_rest_[i][0] + kPoseDx[pose];
+            a.coor[1] = lig_rest_[i][1] + kPoseDy[pose];
+            a.coor[2] = lig_rest_[i][2] + kPoseDz[pose];
+        }
+    }
+
+    void restore_rest() { apply_pose(0); }
+
+    PoseRecord capture_pose(int rc)
+    {
+        PoseRecord rec;
+        rec.vcontacts_rc = rc;
+        rec.calc_count = vc_.calc_count > 0 ? vc_.calc_count : fa_.atm_cnt_real;
+        rec.dim = vc_.dim;
+        rec.fastpath_used = read_fastpath_used(vc_);
+        rec.fastpath_fn = vc_fastpath_active();
+        const int n = rec.calc_count;
+        rec.boxnum.resize(static_cast<size_t>(n), -1);
+        rec.calclist.assign(calclist_.begin(), calclist_.begin() + n);
+        for (int i = 0; i < n; ++i) rec.boxnum[static_cast<size_t>(i)] = calc_[static_cast<size_t>(i)].boxnum;
+
+        const int dim3 = rec.dim * rec.dim * rec.dim;
+        rec.box_slices = sorted_box_slices(vc_.box, dim3, calclist_.data(), n);
+
+        rec.scorable.reserve(static_cast<size_t>(kNLig));
+        for (int i = 0; i < n; ++i) {
+            if (!calc_[static_cast<size_t>(i)].score) continue;
+            AtomRecord ar;
+            ar.boxnum = calc_[static_cast<size_t>(i)].boxnum;
+            ar.sas_field = calc_[static_cast<size_t>(i)].SAS;
+            ar.chain = walk_ca_chain(vc_, i);
+            const float rad = calc_[static_cast<size_t>(i)].atom
+                                  ? calc_[static_cast<size_t>(i)].atom->radius
+                                  : kRadius;
+            const double rado = static_cast<double>(rad) + static_cast<double>(Rw);
+            double sas = 4.0 * static_cast<double>(PI) * rado * rado;
+            for (const auto& t : ar.chain) sas -= t.area;
+            ar.sas_from_chain = sas;
+            rec.scorable.push_back(std::move(ar));
+        }
+        return rec;
+    }
+
+    PoseRecord eval_vcontacts(int pose)
+    {
+        apply_pose(pose);
+        wire_scorable_fields(vc_, scorable_buf_.data(), kNAtoms);
+        const int rc = Vcontacts(&fa_, atoms_.data(), residues_.data(), &vc_,
+                                 /*clash_value=*/nullptr, /*non_scorable=*/false);
+        PoseRecord rec = capture_pose(rc);
+        free_vc_box();
+        return rec;
+    }
+
+    std::vector<PoseRecord> eval_series()
+    {
+        std::vector<PoseRecord> out;
+        out.reserve(static_cast<size_t>(kNPoses));
+        for (int p = 0; p < kNPoses; ++p) out.push_back(eval_vcontacts(p));
+        return out;
+    }
+
+    IndexRecord eval_index()
+    {
+        wire_scorable_fields(vc_, scorable_buf_.data(), kNAtoms);
+        std::map<std::string, atomindex*> indexed;
+        atomindex* prev = nullptr;
+        int dim = 0;
+        int calc_count = 0;
+        atomindex* box = index_protein(&fa_, atoms_.data(), residues_.data(),
+                                       calc_.data(), calclist_.data(), &dim,
+                                       fa_.atm_cnt_real, prev, indexed, &calc_count);
+        IndexRecord rec;
+        rec.dim = dim;
+        rec.calc_count = calc_count;
+        rec.fastpath_used = read_fastpath_used(vc_);
+        rec.fastpath_fn = vc_fastpath_active();
+        rec.boxnum.resize(static_cast<size_t>(calc_count), -1);
+        rec.calclist.assign(calclist_.begin(), calclist_.begin() + calc_count);
+        for (int i = 0; i < calc_count; ++i) {
+            rec.boxnum[static_cast<size_t>(i)] = calc_[static_cast<size_t>(i)].boxnum;
+        }
+        const int dim3 = dim * dim * dim;
+        rec.box_slices = sorted_box_slices(box, dim3, calclist_.data(), calc_count);
+        if (box) std::free(box);
+        return rec;
+    }
+
+    void expect_fastpath_off()
+    {
+        EXPECT_FALSE(vc_fastpath_active())
+            << "vc_fastpath_active() must be false when the flag is OFF";
+        const int used = read_fastpath_used(vc_);
+        if (used >= 0) {
+            EXPECT_EQ(used, 0) << "fastpath_used must be 0 when the flag is OFF";
+        }
+    }
+};
+
+// Flag OFF, two evals of the same pose: no sticky state.
+TEST_F(RigidFastpathBitIdentity, OffSecondCallMatchesFirstOff)
+{
+    set_rigid_fastpath(false);
+    const PoseRecord a = eval_vcontacts(0);
+    const PoseRecord b = eval_vcontacts(0);
+    expect_pose_eq(a, b, "OFF call1 vs OFF call2 (pose 0)");
+    EXPECT_GE(static_cast<int>(a.scorable.size()), 1);
+    expect_fastpath_off();
+}
+
+// Gold OFF series vs ON series: boxnum, SAS, and ca_rec chain are bit-identical.
+TEST_F(RigidFastpathBitIdentity, OnMatchesOffBitIdentical)
+{
+    set_rigid_fastpath(false);
+    const std::vector<PoseRecord> off = eval_series();
+    ASSERT_EQ(static_cast<int>(off.size()), kNPoses);
+
+    restore_rest();
+    set_rigid_fastpath(true);
+    std::vector<PoseRecord> on;
+    on.reserve(static_cast<size_t>(kNPoses));
+    for (int p = 0; p < kNPoses; ++p) {
+        on.push_back(eval_vcontacts(p));
+    }
+    ASSERT_EQ(on.size(), off.size());
+
+    for (int p = 0; p < kNPoses; ++p) {
+        const std::string ctx = "OFF vs ON pose " + std::to_string(p);
+        expect_pose_eq(off[static_cast<size_t>(p)], on[static_cast<size_t>(p)], ctx.c_str());
+    }
+
+    // In-box poses should produce a real SAS/contact record, not just empty
+    // bookkeeping. OOB (pose 4) may still produce ligand-ligand contacts.
+    EXPECT_EQ(off[0].vcontacts_rc, 0) << "pose 0 Vcontacts rc (geometry/stub gap if nonzero)";
+    EXPECT_FALSE(off[0].scorable.empty());
+    bool any_chain = false;
+    for (const auto& ar : off[0].scorable) {
+        if (!ar.chain.empty()) any_chain = true;
+    }
+    EXPECT_TRUE(any_chain) << "expected at least one ca_rec contact on pose 0";
+}
+
+// After ON, unsetenv and re-run OFF: still matches the original OFF gold.
+TEST_F(RigidFastpathBitIdentity, OffAfterOnStillMatchesOriginalOff)
+{
+    set_rigid_fastpath(false);
+    const std::vector<PoseRecord> gold = eval_series();
+
+    restore_rest();
+    set_rigid_fastpath(true);
+    (void)eval_series();
+
+    restore_rest();
+    set_rigid_fastpath(false);
+    const std::vector<PoseRecord> off2 = eval_series();
+
+    ASSERT_EQ(gold.size(), off2.size());
+    for (int p = 0; p < kNPoses; ++p) {
+        const std::string ctx = "gold OFF vs post-ON OFF pose " + std::to_string(p);
+        expect_pose_eq(gold[static_cast<size_t>(p)], off2[static_cast<size_t>(p)], ctx.c_str());
+    }
+    expect_fastpath_off();
+}
+
+// index_protein-only bookkeeping: boxnum + per-box Calclist multiset.
+TEST_F(RigidFastpathBitIdentity, IndexProteinOffVsOnBitIdentical)
+{
+    apply_pose(0);
+    set_rigid_fastpath(false);
+    const IndexRecord off1 = eval_index();
+    const IndexRecord off2 = eval_index();
+    expect_index_eq(off1, off2, "index OFF call1 vs OFF call2");
+    EXPECT_EQ(off1.calc_count, kNAtoms);
+    EXPECT_EQ(static_cast<int>(off1.boxnum.size()), kNAtoms);
+
+    set_rigid_fastpath(true);
+    const IndexRecord on1 = eval_index();  // snapshot / first ON
+    const IndexRecord on2 = eval_index();  // incremental if the flag is wired
+    expect_index_eq(off1, on1, "index OFF vs ON call1");
+    expect_index_eq(off1, on2, "index OFF vs ON call2");
+
+    // Move only scorable atoms; rigid boxnums stay put under ON (and should
+    // recompute to the same cells under OFF).
+    apply_pose(1);
+    const IndexRecord on_moved = eval_index();
+    ASSERT_EQ(on_moved.boxnum.size(), on2.boxnum.size());
+    for (int i = 0; i < kNRec && i < on_moved.calc_count; ++i) {
+        EXPECT_EQ(on_moved.boxnum[static_cast<size_t>(i)],
+                  on2.boxnum[static_cast<size_t>(i)])
+            << "rigid boxnum drifted under ON after ligand move, atom " << i;
+    }
+
+    set_rigid_fastpath(false);
+    apply_pose(1);
+    const IndexRecord off_moved = eval_index();
+    expect_index_eq(off_moved, on_moved, "index OFF vs ON after ligand move");
+
+    // OOB translation: still bit-identical, grid may grow.
+    apply_pose(4);
+    set_rigid_fastpath(false);
+    const IndexRecord off_oob = eval_index();
+    set_rigid_fastpath(true);
+    (void)eval_index();  // first ON at this grid
+    const IndexRecord on_oob = eval_index();
+    expect_index_eq(off_oob, on_oob, "index OFF vs ON OOB pose");
+}
+
+// First ON eval may snapshot (legacy path). Call 2+ on a stable grid must
+// report the incremental path once the flag is wired in index_protein.
+TEST_F(RigidFastpathBitIdentity, FastpathActiveOnStableSecondOnEval)
+{
+    set_rigid_fastpath(true);
+    const PoseRecord first = eval_vcontacts(0);
+    (void)first;  // snapshot; do not require fastpath_used==1
+    const PoseRecord second = eval_vcontacts(1);  // same grid, ligand moved
+    EXPECT_TRUE(second.fastpath_fn)
+        << "vc_fastpath_active() must be true on stable-grid ON call 2+";
+    if (second.fastpath_used >= 0) {
+        EXPECT_EQ(second.fastpath_used, 1)
+            << "fastpath_used must be 1 on stable-grid ON call 2+";
+    }
+
+    restore_rest();
+    set_rigid_fastpath(false);
+    const PoseRecord off = eval_vcontacts(0);
+    EXPECT_FALSE(off.fastpath_fn);
+    if (off.fastpath_used >= 0) {
+        EXPECT_EQ(off.fastpath_used, 0);
+    }
+}
+
+// Default-OFF: never leave the flag set (TearDown also unsets).
+TEST_F(RigidFastpathBitIdentity, FlagDoesNotLeak)
+{
+    set_rigid_fastpath(true);
+    (void)eval_vcontacts(0);
+    clear_fastpath_env();
+    EXPECT_EQ(std::getenv(kFlag), nullptr);
+}


### PR DESCRIPTION
## Summary

Experimental acceleration work from the resumed OpenCode session (`ses_004387414ffeP32UMX2X4aj43A`), isolated worktree only. **Do not merge until Astex-85 A/B of the ON arms exists.** Official campaign `main` / Arm B (`PLAN_rng_ab.md`) is untouched.

### Chunk 1 — rigid-receptor fast path + flag overlay
- `FLEXAIDDS_RIGID_FASTPATH` (default **OFF**): incremental Voronoi index so per-eval cost tracks scorable atoms. Bookkeeping only; tests assert bit-identical boxnum / Calclist / `ca_rec`.
- Overlay `FLEXAIDDS_FLAGS=hoist,epoch,fastpath,…` plus `apply_to_environ()`. **No knobs deleted.** Mutual-exclusion losers are auto-disabled.

### Chunk 2 — cube-screen two-stage wiring + provenance
- Clean-room wording: published method (bioRxiv **2025.02.17.638675v2**, Zenodo **10.5281/zenodo.16861024**). Removed “translation of `process_target.py`”. GPL NRGRank source is not a dependency; the Zenodo record is CC-BY-4.0 supplementary scores/sites, not the energy matrix.
- `--screen` now goes through `TwoStageScreener` and writes `{prefix}_screen/unified.csv` + `RUN_RECEIPT.json`.
- `--screen-dock` (default OFF) sets a Stage-2 hook labeled **`surrogate`** (composition placeholder, same honesty as `ParallelCampaign`). Not a Voronoi CF and not ΔG.
- `--campaign --coarse-prefilter` (default OFF) cube-screens the library and docks only top-N through the existing campaign loop.
- `flexaid_screen` also emits unified CSV + receipt.

## Change class (pick **one** primary)

- [x] **Science enhancement** — opt-in; env/CLI-gated **OFF**

`python3 scripts/classify_diff.py origin/main HEAD` → `VERDICT: engine-critical`. Intent is gated OFF.

## Science-Impact

- [x] gated OFF — `FLEXAIDDS_RIGID_FASTPATH` / `FLEXAIDDS_FLAGS`; `--screen-dock`; `--coarse-prefilter`

## Scope

- [x] Experimental surface only

## Release impact

- [x] affects CLI behavior (new opt-in flags; `--screen` now also writes screen artifacts)
- [x] no user-facing default ranking change

## Validation

- [x] unit tests
  - `test_flexaidds_flags` 9/9
  - `test_rigid_fastpath` 6/6
  - `test_vcontacts` 22/22
  - `test_coarse_screen` 30/30 (unified CSV/receipt + mini enrichment)
- [ ] smoke benchmark / Astex-85 ON-arm (required before merge)
- [x] isolated clang++ + Homebrew GTest (no LTO campaign binary)

## Security and safety

- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

## Reproducibility

- [x] no benchmark claim involved
- [x] benchmark language remains preliminary

## Notes

- Draft on purpose. Reviewers: `--screen` stdout ranking is still coarse CF; extra files are new. `--screen-dock` is **not** a real GA dock.
- Worktree: `/Users/lp.more/Projects/FlexAIDdS-exp-fastpath`.