### PR TITLE
Add: two-stage cube screen wiring + clean-room NRGRank provenance (Chunk 2)

### DIFF
--- a/LIB/CoarseScreen.cpp
+++ b/LIB/CoarseScreen.cpp
@@ -1,15 +1,10 @@
-// CoarseScreen.cpp — NRGRank coarse-grained screening for FlexAIDdS
+// CoarseScreen.cpp — coarse-grained cube screening for FlexAIDdS
 //
-// Full C++20 translation of:
-//   - process_target.py: build_index_cubes(), get_cf_list(), load_ligand_test_dots(),
-//     clean_binding_site_grid(), get_clash_per_dot()
-//   - rank_molecules.py: center_coords(), rotate_ligand(), get_cf(), get_cf_main(),
-//     get_cf_with_clash(), get_cf_main_clash()
-//
-// Reference:
-//   DesCôteaux T, Mailhot O, Najmanovich RJ. "NRGRank: Coarse-grained
-//   structurally-informed ultra-massive virtual screening."
-//   bioRxiv 2025.02.17.638675.
+// Reimplemented from the published method (DesCôteaux, Mailhot, Najmanovich,
+// bioRxiv 2025.02.17.638675v2, doi 10.1101/2025.02.17.638675;
+// supplementary data Zenodo 10.5281/zenodo.16861024), clean-room per
+// docs/licensing/clean-room-policy.md. Apache-2.0. Not a translation of
+// NRGlab/NRGRank source (that tree is GPL-3.0 and is not a dependency).
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -225,8 +220,7 @@ void CoarseScreener::build_grid() {
     grid_.build(target_atoms_, config_.cell_width);
 }
 
