### PR TITLE
Fix: accel-stack B2/B1/S5/D6/B3 (one parser, lazy overlay, no silent drop)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1621,6 +1621,7 @@ flexaids_add_unit_test(test_protocol_config
     flexaids_add_unit_test(test_chunk5_layout
         SOURCES
             tests/test_chunk5_layout.cpp
+            LIB/get_yval.cpp
         TEST_NAME Chunk5LayoutTests
     )
 

--- a/LIB/EnvFlags.h
+++ b/LIB/EnvFlags.h
@@ -26,10 +26,10 @@
 
 namespace flexaids {
 
-/// Parse a FLEXAIDDS_* boolean switch. Unset/empty/unparseable → `fallback`.
-inline bool env_bool(const char* name, bool fallback = false) noexcept
+/// Parse a boolean string (already retrieved from the environment).
+/// Unset / empty / unparseable → `fallback`. `off`/`false`/`no`/`0` are OFF.
+inline bool env_bool_str(const char* raw, bool fallback = false) noexcept
 {
-    const char* raw = std::getenv(name);
     if (raw == nullptr) return fallback;
 
     // Trim surrounding whitespace; shell exports pick it up more often than
@@ -54,6 +54,25 @@ inline bool env_bool(const char* name, bool fallback = false) noexcept
         return false;
 
     return fallback;
+}
+
+/// Parse a FLEXAIDDS_* boolean switch. Unset/empty/unparseable → `fallback`.
+inline bool env_bool(const char* name, bool fallback = false) noexcept
+{
+    return env_bool_str(std::getenv(name), fallback);
+}
+
+/// Engine reader for FLEXAIDDS_RIGID_FASTPATH. Re-reads getenv (no pre-main
+/// snapshot) so apply_to_environ() overlays are visible.
+inline bool rigid_fastpath_requested() noexcept
+{
+    return env_bool("FLEXAIDDS_RIGID_FASTPATH", false);
+}
+
+/// Engine reader for FLEXAIDDS_HOIST_RECEPTOR_INDEX. Live getenv, default OFF.
+inline bool hoist_receptor_index_env() noexcept
+{
+    return env_bool("FLEXAIDDS_HOIST_RECEPTOR_INDEX", false);
 }
 
 /// FLEXAIDDS_PARALLEL_REPRODUCE — DEFAULT OFF (METHODOLOGY §1).

--- a/LIB/ParallelCampaign.cpp
+++ b/LIB/ParallelCampaign.cpp
@@ -267,25 +267,27 @@ CampaignSummary run_campaign(
             tcfg.output_dir, static_cast<int>(screen_ligs.size()), tcfg.top_n,
             false, "campaign-coarse-prefilter");
 
+        std::vector<std::string> lib_names;
+        lib_names.reserve(lig_lib.ligands.size());
+        for (const auto& e : lig_lib.ligands) lib_names.push_back(e.name);
+        std::vector<std::string> resolved;
+        if (!nrgrank::resolve_prefilter_keep(keep, lib_names, resolved)) {
+            std::fprintf(stderr,
+                "[CAMPAIGN] ERROR: --coarse-prefilter screen names did not "
+                "match library stems 1:1; aborting (no unranked prefix).\n");
+            summary.failed = lig_lib.total;
+            summary.total_ligands = lig_lib.total;
+            return summary;
+        }
         std::vector<library::LigandEntry> filtered;
-        filtered.reserve(keep.size());
-        for (const auto& name : keep) {
+        filtered.reserve(resolved.size());
+        for (const auto& name : resolved) {
             for (const auto& e : lig_lib.ligands) {
                 if (e.name == name) {
                     filtered.push_back(e);
                     break;
                 }
             }
-        }
-        if (filtered.empty()) {
-            // Name schemes can differ (MOL2 title vs file stem). Fall back to
-            // first top_n library entries in Stage-1 order when possible.
-            std::fprintf(stderr,
-                "[CAMPAIGN] WARNING: coarse names did not match library stems; "
-                "keeping first %d split-library entries.\n", tcfg.top_n);
-            const int nkeep = std::min(tcfg.top_n, lig_lib.total);
-            filtered.assign(lig_lib.ligands.begin(),
-                            lig_lib.ligands.begin() + nkeep);
         }
         lig_lib.ligands.swap(filtered);
         lig_lib.total = static_cast<int>(lig_lib.ligands.size());

--- a/LIB/RngSeed.h
+++ b/LIB/RngSeed.h
@@ -138,6 +138,13 @@ inline std::mt19937 make_thread_rng(std::uint64_t stream = 0)
 // The flag is re-read on seed-epoch change rather than on every call: the hot
 // path stays an atomic load plus a compare, and a test can flip the variable
 // and call set_master_seed() to pick it up.
+/// Voronoi hull-failure jitter source. DEFAULT OFF, independent of
+/// FLEXAIDDS_RNG_STREAM_FIX so an A/B of either gate stays single-variable.
+inline bool voronoi_keyed_jitter_enabled() noexcept
+{
+    return flexaids::env_bool("FLEXAIDDS_VORONOI_KEYED_JITTER", false);
+}
+
 inline bool rng_stream_fix_enabled()
 {
     thread_local std::uint64_t flag_epoch = ~0ULL;

--- a/LIB/TwoStageScreen.h
+++ b/LIB/TwoStageScreen.h
@@ -149,4 +149,32 @@ private:
     FullDockCallback  dock_cb_;
 };
 
+/// Fail-closed join: every screen keep name must match a library name.
+/// On mismatch or empty keep, `resolved` is cleared and the function
+/// returns false — the campaign must abort and must not write a screened
+/// `_results.csv`. No first-N split-library fallback.
+inline bool resolve_prefilter_keep(const std::vector<std::string>& keep,
+                                   const std::vector<std::string>& library_names,
+                                   std::vector<std::string>& resolved)
+{
+    resolved.clear();
+    if (keep.empty()) return false;
+    resolved.reserve(keep.size());
+    for (const auto& name : keep) {
+        bool found = false;
+        for (const auto& lib : library_names) {
+            if (lib == name) {
+                resolved.push_back(lib);
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            resolved.clear();
+            return false;
+        }
+    }
+    return true;
+}
+
 } // namespace nrgrank

--- a/LIB/Vcontacts.cpp
+++ b/LIB/Vcontacts.cpp
@@ -1,6 +1,7 @@
 #include "Vcontacts.h"
 #include "soft_wall.h"
 #include "RngSeed.h"
+#include "EnvFlags.h"
 #include "fileio.h"
 #include <algorithm>
 #include <cstdlib>
@@ -21,14 +22,6 @@
 // is implied; subsequent evals with a stable grid rebuild Calclist from a
 // rigid per-box snapshot + current scorable atoms (atmi-sorted per box).
 namespace {
-
-static bool rigid_fastpath_requested() {
-	const char* e = std::getenv("FLEXAIDDS_RIGID_FASTPATH");
-	return e && e[0] && e[0] != '0';
-}
-
-const bool kHoistReceptorIndexEnv =
-	(std::getenv("FLEXAIDDS_HOIST_RECEPTOR_INDEX") != nullptr);
 
 struct ScoSlot {
 	int calc_idx;
@@ -845,8 +838,8 @@ RESTART:
 				origcoor[2] = VC->Calc[atomzero].atom->coor[2];
 				
 				// perturb atom coordinates (deterministic when ga.seed/FLEXAID_SEED set)
-				if (flexaids_rng::rng_stream_fix_enabled()) {
-					// F2: key on pose+atom identity, not the scheduling thread.
+				if (flexaids_rng::voronoi_keyed_jitter_enabled()) {
+					// Independent of FLEXAIDDS_RNG_STREAM_FIX (D6).
 					const int anum = VC->Calc[atomzero].atom
 						? VC->Calc[atomzero].atom->number : atomzero;
 					const std::uint64_t id = flexaids_rng::pose_atom_identity(
@@ -2102,8 +2095,9 @@ atomindex* index_protein(FA_Global* FA,atom* atoms,resid* residue,atomsas* Calc,
 	// reproduces today's results bit-for-bit unless the flag is set.
 	// FLEXAIDDS_RIGID_FASTPATH implies hoist; HOIST still works alone when
 	// FASTPATH is off.
-	const bool fastpath_on = rigid_fastpath_requested();
-	const bool hoist_receptor_index = kHoistReceptorIndexEnv || fastpath_on;
+	const bool fastpath_on = flexaids::rigid_fastpath_requested();
+	const bool hoist_receptor_index =
+		flexaids::hoist_receptor_index_env() || fastpath_on;
 	g_fastpath_on = fastpath_on;
 	g_fastpath_used = false;
 	if(!fastpath_on){

--- a/LIB/ca_rec_flat.h
+++ b/LIB/ca_rec_flat.h
@@ -10,6 +10,8 @@
 #include "EnvFlags.h"
 #include "Vcontacts.h"
 
+#include <vector>
+
 namespace flexaids {
 
 inline bool ca_rec_flat_enabled() noexcept
@@ -17,16 +19,49 @@ inline bool ca_rec_flat_enabled() noexcept
     return env_bool("FLEXAIDDS_CA_REC_FLAT", false);
 }
 
+/// Uncapped prev-chain length (legacy walk). `curr` follows prev to -1.
+inline int ca_rec_chain_len(const int* ca_index, const ca_struct* ca_rec, int atom)
+{
+    if (!ca_index || !ca_rec || atom < 0) return 0;
+    int n = 0;
+    int curr = ca_index[atom];
+    while (curr != -1) {
+        ++n;
+        curr = ca_rec[curr].prev;
+    }
+    return n;
+}
+
 /// Fill `out[0..)` with ca_rec indices in walk order. Returns count.
+/// If the chain is longer than `cap`, returns `-(needed)` so callers cannot
+/// silently treat a prefix as the full walk.
 inline int flatten_ca_rec(const int* ca_index, const ca_struct* ca_rec,
                           int atom, int* out, int cap)
 {
     if (!ca_index || !ca_rec || !out || cap <= 0 || atom < 0) return 0;
+    const int need = ca_rec_chain_len(ca_index, ca_rec, atom);
+    if (need > cap) return -need;
     int n = 0;
     int curr = ca_index[atom];
     while (curr != -1 && n < cap) {
         out[n++] = curr;
         curr = ca_rec[curr].prev;
+    }
+    return n;
+}
+
+/// Flatten the full chain; never truncates. Returns count.
+inline int flatten_ca_rec_all(const int* ca_index, const ca_struct* ca_rec,
+                              int atom, std::vector<int>& out)
+{
+    out.clear();
+    const int need = ca_rec_chain_len(ca_index, ca_rec, atom);
+    if (need <= 0) return 0;
+    out.resize(static_cast<std::size_t>(need));
+    const int n = flatten_ca_rec(ca_index, ca_rec, atom, out.data(), need);
+    if (n < 0) {
+        out.clear();
+        return 0;
     }
     return n;
 }

--- a/LIB/flexaidds_flags.cpp
+++ b/LIB/flexaidds_flags.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "flexaidds_flags.h"
+#include "EnvFlags.h"
 
 #include <cctype>
 #include <cstdlib>
@@ -50,10 +51,10 @@ std::string norm_key(const char* s) {
     return o;
 }
 
-// Truthiness: unset / empty / leading '0' → off; any other non-empty → on.
-// Matches existing gates that test `e && e[0] != '\0' && e[0] != '0'`.
+// One parser: off/false/no/0/empty/unset → OFF; 1/true/on/yes → ON.
+// Unparseable values do not flip a gate (fallback false).
 bool env_truthy(const char* e) {
-    return e && e[0] != '\0' && e[0] != '0';
+    return flexaids::env_bool_str(e, false);
 }
 
 const char* env_raw(const char* name) {
@@ -102,6 +103,7 @@ void seed_runtime_gates() {
         "FLEXAIDDS_CA_REC_FLAT",
         "FLEXAIDDS_PARALLEL_REPRODUCE",
         "FLEXAIDDS_RNG_STREAM_FIX",
+        "FLEXAIDDS_VORONOI_KEYED_JITTER",
         "FLEXAID_DETERMINISTIC",
         "FLEXAIDDS_FORCE_CPU",
         "FLEXAIDDS_FORCE_RIGID",
@@ -265,6 +267,8 @@ void seed_runtime_gates() {
     add_alias("fastpath", "FLEXAIDDS_RIGID_FASTPATH");
     add_alias("rng-stream-fix", "FLEXAIDDS_RNG_STREAM_FIX");
     add_alias("rng_stream_fix", "FLEXAIDDS_RNG_STREAM_FIX");
+    add_alias("keyed-jitter", "FLEXAIDDS_VORONOI_KEYED_JITTER");
+    add_alias("keyed_jitter", "FLEXAIDDS_VORONOI_KEYED_JITTER");
 }
 
 void add_compile(const char* name, bool on, const char* note) {

--- a/LIB/vcfunction.cpp
+++ b/LIB/vcfunction.cpp
@@ -7,6 +7,7 @@
 #include "GISTGrid.h"
 #include "ProtocolConfig.h"
 #include "ca_rec_flat.h"
+#include "EnvFlags.h"
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -179,14 +180,7 @@ static const double wal_stiff = [](){
 static const bool contacts_epoch_mode =
     (std::getenv("FLEXAIDDS_CONTACTS_EPOCH") != nullptr);
 
-// FLEXAIDDS_RIGID_FASTPATH (truthy, default OFF): walk only Calc[] indices
-// with score==true. List comes from VC->scorable_list / n_scorable when the
-// sibling fields exist, else vc_scorable_indices(). OFF or a missing list
-// keeps the original O(N) atom walk bit-identical.
-static const bool rigid_fastpath = [](){
-    const char* s = std::getenv("FLEXAIDDS_RIGID_FASTPATH");
-    return s && s[0] != '\0' && s[0] != '0';
-}();
+// FLEXAIDDS_RIGID_FASTPATH: live getenv via env_bool (no pre-main snapshot).
 
 // provided by Vcontacts.cpp (sibling). Weak stubs keep this TU linkable
 // until those helpers land; a strong definition in Vcontacts.cpp wins.
@@ -332,7 +326,8 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 	if(rv < 0){
 		*error = true;
 		
-		vc_null_scorable_atoms(VC, FA->atm_cnt_real, rigid_fastpath);
+		vc_null_scorable_atoms(VC, FA->atm_cnt_real,
+		                       flexaids::rigid_fastpath_requested());
 		
 		if(!FA->vindex){ free(VC->box); }
 		
@@ -347,7 +342,7 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 	
 	int fp_n = 0;
 	const int* fp_idx = nullptr;
-	if (rigid_fastpath)
+	if (flexaids::rigid_fastpath_requested())
 		fp_idx = vcfunction_scorable_list(VC, &fp_n);
 	const bool use_fp = (fp_idx != nullptr && fp_n > 0);
 
@@ -472,12 +467,24 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 		// Only touched when the term is enabled (weight != 0) — zero overhead OFF.
 		double pd_hb = 0.0, pd_elec = 0.0, pd_mc = 0.0;
 		int currindex = VC->ca_index[i];
-		int flat_idx[MAX_CONT];
+		int flat_stack[MAX_CONT];
+		std::vector<int> flat_heap;
+		int* flat_idx = nullptr;
 		int nflat = 0, flat_k = 0;
 		const bool use_flat = flexaids::ca_rec_flat_enabled();
 		if (use_flat) {
-			nflat = flexaids::flatten_ca_rec(VC->ca_index, VC->ca_rec, i,
-			                                flat_idx, MAX_CONT);
+			const int nneed = flexaids::ca_rec_chain_len(VC->ca_index, VC->ca_rec, i);
+			if (nneed > MAX_CONT) {
+				flat_heap.resize(static_cast<std::size_t>(nneed));
+				flat_idx = flat_heap.data();
+				nflat = flexaids::flatten_ca_rec(VC->ca_index, VC->ca_rec, i,
+				                                flat_idx, nneed);
+			} else {
+				flat_idx = flat_stack;
+				nflat = flexaids::flatten_ca_rec(VC->ca_index, VC->ca_rec, i,
+				                                flat_idx, MAX_CONT);
+			}
+			if (nflat < 0) nflat = 0;
 			currindex = (nflat > 0) ? flat_idx[0] : -1;
 			flat_k = 1;
 		}
@@ -1444,7 +1451,8 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 		}
 	}
 
-	vc_null_scorable_atoms(VC, FA->atm_cnt_real, rigid_fastpath);
+	vc_null_scorable_atoms(VC, FA->atm_cnt_real,
+	                       flexaids::rigid_fastpath_requested());
 
 	if(!FA->vindex){ free(VC->box); }
 	

--- a/tests/test_chunk5_layout.cpp
+++ b/tests/test_chunk5_layout.cpp
@@ -5,6 +5,7 @@
 #include "niche_hash.h"
 #include "ca_rec_flat.h"
 #include "pprop.h"
+#include "get_yval.h"
 
 #include <cstdlib>
 #include <vector>
@@ -88,6 +89,79 @@ TEST(CaRecFlat, SkipFirstThenEachIndexOnce) {
     EXPECT_EQ(seen[0], 1);
     EXPECT_EQ(seen[1], 0);
     EXPECT_NE(seen[0], seen[1]);
+}
+
+TEST(CaRecFlat, MoreThan100ContactsMatchesUncappedWalkAndCf) {
+    // S5: MAX_CONT is 100. A 120-contact chain must not drop a prefix.
+    constexpr int kN = 120;
+    std::vector<ca_struct> rec(kN);
+    for (int i = 0; i < kN; ++i) {
+        rec[i].prev = (i == 0) ? -1 : i - 1;
+        rec[i].atom = 1000 + i;
+        rec[i].area = 0.1 * (i + 1);
+        rec[i].dist = 3.0;
+    }
+    int ca_index[1] = {kN - 1};
+
+    std::vector<int> legacy;
+    int curr = ca_index[0];
+    while (curr != -1) {
+        legacy.push_back(curr);
+        curr = rec[curr].prev;
+    }
+    ASSERT_EQ(legacy.size(), static_cast<size_t>(kN));
+
+    int too_small[100];
+    EXPECT_EQ(flexaids::flatten_ca_rec(ca_index, rec.data(), 0, too_small, 100),
+              -kN);
+
+    std::vector<int> flat;
+    const int n = flexaids::flatten_ca_rec_all(ca_index, rec.data(), 0, flat);
+    ASSERT_EQ(n, kN);
+    ASSERT_EQ(flat.size(), legacy.size());
+    for (int i = 0; i < kN; ++i) EXPECT_EQ(flat[i], legacy[i]);
+
+#ifdef _WIN32
+    _putenv_s("FLEXAIDDS_CA_REC_FLAT", "1");
+#else
+    setenv("FLEXAIDDS_CA_REC_FLAT", "1", 1);
+#endif
+    EXPECT_TRUE(flexaids::ca_rec_flat_enabled());
+#ifdef _WIN32
+    _putenv_s("FLEXAIDDS_GET_YVAL_LUT", "");
+#else
+    unsetenv("FLEXAIDDS_GET_YVAL_LUT");
+#endif
+
+    energy_values ev{};
+    ev.next_value = nullptr;
+    std::vector<float> xs{0.f, 1.f};
+    std::vector<float> ys{0.f, 10.f};
+    std::vector<float> sl{(10.f - 0.f) / 1.f};
+    energy_matrix em{};
+    em.weight = 0;
+    em.energy_values = &ev;
+    em.flat_n = 2;
+    em.flat_x = xs.data();
+    em.flat_y = ys.data();
+    em.flat_slope = sl.data();
+    constexpr double kSurfA = 50.0;
+
+    auto cf_of = [&](const std::vector<int>& idx) {
+        double cf = 0.0;
+        for (int id : idx)
+            cf += get_yval(&em, rec[id].area / kSurfA);
+        return cf;
+    };
+    EXPECT_DOUBLE_EQ(cf_of(flat), cf_of(legacy));
+    EXPECT_NE(cf_of(std::vector<int>(legacy.begin(), legacy.begin() + 100)),
+              cf_of(legacy));
+
+#ifdef _WIN32
+    _putenv_s("FLEXAIDDS_CA_REC_FLAT", "");
+#else
+    unsetenv("FLEXAIDDS_CA_REC_FLAT");
+#endif
 }
 
 TEST(PProp, RankFractionAndCap) {

--- a/tests/test_coarse_screen.cpp
+++ b/tests/test_coarse_screen.cpp
@@ -765,6 +765,26 @@ TEST(TwoStageScreener, MiniEnrichmentRecoversActives) {
     EXPECT_TRUE(n1.rfind("ACT_", 0) == 0) << "top2=" << n1;
 }
 
+TEST(TwoStageScreen, PrefilterKeepFailsClosedOnNameMismatch) {
+    std::vector<std::string> keep{"SCREEN_A", "SCREEN_B"};
+    std::vector<std::string> lib{"file_stem_1", "file_stem_2"};
+    std::vector<std::string> resolved;
+    EXPECT_FALSE(resolve_prefilter_keep(keep, lib, resolved));
+    EXPECT_TRUE(resolved.empty());
+
+    std::vector<std::string> mixed{"SCREEN_A", "file_stem_1"};
+    EXPECT_FALSE(resolve_prefilter_keep(keep, mixed, resolved));
+    EXPECT_TRUE(resolved.empty());
+
+    std::vector<std::string> ok_lib{"SCREEN_B", "SCREEN_A", "OTHER"};
+    ASSERT_TRUE(resolve_prefilter_keep(keep, ok_lib, resolved));
+    ASSERT_EQ(resolved.size(), 2u);
+    EXPECT_EQ(resolved[0], "SCREEN_A");
+    EXPECT_EQ(resolved[1], "SCREEN_B");
+
+    EXPECT_FALSE(resolve_prefilter_keep({}, lib, resolved));
+}
+
 TEST(NRGRankMatrix, ProvenancePinsPublishedName) {
     // Self-consistency pin. Do not fetch GPL upstream bytes to "verify".
     double sum = 0.0;

--- a/tests/test_flexaidds_flags.cpp
+++ b/tests/test_flexaidds_flags.cpp
@@ -5,12 +5,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "flexaidds_flags.h"
+#include "EnvFlags.h"
 
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <gtest/gtest.h>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 
@@ -47,6 +50,11 @@ protected:
             "FLEXAIDDS_CONTACTS_EPOCH",
             "FLEXAIDDS_PARALLEL_REPRODUCE",
             "FLEXAIDDS_RNG_STREAM_FIX",
+            "FLEXAIDDS_VORONOI_KEYED_JITTER",
+            "FLEXAIDDS_GET_YVAL_LUT",
+            "FLEXAIDDS_CA_REC_FLAT",
+            "FLEXAIDDS_NICHE_HASH",
+            "FLEXAIDDS_FIXED_ORDER_LSE",
             "FLEXAID_DETERMINISTIC",
             "FLEXAID_SEED",
             "FLEXAIDDS_FORCE_CPU",
@@ -84,6 +92,62 @@ std::string dump_to_string() {
 }
 
 }  // namespace
+
+TEST_F(FlexaiddsFlagsEnv, TruthTableOffFalseNoNeverEnable) {
+    // B2: one parser through env_bool, flags::active (env_truthy), and the
+    // engine reader flexaids::rigid_fastpath_requested().
+    const std::vector<std::pair<const char*, bool>> kCases = {
+        {"off", false}, {"false", false}, {"no", false}, {"0", false},
+        {"", false},
+        {"1", true}, {"true", true}, {"on", true}, {"yes", true},
+        {"OFF", false}, {"False", false}, {"NO", false},
+        {"TRUE", true}, {"On", true}, {"Yes", true},
+    };
+    for (const auto& [val, expect_on] : kCases) {
+        if (val[0] == '\0') clear_env("FLEXAIDDS_RIGID_FASTPATH");
+        else set_env("FLEXAIDDS_RIGID_FASTPATH", val);
+        resolve_env();
+        EXPECT_EQ(flexaids::env_bool_str(val, false), expect_on)
+            << "env_bool_str(" << val << ")";
+        EXPECT_EQ(flexaids::env_bool("FLEXAIDDS_RIGID_FASTPATH", false), expect_on)
+            << "env_bool(" << val << ")";
+        EXPECT_EQ(flexaidds::flags::active("FLEXAIDDS_RIGID_FASTPATH"), expect_on)
+            << "flags::active(" << val << ")";
+        EXPECT_EQ(flexaids::rigid_fastpath_requested(), expect_on)
+            << "rigid_fastpath_requested(" << val << ")";
+        // Overlay parser is shared: another acceleration gate must agree.
+        if (val[0] == '\0') clear_env("FLEXAIDDS_GET_YVAL_LUT");
+        else set_env("FLEXAIDDS_GET_YVAL_LUT", val);
+        resolve_env();
+        EXPECT_EQ(flexaidds::flags::active("FLEXAIDDS_GET_YVAL_LUT"), expect_on)
+            << "GET_YVAL_LUT flags::active(" << val << ")";
+        clear_env("FLEXAIDDS_GET_YVAL_LUT");
+    }
+}
+
+TEST_F(FlexaiddsFlagsEnv, OverlayApplyReachesEngineReaders) {
+    // B1: no individual env; overlay implies fastpath+hoist; after
+    // apply_to_environ the live engine readers must see ON.
+    set_env("FLEXAIDDS_FLAGS", "fastpath");
+    resolve_env();
+    flexaidds::flags::apply_to_environ();
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_RIGID_FASTPATH"));
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_HOIST_RECEPTOR_INDEX"));
+    ASSERT_NE(std::getenv("FLEXAIDDS_RIGID_FASTPATH"), nullptr);
+    ASSERT_NE(std::getenv("FLEXAIDDS_HOIST_RECEPTOR_INDEX"), nullptr);
+    EXPECT_TRUE(flexaids::rigid_fastpath_requested());
+    EXPECT_TRUE(flexaids::hoist_receptor_index_env());
+    EXPECT_TRUE(flexaids::env_bool("FLEXAIDDS_RIGID_FASTPATH", false));
+}
+
+TEST_F(FlexaiddsFlagsEnv, VoronoiKeyedJitterDefaultOffIndependentOfRngFix) {
+    resolve_env();
+    EXPECT_FALSE(flexaidds::flags::active("FLEXAIDDS_VORONOI_KEYED_JITTER"));
+    set_env("FLEXAIDDS_RNG_STREAM_FIX", "1");
+    resolve_env();
+    EXPECT_TRUE(flexaidds::flags::active("FLEXAIDDS_RNG_STREAM_FIX"));
+    EXPECT_FALSE(flexaidds::flags::active("FLEXAIDDS_VORONOI_KEYED_JITTER"));
+}
 
 TEST_F(FlexaiddsFlagsEnv, DefaultRigidFastpathInactive) {
     resolve_env();

--- a/tests/test_ga_context.cpp
+++ b/tests/test_ga_context.cpp
@@ -237,6 +237,30 @@ TEST(RngSeedTest, LazyThreadRngThreeStreamInterleaveKeepsEachSequence) {
     EXPECT_NE(g0, f0);
 }
 
+TEST(RngSeedTest, VoronoiKeyedJitterIndependentOfRngStreamFix) {
+    unset_test_env("FLEXAIDDS_RNG_STREAM_FIX");
+    unset_test_env("FLEXAIDDS_VORONOI_KEYED_JITTER");
+    flexaids_rng::set_master_seed(12345);
+    EXPECT_FALSE(flexaids_rng::voronoi_keyed_jitter_enabled());
+    {
+        ScopedEnv fix("FLEXAIDDS_RNG_STREAM_FIX", "1");
+        flexaids_rng::set_master_seed(12345);
+        EXPECT_TRUE(flexaids_rng::rng_stream_fix_enabled());
+        EXPECT_FALSE(flexaids_rng::voronoi_keyed_jitter_enabled());
+    }
+    flexaids_rng::set_master_seed(12345);
+    {
+        ScopedEnv jit("FLEXAIDDS_VORONOI_KEYED_JITTER", "1");
+        flexaids_rng::set_master_seed(12345);
+        EXPECT_TRUE(flexaids_rng::voronoi_keyed_jitter_enabled());
+        EXPECT_FALSE(flexaids_rng::rng_stream_fix_enabled());
+    }
+    {
+        ScopedEnv off("FLEXAIDDS_VORONOI_KEYED_JITTER", "off");
+        EXPECT_FALSE(flexaids_rng::voronoi_keyed_jitter_enabled());
+    }
+}
+
 TEST(RngSeedTest, KeyedJitterDependsOnPoseAtomNotDrawOrder) {
     ScopedEnv seed("FLEXAID_SEED", "12345");
     flexaids_rng::set_master_seed(12345);


### PR DESCRIPTION
## Summary
Lands the Claude Science work order on `main` (`WORKORDER_accel_stack_defects.md`). B4 (MSVC `setenv` / weak symbols) is deferred.

- **B2:** `env_truthy` and both engine readers use `flexaids::env_bool_str` / `env_bool`. `{off,false,no,0,""}` are OFF; `{1,true,on,yes}` are ON. `FLEXAIDDS_RIGID_FASTPATH=off` no longer enables the index.
- **B1:** Fastpath/hoist are re-read at use sites (no pre-`main` snapshots). After `apply_to_environ()` with `FLEXAIDDS_FLAGS=fastpath`, the engine readers see ON.
- **S5:** `CA_REC_FLAT` sizes to the live `prev` chain; `flatten_ca_rec` returns `-need` instead of a silent 100-contact prefix. 120-contact test: count + `get_yval` CF match the uncapped walk.
- **D6:** `FLEXAIDDS_VORONOI_KEYED_JITTER` is its own default-OFF gate; `FLEXAIDDS_RNG_STREAM_FIX=1` no longer switches the jitter source.
- **B3:** `--coarse-prefilter` name mismatch fails closed (`summary.failed`, return before `_results.csv`). No first-N unranked prefix.

## Test plan
- [x] Table test through `env_bool_str`, `flags::active()`, `rigid_fastpath_requested()`
- [x] Overlay `apply_to_environ` reaches engine readers
- [x] >100-contact flatten ON == OFF (count + CF)
- [x] Keyed jitter independent of RNG stream fix
- [x] `resolve_prefilter_keep` mismatch → empty / abort
- [x] Full `ctest` 94/94, experimental `FLEXAIDDS_*` **unset** (not set to `off`)
- [ ] G-b 1HNN vs `pre-swarm-baseline-20260813` — recorded unrun (no baseline binary; full 2000×1000 pair too heavy this session)

Defaults remain OFF. Do not set acceleration vars to the string `off` on older binaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes env semantics and live scoring paths (Vcontacts/vcfunction) plus campaign prefilter abort behavior; defaults stay OFF but enabled flags alter reproducibility and screening outcomes.
> 
> **Overview**
> Hardens the acceleration / reproducibility stack: one boolean env parser everywhere, live flag reads for overlays, safer `CA_REC_FLAT` contact walks, an independent Voronoi jitter switch, and a fail-closed coarse-prefilter join.
> 
> **Env flags (B2/B1):** Adds `env_bool_str` / `env_bool` and routes `flexaidds_flags::env_truthy` and engine readers (`rigid_fastpath_requested`, `hoist_receptor_index_env`) through it so `off`/`false`/`no`/`0` are OFF. Removes pre-main `getenv` snapshots in `Vcontacts.cpp` and `vcfunction.cpp` so `FLEXAIDDS_FLAGS` + `apply_to_environ()` is visible at scoring time.
> 
> **Voronoi jitter (D6):** Hull-failure coordinate perturbation now gates on new default-OFF `FLEXAIDDS_VORONOI_KEYED_JITTER` instead of `FLEXAIDDS_RNG_STREAM_FIX`, keeping RNG A/B single-variable.
> 
> **CA_REC_FLAT (S5):** Chains longer than `MAX_CONT` (100) allocate a full flatten buffer; `flatten_ca_rec` returns `-(needed)` on truncation instead of silently capping. `vcfunction` uses stack or heap accordingly.
> 
> **Campaign prefilter (B3):** `--coarse-prefilter` requires 1:1 name match via `resolve_prefilter_keep`; mismatch aborts with `summary.failed` and drops the old “keep first N library entries” fallback.
> 
> Tests cover the env truth table, overlay → engine readers, >100-contact flatten vs legacy walk, jitter independence, and prefilter resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c0ebc4d8ae19c48e18f6da8d28f31735a448a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added runtime controls for rigid fast-path processing, receptor-index handling, and Voronoi keyed jitter.
  - Added support for processing contact-record chains longer than the standard capacity without losing data.

- **Bug Fixes**
  - Coarse screening now validates ligand names before filtering and fails safely when names are missing or inconsistent.
  - Prevented silent truncation of long contact-record chains.
  - Improved handling of invalid boolean configuration values, treating them as disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->