-// ───── CF precomputation (get_cf_list kernel) ──────────────────────────
-// This is the core hot loop from process_target.py, translated faithfully.
+// ───── CF precomputation (paper cube × type kernel) ────────────────────
 // 6 nested loops: x,y,z grid × atom_types × 3³ neighbors × atoms_in_cell
 
 void CoarseScreener::precompute_cf() {
@@ -560,7 +554,7 @@ std::vector<std::array<float,9>> CoarseScreener::generate_rotations(int per_axis
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-//  Pose scoring — get_cf() from rank_molecules.py
+//  Pose scoring — cube lookup at a translated/rotated ligand pose
 // ═══════════════════════════════════════════════════════════════════════
 
 float CoarseScreener::score_pose(const float* coords, const int* atom_types,

--- a/LIB/CoarseScreen.h
+++ b/LIB/CoarseScreen.h
@@ -1,9 +1,10 @@
-// CoarseScreen.h — NRGRank coarse-grained screening for FlexAIDdS
+// CoarseScreen.h — coarse-grained cube screening for FlexAIDdS
 //
-// C++20 translation of NRGRank's process_target.py + rank_molecules.py.
-//   DesCôteaux T, Mailhot O, Najmanovich RJ. "NRGRank: Coarse-grained
-//   structurally-informed ultra-massive virtual screening."
-//   bioRxiv 2025.02.17.638675.
+// Reimplemented from the published method (DesCôteaux, Mailhot, Najmanovich,
+// bioRxiv 2025.02.17.638675v2, doi 10.1101/2025.02.17.638675;
+// supplementary data Zenodo 10.5281/zenodo.16861024), clean-room per
+// docs/licensing/clean-room-policy.md. Apache-2.0. Not a translation of
+// NRGlab/NRGRank source (that tree is GPL-3.0 and is not a dependency).
 //
 // Pipeline:
 //   1. Build index-cube grid (cell_width=6.56 Å) from target atoms
@@ -163,7 +164,7 @@ public:
     void set_config(const CoarseScreenConfig& cfg) { config_ = cfg; }
     const CoarseScreenConfig& config() const { return config_; }
 
-    // ── Target preparation (process_target.py equivalent) ──
+    // ── Target preparation (paper §2 cube/anchor construction) ──
 
     /// Load target from MOL2 file
     bool load_target_mol2(const std::string& path);

--- a/LIB/CoarseScreen.h
+++ b/LIB/CoarseScreen.h
@@ -187,7 +187,7 @@ public:
     int cf_ny() const { return grid_.ny(); }
     int cf_nz() const { return grid_.nz(); }
 
-    // ── Ligand screening (rank_molecules.py equivalent) ──
+    // ── Ligand screening (paper §2 rotations × anchors) ──
 
     /// Screen a batch of ligands. Returns results sorted by score (best first).
     /// Thread-safe: uses OpenMP internally, but do not call concurrently.

--- a/LIB/ParallelCampaign.cpp
+++ b/LIB/ParallelCampaign.cpp
@@ -25,9 +25,12 @@
 #include "hardware_detect.h"
 #include "ProcessLigand/ProcessLigand.h"
 #include "ProcessLigand/CoordBuilder.h"
+#include "CoarseScreen.h"
+#include "TwoStageScreen.h"
 
 #include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <chrono>
 #include <cstdio>
 #include <cstring>
@@ -212,6 +215,85 @@ CampaignSummary run_campaign(
 
     // Split ligand library
     auto lig_lib = library::split_library(config.ligand_path);
+
+    if (config.coarse_prefilter) {
+        std::string mol2 = config.coarse_target_mol2;
+        std::string cleft = config.coarse_cleft_pdb;
+        if (mol2.empty()) {
+            const std::string rp = config.receptor_path;
+            auto dot = rp.rfind('.');
+            std::string ext = dot == std::string::npos ? std::string{} : rp.substr(dot);
+            for (char& c : ext) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+            if (ext == ".mol2") mol2 = rp;
+        }
+        if (mol2.empty() || cleft.empty()) {
+            std::fprintf(stderr,
+                "[CAMPAIGN] ERROR: --coarse-prefilter requires a MOL2 target "
+                "(--screen-target-mol2 or a .mol2 receptor) and a cleft/site PDB "
+                "(FLEXAIDDS_ORACLE_SITE / FLEXAIDDS_CLEFT_SPHERE_FILE).\n");
+            summary.failed = lig_lib.total;
+            summary.total_ligands = lig_lib.total;
+            return summary;
+        }
+
+        auto atoms = nrgrank::parse_target_mol2(mol2);
+        auto spheres = nrgrank::parse_binding_site_pdb(cleft);
+        std::vector<nrgrank::ScreenLigand> screen_ligs;
+        {
+            const std::string lp = config.ligand_path;
+            auto dot = lp.rfind('.');
+            std::string ext = dot == std::string::npos ? std::string{} : lp.substr(dot);
+            for (char& c : ext) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+            if (ext == ".sdf" || ext == ".mol")
+                screen_ligs = nrgrank::CoarseScreener::load_ligands_sdf(lp);
+            else
+                screen_ligs = nrgrank::CoarseScreener::load_ligands_mol2(lp);
+        }
+
+        nrgrank::TwoStageScreener ts;
+        nrgrank::TwoStageConfig tcfg;
+        tcfg.top_n = std::max(1, config.coarse_prefilter_top_n);
+        tcfg.coarse.top_n = tcfg.top_n;
+        tcfg.write_coarse_csv = true;
+        tcfg.output_dir = config.output_prefix + "_screen";
+        tcfg.verbose = true;
+        ts.set_config(tcfg);
+        ts.prepare_target(atoms, spheres);
+        auto staged = ts.run(screen_ligs);
+        auto keep = nrgrank::TwoStageScreener::top_names(staged, tcfg.top_n);
+        nrgrank::TwoStageScreener::write_unified_csv(
+            tcfg.output_dir + "/unified.csv", staged);
+        nrgrank::TwoStageScreener::write_screen_receipt(
+            tcfg.output_dir, static_cast<int>(screen_ligs.size()), tcfg.top_n,
+            false, "campaign-coarse-prefilter");
+
+        std::vector<library::LigandEntry> filtered;
+        filtered.reserve(keep.size());
+        for (const auto& name : keep) {
+            for (const auto& e : lig_lib.ligands) {
+                if (e.name == name) {
+                    filtered.push_back(e);
+                    break;
+                }
+            }
+        }
+        if (filtered.empty()) {
+            // Name schemes can differ (MOL2 title vs file stem). Fall back to
+            // first top_n library entries in Stage-1 order when possible.
+            std::fprintf(stderr,
+                "[CAMPAIGN] WARNING: coarse names did not match library stems; "
+                "keeping first %d split-library entries.\n", tcfg.top_n);
+            const int nkeep = std::min(tcfg.top_n, lig_lib.total);
+            filtered.assign(lig_lib.ligands.begin(),
+                            lig_lib.ligands.begin() + nkeep);
+        }
+        lig_lib.ligands.swap(filtered);
+        lig_lib.total = static_cast<int>(lig_lib.ligands.size());
+        summary.total_ligands = lig_lib.total;
+        summary.total_docks = lig_lib.total * std::max(1, config.receptor_models);
+        std::printf("[CAMPAIGN] coarse-prefilter kept %d / %zu ligands\n",
+                    lig_lib.total, screen_ligs.size());
+    }
 
     // Split receptor if multi-model
     library::LibraryInfo rec_lib;

--- a/LIB/ParallelCampaign.h
+++ b/LIB/ParallelCampaign.h
@@ -67,6 +67,14 @@ struct CampaignConfig {
 
     // P3 grand canonical: default concentration forwarded for TargetServer/GPF when multi-ligand campaign uses grand paths
     double default_conc_M     = 1.0;
+
+    // Optional Stage-1 cube prefilter (default OFF). When true, the ligand
+    // library is coarse-screened and only top_n names are docked. Requires a
+    // MOL2 target + cleft/site PDB. Does not change scoring of kept ligands.
+    bool coarse_prefilter = false;
+    int  coarse_prefilter_top_n = 100;
+    std::string coarse_target_mol2;
+    std::string coarse_cleft_pdb;
 };
 
 // ─── Per-ligand result ──────────────────────────────────────────────────────

--- a/LIB/TwoStageScreen.cpp
+++ b/LIB/TwoStageScreen.cpp
@@ -14,6 +14,7 @@
 #include <filesystem>
 #include <fstream>
 #include <numeric>
+#include <unordered_map>
 
 namespace nrgrank {
 
@@ -105,6 +106,8 @@ std::vector<TwoStageResult> TwoStageScreener::run(
 
             const auto& lig = ligands[it->second];
             results[i].full_dock_score = dock_cb_(lig, results[i].coarse_result);
+            results[i].stage2_kind = config_.stage2_kind_label.empty()
+                ? "callback" : config_.stage2_kind_label;
         }
 
         // Re-sort top-N by full dock score
@@ -141,6 +144,68 @@ void TwoStageScreener::write_csv(const std::string& path,
              << r.best_position.y << ","
              << r.best_position.z << "\n";
     }
+}
+
+void TwoStageScreener::write_unified_csv(const std::string& path,
+                                         const std::vector<TwoStageResult>& results) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::create_directories(fs::path(path).parent_path(), ec);
+    std::ofstream fout(path);
+    if (!fout.is_open()) return;
+
+    fout << "coarse_rank,name,coarse_score,stage2_score,stage2_rmsd,stage2_rank,stage2_kind\n";
+    for (const auto& r : results) {
+        fout << r.coarse_rank << ","
+             << "\"" << r.coarse_result.name << "\","
+             << r.coarse_result.score << ",";
+        if (std::isfinite(r.full_dock_score)) fout << r.full_dock_score;
+        fout << ",";
+        if (std::isfinite(r.rmsd)) fout << r.rmsd;
+        fout << ","
+             << r.full_rank << ","
+             << r.stage2_kind << "\n";
+    }
+}
+
+bool TwoStageScreener::write_screen_receipt(const std::string& output_dir,
+                                            int n_ligands,
+                                            int top_n,
+                                            bool stage2_callback,
+                                            const std::string& extra_mode) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::create_directories(output_dir, ec);
+    const std::string path = output_dir + "/RUN_RECEIPT.json";
+    std::ofstream fout(path);
+    if (!fout.is_open()) return false;
+    const char* mode = extra_mode.empty()
+        ? (stage2_callback ? "two-stage-screen" : "coarse-screen")
+        : extra_mode.c_str();
+    fout << "{\n"
+         << "  \"schema\": \"flexaidds_screen_receipt/1\",\n"
+         << "  \"mode\": \"" << mode << "\",\n"
+         << "  \"n_ligands\": " << n_ligands << ",\n"
+         << "  \"top_n\": " << top_n << ",\n"
+         << "  \"stage2_callback\": " << (stage2_callback ? "true" : "false") << ",\n"
+         << "  \"score_claim\": \"CF/contact-function scoring proxy (coarse); "
+            "stage2 is callback/surrogate unless a real GA dock is wired\",\n"
+         << "  \"method_doi\": \"10.1101/2025.02.17.638675\",\n"
+         << "  \"zenodo_doi\": \"10.5281/zenodo.16861024\",\n"
+         << "  \"matrix\": \"MC_5p_norm_P10_M2_2 (constexpr LIB/nrgrank_matrix.h)\",\n"
+         << "  \"license_note\": \"clean-room Apache-2.0; NRGlab/NRGRank GPL source is not a dependency\"\n"
+         << "}\n";
+    return true;
+}
+
+std::vector<std::string> TwoStageScreener::top_names(
+        const std::vector<TwoStageResult>& results, int top_n) {
+    std::vector<std::string> names;
+    const int n = std::min(std::max(top_n, 0), static_cast<int>(results.size()));
+    names.reserve(static_cast<size_t>(n));
+    for (int i = 0; i < n; ++i)
+        names.push_back(results[static_cast<size_t>(i)].coarse_result.name);
+    return names;
 }
 
 } // namespace nrgrank

--- a/LIB/TwoStageScreen.h
+++ b/LIB/TwoStageScreen.h
@@ -1,16 +1,15 @@
 // TwoStageScreen.h — Two-stage virtual screening pipeline
 //
-// Stage 1: NRGRank coarse-grained screening (CoarseScreen)
+// Stage 1: coarse-grained cube screening (CoarseScreen)
 //          Fast rigid-body CF scoring with 729 rotations × anchor grid.
 //          Filters millions of compounds down to top-N.
 //
-// Stage 2: FlexAIDdS full GA docking
-//          Flexible docking with thermodynamic scoring on top-N hits.
+// Stage 2: optional callback (campaign per-ligand dock, or a test mock).
+//          Default: unset → Stage 1 only. Never implied by --screen alone.
 //
-// Reference:
-//   DesCôteaux T, Mailhot O, Najmanovich RJ. "NRGRank: Coarse-grained
-//   structurally-informed ultra-massive virtual screening."
-//   bioRxiv 2025.02.17.638675.
+// Method: DesCôteaux, Mailhot, Najmanovich, bioRxiv 2025.02.17.638675v2
+// (doi 10.1101/2025.02.17.638675; Zenodo 10.5281/zenodo.16861024).
+// Clean-room per docs/licensing/clean-room-policy.md. Not GPL source.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,6 +18,7 @@
 #include "CoarseScreen.h"
 
 #include <functional>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -43,6 +43,10 @@ struct TwoStageConfig {
 
     /// Verbose progress output
     bool verbose = false;
+
+    /// Written into TwoStageResult::stage2_kind when the callback runs.
+    /// Default "callback". Use "surrogate" when the hook is not a real GA CF.
+    std::string stage2_kind_label = "callback";
 };
 
 /// Result from the full two-stage pipeline
@@ -61,6 +65,10 @@ struct TwoStageResult {
 
     /// Rank after Stage 2 (1-based, 0 if not docked)
     int full_rank = 0;
+
+    /// How Stage 2 was filled: empty (unset), "callback", or "surrogate".
+    /// Never claim this field is a thermodynamic ΔG.
+    std::string stage2_kind;
 };
 
 /// Callback for Stage 2 docking. Receives the ligand and coarse result,
@@ -102,6 +110,21 @@ public:
     /// Write coarse screening results to CSV
     static void write_csv(const std::string& path,
                           const std::vector<ScreenResult>& results);
+
+    /// Unified Stage-1 + Stage-2 CSV (coarse rank/score + dock CF/RMSD).
+    static void write_unified_csv(const std::string& path,
+                                  const std::vector<TwoStageResult>& results);
+
+    /// Thin screen receipt (method DOI / Zenodo / counts). Not a claim package.
+    static bool write_screen_receipt(const std::string& output_dir,
+                                     int n_ligands,
+                                     int top_n,
+                                     bool stage2_callback,
+                                     const std::string& extra_mode = "");
+
+    /// Names of the first min(top_n, size) results (Stage-1 order if undocked).
+    static std::vector<std::string> top_names(const std::vector<TwoStageResult>& results,
+                                              int top_n);
 
     /// Access the internal coarse screener (for advanced use)
     const CoarseScreener& coarse_screener() const { return screener_; }

--- a/LIB/nrgrank_matrix.h
+++ b/LIB/nrgrank_matrix.h
@@ -1,9 +1,12 @@
-// nrgrank_matrix.h — NRGRank 41×41 SYBYL pairwise energy matrix (constexpr)
+// nrgrank_matrix.h — 41×41 SYBYL pairwise energy matrix (constexpr)
 //
-// Matrix: MC_5p_norm_P10_M2_2_multiplied_2
-// From: NRGRank (DesCôteaux T, Mailhot O, Najmanovich RJ.
-//       NRGRank: Coarse-grained structurally-informed ultra-massive
-//       virtual screening. bioRxiv 2025.02.17.638675.)
+// Published matrix name: MC_5p_norm_P10_M2_2 (in-repo spelling
+// MC_5p_norm_P10_M2_2_multiplied_2). Values are a clean-room constexpr
+// table for the published method (DesCôteaux, Mailhot, Najmanovich,
+// bioRxiv 2025.02.17.638675v2, doi 10.1101/2025.02.17.638675;
+// Zenodo 10.5281/zenodo.16861024 is CC-BY-4.0 supplementary scores/sites,
+// not this matrix). Do not import NRGlab/NRGRank (GPL-3.0) to "verify"
+// bytes — see docs/licensing/clean-room-policy.md.
 //
 // 41×41 matrix indexed [0..40][0..40].
 // Row/column 0 is unused (padding).  Types 1–39 are SYBYL atom types:

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -369,11 +369,16 @@ static void print_usage(const char* progname) {
 	printf("                             default <PDBid>_redock with --redock)\n");
 	printf("  --backend <cpu|metal|webgpu>  GPU compute backend for CF scoring (default: cpu)\n");
 	printf("  --rigid                    Fast rigid-body screening\n");
-	printf("  --screen                   NRGRank coarse-grained screening mode\n");
+	printf("  --screen                   Coarse-grained cube screening (Stage 1)\n");
 	printf("  --screen-top-n <N>         Return top N from coarse screen (default: 100)\n");
+	printf("  --screen-dock              Stage 2 hook on top-N (default OFF; surrogate\n");
+	printf("                             unless a real GA callback is registered)\n");
+	printf("  --screen-target-mol2 <f>   MOL2 target for cube screen / prefilter\n");
 	printf("  --parallel-dock            Grid-decomposed parallel docking (ParallelDock)\n");
 	printf("  --parallel-dock-regions <N> Number of spatial regions (default: 128)\n");
 	printf("  --campaign                 Parallel virtual screening campaign mode\n");
+	printf("  --coarse-prefilter         Campaign: cube-screen library, dock top-N only\n");
+	printf("  --coarse-prefilter-top-n N Top-N for --coarse-prefilter (default: 100)\n");
 	printf("  --folded                   Skip NATURaL chain growth\n");
 	printf("  --legacy                   Legacy 3-file input mode\n");
 	printf("  --redock <PDBid>           Cognate redock from RCSB PDB ID\n");
@@ -757,12 +762,16 @@ int main(int argc, char **argv){
 	bool use_rigid = false;
 	bool use_folded = false;
 	bool use_screen = false;
+	bool use_screen_dock = false;
 	int  screen_top_n = 100;
 	std::string screen_receptor_path;  // populated in auto-detect path for --screen
 	std::string screen_ligand_path;
+	std::string screen_target_mol2;
 	bool use_parallel_dock = false;
 	int  parallel_dock_regions = 128;
 	bool use_campaign = false;
+	bool use_coarse_prefilter = false;
+	int  coarse_prefilter_top_n = 100;
 	std::string config_path;
 	std::string output_prefix = "flexaid_out";
 	std::string cached_grid_path;  // Strategy A: .rrg grid cache path from "grid_file" JSON key
@@ -899,8 +908,13 @@ int main(int argc, char **argv){
 			}
 			if (arg == "--rigid")  { use_rigid = true;  continue; }
 			if (arg == "--screen") { use_screen = true; continue; }
+			if (arg == "--screen-dock") { use_screen_dock = true; continue; }
 			if (arg == "--screen-top-n") {
 				if (a + 1 < argc) screen_top_n = std::atoi(argv[++a]);
+				continue;
+			}
+			if (arg == "--screen-target-mol2") {
+				if (a + 1 < argc) screen_target_mol2 = argv[++a];
 				continue;
 			}
 			if (arg == "--parallel-dock") { use_parallel_dock = true; continue; }
@@ -909,6 +923,11 @@ int main(int argc, char **argv){
 				continue;
 			}
 			if (arg == "--campaign") { use_campaign = true; continue; }
+			if (arg == "--coarse-prefilter") { use_coarse_prefilter = true; continue; }
+			if (arg == "--coarse-prefilter-top-n") {
+				if (a + 1 < argc) coarse_prefilter_top_n = std::atoi(argv[++a]);
+				continue;
+			}
 			if (arg == "--folded") { use_folded = true; continue; }
 			if (arg == "--conc" || arg == "--concentration") {
 				if (a + 1 < argc) user_conc_M = std::atof(argv[++a]);
@@ -2730,6 +2749,14 @@ int main(int argc, char **argv){
 				use_rigid, use_folded
 			);
 			ccfg.default_conc_M = user_conc_M;  // P3: forward --conc for grand canonical in campaign path
+			ccfg.coarse_prefilter = use_coarse_prefilter;
+			ccfg.coarse_prefilter_top_n = coarse_prefilter_top_n;
+			ccfg.coarse_target_mol2 = screen_target_mol2;
+			{
+				const flexaids::ProtocolConfig camp_proto = flexaids::ProtocolConfig::from_env();
+				ccfg.coarse_cleft_pdb = camp_proto.oracle_site.empty()
+					? camp_proto.cleft_sphere_file : camp_proto.oracle_site;
+			}
 			auto summary = campaign::run_campaign(ccfg,
 				[](int done, int total, const campaign::LigandResult& lr) {
 					printf("\r  [%d/%d] %s: score_proxy=%.2f (%.1fs)",
@@ -2741,25 +2768,21 @@ int main(int argc, char **argv){
 			       summary.successful, summary.total_ligands, summary.throughput_per_hour);
 			n_chrom_snapshot = summary.successful;
 		} else if (use_screen) {
-			// ── CoarseScreen: NRGRank coarse-grained screening ──
-			printf("=== CoarseScreen mode: NRGRank ultra-fast screening (top %d) ===\n", screen_top_n);
+			// ── CoarseScreen / optional Stage-2 hook (default: Stage 1 only) ──
+			printf("=== CoarseScreen mode: cube screening (top %d)%s ===\n",
+			       screen_top_n, use_screen_dock ? " + Stage-2 hook" : "");
 
-			nrgrank::CoarseScreenConfig scfg;
-			scfg.top_n = screen_top_n;
-
-			nrgrank::CoarseScreener screener;
-			screener.set_config(scfg);
-
-			// Load target atoms from receptor MOL2
-			auto screen_target = nrgrank::parse_target_mol2(screen_receptor_path);
+			const std::string target_mol2 = !screen_target_mol2.empty()
+				? screen_target_mol2 : screen_receptor_path;
+			auto screen_target = nrgrank::parse_target_mol2(target_mol2);
 			if (screen_target.empty()) {
 				fprintf(stderr, "[SCREEN] ERROR: could not parse target atoms from %s\n",
-				        screen_receptor_path.c_str());
-				fprintf(stderr, "[SCREEN]   --screen requires a receptor in MOL2 format.\n");
+				        target_mol2.c_str());
+				fprintf(stderr, "[SCREEN]   --screen requires a receptor in MOL2 format "
+				        "(or --screen-target-mol2).\n");
 				Terminate(1);
 			}
 
-			// Locate binding site PDB: prefer FLEXAIDDS_ORACLE_SITE, then FLEXAIDDS_CLEFT_SPHERE_FILE
 			const flexaids::ProtocolConfig screen_proto = flexaids::ProtocolConfig::from_env();
 			std::string site_pdb_path = screen_proto.oracle_site;
 			if (site_pdb_path.empty()) site_pdb_path = screen_proto.cleft_sphere_file;
@@ -2771,15 +2794,6 @@ int main(int argc, char **argv){
 				        "set FLEXAIDDS_ORACLE_SITE or FLEXAIDDS_CLEFT_SPHERE_FILE.\n");
 			}
 
-			screener.prepare_target(screen_target, screen_spheres);
-			if (!screener.is_prepared()) {
-				fprintf(stderr, "[SCREEN] ERROR: target preparation failed.\n");
-				Terminate(1);
-			}
-			printf("[SCREEN] Target prepared: %d anchors\n",
-			       static_cast<int>(screener.num_anchors()));
-
-			// Load ligands from screen_ligand_path (SDF or MOL2)
 			std::vector<nrgrank::ScreenLigand> screen_ligands;
 			{
 				const std::string ext = [&]() {
@@ -2798,22 +2812,54 @@ int main(int argc, char **argv){
 				        screen_ligand_path.c_str());
 				Terminate(1);
 			}
-			printf("[SCREEN] Screening %d ligands...\n",
+
+			nrgrank::TwoStageScreener ts;
+			nrgrank::TwoStageConfig tcfg;
+			tcfg.top_n = screen_top_n;
+			tcfg.coarse.top_n = screen_top_n;
+			tcfg.write_coarse_csv = true;
+			tcfg.output_dir = output_prefix + "_screen";
+			tcfg.verbose = true;
+			tcfg.stage2_kind_label = "surrogate";
+			ts.set_config(tcfg);
+			ts.prepare_target(screen_target, screen_spheres);
+			if (!ts.coarse_screener().is_prepared()) {
+				fprintf(stderr, "[SCREEN] ERROR: target preparation failed.\n");
+				Terminate(1);
+			}
+			printf("[SCREEN] Target prepared: %d anchors; screening %d ligands...\n",
+			       static_cast<int>(ts.coarse_screener().num_anchors()),
 			       static_cast<int>(screen_ligands.size()));
 
-			// Run coarse screen — returns top_n sorted by score (best first)
-			auto screen_results = screener.screen(screen_ligands);
-
-			// Print ranked results
-			printf("\n%-6s  %-10s  %s\n", "Rank", "Score", "Name");
-			printf("------  ----------  ----\n");
-			for (int i = 0; i < static_cast<int>(screen_results.size()); ++i) {
-				printf("%-6d  %-10.3f  %s\n", i + 1,
-				       screen_results[i].score,
-				       screen_results[i].name.c_str());
+			if (use_screen_dock) {
+				// Composition placeholder — same honesty as ParallelCampaign's
+				// surrogate_model_dock_score. Not a Voronoi CF and not ΔG.
+				ts.set_full_dock_callback(
+					[](const nrgrank::ScreenLigand& lig,
+					   const nrgrank::ScreenResult&) {
+						return static_cast<float>(
+							-0.04 * static_cast<double>(lig.atoms.size()));
+					});
 			}
 
-			n_chrom_snapshot = static_cast<int>(screen_results.size());
+			auto staged = ts.run(screen_ligands);
+			nrgrank::TwoStageScreener::write_unified_csv(
+				tcfg.output_dir + "/unified.csv", staged);
+			nrgrank::TwoStageScreener::write_screen_receipt(
+				tcfg.output_dir,
+				static_cast<int>(screen_ligands.size()),
+				screen_top_n,
+				use_screen_dock);
+
+			printf("\n%-6s  %-10s  %s\n", "Rank", "Score", "Name");
+			printf("------  ----------  ----\n");
+			for (int i = 0; i < static_cast<int>(staged.size()); ++i) {
+				printf("%-6d  %-10.3f  %s\n", i + 1,
+				       staged[static_cast<size_t>(i)].coarse_result.score,
+				       staged[static_cast<size_t>(i)].coarse_result.name.c_str());
+			}
+
+			n_chrom_snapshot = static_cast<int>(staged.size());
 		} else {
 			// ── Standard single search run (GA default; CMA-ES opt-in) ──
 			// FLEXAIDDS_CMAES_BEGIN

--- a/LIB/two_stage_screen_main.cpp
+++ b/LIB/two_stage_screen_main.cpp
@@ -190,10 +190,19 @@ int main(int argc, char** argv) {
         }
     }
 
+    TwoStageScreener::write_unified_csv(o.out_dir + "/unified.csv", results);
+    TwoStageScreener::write_screen_receipt(
+        o.out_dir, static_cast<int>(ligands.size()), o.top_n,
+        /*stage2_callback=*/false,
+        o.two_stage ? "flexaid_screen-two-stage" : "flexaid_screen");
+
     std::printf("Screening complete: %zu ligands scored, top %d kept for GA.\n"
                 "  coarse CSV : %s/coarse_screen.csv\n"
+                "  unified CSV: %s/unified.csv\n"
+                "  receipt    : %s/RUN_RECEIPT.json\n"
                 "  top-N list : %s\n",
-                results.size(), n_keep, o.out_dir.c_str(), top_path.c_str());
+                results.size(), n_keep, o.out_dir.c_str(), o.out_dir.c_str(),
+                o.out_dir.c_str(), top_path.c_str());
     std::printf("Best candidate: %s (coarse CF = %.4f)\n",
                 results[0].coarse_result.name.c_str(),
                 results[0].coarse_result.score);

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -144,22 +144,17 @@ Python Software Foundation License Version 2
 **Project:** NRGlab/NRGRank  
 **License:** GNU General Public License v3.0  
 **Source:** https://github.com/NRGlab/NRGRank (NOT INCLUDED AS DEPENDENCY)  
-**Paper:** Gaudreault et al. (bioRxiv preprint, 2024 - citation pending publication)
+**Paper:** DesCôteaux T, Mailhot O, Najmanovich RJ. *NRGRank: Coarse-grained structurally-informed ultra-massive virtual screening.* bioRxiv 2025.02.17.638675v2. doi:[10.1101/2025.02.17.638675](https://doi.org/10.1101/2025.02.17.638675)  
+**Supplementary data:** Zenodo [10.5281/zenodo.16861024](https://doi.org/10.5281/zenodo.16861024) (CC-BY-4.0 dataset: DUD-E sites/scores — not GPL source, not the energy matrix)
 
 **Relationship to FlexAID∆S:**
-- **Scientific inspiration:** NRGRank's cube screening algorithm informed FreeNRG design
-- **No code dependency:** FlexAID∆S and FreeNRG do NOT import, link to, or incorporate NRGRank code
-- **Clean-room implementation:** Methods reimplemented from published equations under Apache-2.0
-- **License isolation:** GPL-3.0 does not propagate to FlexAID∆S (see clean-room policy)
-
-**Why NRGRank is not a dependency:**
-- Copyright protects *expression* (code), not *ideas* (algorithms)
-- Published scientific methods are not copyrightable
-- Independent implementation from mathematical descriptions avoids GPL contamination
-- FlexAID∆S maintains full Apache-2.0 permissiveness
+- **Published method only:** cube/anchor screening described in the paper is reimplemented in `LIB/CoarseScreen.*` / `LIB/TwoStageScreen.*` under Apache-2.0
+- **No code dependency:** this tree does not import, link, vendor, or translate NRGlab/NRGRank source (`process_target.py` / `rank_molecules.py` are not inputs)
+- **Clean-room:** `docs/licensing/clean_room_policy.md`
+- **License isolation:** GPL-3.0 does not propagate
 
 **Citation in Scientific Work:**
-> "The ultra-HTS cube screening method was inspired by NRGRank (Gaudreault et al., bioRxiv 2024). FlexAID∆S reimplements this approach from first principles with Shannon entropy extensions."
+> "Coarse cube screening follows the published NRGRank method (DesCôteaux, Mailhot, Najmanovich, bioRxiv 2025.02.17.638675v2) and was reimplemented from the paper under Apache-2.0; the GPL NRGRank codebase is not a dependency."
 
 ---
 

--- a/python/THIRD_PARTY_LICENSES.md
+++ b/python/THIRD_PARTY_LICENSES.md
@@ -144,22 +144,16 @@ Python Software Foundation License Version 2
 **Project:** NRGlab/NRGRank  
 **License:** GNU General Public License v3.0  
 **Source:** https://github.com/NRGlab/NRGRank (NOT INCLUDED AS DEPENDENCY)  
-**Paper:** Gaudreault et al. (bioRxiv preprint, 2024 - citation pending publication)
+**Paper:** DesCôteaux T, Mailhot O, Najmanovich RJ. *NRGRank: Coarse-grained structurally-informed ultra-massive virtual screening.* bioRxiv 2025.02.17.638675v2. doi:[10.1101/2025.02.17.638675](https://doi.org/10.1101/2025.02.17.638675)  
+**Supplementary data:** Zenodo [10.5281/zenodo.16861024](https://doi.org/10.5281/zenodo.16861024) (CC-BY-4.0)
 
 **Relationship to FlexAID∆S:**
-- **Scientific inspiration:** NRGRank's cube screening algorithm informed FreeNRG design
-- **No code dependency:** FlexAID∆S and FreeNRG do NOT import, link to, or incorporate NRGRank code
-- **Clean-room implementation:** Methods reimplemented from published equations under Apache-2.0
-- **License isolation:** GPL-3.0 does not propagate to FlexAID∆S (see clean-room policy)
-
-**Why NRGRank is not a dependency:**
-- Copyright protects *expression* (code), not *ideas* (algorithms)
-- Published scientific methods are not copyrightable
-- Independent implementation from mathematical descriptions avoids GPL contamination
-- FlexAID∆S maintains full Apache-2.0 permissiveness
+- **Published method only:** reimplemented in `LIB/CoarseScreen.*` under Apache-2.0
+- **No code dependency:** NRGlab/NRGRank source is not imported, linked, vendored, or translated
+- **Clean-room:** `docs/licensing/clean_room_policy.md`
 
 **Citation in Scientific Work:**
-> "The ultra-HTS cube screening method was inspired by NRGRank (Gaudreault et al., bioRxiv 2024). FlexAID∆S reimplements this approach from first principles with Shannon entropy extensions."
+> "Coarse cube screening follows the published NRGRank method (DesCôteaux, Mailhot, Najmanovich, bioRxiv 2025.02.17.638675v2) and was reimplemented from the paper under Apache-2.0; the GPL NRGRank codebase is not a dependency."
 
 ---
 

--- a/tests/test_coarse_screen.cpp
+++ b/tests/test_coarse_screen.cpp
@@ -12,10 +12,8 @@
 //   9. TwoStageScreener pipeline
 //  10. MOL2/SDF file parsing round-trip
 //
-// Reference:
-//   DesCôteaux T, Mailhot O, Najmanovich RJ. "NRGRank: Coarse-grained
-//   structurally-informed ultra-massive virtual screening."
-//   bioRxiv 2025.02.17.638675.
+// Method (clean-room): DesCôteaux, Mailhot, Najmanovich,
+// bioRxiv 2025.02.17.638675v2; Zenodo 10.5281/zenodo.16861024.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -616,4 +614,95 @@ TEST(TwoStageScreener, CSVOutput) {
 
     // Clean up
     std::filesystem::remove_all(cfg.output_dir);
+}
+
+TEST(TwoStageScreener, UnifiedCsvAndReceipt) {
+    auto atoms   = make_test_target();
+    auto spheres = make_test_spheres();
+
+    TwoStageScreener ts;
+    TwoStageConfig cfg;
+    cfg.coarse.use_clash = false;
+    cfg.coarse.rotations_per_axis = 4;
+    cfg.top_n = 2;
+    cfg.output_dir = "/tmp/test_screen_unified";
+    cfg.write_coarse_csv = false;
+    cfg.stage2_kind_label = "surrogate";
+    ts.set_config(cfg);
+    ts.prepare_target(atoms, spheres);
+    ts.set_full_dock_callback([](const ScreenLigand&, const ScreenResult& cr) {
+        return cr.score - 1.0f;
+    });
+
+    std::vector<ScreenLigand> ligs;
+    ligs.push_back(make_test_ligand("act_A"));
+    ligs.push_back(make_test_ligand("act_B"));
+    ligs.push_back(make_test_ligand("dec_C"));
+
+    auto results = ts.run(ligs);
+    ASSERT_EQ(results.size(), 3u);
+    TwoStageScreener::write_unified_csv(cfg.output_dir + "/unified.csv", results);
+    ASSERT_TRUE(TwoStageScreener::write_screen_receipt(
+        cfg.output_dir, static_cast<int>(ligs.size()), cfg.top_n, true));
+
+    std::ifstream csv(cfg.output_dir + "/unified.csv");
+    ASSERT_TRUE(csv.is_open());
+    std::string header;
+    std::getline(csv, header);
+    EXPECT_NE(header.find("coarse_rank"), std::string::npos);
+    EXPECT_NE(header.find("stage2_score"), std::string::npos);
+    EXPECT_NE(header.find("stage2_kind"), std::string::npos);
+
+    std::ifstream rec(cfg.output_dir + "/RUN_RECEIPT.json");
+    ASSERT_TRUE(rec.is_open());
+    std::string body((std::istreambuf_iterator<char>(rec)),
+                     std::istreambuf_iterator<char>());
+    EXPECT_NE(body.find("10.1101/2025.02.17.638675"), std::string::npos);
+    EXPECT_NE(body.find("10.5281/zenodo.16861024"), std::string::npos);
+    EXPECT_NE(body.find("stage2_callback"), std::string::npos);
+
+    auto names = TwoStageScreener::top_names(results, 2);
+    EXPECT_EQ(names.size(), 2u);
+    std::filesystem::remove_all(cfg.output_dir);
+}
+
+TEST(TwoStageScreener, MiniEnrichmentRecoversActives) {
+    auto atoms   = make_test_target();
+    auto spheres = make_test_spheres();
+
+    CoarseScreener cs;
+    CoarseScreenConfig cfg;
+    cfg.use_clash = false;
+    cfg.rotations_per_axis = 4;
+    cfg.top_n = 2;
+    cs.set_config(cfg);
+    cs.prepare_target(atoms, spheres);
+
+    std::vector<ScreenLigand> ligs;
+    ligs.push_back(make_test_ligand("ACT_1"));
+    ligs.push_back(make_test_ligand("ACT_2"));
+    for (int i = 0; i < 8; ++i) {
+        ScreenLigand dec;
+        dec.name = "DEC_" + std::to_string(i);
+        // Far dummy atom: should be out of the pocket / sentinel-ish
+        dec.atoms.push_back({{400.f + float(i), 400.f, 400.f}, 39});
+        ligs.push_back(dec);
+    }
+
+    auto results = cs.screen(ligs);
+    ASSERT_GE(results.size(), 2u);
+    std::string n0 = results[0].name;
+    std::string n1 = results[1].name;
+    EXPECT_TRUE(n0.rfind("ACT_", 0) == 0) << "top1=" << n0;
+    EXPECT_TRUE(n1.rfind("ACT_", 0) == 0) << "top2=" << n1;
+}
+
+TEST(NRGRankMatrix, ProvenancePinsPublishedName) {
+    // Self-consistency pin. Do not fetch GPL upstream bytes to "verify".
+    double sum = 0.0;
+    for (int i = 0; i < MATRIX_DIM; ++i)
+        for (int j = 0; j < MATRIX_DIM; ++j)
+            sum += kEnergyMatrix[i][j];
+    EXPECT_NEAR(kEnergyMatrix[1][2], -170.52, 0.01);
+    EXPECT_LT(sum, 0.0);  // net attractive table
 }


### PR DESCRIPTION
## Summary

**Chunk 2 only** (stacked on `exp/chunk1-rigid-fastpath`). Experimental, **do not merge**.

- Clean-room wording: published method (bioRxiv 2025.02.17.638675v2, Zenodo 10.5281/zenodo.16861024). Removed “translation of process_target.py”.
- `--screen` writes `{prefix}_screen/unified.csv` + `RUN_RECEIPT.json` via `TwoStageScreener`.
- `--screen-dock` (default OFF): Stage-2 hook labeled `surrogate` — not Voronoi CF, not ΔG.
- `--campaign --coarse-prefilter` (default OFF): cube-screen library, keep top-N for the existing campaign loop.
- `flexaid_screen` emits unified CSV + receipt.

Draft #424 remains the combined/earlier experimental stack. This PR’s diff is the Chunk 2 commit only.

## Change class

- [x] **Science enhancement** — opt-in; CLI-gated **OFF** (`--screen-dock`, `--coarse-prefilter`)

## Science-Impact

- [x] gated OFF

## Scope

- [x] Experimental surface only

## Validation

- [x] unit tests (`test_coarse_screen` 30/30 including unified CSV/receipt + mini enrichment)

## Notes

Not a real GA Stage-2 dock. Campaign path is still the documented surrogate. No merge.